### PR TITLE
SaveImage: multithread image saving

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1642,17 +1642,20 @@ class SaveImage:
 
         # Note: when saving multiple images it can be much faster with multithreading
         with concurrent.futures.ThreadPoolExecutor() as exe:
+            futures = []
             for (batch_number, image) in enumerate(images):
                 filename_with_batch_num = filename.replace("%batch_num%", str(batch_number))
                 file = f"{filename_with_batch_num}_{counter:05}_.png"
 
-                exe.submit(save_png, image, full_output_folder, file, prompt, extra_pnginfo, self.compress_level)
+                futures.append(exe.submit(save_png, image, full_output_folder, file, prompt, extra_pnginfo, self.compress_level))
                 results.append({
                     "filename": file,
                     "subfolder": subfolder,
                     "type": self.type
                 })
                 counter += 1
+            for f in futures:
+                f.result() # propagate exception
 
         return { "ui": { "images": results } }
 

--- a/nodes.py
+++ b/nodes.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import concurrent.futures
 import torch
 
 
@@ -1638,29 +1639,35 @@ class SaveImage:
         filename_prefix += self.prefix_append
         full_output_folder, filename, counter, subfolder, filename_prefix = folder_paths.get_save_image_path(filename_prefix, self.output_dir, images[0].shape[1], images[0].shape[0])
         results = list()
-        for (batch_number, image) in enumerate(images):
-            i = 255. * image.cpu().numpy()
-            img = Image.fromarray(np.clip(i, 0, 255).astype(np.uint8))
-            metadata = None
-            if not args.disable_metadata:
-                metadata = PngInfo()
-                if prompt is not None:
-                    metadata.add_text("prompt", json.dumps(prompt))
-                if extra_pnginfo is not None:
-                    for x in extra_pnginfo:
-                        metadata.add_text(x, json.dumps(extra_pnginfo[x]))
 
-            filename_with_batch_num = filename.replace("%batch_num%", str(batch_number))
-            file = f"{filename_with_batch_num}_{counter:05}_.png"
-            img.save(os.path.join(full_output_folder, file), pnginfo=metadata, compress_level=self.compress_level)
-            results.append({
-                "filename": file,
-                "subfolder": subfolder,
-                "type": self.type
-            })
-            counter += 1
+        # Note: when saving multiple images it can be much faster with multithreading
+        with concurrent.futures.ThreadPoolExecutor() as exe:
+            for (batch_number, image) in enumerate(images):
+                filename_with_batch_num = filename.replace("%batch_num%", str(batch_number))
+                file = f"{filename_with_batch_num}_{counter:05}_.png"
+
+                exe.submit(save_png, image, full_output_folder, file, prompt, extra_pnginfo, self.compress_level)
+                results.append({
+                    "filename": file,
+                    "subfolder": subfolder,
+                    "type": self.type
+                })
+                counter += 1
 
         return { "ui": { "images": results } }
+
+def save_png(image, full_output_folder, filename, prompt, extra_pnginfo, compress_level):
+    i = 255. * image.cpu().numpy()
+    img = Image.fromarray(np.clip(i, 0, 255).astype(np.uint8))
+    metadata = None
+    if not args.disable_metadata:
+        metadata = PngInfo()
+        if prompt is not None:
+            metadata.add_text("prompt", json.dumps(prompt))
+        if extra_pnginfo is not None:
+            for x in extra_pnginfo:
+                metadata.add_text(x, json.dumps(extra_pnginfo[x]))
+    img.save(os.path.join(full_output_folder, filename), pnginfo=metadata, compress_level=compress_level)
 
 class PreviewImage(SaveImage):
     def __init__(self):


### PR DESCRIPTION
Speeds up saving of multiple images at once by saving each image using a thread pool.

Motivation: I have a workflow where I upscale a video and save each frame (e.g. 81 frames) as a png. The current `SaveImage` sequential saving of each frame can be slow.

### Impl notes
It may be slightly more efficient to check if there is just one image and omit the thread pool, but in my testing this doesn't seem to make much difference so I opted to keep the code simpler by always using the pool.

###  Benchmark:  `SaveImage` to save 81 3024x1360 frames as pngs
_Tested on Arch Linux, Ryzen 7 5800X_

#### before (sequential)
`#6 [SaveImage]: 30.01s`

#### PR (multithread)
`#6 [SaveImage]: 6.69s`

Significantly faster using multithreading.

<details>
<summary>Different max_workers results</summary>

Trying different max workers suggests the default is good and should adjust well to users CPUs (mine has 16 logical cores).
  
#### PR (max_workers=2)
`#6 [SaveImage]: 17.60s`

#### PR (max_workers=5)
`#6 [SaveImage]: 8.73s`

#### PR (max_workers=64)
`#6 [SaveImage]: 6.22s`

</details>

### Benchmark: `SaveImage` to save a single 3024x1360 frame as a png
#### before (sequential)
`#6 [SaveImage]: 0.35s`

#### PR (multithread)
`#6 [SaveImage]: 0.38s`

Same speed either way.