### PR TITLE
Add sampler lifecycle callbacks

### DIFF
--- a/comfy/patcher_extension.py
+++ b/comfy/patcher_extension.py
@@ -13,6 +13,9 @@ class CallbacksMP:
     ON_REGISTER_ALL_HOOK_PATCHES = "on_register_all_hook_patches"
     ON_INJECT_MODEL = "on_inject_model"
     ON_EJECT_MODEL = "on_eject_model"
+    ON_SAMPLER_START = "on_sampler_start"
+    ON_SAMPLER_STEP = "on_sampler_step"
+    ON_SAMPLER_END = "on_sampler_end"
 
     # callbacks dict is in the format:
     # {"call_type": {"key": [Callable1, Callable2, ...]} }

--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -993,6 +993,25 @@ class KSAMPLER(Sampler):
         noise = model_wrap.inner_model.model_sampling.noise_scaling(sigmas[0], noise, latent_image, self.max_denoise(model_wrap, sigmas))
 
         total_steps = len(sigmas) - 1
+        model_options = extra_args.get("model_options", {})
+        callback_types = comfy.patcher_extension.CallbacksMP
+        get_callbacks = comfy.patcher_extension.get_all_callbacks
+        sampler_function_name = getattr(self.sampler_function, "__name__", self.sampler_function.__class__.__name__)
+        sampler_start_callbacks = get_callbacks(callback_types.ON_SAMPLER_START, model_options, is_model_options=True)
+        sampler_step_callbacks = get_callbacks(callback_types.ON_SAMPLER_STEP, model_options, is_model_options=True)
+        sampler_end_callbacks = get_callbacks(callback_types.ON_SAMPLER_END, model_options, is_model_options=True)
+
+        if len(sampler_start_callbacks) > 0:
+            sampler_info = {
+                "total_steps": total_steps,
+                "sample_sigmas": sigmas,
+                "noise_shape": tuple(noise.shape),
+                "latent_shape": tuple(latent_image.shape) if latent_image is not None else None,
+                "sampler_function": sampler_function_name,
+            }
+            for sampler_callback in sampler_start_callbacks:
+                sampler_callback(sampler_info)
+
         first_step = True
         def k_callback(x):
             nonlocal first_step
@@ -1001,9 +1020,36 @@ class KSAMPLER(Sampler):
                 first_step = False
             if callback is not None:
                 callback(x["i"], x["denoised"], x["x"], total_steps)
+            if len(sampler_step_callbacks) == 0:
+                return
+
+            step = x["i"]
+            sigma_next = sigmas[step + 1] if step + 1 < len(sigmas) else None
+            sampler_info = {
+                "step": step,
+                "total_steps": total_steps,
+                "sigma": x.get("sigma", sigmas[step] if step < len(sigmas) else None),
+                "sigma_next": sigma_next,
+                "sigma_hat": x.get("sigma_hat", None),
+                "sample_sigmas": sigmas,
+                "x_shape": tuple(x["x"].shape) if "x" in x else None,
+                "denoised_shape": tuple(x["denoised"].shape) if "denoised" in x else None,
+                "sampler_function": sampler_function_name,
+            }
+            for sampler_callback in sampler_step_callbacks:
+                sampler_callback(sampler_info)
 
         samples = self.sampler_function(model_k, noise, sigmas, extra_args=extra_args, callback=k_callback, disable=disable_pbar, **self.extra_options)
         samples = model_wrap.inner_model.model_sampling.inverse_noise_scaling(sigmas[-1], samples)
+        if len(sampler_end_callbacks) > 0:
+            sampler_info = {
+                "total_steps": total_steps,
+                "sample_sigmas": sigmas,
+                "samples_shape": tuple(samples.shape),
+                "sampler_function": sampler_function_name,
+            }
+            for sampler_callback in sampler_end_callbacks:
+                sampler_callback(sampler_info)
         return samples
 
 

--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -1000,17 +1000,23 @@ class KSAMPLER(Sampler):
         sampler_start_callbacks = get_callbacks(callback_types.ON_SAMPLER_START, model_options, is_model_options=True)
         sampler_step_callbacks = get_callbacks(callback_types.ON_SAMPLER_STEP, model_options, is_model_options=True)
         sampler_end_callbacks = get_callbacks(callback_types.ON_SAMPLER_END, model_options, is_model_options=True)
+        sampler_sigmas = None
+        if len(sampler_start_callbacks) > 0 or len(sampler_step_callbacks) > 0 or len(sampler_end_callbacks) > 0:
+            sampler_sigmas = tuple(float(sigma) for sigma in sigmas)
+        def sampler_sigma_value(sigma):
+            return float(sigma) if sigma is not None else None
 
-        if len(sampler_start_callbacks) > 0:
-            sampler_info = {
-                "total_steps": total_steps,
-                "sample_sigmas": sigmas,
-                "noise_shape": tuple(noise.shape),
-                "latent_shape": tuple(latent_image.shape) if latent_image is not None else None,
-                "sampler_function": sampler_function_name,
-            }
-            for sampler_callback in sampler_start_callbacks:
-                sampler_callback(sampler_info)
+        def emit_sampler_start_callbacks():
+            if len(sampler_start_callbacks) > 0:
+                sampler_info = {
+                    "total_steps": total_steps,
+                    "sample_sigmas": sampler_sigmas,
+                    "noise_shape": tuple(noise.shape),
+                    "latent_shape": tuple(latent_image.shape) if latent_image is not None else None,
+                    "sampler_function": sampler_function_name,
+                }
+                for sampler_callback in sampler_start_callbacks:
+                    sampler_callback(dict(sampler_info))
 
         first_step = True
         def k_callback(x):
@@ -1024,38 +1030,53 @@ class KSAMPLER(Sampler):
                 return
 
             step = x["i"]
+            sigma = x.get("sigma", sigmas[step] if step < len(sigmas) else None)
             sigma_next = sigmas[step + 1] if step + 1 < len(sigmas) else None
             sampler_info = {
                 "step": step,
                 "total_steps": total_steps,
-                "sigma": x.get("sigma", sigmas[step] if step < len(sigmas) else None),
-                "sigma_next": sigma_next,
-                "sigma_hat": x.get("sigma_hat", None),
-                "sample_sigmas": sigmas,
+                "sigma": sampler_sigma_value(sigma),
+                "sigma_next": sampler_sigma_value(sigma_next),
+                "sigma_hat": sampler_sigma_value(x.get("sigma_hat", None)),
+                "sample_sigmas": sampler_sigmas,
                 "x_shape": tuple(x["x"].shape) if "x" in x else None,
                 "denoised_shape": tuple(x["denoised"].shape) if "denoised" in x else None,
                 "sampler_function": sampler_function_name,
             }
             for sampler_callback in sampler_step_callbacks:
-                sampler_callback(sampler_info)
+                sampler_callback(dict(sampler_info))
 
         samples = None
         sampling_succeeded = False
-        try:
-            samples = self.sampler_function(model_k, noise, sigmas, extra_args=extra_args, callback=k_callback, disable=disable_pbar, **self.extra_options)
-            samples = model_wrap.inner_model.model_sampling.inverse_noise_scaling(sigmas[-1], samples)
-            sampling_succeeded = True
-            return samples
-        finally:
+        def emit_sampler_end_callbacks():
             if len(sampler_end_callbacks) > 0:
                 sampler_info = {
                     "total_steps": total_steps,
-                    "sample_sigmas": sigmas,
+                    "sample_sigmas": sampler_sigmas,
                     "samples_shape": tuple(samples.shape) if sampling_succeeded else None,
                     "sampler_function": sampler_function_name,
                 }
                 for sampler_callback in sampler_end_callbacks:
-                    sampler_callback(sampler_info)
+                    sampler_callback(dict(sampler_info))
+
+        sampling_error = None
+        try:
+            try:
+                emit_sampler_start_callbacks()
+                samples = self.sampler_function(model_k, noise, sigmas, extra_args=extra_args, callback=k_callback, disable=disable_pbar, **self.extra_options)
+                samples = model_wrap.inner_model.model_sampling.inverse_noise_scaling(sigmas[-1], samples)
+                sampling_succeeded = True
+                return samples
+            except BaseException as error:
+                sampling_error = error
+                raise
+        finally:
+            try:
+                emit_sampler_end_callbacks()
+            except BaseException as callback_error:
+                if sampling_error is not None:
+                    raise sampling_error from callback_error
+                raise
 
 
 def ksampler(sampler_name, extra_options={}, inpaint_options={}):

--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -1039,18 +1039,23 @@ class KSAMPLER(Sampler):
             for sampler_callback in sampler_step_callbacks:
                 sampler_callback(sampler_info)
 
-        samples = self.sampler_function(model_k, noise, sigmas, extra_args=extra_args, callback=k_callback, disable=disable_pbar, **self.extra_options)
-        samples = model_wrap.inner_model.model_sampling.inverse_noise_scaling(sigmas[-1], samples)
-        if len(sampler_end_callbacks) > 0:
-            sampler_info = {
-                "total_steps": total_steps,
-                "sample_sigmas": sigmas,
-                "samples_shape": tuple(samples.shape),
-                "sampler_function": sampler_function_name,
-            }
-            for sampler_callback in sampler_end_callbacks:
-                sampler_callback(sampler_info)
-        return samples
+        samples = None
+        sampling_succeeded = False
+        try:
+            samples = self.sampler_function(model_k, noise, sigmas, extra_args=extra_args, callback=k_callback, disable=disable_pbar, **self.extra_options)
+            samples = model_wrap.inner_model.model_sampling.inverse_noise_scaling(sigmas[-1], samples)
+            sampling_succeeded = True
+            return samples
+        finally:
+            if len(sampler_end_callbacks) > 0:
+                sampler_info = {
+                    "total_steps": total_steps,
+                    "sample_sigmas": sigmas,
+                    "samples_shape": tuple(samples.shape) if sampling_succeeded else None,
+                    "sampler_function": sampler_function_name,
+                }
+                for sampler_callback in sampler_end_callbacks:
+                    sampler_callback(sampler_info)
 
 
 def ksampler(sampler_name, extra_options={}, inpaint_options={}):

--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -1038,18 +1038,23 @@ class KSAMPLER(Sampler):
                 for sampler_callback in sampler_step_callbacks:
                     sampler_callback(sampler_info)
 
-        samples = self.sampler_function(model_k, noise, sigmas, extra_args=extra_args, callback=k_callback, disable=disable_pbar, **self.extra_options)
-        samples = model_wrap.inner_model.model_sampling.inverse_noise_scaling(sigmas[-1], samples)
-        if len(sampler_end_callbacks) > 0:
-            sampler_info = {
-                "total_steps": total_steps,
-                "sample_sigmas": sigmas,
-                "samples_shape": tuple(samples.shape),
-                "sampler_function": sampler_function_name,
-            }
-            for sampler_callback in sampler_end_callbacks:
-                sampler_callback(sampler_info)
-        return samples
+        samples = None
+        sampling_succeeded = False
+        try:
+            samples = self.sampler_function(model_k, noise, sigmas, extra_args=extra_args, callback=k_callback, disable=disable_pbar, **self.extra_options)
+            samples = model_wrap.inner_model.model_sampling.inverse_noise_scaling(sigmas[-1], samples)
+            sampling_succeeded = True
+            return samples
+        finally:
+            if len(sampler_end_callbacks) > 0:
+                sampler_info = {
+                    "total_steps": total_steps,
+                    "sample_sigmas": sigmas,
+                    "samples_shape": tuple(samples.shape) if sampling_succeeded else None,
+                    "sampler_function": sampler_function_name,
+                }
+                for sampler_callback in sampler_end_callbacks:
+                    sampler_callback(sampler_info)
 
 
 def ksampler(sampler_name, extra_options={}, inpaint_options={}):

--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -996,11 +996,59 @@ class KSAMPLER(Sampler):
 
         k_callback = None
         total_steps = len(sigmas) - 1
-        if callback is not None:
-            k_callback = lambda x: callback(x["i"], x["denoised"], x["x"], total_steps)
+        model_options = extra_args.get("model_options", {})
+        callback_types = comfy.patcher_extension.CallbacksMP
+        get_callbacks = comfy.patcher_extension.get_all_callbacks
+        sampler_function_name = getattr(self.sampler_function, "__name__", self.sampler_function.__class__.__name__)
+        sampler_start_callbacks = get_callbacks(callback_types.ON_SAMPLER_START, model_options, is_model_options=True)
+        sampler_step_callbacks = get_callbacks(callback_types.ON_SAMPLER_STEP, model_options, is_model_options=True)
+        sampler_end_callbacks = get_callbacks(callback_types.ON_SAMPLER_END, model_options, is_model_options=True)
+
+        if len(sampler_start_callbacks) > 0:
+            sampler_info = {
+                "total_steps": total_steps,
+                "sample_sigmas": sigmas,
+                "noise_shape": tuple(noise.shape),
+                "latent_shape": tuple(latent_image.shape) if latent_image is not None else None,
+                "sampler_function": sampler_function_name,
+            }
+            for sampler_callback in sampler_start_callbacks:
+                sampler_callback(sampler_info)
+
+        if callback is not None or len(sampler_step_callbacks) > 0:
+            def k_callback(x):
+                if callback is not None:
+                    callback(x["i"], x["denoised"], x["x"], total_steps)
+                if len(sampler_step_callbacks) == 0:
+                    return
+
+                step = x["i"]
+                sigma_next = sigmas[step + 1] if step + 1 < len(sigmas) else None
+                sampler_info = {
+                    "step": step,
+                    "total_steps": total_steps,
+                    "sigma": x.get("sigma", sigmas[step] if step < len(sigmas) else None),
+                    "sigma_next": sigma_next,
+                    "sigma_hat": x.get("sigma_hat", None),
+                    "sample_sigmas": sigmas,
+                    "x_shape": tuple(x["x"].shape) if "x" in x else None,
+                    "denoised_shape": tuple(x["denoised"].shape) if "denoised" in x else None,
+                    "sampler_function": sampler_function_name,
+                }
+                for sampler_callback in sampler_step_callbacks:
+                    sampler_callback(sampler_info)
 
         samples = self.sampler_function(model_k, noise, sigmas, extra_args=extra_args, callback=k_callback, disable=disable_pbar, **self.extra_options)
         samples = model_wrap.inner_model.model_sampling.inverse_noise_scaling(sigmas[-1], samples)
+        if len(sampler_end_callbacks) > 0:
+            sampler_info = {
+                "total_steps": total_steps,
+                "sample_sigmas": sigmas,
+                "samples_shape": tuple(samples.shape),
+                "sampler_function": sampler_function_name,
+            }
+            for sampler_callback in sampler_end_callbacks:
+                sampler_callback(sampler_info)
         return samples
 
 

--- a/tests-unit/comfy_test/sampler_callbacks_test.py
+++ b/tests-unit/comfy_test/sampler_callbacks_test.py
@@ -49,6 +49,14 @@ def _failing_sampler_function(model, noise, sigmas, extra_args=None, callback=No
     raise RuntimeError("sampling failed")
 
 
+class _SamplerAbort(BaseException):
+    pass
+
+
+def _aborting_sampler_function(model, noise, sigmas, extra_args=None, callback=None, disable=False, **kwargs):
+    raise _SamplerAbort("sampling aborted")
+
+
 @pytest.fixture
 def extra_args():
     return {"model_options": {}}
@@ -75,16 +83,36 @@ def test_sampling_unchanged_without_lifecycle_callbacks(extra_args):
 
 def test_start_step_end_callbacks_are_delivered(extra_args):
     started, stepped, ended = [], [], []
-    _register(extra_args, patcher_extension.CallbacksMP.ON_SAMPLER_START, started.append)
-    _register(extra_args, patcher_extension.CallbacksMP.ON_SAMPLER_STEP, stepped.append)
-    _register(extra_args, patcher_extension.CallbacksMP.ON_SAMPLER_END, ended.append)
+    events = []
+
+    def start_callback(info):
+        events.append("start")
+        started.append(info)
+
+    def step_callback(info):
+        events.append(f"step:{info['step']}")
+        stepped.append(info)
+
+    def end_callback(info):
+        events.append("end")
+        ended.append(info)
+
+    def legacy_callback(i, denoised, x, total_steps):
+        events.append(f"legacy:{i}")
+
+    _register(extra_args, patcher_extension.CallbacksMP.ON_SAMPLER_START, start_callback)
+    _register(extra_args, patcher_extension.CallbacksMP.ON_SAMPLER_STEP, step_callback)
+    _register(extra_args, patcher_extension.CallbacksMP.ON_SAMPLER_END, end_callback)
 
     KSAMPLER(_sampler_function).sample(
-        _ModelWrap(), SIGMAS, extra_args, None, NOISE, latent_image=LATENT,
+        _ModelWrap(), SIGMAS, extra_args, legacy_callback, NOISE, latent_image=LATENT,
     )
+
+    assert events == ["start", "legacy:0", "step:0", "legacy:1", "step:1", "end"]
 
     assert len(started) == 1
     assert started[0]["total_steps"] == 2
+    assert started[0]["sample_sigmas"] == tuple(float(sigma) for sigma in SIGMAS)
     assert started[0]["noise_shape"] == tuple(NOISE.shape)
     assert started[0]["latent_shape"] == tuple(LATENT.shape)
     assert started[0]["sampler_function"] == "_sampler_function"
@@ -94,18 +122,25 @@ def test_start_step_end_callbacks_are_delivered(extra_args):
     assert float(stepped[0]["sigma"]) == pytest.approx(float(SIGMAS[0]))
     assert float(stepped[0]["sigma_next"]) == pytest.approx(float(SIGMAS[1]))
     assert float(stepped[1]["sigma_next"]) == pytest.approx(float(SIGMAS[2]))
+    assert stepped[0]["sample_sigmas"] == tuple(float(sigma) for sigma in SIGMAS)
     assert stepped[0]["x_shape"] == tuple(NOISE.shape)
     assert stepped[0]["denoised_shape"] == tuple(NOISE.shape)
 
     assert len(ended) == 1
     assert ended[0]["total_steps"] == 2
+    assert ended[0]["sample_sigmas"] == tuple(float(sigma) for sigma in SIGMAS)
     assert ended[0]["samples_shape"] == tuple(NOISE.shape)
     assert ended[0]["sampler_function"] == "_sampler_function"
 
 
 def test_end_callback_runs_when_sampling_raises(extra_args):
     ended = []
-    _register(extra_args, patcher_extension.CallbacksMP.ON_SAMPLER_END, ended.append)
+
+    def end_callback(info):
+        ended.append(info)
+        raise RuntimeError("end callback failed")
+
+    _register(extra_args, patcher_extension.CallbacksMP.ON_SAMPLER_END, end_callback)
 
     with pytest.raises(RuntimeError, match="sampling failed"):
         KSAMPLER(_failing_sampler_function).sample(
@@ -116,3 +151,42 @@ def test_end_callback_runs_when_sampling_raises(extra_args):
     assert ended[0]["samples_shape"] is None
     assert ended[0]["total_steps"] == 2
     assert ended[0]["sampler_function"] == "_failing_sampler_function"
+
+
+def test_end_callback_runs_when_sampling_aborts(extra_args):
+    ended = []
+    _register(extra_args, patcher_extension.CallbacksMP.ON_SAMPLER_END, ended.append)
+
+    with pytest.raises(_SamplerAbort, match="sampling aborted"):
+        KSAMPLER(_aborting_sampler_function).sample(
+            _ModelWrap(), SIGMAS, extra_args, None, NOISE, latent_image=LATENT,
+        )
+
+    assert len(ended) == 1
+    assert ended[0]["samples_shape"] is None
+    assert ended[0]["total_steps"] == 2
+    assert ended[0]["sampler_function"] == "_aborting_sampler_function"
+
+
+def test_end_callback_runs_when_start_callback_raises(extra_args):
+    ended = []
+
+    def start_callback(info):
+        raise RuntimeError("start callback failed")
+
+    def end_callback(info):
+        ended.append(info)
+        raise RuntimeError("end callback failed")
+
+    _register(extra_args, patcher_extension.CallbacksMP.ON_SAMPLER_START, start_callback)
+    _register(extra_args, patcher_extension.CallbacksMP.ON_SAMPLER_END, end_callback)
+
+    with pytest.raises(RuntimeError, match="start callback failed"):
+        KSAMPLER(_sampler_function).sample(
+            _ModelWrap(), SIGMAS, extra_args, None, NOISE, latent_image=LATENT,
+        )
+
+    assert len(ended) == 1
+    assert ended[0]["samples_shape"] is None
+    assert ended[0]["total_steps"] == 2
+    assert ended[0]["sampler_function"] == "_sampler_function"

--- a/tests-unit/comfy_test/sampler_callbacks_test.py
+++ b/tests-unit/comfy_test/sampler_callbacks_test.py
@@ -1,0 +1,118 @@
+import pytest
+import torch
+
+import comfy.patcher_extension as patcher_extension
+from comfy.samplers import KSAMPLER
+
+SIGMAS = torch.tensor([14.6, 7.0, 0.0])
+NOISE = torch.zeros(1, 4, 8, 8)
+LATENT = torch.zeros(1, 4, 8, 8)
+
+
+class _ModelSampling:
+    sigma_max = 14.6
+
+    def noise_scaling(self, sigma, noise, latent_image, max_denoise=False):
+        return noise
+
+    def inverse_noise_scaling(self, sigma, latent):
+        return latent
+
+
+class _InnerModel:
+    def __init__(self):
+        self.model_sampling = _ModelSampling()
+
+
+class _ModelPatcher:
+    def __init__(self):
+        self.model = _InnerModel()
+
+
+class _ModelWrap:
+    """Minimal stand-in for CFGGuider: only what KSAMPLER.sample and the first-step log touch."""
+
+    def __init__(self):
+        self.inner_model = _InnerModel()
+        self.model_patcher = _ModelPatcher()
+        self.cfg = 8.0
+
+
+def _sampler_function(model, noise, sigmas, extra_args=None, callback=None, disable=False, **kwargs):
+    for i in range(len(sigmas) - 1):
+        if callback is not None:
+            callback({"i": i, "denoised": noise, "x": noise, "sigma": sigmas[i]})
+    return noise
+
+
+def _failing_sampler_function(model, noise, sigmas, extra_args=None, callback=None, disable=False, **kwargs):
+    raise RuntimeError("sampling failed")
+
+
+@pytest.fixture
+def extra_args():
+    return {"model_options": {}}
+
+
+def _register(extra_args, call_type, callback):
+    patcher_extension.add_callback(call_type, callback, extra_args["model_options"], is_model_options=True)
+
+
+def test_sampling_unchanged_without_lifecycle_callbacks(extra_args):
+    """No registered lifecycle callbacks: the legacy per-step callback still fires and the result is returned."""
+    legacy_steps = []
+    sampler = KSAMPLER(_sampler_function)
+
+    samples = sampler.sample(
+        _ModelWrap(), SIGMAS, extra_args,
+        lambda i, denoised, x, total_steps: legacy_steps.append((i, total_steps)),
+        NOISE, latent_image=LATENT,
+    )
+
+    assert samples.shape == NOISE.shape
+    assert legacy_steps == [(0, 2), (1, 2)]
+
+
+def test_start_step_end_callbacks_are_delivered(extra_args):
+    started, stepped, ended = [], [], []
+    _register(extra_args, patcher_extension.CallbacksMP.ON_SAMPLER_START, started.append)
+    _register(extra_args, patcher_extension.CallbacksMP.ON_SAMPLER_STEP, stepped.append)
+    _register(extra_args, patcher_extension.CallbacksMP.ON_SAMPLER_END, ended.append)
+
+    KSAMPLER(_sampler_function).sample(
+        _ModelWrap(), SIGMAS, extra_args, None, NOISE, latent_image=LATENT,
+    )
+
+    assert len(started) == 1
+    assert started[0]["total_steps"] == 2
+    assert started[0]["noise_shape"] == tuple(NOISE.shape)
+    assert started[0]["latent_shape"] == tuple(LATENT.shape)
+    assert started[0]["sampler_function"] == "_sampler_function"
+
+    assert [s["step"] for s in stepped] == [0, 1]
+    assert [s["total_steps"] for s in stepped] == [2, 2]
+    assert float(stepped[0]["sigma"]) == pytest.approx(float(SIGMAS[0]))
+    assert float(stepped[0]["sigma_next"]) == pytest.approx(float(SIGMAS[1]))
+    assert float(stepped[1]["sigma_next"]) == pytest.approx(float(SIGMAS[2]))
+    assert stepped[0]["x_shape"] == tuple(NOISE.shape)
+    assert stepped[0]["denoised_shape"] == tuple(NOISE.shape)
+
+    assert len(ended) == 1
+    assert ended[0]["total_steps"] == 2
+    assert ended[0]["samples_shape"] == tuple(NOISE.shape)
+    assert ended[0]["sampler_function"] == "_sampler_function"
+
+
+def test_end_callback_runs_when_sampling_raises(extra_args):
+    ended = []
+    _register(extra_args, patcher_extension.CallbacksMP.ON_SAMPLER_END, ended.append)
+
+    with pytest.raises(RuntimeError, match="sampling failed"):
+        KSAMPLER(_failing_sampler_function).sample(
+            _ModelWrap(), SIGMAS, extra_args, None, NOISE, latent_image=LATENT,
+        )
+
+    assert len(ended) == 1
+    assert ended[0]["samples_shape"] is None
+    assert ended[0]["total_steps"] == 2
+    assert ended[0]["sampler_function"] == "_failing_sampler_function"


### PR DESCRIPTION
## Summary

Adds three sampler lifecycle callback identifiers to `CallbacksMP`:

- `ON_SAMPLER_START`
- `ON_SAMPLER_STEP`
- `ON_SAMPLER_END`

`KSAMPLER.sample()` now emits these callbacks around the existing k-diffusion callback path. The callbacks receive sampling metadata such as step index, sigmas, total step count, sampler function name, and tensor shapes.

## Motivation

Some custom nodes need to observe sampler lifecycle information for debugging, profiling, progress tracking, or step-aware extension behavior. Today those extensions often need to wrap or replace sampler internals even when they only need metadata.

Comfy already exposes wrappers and callbacks through `patcher_extension`; this change extends that existing mechanism to sampler lifecycle events without adding node UI or changing default sampling behavior.

## Scope

This intentionally does not expose mutable latent tensors to callbacks. The step callback includes `x_shape` and `denoised_shape`, not the tensors themselves.

If there is interest in a latent observer or transform callback later, that should be handled separately because it needs a more explicit contract for ordering, mutation, dtype/device/shape validation, batching, masks, determinism, and multiple callbacks.

## Compatibility

- No callbacks registered: no intended behavior change.
- Existing preview/progress callback path is preserved.
- No new node inputs or UI changes.

## Testing

- `python3 -m py_compile comfy/patcher_extension.py comfy/samplers.py`
- `git diff --check`
- Local smoke test with a stub `KSAMPLER` sampler function verified that `ON_SAMPLER_START`, `ON_SAMPLER_STEP`, and `ON_SAMPLER_END` callbacks are emitted in order while preserving the existing callback path.