### PR TITLE
Enable fp8 ops by default on gfx1200

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -348,7 +348,7 @@ try:
 #                    if any((a in arch) for a in ["gfx1201"]):
 #                        ENABLE_PYTORCH_ATTENTION = True
         if torch_version_numeric >= (2, 7) and rocm_version >= (6, 4):
-            if any((a in arch) for a in ["gfx1201", "gfx942", "gfx950"]):  # TODO: more arches
+            if any((a in arch) for a in ["gfx1200", "gfx1201", "gfx942", "gfx950"]):  # TODO: more arches
                 SUPPORT_FP8_OPS = True
 
 except:


### PR DESCRIPTION
A PR like https://github.com/comfyanonymous/ComfyUI/pull/8464, enables fp8 ops by default on gfx1200 too.