### PR TITLE
feat: Add expected_outputs for conditional output computation

### DIFF
--- a/comfy_api/latest/_io.py
+++ b/comfy_api/latest/_io.py
@@ -1655,7 +1655,11 @@ class Schema:
     """When True, cache will invalidate when output connections change, and expected_outputs will be available.
 
     Use this for nodes that can skip computing outputs that aren't connected downstream.
-    Access via `get_executing_context().expected_outputs` - outputs NOT in the set are definitely unused."""
+    Check `comfy_execution.utils.is_output_needed(i)` inside execute() - False means output i is definitely unused
+    and safe to skip. Only nodes with this flag receive expected_outputs; all others see None.
+
+    Limitation: consumers must exist before this node runs - a subgraph expansion that
+    hand-builds a link to a pre-existing node's already-skipped output reads a stale value."""
 
     def validate(self):
         '''Validate the schema:

--- a/comfy_api/latest/_io.py
+++ b/comfy_api/latest/_io.py
@@ -1651,6 +1651,11 @@ class Schema:
     Use this for nodes with interactive/operable UI regions that produce intermediate outputs
     (e.g., Image Crop, Painter) rather than final outputs (e.g., Save Image).
     """
+    lazy_outputs: bool=False
+    """When True, cache will invalidate when output connections change, and expected_outputs will be available.
+
+    Use this for nodes that can skip computing outputs that aren't connected downstream.
+    Access via `get_executing_context().expected_outputs` - outputs NOT in the set are definitely unused."""
 
     def validate(self):
         '''Validate the schema:
@@ -2108,6 +2113,14 @@ class _ComfyNodeBaseInternal(_ComfyNodeInternal):
             cls.GET_SCHEMA()
         return cls._ACCEPT_ALL_INPUTS
 
+    _LAZY_OUTPUTS = None
+    @final
+    @classproperty
+    def LAZY_OUTPUTS(cls):  # noqa
+        if cls._LAZY_OUTPUTS is None:
+            cls.GET_SCHEMA()
+        return cls._LAZY_OUTPUTS
+
     @final
     @classmethod
     def INPUT_TYPES(cls) -> dict[str, dict]:
@@ -2152,6 +2165,8 @@ class _ComfyNodeBaseInternal(_ComfyNodeInternal):
             cls._NOT_IDEMPOTENT = schema.not_idempotent
         if cls._ACCEPT_ALL_INPUTS is None:
             cls._ACCEPT_ALL_INPUTS = schema.accept_all_inputs
+        if cls._LAZY_OUTPUTS is None:
+            cls._LAZY_OUTPUTS = schema.lazy_outputs
 
         if cls._RETURN_TYPES is None:
             output = []

--- a/comfy_execution/caching.py
+++ b/comfy_execution/caching.py
@@ -6,7 +6,7 @@ import time
 import torch
 from typing import Sequence, Mapping, Dict
 from comfy.model_patcher import ModelPatcher
-from comfy_execution.graph import DynamicPrompt
+from comfy_execution.graph import DynamicPrompt, get_expected_outputs_for_node
 from abc import ABC, abstractmethod
 
 import nodes
@@ -116,6 +116,10 @@ class CacheKeySetInputSignature(CacheKeySet):
         signature = [class_type, await self.is_changed_cache.get(node_id)]
         if self.include_node_id_in_input() or (hasattr(class_def, "NOT_IDEMPOTENT") and class_def.NOT_IDEMPOTENT) or include_unique_id_in_input(class_type):
             signature.append(node_id)
+        # Include expected_outputs in cache key for nodes that opt in via LAZY_OUTPUTS
+        if hasattr(class_def, 'LAZY_OUTPUTS') and class_def.LAZY_OUTPUTS:
+            expected = get_expected_outputs_for_node(dynprompt, node_id)
+            signature.append(("expected_outputs", tuple(sorted(expected))))
         inputs = node["inputs"]
         for key in sorted(inputs.keys()):
             if is_link(inputs[key]):

--- a/comfy_execution/graph.py
+++ b/comfy_execution/graph.py
@@ -24,19 +24,7 @@ def get_expected_outputs_for_node(dynprompt, node_id: str) -> frozenset:
     Returns outputs that MIGHT be used.
     Outputs NOT in this set are DEFINITELY not used and safe to skip.
     """
-    expected = set()
-    for other_node_id in dynprompt.all_node_ids():
-        try:
-            node_data = dynprompt.get_node(other_node_id)
-        except NodeNotFoundError:
-            continue
-        inputs = node_data.get("inputs", {})
-        for input_name, value in inputs.items():
-            if is_link(value):
-                from_node_id, from_socket = value
-                if from_node_id == node_id:
-                    expected.add(from_socket)
-    return frozenset(expected)
+    return dynprompt.get_expected_outputs_map().get(node_id, frozenset())
 
 
 class DynamicPrompt:
@@ -47,6 +35,7 @@ class DynamicPrompt:
         self.ephemeral_prompt = {}
         self.ephemeral_parents = {}
         self.ephemeral_display = {}
+        self._expected_outputs_map = None
 
     def get_node(self, node_id):
         if node_id in self.ephemeral_prompt:
@@ -62,6 +51,7 @@ class DynamicPrompt:
         self.ephemeral_prompt[node_id] = node_info
         self.ephemeral_parents[node_id] = parent_id
         self.ephemeral_display[node_id] = display_id
+        self._expected_outputs_map = None
 
     def get_real_node_id(self, node_id):
         while node_id in self.ephemeral_parents:
@@ -78,6 +68,26 @@ class DynamicPrompt:
 
     def all_node_ids(self):
         return set(self.original_prompt.keys()).union(set(self.ephemeral_prompt.keys()))
+
+    def _build_expected_outputs_map(self):
+        result = {}
+        for node_id in self.all_node_ids():
+            try:
+                node_data = self.get_node(node_id)
+            except NodeNotFoundError:
+                continue
+            for value in node_data.get("inputs", {}).values():
+                if is_link(value):
+                    from_node_id, from_socket = value
+                    if from_node_id not in result:
+                        result[from_node_id] = set()
+                    result[from_node_id].add(from_socket)
+        self._expected_outputs_map = {k: frozenset(v) for k, v in result.items()}
+
+    def get_expected_outputs_map(self):
+        if self._expected_outputs_map is None:
+            self._build_expected_outputs_map()
+        return self._expected_outputs_map
 
     def get_original_prompt(self):
         return self.original_prompt

--- a/comfy_execution/graph.py
+++ b/comfy_execution/graph.py
@@ -22,7 +22,10 @@ class NodeNotFoundError(Exception):
 def get_expected_outputs_for_node(dynprompt, node_id: str) -> frozenset:
     """Get the set of output indices that are connected downstream.
     Returns outputs that MIGHT be used.
-    Outputs NOT in this set are DEFINITELY not used and safe to skip.
+    Outputs NOT in this set are DEFINITELY not used and safe to skip
+    (see Schema.lazy_outputs for the one expansion-related limitation).
+
+    Includes input links and consumers registered via add_output_consumer.
     """
     return dynprompt.get_expected_outputs_map().get(node_id, frozenset())
 
@@ -35,6 +38,8 @@ class DynamicPrompt:
         self.ephemeral_prompt = {}
         self.ephemeral_parents = {}
         self.ephemeral_display = {}
+        # Output sockets consumed outside of input links (subgraph expansions)
+        self._external_output_consumers = {}
         self._expected_outputs_map = None
 
     def get_node(self, node_id):
@@ -69,19 +74,22 @@ class DynamicPrompt:
     def all_node_ids(self):
         return set(self.original_prompt.keys()).union(set(self.ephemeral_prompt.keys()))
 
+    def add_output_consumer(self, node_id, socket):
+        """Record an output socket consumed outside of input links, e.g. a subgraph
+        expansion mapping its parent's output to this node's output."""
+        self._external_output_consumers.setdefault(node_id, set()).add(socket)
+        self._expected_outputs_map = None
+
     def _build_expected_outputs_map(self):
         result = {}
         for node_id in self.all_node_ids():
-            try:
-                node_data = self.get_node(node_id)
-            except NodeNotFoundError:
-                continue
+            node_data = self.get_node(node_id)
             for value in node_data.get("inputs", {}).values():
                 if is_link(value):
                     from_node_id, from_socket = value
-                    if from_node_id not in result:
-                        result[from_node_id] = set()
-                    result[from_node_id].add(from_socket)
+                    result.setdefault(from_node_id, set()).add(from_socket)
+        for node_id, sockets in self._external_output_consumers.items():
+            result.setdefault(node_id, set()).update(sockets)
         self._expected_outputs_map = {k: frozenset(v) for k, v in result.items()}
 
     def get_expected_outputs_map(self):

--- a/comfy_execution/graph.py
+++ b/comfy_execution/graph.py
@@ -18,6 +18,27 @@ class NodeInputError(Exception):
 class NodeNotFoundError(Exception):
     pass
 
+
+def get_expected_outputs_for_node(dynprompt, node_id: str) -> frozenset:
+    """Get the set of output indices that are connected downstream.
+    Returns outputs that MIGHT be used.
+    Outputs NOT in this set are DEFINITELY not used and safe to skip.
+    """
+    expected = set()
+    for other_node_id in dynprompt.all_node_ids():
+        try:
+            node_data = dynprompt.get_node(other_node_id)
+        except NodeNotFoundError:
+            continue
+        inputs = node_data.get("inputs", {})
+        for input_name, value in inputs.items():
+            if is_link(value):
+                from_node_id, from_socket = value
+                if from_node_id == node_id:
+                    expected.add(from_socket)
+    return frozenset(expected)
+
+
 class DynamicPrompt:
     def __init__(self, original_prompt):
         # The original prompt provided by the user

--- a/comfy_execution/utils.py
+++ b/comfy_execution/utils.py
@@ -1,21 +1,26 @@
 import contextvars
-from typing import Optional, NamedTuple
+from typing import NamedTuple, FrozenSet
 
 class ExecutionContext(NamedTuple):
     """
     Context information about the currently executing node.
 
     Attributes:
+        prompt_id: The ID of the current prompt execution
         node_id: The ID of the currently executing node
         list_index: The index in a list being processed (for operations on batches/lists)
+        expected_outputs: Set of output indices that might be used downstream.
+                         Outputs NOT in this set are definitely unused (safe to skip).
+                         None means the information is not available.
     """
     prompt_id: str
     node_id: str
-    list_index: Optional[int]
+    list_index: int | None
+    expected_outputs: FrozenSet[int] | None = None
 
-current_executing_context: contextvars.ContextVar[Optional[ExecutionContext]] = contextvars.ContextVar("current_executing_context", default=None)
+current_executing_context: contextvars.ContextVar[ExecutionContext | None] = contextvars.ContextVar("current_executing_context", default=None)
 
-def get_executing_context() -> Optional[ExecutionContext]:
+def get_executing_context() -> ExecutionContext | None:
     return current_executing_context.get(None)
 
 class CurrentNodeContext:
@@ -25,15 +30,22 @@ class CurrentNodeContext:
     Sets the current_executing_context on enter and resets it on exit.
 
     Example:
-        with CurrentNodeContext(node_id="123", list_index=0):
+        with CurrentNodeContext(prompt_id="abc", node_id="123", list_index=0):
             # Code that should run with the current node context set
             process_image()
     """
-    def __init__(self, prompt_id: str, node_id: str, list_index: Optional[int] = None):
+    def __init__(
+        self,
+        prompt_id: str,
+        node_id: str,
+        list_index: int | None = None,
+        expected_outputs: FrozenSet[int] | None = None,
+    ):
         self.context = ExecutionContext(
-            prompt_id= prompt_id,
-            node_id= node_id,
-            list_index= list_index
+            prompt_id=prompt_id,
+            node_id=node_id,
+            list_index=list_index,
+            expected_outputs=expected_outputs,
         )
         self.token = None
 

--- a/comfy_execution/utils.py
+++ b/comfy_execution/utils.py
@@ -23,6 +23,19 @@ current_executing_context: contextvars.ContextVar[ExecutionContext | None] = con
 def get_executing_context() -> ExecutionContext | None:
     return current_executing_context.get(None)
 
+
+def is_output_needed(output_index: int) -> bool:
+    """Check if an output at the given index is connected downstream.
+
+    Returns True if the output might be used (should be computed).
+    Returns False if the output is definitely not connected (safe to skip).
+    """
+    ctx = get_executing_context()
+    if ctx is None or ctx.expected_outputs is None:
+        return True
+    return output_index in ctx.expected_outputs
+
+
 class CurrentNodeContext:
     """
     Context manager for setting the current executing node context.

--- a/comfy_execution/utils.py
+++ b/comfy_execution/utils.py
@@ -29,6 +29,10 @@ def is_output_needed(output_index: int) -> bool:
 
     Returns True if the output might be used (should be computed).
     Returns False if the output is definitely not connected (safe to skip).
+
+    Only meaningful for LAZY_OUTPUTS nodes; for all others expected_outputs is
+    None and this always returns True (skipping without the flag would not be
+    reflected in the cache key).
     """
     ctx = get_executing_context()
     if ctx is None or ctx.expected_outputs is None:

--- a/execution.py
+++ b/execution.py
@@ -561,7 +561,10 @@ async def execute(server, dynprompt, caches, current_item, extra_data, executed,
                 # TODO - How to handle this with async functions without contextvars (which requires Python 3.12)?
                 GraphBuilder.set_default_prefix(unique_id, call_index, 0)
 
-            expected_outputs = get_expected_outputs_for_node(dynprompt, unique_id)
+            if getattr(class_def, "LAZY_OUTPUTS", False):
+                expected_outputs = get_expected_outputs_for_node(dynprompt, unique_id)
+            else:
+                expected_outputs = None
             try:
                 output_data, output_ui, has_subgraph, has_pending_tasks = await get_output_data(prompt_id, unique_id, obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data, expected_outputs=expected_outputs)
             finally:
@@ -620,6 +623,7 @@ async def execute(server, dynprompt, caches, current_item, extra_data, executed,
                         if is_link(node_outputs[i]):
                             from_node_id, from_socket = node_outputs[i][0], node_outputs[i][1]
                             new_output_links.append((from_node_id, from_socket))
+                            dynprompt.add_output_consumer(from_node_id, from_socket)
                     cached_outputs.append((True, node_outputs))
             new_node_ids = set(new_node_ids)
             for cache in caches.all:

--- a/execution.py
+++ b/execution.py
@@ -35,6 +35,7 @@ from comfy_execution.graph import (
     ExecutionBlocker,
     ExecutionList,
     get_input_info,
+    get_expected_outputs_for_node,
 )
 from comfy_execution.graph_utils import GraphBuilder, is_link
 from comfy_execution.validation import validate_node_input
@@ -237,7 +238,18 @@ async def resolve_map_node_over_list_results(results):
                 raise exc
         return [x.result() if isinstance(x, asyncio.Task) else x for x in results]
 
-async def _async_map_node_over_list(prompt_id, unique_id, obj, input_data_all, func, allow_interrupt=False, execution_block_cb=None, pre_execute_cb=None, v3_data=None):
+async def _async_map_node_over_list(
+    prompt_id,
+    unique_id,
+    obj,
+    input_data_all,
+    func,
+    allow_interrupt=False,
+    execution_block_cb=None,
+    pre_execute_cb=None,
+    v3_data=None,
+    expected_outputs=None,
+):
     # check if node wants the lists
     input_is_list = getattr(obj, "INPUT_IS_LIST", False)
 
@@ -287,10 +299,12 @@ async def _async_map_node_over_list(prompt_id, unique_id, obj, input_data_all, f
             else:
                 f = getattr(obj, func)
             if inspect.iscoroutinefunction(f):
-                async def async_wrapper(f, prompt_id, unique_id, list_index, args):
-                    with CurrentNodeContext(prompt_id, unique_id, list_index):
+                async def async_wrapper(f, prompt_id, unique_id, list_index, args, expected_outputs):
+                    with CurrentNodeContext(prompt_id, unique_id, list_index, expected_outputs):
                         return await f(**args)
-                task = asyncio.create_task(async_wrapper(f, prompt_id, unique_id, index, args=inputs))
+                task = asyncio.create_task(
+                    async_wrapper(f, prompt_id, unique_id, index, args=inputs, expected_outputs=expected_outputs)
+                )
                 # Give the task a chance to execute without yielding
                 await asyncio.sleep(0)
                 if task.done():
@@ -299,7 +313,7 @@ async def _async_map_node_over_list(prompt_id, unique_id, obj, input_data_all, f
                 else:
                     results.append(task)
             else:
-                with CurrentNodeContext(prompt_id, unique_id, index):
+                with CurrentNodeContext(prompt_id, unique_id, index, expected_outputs):
                     result = f(**inputs)
                 results.append(result)
         else:
@@ -337,8 +351,17 @@ def merge_result_data(results, obj):
             output.append([o[i] for o in results])
     return output
 
-async def get_output_data(prompt_id, unique_id, obj, input_data_all, execution_block_cb=None, pre_execute_cb=None, v3_data=None):
-    return_values = await _async_map_node_over_list(prompt_id, unique_id, obj, input_data_all, obj.FUNCTION, allow_interrupt=True, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data)
+async def get_output_data(
+    prompt_id,
+    unique_id,
+    obj,
+    input_data_all,
+    execution_block_cb=None,
+    pre_execute_cb=None,
+    v3_data=None,
+    expected_outputs=None,
+):
+    return_values = await _async_map_node_over_list(prompt_id, unique_id, obj, input_data_all, obj.FUNCTION, allow_interrupt=True, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data, expected_outputs=expected_outputs)
     has_pending_task = any(isinstance(r, asyncio.Task) and not r.done() for r in return_values)
     if has_pending_task:
         return return_values, {}, False, has_pending_task
@@ -538,8 +561,9 @@ async def execute(server, dynprompt, caches, current_item, extra_data, executed,
                 # TODO - How to handle this with async functions without contextvars (which requires Python 3.12)?
                 GraphBuilder.set_default_prefix(unique_id, call_index, 0)
 
+            expected_outputs = get_expected_outputs_for_node(dynprompt, unique_id)
             try:
-                output_data, output_ui, has_subgraph, has_pending_tasks = await get_output_data(prompt_id, unique_id, obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data)
+                output_data, output_ui, has_subgraph, has_pending_tasks = await get_output_data(prompt_id, unique_id, obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data, expected_outputs=expected_outputs)
             finally:
                 if comfy.memory_management.aimdo_enabled:
                     if args.verbose == "DEBUG":

--- a/tests-unit/execution_test/expected_outputs_test.py
+++ b/tests-unit/execution_test/expected_outputs_test.py
@@ -123,6 +123,30 @@ class TestGetExpectedOutputsForNode:
         expected = get_expected_outputs_for_node(dynprompt, "1")
         assert expected == frozenset({0})
 
+    def test_ephemeral_node_invalidates_cache(self):
+        """Test that adding ephemeral nodes updates expected outputs."""
+        prompt = {
+            "1": {"class_type": "SourceNode", "inputs": {}},
+            "2": {"class_type": "ConsumerNode", "inputs": {"image": ["1", 0]}},
+        }
+        dynprompt = DynamicPrompt(prompt)
+
+        # Initially only output 0 is connected
+        expected = get_expected_outputs_for_node(dynprompt, "1")
+        assert expected == frozenset({0})
+
+        # Add an ephemeral node that connects to output 1
+        dynprompt.add_ephemeral_node(
+            "eph_1",
+            {"class_type": "EphemeralNode", "inputs": {"data": ["1", 1]}},
+            parent_id="2",
+            display_id="2",
+        )
+
+        # Now both outputs 0 and 1 should be expected
+        expected = get_expected_outputs_for_node(dynprompt, "1")
+        assert expected == frozenset({0, 1})
+
 
 class TestExecutionContext:
     """Tests for ExecutionContext with expected_outputs field."""

--- a/tests-unit/execution_test/expected_outputs_test.py
+++ b/tests-unit/execution_test/expected_outputs_test.py
@@ -1,0 +1,269 @@
+"""Unit tests for the expected_outputs feature.
+
+This feature allows nodes to know at runtime which outputs are connected downstream,
+enabling them to skip computing outputs that aren't needed.
+"""
+
+from comfy_api.latest import IO
+from comfy_execution.graph import DynamicPrompt, get_expected_outputs_for_node
+from comfy_execution.utils import (
+    CurrentNodeContext,
+    ExecutionContext,
+    get_executing_context,
+)
+
+
+class TestGetExpectedOutputsForNode:
+    """Tests for get_expected_outputs_for_node() function."""
+
+    def test_single_output_connected(self):
+        """Test node with single output connected to one downstream node."""
+        prompt = {
+            "1": {"class_type": "SourceNode", "inputs": {}},
+            "2": {"class_type": "ConsumerNode", "inputs": {"image": ["1", 0]}},
+        }
+        dynprompt = DynamicPrompt(prompt)
+        expected = get_expected_outputs_for_node(dynprompt, "1")
+        assert expected == frozenset({0})
+
+    def test_multiple_outputs_partial_connected(self):
+        """Test node with multiple outputs, only some connected."""
+        prompt = {
+            "1": {"class_type": "MultiOutputNode", "inputs": {}},
+            "2": {"class_type": "ConsumerA", "inputs": {"input": ["1", 0]}},
+            # Output 1 is not connected
+            "3": {"class_type": "ConsumerC", "inputs": {"input": ["1", 2]}},
+        }
+        dynprompt = DynamicPrompt(prompt)
+        expected = get_expected_outputs_for_node(dynprompt, "1")
+        assert expected == frozenset({0, 2})
+        assert 1 not in expected  # Output 1 is definitely unused
+
+    def test_no_outputs_connected(self):
+        """Test node with no outputs connected."""
+        prompt = {
+            "1": {"class_type": "SourceNode", "inputs": {}},
+            "2": {"class_type": "OtherNode", "inputs": {}},
+        }
+        dynprompt = DynamicPrompt(prompt)
+        expected = get_expected_outputs_for_node(dynprompt, "1")
+        assert expected == frozenset()
+
+    def test_same_output_connected_multiple_times(self):
+        """Test same output connected to multiple downstream nodes."""
+        prompt = {
+            "1": {"class_type": "SourceNode", "inputs": {}},
+            "2": {"class_type": "ConsumerA", "inputs": {"input": ["1", 0]}},
+            "3": {"class_type": "ConsumerB", "inputs": {"input": ["1", 0]}},
+            "4": {"class_type": "ConsumerC", "inputs": {"input": ["1", 0]}},
+        }
+        dynprompt = DynamicPrompt(prompt)
+        expected = get_expected_outputs_for_node(dynprompt, "1")
+        assert expected == frozenset({0})
+
+    def test_node_not_in_prompt(self):
+        """Test getting expected outputs for a node not in the prompt."""
+        prompt = {
+            "1": {"class_type": "SourceNode", "inputs": {}},
+        }
+        dynprompt = DynamicPrompt(prompt)
+        expected = get_expected_outputs_for_node(dynprompt, "999")
+        assert expected == frozenset()
+
+    def test_chained_nodes(self):
+        """Test expected outputs in a chain of nodes."""
+        prompt = {
+            "1": {"class_type": "SourceNode", "inputs": {}},
+            "2": {"class_type": "MiddleNode", "inputs": {"input": ["1", 0]}},
+            "3": {"class_type": "EndNode", "inputs": {"input": ["2", 0]}},
+        }
+        dynprompt = DynamicPrompt(prompt)
+
+        # Node 1's output 0 is connected to node 2
+        expected_1 = get_expected_outputs_for_node(dynprompt, "1")
+        assert expected_1 == frozenset({0})
+
+        # Node 2's output 0 is connected to node 3
+        expected_2 = get_expected_outputs_for_node(dynprompt, "2")
+        assert expected_2 == frozenset({0})
+
+        # Node 3 has no downstream connections
+        expected_3 = get_expected_outputs_for_node(dynprompt, "3")
+        assert expected_3 == frozenset()
+
+    def test_complex_graph(self):
+        """Test expected outputs in a complex graph with multiple connections."""
+        prompt = {
+            "1": {"class_type": "MultiOutputNode", "inputs": {}},
+            "2": {"class_type": "ProcessorA", "inputs": {"image": ["1", 0], "mask": ["1", 1]}},
+            "3": {"class_type": "ProcessorB", "inputs": {"data": ["1", 2]}},
+            "4": {"class_type": "Combiner", "inputs": {"a": ["2", 0], "b": ["3", 0]}},
+        }
+        dynprompt = DynamicPrompt(prompt)
+
+        # Node 1 has outputs 0, 1, 2 all connected
+        expected = get_expected_outputs_for_node(dynprompt, "1")
+        assert expected == frozenset({0, 1, 2})
+
+    def test_constant_inputs_ignored(self):
+        """Test that constant (non-link) inputs don't affect expected outputs."""
+        prompt = {
+            "1": {"class_type": "SourceNode", "inputs": {}},
+            "2": {
+                "class_type": "ConsumerNode",
+                "inputs": {
+                    "image": ["1", 0],
+                    "value": 42,
+                    "name": "test",
+                },
+            },
+        }
+        dynprompt = DynamicPrompt(prompt)
+        expected = get_expected_outputs_for_node(dynprompt, "1")
+        assert expected == frozenset({0})
+
+
+class TestExecutionContext:
+    """Tests for ExecutionContext with expected_outputs field."""
+
+    def test_context_with_expected_outputs(self):
+        """Test creating ExecutionContext with expected_outputs."""
+        ctx = ExecutionContext(
+            prompt_id="prompt-123", node_id="node-456", list_index=0, expected_outputs=frozenset({0, 2})
+        )
+        assert ctx.prompt_id == "prompt-123"
+        assert ctx.node_id == "node-456"
+        assert ctx.list_index == 0
+        assert ctx.expected_outputs == frozenset({0, 2})
+
+    def test_context_without_expected_outputs(self):
+        """Test ExecutionContext defaults to None for expected_outputs."""
+        ctx = ExecutionContext(prompt_id="prompt-123", node_id="node-456", list_index=0)
+        assert ctx.expected_outputs is None
+
+    def test_context_empty_expected_outputs(self):
+        """Test ExecutionContext with empty expected_outputs set."""
+        ctx = ExecutionContext(
+            prompt_id="prompt-123", node_id="node-456", list_index=None, expected_outputs=frozenset()
+        )
+        assert ctx.expected_outputs == frozenset()
+        assert len(ctx.expected_outputs) == 0
+
+
+class TestCurrentNodeContext:
+    """Tests for CurrentNodeContext context manager with expected_outputs."""
+
+    def test_context_manager_with_expected_outputs(self):
+        """Test CurrentNodeContext sets and resets context correctly."""
+        assert get_executing_context() is None
+
+        with CurrentNodeContext("prompt-1", "node-1", 0, frozenset({0, 1})):
+            ctx = get_executing_context()
+            assert ctx is not None
+            assert ctx.prompt_id == "prompt-1"
+            assert ctx.node_id == "node-1"
+            assert ctx.list_index == 0
+            assert ctx.expected_outputs == frozenset({0, 1})
+
+        assert get_executing_context() is None
+
+    def test_context_manager_without_expected_outputs(self):
+        """Test CurrentNodeContext works without expected_outputs (backwards compatible)."""
+        with CurrentNodeContext("prompt-1", "node-1"):
+            ctx = get_executing_context()
+            assert ctx is not None
+            assert ctx.expected_outputs is None
+
+    def test_nested_context_managers(self):
+        """Test nested CurrentNodeContext managers."""
+        with CurrentNodeContext("prompt-1", "node-1", 0, frozenset({0})):
+            ctx1 = get_executing_context()
+            assert ctx1.expected_outputs == frozenset({0})
+
+            with CurrentNodeContext("prompt-1", "node-2", 0, frozenset({1, 2})):
+                ctx2 = get_executing_context()
+                assert ctx2.expected_outputs == frozenset({1, 2})
+                assert ctx2.node_id == "node-2"
+
+            # After inner context exits, should be back to outer context
+            ctx1_again = get_executing_context()
+            assert ctx1_again.expected_outputs == frozenset({0})
+            assert ctx1_again.node_id == "node-1"
+
+    def test_output_check_pattern(self):
+        """Test the typical pattern nodes will use to check expected outputs."""
+        with CurrentNodeContext("prompt-1", "node-1", 0, frozenset({0, 2})):
+            ctx = get_executing_context()
+
+            # Typical usage pattern
+            if ctx and ctx.expected_outputs is not None:
+                should_compute_0 = 0 in ctx.expected_outputs
+                should_compute_1 = 1 in ctx.expected_outputs
+                should_compute_2 = 2 in ctx.expected_outputs
+            else:
+                # Fallback when info not available
+                should_compute_0 = should_compute_1 = should_compute_2 = True
+
+            assert should_compute_0 is True
+            assert should_compute_1 is False  # Not in expected_outputs
+            assert should_compute_2 is True
+
+
+class TestSchemaLazyOutputs:
+    """Tests for lazy_outputs in V3 Schema."""
+
+    def test_schema_lazy_outputs_default(self):
+        """Test that lazy_outputs defaults to False."""
+        schema = IO.Schema(
+            node_id="TestNode",
+            inputs=[],
+            outputs=[IO.Float.Output()],
+        )
+        assert schema.lazy_outputs is False
+
+    def test_schema_lazy_outputs_true(self):
+        """Test setting lazy_outputs to True."""
+        schema = IO.Schema(
+            node_id="TestNode",
+            lazy_outputs=True,
+            inputs=[],
+            outputs=[IO.Float.Output()],
+        )
+        assert schema.lazy_outputs is True
+
+    def test_v3_node_lazy_outputs_property(self):
+        """Test that LAZY_OUTPUTS property works on V3 nodes."""
+
+        class TestNodeWithLazyOutputs(IO.ComfyNode):
+            @classmethod
+            def define_schema(cls):
+                return IO.Schema(
+                    node_id="TestNodeWithLazyOutputs",
+                    lazy_outputs=True,
+                    inputs=[],
+                    outputs=[IO.Float.Output()],
+                )
+
+            @classmethod
+            def execute(cls):
+                return IO.NodeOutput(1.0)
+
+        assert TestNodeWithLazyOutputs.LAZY_OUTPUTS is True
+
+    def test_v3_node_lazy_outputs_default(self):
+        """Test that LAZY_OUTPUTS defaults to False on V3 nodes."""
+
+        class TestNodeWithoutLazyOutputs(IO.ComfyNode):
+            @classmethod
+            def define_schema(cls):
+                return IO.Schema(
+                    node_id="TestNodeWithoutLazyOutputs",
+                    inputs=[],
+                    outputs=[IO.Float.Output()],
+                )
+
+            @classmethod
+            def execute(cls):
+                return IO.NodeOutput(1.0)
+
+        assert TestNodeWithoutLazyOutputs.LAZY_OUTPUTS is False

--- a/tests-unit/execution_test/expected_outputs_test.py
+++ b/tests-unit/execution_test/expected_outputs_test.py
@@ -10,6 +10,7 @@ from comfy_execution.utils import (
     CurrentNodeContext,
     ExecutionContext,
     get_executing_context,
+    is_output_needed,
 )
 
 
@@ -267,3 +268,31 @@ class TestSchemaLazyOutputs:
                 return IO.NodeOutput(1.0)
 
         assert TestNodeWithoutLazyOutputs.LAZY_OUTPUTS is False
+
+
+class TestIsOutputNeeded:
+    """Tests for is_output_needed() helper function."""
+
+    def test_output_needed_when_in_expected(self):
+        """Test that output is needed when in expected_outputs."""
+        with CurrentNodeContext("prompt-1", "node-1", 0, frozenset({0, 2})):
+            assert is_output_needed(0) is True
+            assert is_output_needed(2) is True
+
+    def test_output_not_needed_when_not_in_expected(self):
+        """Test that output is not needed when not in expected_outputs."""
+        with CurrentNodeContext("prompt-1", "node-1", 0, frozenset({0, 2})):
+            assert is_output_needed(1) is False
+            assert is_output_needed(3) is False
+
+    def test_output_needed_when_no_context(self):
+        """Test that output is needed when no context."""
+        assert get_executing_context() is None
+        assert is_output_needed(0) is True
+        assert is_output_needed(1) is True
+
+    def test_output_needed_when_expected_outputs_is_none(self):
+        """Test that output is needed when expected_outputs is None."""
+        with CurrentNodeContext("prompt-1", "node-1", 0, None):
+            assert is_output_needed(0) is True
+            assert is_output_needed(1) is True

--- a/tests-unit/execution_test/expected_outputs_test.py
+++ b/tests-unit/execution_test/expected_outputs_test.py
@@ -148,6 +148,45 @@ class TestGetExpectedOutputsForNode:
         assert expected == frozenset({0, 1})
 
 
+class TestExternalOutputConsumers:
+    """Tests for DynamicPrompt.add_output_consumer() — out-of-band consumers
+    (subgraph expansion output mappings) that have no input link in the prompt."""
+
+    def test_external_consumer_only(self):
+        """A socket consumed only externally must appear in expected outputs."""
+        prompt = {
+            "1": {"class_type": "SourceNode", "inputs": {}},
+        }
+        dynprompt = DynamicPrompt(prompt)
+        assert get_expected_outputs_for_node(dynprompt, "1") == frozenset()
+
+        dynprompt.add_output_consumer("1", 1)
+        assert get_expected_outputs_for_node(dynprompt, "1") == frozenset({1})
+
+    def test_external_consumer_merges_with_links(self):
+        """External consumers merge with input-link consumers."""
+        prompt = {
+            "1": {"class_type": "SourceNode", "inputs": {}},
+            "2": {"class_type": "ConsumerNode", "inputs": {"image": ["1", 0]}},
+        }
+        dynprompt = DynamicPrompt(prompt)
+        dynprompt.add_output_consumer("1", 2)
+        assert get_expected_outputs_for_node(dynprompt, "1") == frozenset({0, 2})
+
+    def test_external_consumer_invalidates_cached_map(self):
+        """Registering after the map was built must invalidate the cache."""
+        prompt = {
+            "1": {"class_type": "SourceNode", "inputs": {}},
+            "2": {"class_type": "ConsumerNode", "inputs": {"image": ["1", 0]}},
+        }
+        dynprompt = DynamicPrompt(prompt)
+        # Build (and cache) the map first
+        assert get_expected_outputs_for_node(dynprompt, "1") == frozenset({0})
+
+        dynprompt.add_output_consumer("1", 1)
+        assert get_expected_outputs_for_node(dynprompt, "1") == frozenset({0, 1})
+
+
 class TestExecutionContext:
     """Tests for ExecutionContext with expected_outputs field."""
 

--- a/tests/execution/test_execution.py
+++ b/tests/execution/test_execution.py
@@ -672,6 +672,46 @@ class TestExecution:
         assert numpy.array(images0[0]).min() == 255, "Output 0 should be white"
         assert numpy.array(images2[0]).min() == 255, "Output 2 should be white"
 
+    def test_expected_outputs_expansion_output_mapping(self, client: ComfyClient, builder: GraphBuilder):
+        """A socket consumed only via an expansion's parent-output mapping must still
+        be in the inner LAZY_OUTPUTS node's expected_outputs (white, not black)."""
+        g = builder
+        expander = g.node("TestExpectedOutputsExpansion", height=80, width=80)
+        output = g.node("PreviewImage", images=expander.out(0))
+
+        result = client.run(g)
+
+        images = result.get_images(output)
+        assert len(images) == 1, "Should have 1 image"
+        assert numpy.array(images[0]).min() == 255, (
+            "Inner node skipped an output that is consumed via the expansion's "
+            "parent-output mapping (expected white, got black)"
+        )
+
+    def test_expected_outputs_requires_opt_in(self, client: ComfyClient, builder: GraphBuilder, server):
+        """Nodes without LAZY_OUTPUTS must see expected_outputs=None: their cache key
+        ignores topology, so a skipped output would be served stale after rewiring."""
+        g = builder
+        node = g.node("TestExpectedOutputsNotOptedIn", height=96, width=96)
+        output0 = g.node("PreviewImage", images=node.out(0))
+
+        # Only output 0 connected: correct gating -> node sees None, computes all
+        result1 = client.run(g)
+        assert numpy.array(result1.get_images(output0)[0]).min() == 255
+
+        # Connect output 1: key unchanged -> cache hit must still serve correct data
+        output1 = g.node("PreviewImage", images=node.out(1))
+        result2 = client.run(g)
+
+        if server["should_cache_results"]:
+            assert not result2.did_run(node), "Node should be a cache hit (key ignores topology)"
+        images1 = result2.get_images(output1)
+        assert len(images1) == 1, "Should have 1 image for output1"
+        assert numpy.array(images1[0]).min() == 255, (
+            "Non-opted-in node observed expected_outputs and skipped output 1; "
+            "the stale skipped value was then served from cache"
+        )
+
     def test_parallel_sleep_nodes(self, client: ComfyClient, builder: GraphBuilder, skip_timing_checks):
         # Warmup execution to ensure server is fully initialized
         run_warmup(client)

--- a/tests/execution/test_execution.py
+++ b/tests/execution/test_execution.py
@@ -573,6 +573,104 @@ class TestExecution:
         else:
             assert result.did_run(test_node), "The execution should have been re-run"
 
+    def test_expected_outputs_all_connected(self, client: ComfyClient, builder: GraphBuilder):
+        """Test that expected_outputs contains all connected outputs."""
+        g = builder
+        # Create a node with 3 outputs, all connected
+        expected_outputs_node = g.node("TestExpectedOutputs", height=64, width=64)
+
+        # Connect all 3 outputs to preview nodes
+        output0 = g.node("PreviewImage", images=expected_outputs_node.out(0))
+        output1 = g.node("PreviewImage", images=expected_outputs_node.out(1))
+        output2 = g.node("PreviewImage", images=expected_outputs_node.out(2))
+
+        result = client.run(g)
+
+        # All outputs should be white (255) since all are connected
+        images0 = result.get_images(output0)
+        images1 = result.get_images(output1)
+        images2 = result.get_images(output2)
+
+        assert len(images0) == 1, "Should have 1 image for output0"
+        assert len(images1) == 1, "Should have 1 image for output1"
+        assert len(images2) == 1, "Should have 1 image for output2"
+
+        # White pixels = 255, meaning output was in expected_outputs
+        assert numpy.array(images0[0]).min() == 255, "Output 0 should be white (was expected)"
+        assert numpy.array(images1[0]).min() == 255, "Output 1 should be white (was expected)"
+        assert numpy.array(images2[0]).min() == 255, "Output 2 should be white (was expected)"
+
+    def test_expected_outputs_partial_connected(self, client: ComfyClient, builder: GraphBuilder):
+        """Test that expected_outputs only contains connected outputs."""
+        g = builder
+        # Create a node with 3 outputs, only some connected
+        expected_outputs_node = g.node("TestExpectedOutputs", height=64, width=64)
+
+        # Only connect outputs 0 and 2, leave output 1 disconnected
+        output0 = g.node("PreviewImage", images=expected_outputs_node.out(0))
+        # output1 is intentionally not connected
+        output2 = g.node("PreviewImage", images=expected_outputs_node.out(2))
+
+        result = client.run(g)
+
+        # Connected outputs should be white (255)
+        images0 = result.get_images(output0)
+        images2 = result.get_images(output2)
+
+        assert len(images0) == 1, "Should have 1 image for output0"
+        assert len(images2) == 1, "Should have 1 image for output2"
+
+        # White = expected, output 1 is not connected so we can't verify it directly but outputs 0 and 2 should be white
+        assert numpy.array(images0[0]).min() == 255, "Output 0 should be white (was expected)"
+        assert numpy.array(images2[0]).min() == 255, "Output 2 should be white (was expected)"
+
+    def test_expected_outputs_single_connected(self, client: ComfyClient, builder: GraphBuilder):
+        """Test that expected_outputs works with single connected output."""
+        g = builder
+        # Create a node with 3 outputs, only one connected
+        expected_outputs_node = g.node("TestExpectedOutputs", height=64, width=64)
+
+        # Only connect output 1
+        output1 = g.node("PreviewImage", images=expected_outputs_node.out(1))
+
+        result = client.run(g)
+
+        images1 = result.get_images(output1)
+        assert len(images1) == 1, "Should have 1 image for output1"
+
+        # Output 1 should be white (connected), others are not visible in this test
+        assert numpy.array(images1[0]).min() == 255, "Output 1 should be white (was expected)"
+
+    def test_expected_outputs_cache_invalidation(self, client: ComfyClient, builder: GraphBuilder, server):
+        """Test that cache invalidates when output connections change."""
+        g = builder
+        # Use unique dimensions to avoid cache collision with other expected_outputs tests
+        expected_outputs_node = g.node("TestExpectedOutputs", height=32, width=32)
+
+        # First run: only connect output 0
+        output0 = g.node("PreviewImage", images=expected_outputs_node.out(0))
+
+        result1 = client.run(g)
+        assert result1.did_run(expected_outputs_node), "First run should execute the node"
+
+        # Second run: same connections, should be cached
+        result2 = client.run(g)
+        if server["should_cache_results"]:
+            assert not result2.did_run(expected_outputs_node), "Second run should be cached"
+
+        # Third run: add connection to output 2
+        output2 = g.node("PreviewImage", images=expected_outputs_node.out(2))
+
+        result3 = client.run(g)
+        # Because LAZY_OUTPUTS=True, changing connections should invalidate cache
+        if server["should_cache_results"]:
+            assert result3.did_run(expected_outputs_node), "Adding output connection should invalidate cache"
+
+        # Verify both outputs are now white
+        images0 = result3.get_images(output0)
+        images2 = result3.get_images(output2)
+        assert numpy.array(images0[0]).min() == 255, "Output 0 should be white"
+        assert numpy.array(images2[0]).min() == 255, "Output 2 should be white"
 
     def test_parallel_sleep_nodes(self, client: ComfyClient, builder: GraphBuilder, skip_timing_checks):
         # Warmup execution to ensure server is fully initialized

--- a/tests/execution/testing_nodes/testing-pack/specific_tests.py
+++ b/tests/execution/testing_nodes/testing-pack/specific_tests.py
@@ -6,7 +6,7 @@ from .tools import VariantSupport
 from comfy_execution.graph_utils import GraphBuilder
 from comfy.comfy_types.node_typing import ComfyNodeABC
 from comfy.comfy_types import IO
-from comfy_execution.utils import get_executing_context
+from comfy_execution.utils import get_executing_context, is_output_needed
 
 class TestLazyMixImages:
     @classmethod
@@ -510,27 +510,76 @@ class TestExpectedOutputs:
     CATEGORY = "_for_testing"
 
     def execute(self, height, width):
-        ctx = get_executing_context()
-
-        # Default: assume all outputs are expected (backwards compatibility)
-        output0_expected = True
-        output1_expected = True
-        output2_expected = True
-
-        if ctx is not None and ctx.expected_outputs is not None:
-            output0_expected = 0 in ctx.expected_outputs
-            output1_expected = 1 in ctx.expected_outputs
-            output2_expected = 2 in ctx.expected_outputs
-
         # Return white image if expected, black if not
         # This allows tests to verify which outputs were expected via pixel values
         white = torch.ones(1, height, width, 3)
         black = torch.zeros(1, height, width, 3)
 
         return (
-            white if output0_expected else black,
-            white if output1_expected else black,
-            white if output2_expected else black,
+            white if is_output_needed(0) else black,
+            white if is_output_needed(1) else black,
+            white if is_output_needed(2) else black,
+        )
+
+
+class TestExpectedOutputsExpansion:
+    """Expands into an inner LAZY_OUTPUTS node whose output 1 is consumed ONLY via
+    the parent-output mapping (no input link anywhere). If that mapping is not part
+    of the expected-outputs map, the inner node wrongly skips it -> black not white.
+    """
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "height": ("INT", {"default": 64, "min": 1, "max": 1024}),
+                "width": ("INT", {"default": 64, "min": 1, "max": 1024}),
+            },
+        }
+
+    RETURN_TYPES = ("IMAGE",)
+    FUNCTION = "execute"
+    CATEGORY = "_for_testing"
+
+    def execute(self, height, width):
+        g = GraphBuilder()
+        inner = g.node("TestExpectedOutputs", height=height, width=width)
+        return {"result": (inner.out(1),), "expand": g.finalize()}
+
+
+class TestExpectedOutputsNotOptedIn:
+    """Reads expected_outputs WITHOUT declaring LAZY_OUTPUTS; the executor must pass
+    None (such nodes have no cache-key protection against output rewiring). Outputs
+    are white when the node correctly sees None, otherwise they encode membership.
+    """
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "height": ("INT", {"default": 64, "min": 1, "max": 1024}),
+                "width": ("INT", {"default": 64, "min": 1, "max": 1024}),
+            },
+        }
+
+    RETURN_TYPES = ("IMAGE", "IMAGE")
+    RETURN_NAMES = ("output0", "output1")
+    FUNCTION = "execute"
+    CATEGORY = "_for_testing"
+
+    def execute(self, height, width):
+        # Raw context access (not is_output_needed): must distinguish None from a set
+        ctx = get_executing_context()
+        expected = ctx.expected_outputs if ctx is not None else None
+
+        white = torch.ones(1, height, width, 3)
+        black = torch.zeros(1, height, width, 3)
+
+        if expected is None:
+            return (white, white.clone())
+        return (
+            white if 0 in expected else black,
+            white if 1 in expected else black,
         )
 
 
@@ -551,6 +600,8 @@ TEST_NODE_CLASS_MAPPINGS = {
     "TestParallelSleep": TestParallelSleep,
     "TestOutputNodeWithSocketOutput": TestOutputNodeWithSocketOutput,
     "TestExpectedOutputs": TestExpectedOutputs,
+    "TestExpectedOutputsExpansion": TestExpectedOutputsExpansion,
+    "TestExpectedOutputsNotOptedIn": TestExpectedOutputsNotOptedIn,
 }
 
 TEST_NODE_DISPLAY_NAME_MAPPINGS = {
@@ -570,4 +621,6 @@ TEST_NODE_DISPLAY_NAME_MAPPINGS = {
     "TestParallelSleep": "Test Parallel Sleep",
     "TestOutputNodeWithSocketOutput": "Test Output Node With Socket Output",
     "TestExpectedOutputs": "Test Expected Outputs",
+    "TestExpectedOutputsExpansion": "Test Expected Outputs Expansion",
+    "TestExpectedOutputsNotOptedIn": "Test Expected Outputs Not Opted In",
 }


### PR DESCRIPTION
This PR adds the ability for nodes to know at runtime which of their outputs are actually connected downstream. This enables nodes to skip computing expensive outputs that won't be used.

**Motivation**

Some nodes (especially API nodes) produce multiple outputs in different formats (e.g., GLB, FBX, OBJ for 3D models). Currently, all outputs are computed even if only one is connected. This wastes time and bandwidth downloading unused files.

- During execution, `expected_outputs` is computed by scanning which outputs have downstream connections
- Nodes access this via `get_executing_context().expected_outputs`
- Outputs NOT in the set are definitely unused and safe to skip
- Outputs IN the set **might be** used


**Example** of usage:

```python
from comfy_execution.utils import is_output_needed

...


# Output indices: 0=GLB, 1=FBX
glb_file = None
fbx_file = None
if is_output_needed(0):
    glb_file = await download_url_to_file_3d(result.model_urls.glb, "glb", task_id=task_id)
if is_output_needed(1):
    fbx_file = await download_url_to_file_3d(result.model_urls.fbx, "fbx", task_id=task_id)
return IO.NodeOutput(glb_file, fbx_file)     
```            


This feature may also be useful for non-API nodes as nodes can now even change their behavior based on unconnected outputs.