### PR TITLE
Fix safetensor cause python crash on some windows platform

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -167,6 +167,7 @@ parser.add_argument("--disable-pinned-memory", action="store_true", help="Disabl
 
 parser.add_argument("--mmap-torch-files", action="store_true", help="Use mmap when loading ckpt/pt files.")
 parser.add_argument("--disable-mmap", action="store_true", help="Don't use mmap when loading safetensors.")
+parser.add_argument("--sft-alt-loader", action="store_true", help="Use alternate method to load safetensors.")
 
 parser.add_argument("--dont-print-server", action="store_true", help="Don't print server output.")
 parser.add_argument("--quick-test-for-ci", action="store_true", help="Quick test for CI.")

--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -37,6 +37,7 @@ import warnings
 
 MMAP_TORCH_FILES = args.mmap_torch_files
 DISABLE_MMAP = args.disable_mmap
+USE_ALT_SFT_LOADER = args.sft_alt_loader
 
 
 if True:  # ckpt/pt file whitelist for safe loading of old sd files
@@ -102,9 +103,12 @@ def load_safetensors(ckpt, device):
             with warnings.catch_warnings():
                 #We are working with read-only RAM by design
                 warnings.filterwarnings("ignore", message="The given buffer is not writable")
-                sd[name] = torch.frombuffer(mv[start:end], dtype=_TYPES[info["dtype"]]).view(info["shape"])
-                if (device != 'cpu' if isinstance(device, str) else device.type != 'cpu'):
-                    sd[name] = sd[name].to(device)
+                tensor = torch.frombuffer(mv[start:end], dtype=_TYPES[info["dtype"]]).view(info["shape"])
+                if DISABLE_MMAP:
+                    tensor = tensor.to(device=device, copy=True)
+                elif (device != 'cpu' if isinstance(device, str) else device.type != 'cpu'):
+                    tensor = tensor.to(device)
+                sd[name] = tensor
 
     return sd, header.get("__metadata__", {}),
 
@@ -115,8 +119,7 @@ def load_torch_file(ckpt, safe_load=False, device=None, return_metadata=False):
     metadata = None
     if ckpt.lower().endswith(".safetensors") or ckpt.lower().endswith(".sft"):
         try:
-            # TODO: Not sure if this is the best way to bypass the mmap issues
-            if DISABLE_MMAP or enables_dynamic_vram():
+            if USE_ALT_SFT_LOADER or enables_dynamic_vram():
                 sd, metadata = load_safetensors(ckpt, device)
                 if not return_metadata:
                     metadata = None
@@ -125,6 +128,8 @@ def load_torch_file(ckpt, safe_load=False, device=None, return_metadata=False):
                     sd = {}
                     for k in f.keys():
                         tensor = f.get_tensor(k)
+                        if DISABLE_MMAP:  # TODO: Not sure if this is the best way to bypass the mmap issues
+                            tensor = tensor.to(device=device, copy=True)
                         sd[k] = tensor
                     if return_metadata:
                         metadata = f.metadata()

--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -113,7 +113,8 @@ def load_torch_file(ckpt, safe_load=False, device=None, return_metadata=False):
     metadata = None
     if ckpt.lower().endswith(".safetensors") or ckpt.lower().endswith(".sft"):
         try:
-            if enables_dynamic_vram():
+            # TODO: Not sure if this is the best way to bypass the mmap issues
+            if DISABLE_MMAP or enables_dynamic_vram():
                 sd, metadata = load_safetensors(ckpt)
                 if not return_metadata:
                     metadata = None
@@ -122,8 +123,6 @@ def load_torch_file(ckpt, safe_load=False, device=None, return_metadata=False):
                     sd = {}
                     for k in f.keys():
                         tensor = f.get_tensor(k)
-                        if DISABLE_MMAP:  # TODO: Not sure if this is the best way to bypass the mmap issues
-                            tensor = tensor.to(device=device, copy=True)
                         sd[k] = tensor
                     if return_metadata:
                         metadata = f.metadata()

--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -80,7 +80,7 @@ _TYPES = {
     "U16": torch.uint16,
 }
 
-def load_safetensors(ckpt):
+def load_safetensors(ckpt, device):
     f = open(ckpt, "rb")
     mapping = mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ)
     mv = memoryview(mapping)
@@ -103,6 +103,8 @@ def load_safetensors(ckpt):
                 #We are working with read-only RAM by design
                 warnings.filterwarnings("ignore", message="The given buffer is not writable")
                 sd[name] = torch.frombuffer(mv[start:end], dtype=_TYPES[info["dtype"]]).view(info["shape"])
+                if (device != 'cpu' if isinstance(device, str) else device.type != 'cpu'):
+                    sd[name] = sd[name].to(device)
 
     return sd, header.get("__metadata__", {}),
 
@@ -115,7 +117,7 @@ def load_torch_file(ckpt, safe_load=False, device=None, return_metadata=False):
         try:
             # TODO: Not sure if this is the best way to bypass the mmap issues
             if DISABLE_MMAP or enables_dynamic_vram():
-                sd, metadata = load_safetensors(ckpt)
+                sd, metadata = load_safetensors(ckpt, device)
                 if not return_metadata:
                     metadata = None
             else:


### PR DESCRIPTION
### Problem
Python **always** crash when loading `ltx-2-19b-distilled-fp8.safetensors`, even I have enough (48GB) memory.  
Then I found `utils.load_torch_file` and enable `--disable-mmap` option, but problem persistent.  
Later, I discovered that python crashed **before first tensor loaded** (or, before first `f.get_tensor` call return).  

### Solution
By simply call `utils.load_safetensors`, I'm able to load and inference without crash.  
However, without change code, you must sacrificing inference speed by specify `--fast dynamic_vram`.  
So I make this PR, change `enables_dynamic_vram()` check to `DISABLE_MMAP or enables_dynamic_vram()`, and hopefully this will fix #10896 

### Tested with `ltx-2-19b-distilled-fp8.safetensors` on Python 3.11, safetensors 0.6.2, Windows 10.
- Before: Crashed consistently even with `--disable-mmap`.
- After: Loads and inferences successfully with `--disable-mmap`.


* I'm re-downloading weight (as I'm using GGUF) and test with latest safetensors 0.7.0 now