### PR TITLE
docs: use documented API routes in script examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ Supports all operating systems and GPU types (NVIDIA, AMD, Intel, Apple Silicon,
 ## Examples
 See what ComfyUI can do with the [newer template workflows](https://comfy.org/workflows) or old [example workflows](https://comfyanonymous.github.io/ComfyUI_examples/).
 
+## API
+`openapi.yaml` documents the newer `/api/*` endpoints, while the Python examples in `script_examples/` use the local scripting routes served by `server.py` (without the `/api` prefix). In the UI, use `File -> Export (API)` to export the current workflow before sending it to the backend.
+
 ## Features
 - Nodes/graph/flowchart interface to experiment and create complex Stable Diffusion workflows without needing to code anything.
 - NOTE: There are many more models supported than the list below, if you want to see what is supported see our templates list inside ComfyUI.

--- a/README.md
+++ b/README.md
@@ -65,9 +65,6 @@ Supports all operating systems and GPU types (NVIDIA, AMD, Intel, Apple Silicon,
 ## Examples
 See what ComfyUI can do with the [newer template workflows](https://comfy.org/workflows) or old [example workflows](https://comfyanonymous.github.io/ComfyUI_examples/).
 
-## API
-`openapi.yaml` documents the newer `/api/*` endpoints, while the Python examples in `script_examples/` use the local scripting routes served by `server.py` (without the `/api` prefix). In the UI, use `File -> Export (API)` to export the current workflow before sending it to the backend.
-
 ## Features
 - Nodes/graph/flowchart interface to experiment and create complex Stable Diffusion workflows without needing to code anything.
 - NOTE: There are many more models supported than the list below, if you want to see what is supported see our templates list inside ComfyUI.

--- a/script_examples/basic_api_example.py
+++ b/script_examples/basic_api_example.py
@@ -106,7 +106,7 @@ def queue_prompt(prompt):
     # Generate a key here: https://platform.comfy.org/login
 
     data = json.dumps(p).encode('utf-8')
-    req =  request.Request("http://127.0.0.1:8188/prompt", data=data)
+    req =  request.Request("http://127.0.0.1:8188/api/prompt", data=data)
     request.urlopen(req)
 
 

--- a/script_examples/websockets_api_example.py
+++ b/script_examples/websockets_api_example.py
@@ -1,5 +1,5 @@
 #This is an example that uses the websockets api to know when a prompt execution is done
-#Once the prompt execution is done it downloads the images using the /history endpoint
+#Once the prompt execution is done it downloads the images using the /api/jobs endpoint
 
 import websocket #NOTE: websocket-client (https://github.com/websocket-client/websocket-client)
 import uuid
@@ -13,17 +13,17 @@ client_id = str(uuid.uuid4())
 def queue_prompt(prompt, prompt_id):
     p = {"prompt": prompt, "client_id": client_id, "prompt_id": prompt_id}
     data = json.dumps(p).encode('utf-8')
-    req = urllib.request.Request("http://{}/prompt".format(server_address), data=data)
+    req = urllib.request.Request("http://{}/api/prompt".format(server_address), data=data)
     urllib.request.urlopen(req).read()
 
 def get_image(filename, subfolder, folder_type):
     data = {"filename": filename, "subfolder": subfolder, "type": folder_type}
     url_values = urllib.parse.urlencode(data)
-    with urllib.request.urlopen("http://{}/view?{}".format(server_address, url_values)) as response:
+    with urllib.request.urlopen("http://{}/api/view?{}".format(server_address, url_values)) as response:
         return response.read()
 
-def get_history(prompt_id):
-    with urllib.request.urlopen("http://{}/history/{}".format(server_address, prompt_id)) as response:
+def get_job(prompt_id):
+    with urllib.request.urlopen("http://{}/api/jobs/{}".format(server_address, prompt_id)) as response:
         return json.loads(response.read())
 
 def get_images(ws, prompt):
@@ -44,9 +44,9 @@ def get_images(ws, prompt):
             # preview_image = Image.open(bytesIO) # This is your preview in PIL image format, store it in a global
             continue #previews are binary data
 
-    history = get_history(prompt_id)[prompt_id]
-    for node_id in history['outputs']:
-        node_output = history['outputs'][node_id]
+    job = get_job(prompt_id)
+    for node_id in job['outputs']:
+        node_output = job['outputs'][node_id]
         images_output = []
         if 'images' in node_output:
             for image in node_output['images']:

--- a/script_examples/websockets_api_example_ws_images.py
+++ b/script_examples/websockets_api_example_ws_images.py
@@ -5,7 +5,6 @@ import websocket #NOTE: websocket-client (https://github.com/websocket-client/we
 import uuid
 import json
 import urllib.request
-import urllib.parse
 
 server_address = "127.0.0.1:8188"
 client_id = str(uuid.uuid4())
@@ -13,18 +12,8 @@ client_id = str(uuid.uuid4())
 def queue_prompt(prompt):
     p = {"prompt": prompt, "client_id": client_id}
     data = json.dumps(p).encode('utf-8')
-    req =  urllib.request.Request("http://{}/prompt".format(server_address), data=data)
+    req =  urllib.request.Request("http://{}/api/prompt".format(server_address), data=data)
     return json.loads(urllib.request.urlopen(req).read())
-
-def get_image(filename, subfolder, folder_type):
-    data = {"filename": filename, "subfolder": subfolder, "type": folder_type}
-    url_values = urllib.parse.urlencode(data)
-    with urllib.request.urlopen("http://{}/view?{}".format(server_address, url_values)) as response:
-        return response.read()
-
-def get_history(prompt_id):
-    with urllib.request.urlopen("http://{}/history/{}".format(server_address, prompt_id)) as response:
-        return json.loads(response.read())
 
 def get_images(ws, prompt):
     prompt_id = queue_prompt(prompt)['prompt_id']


### PR DESCRIPTION
## Summary

Update the Python scripts in `script_examples/` to use the documented REST API surface instead of the legacy unprefixed routes.

## Changes

- submit workflows through `POST /api/prompt` in all three examples
- download generated files through `GET /api/view`
- retrieve completed outputs through `GET /api/jobs/{job_id}`, replacing the legacy history response handling
- remove unused history and file-download helpers from the direct WebSocket image example
- keep the WebSocket connection on `/ws`, which remains the documented WebSocket route
- remove the README workaround that explained the previous discrepancy

## Testing

- `py -m compileall -q script_examples/basic_api_example.py script_examples/websockets_api_example.py script_examples/websockets_api_example_ws_images.py`
- `py -m ruff check script_examples/basic_api_example.py script_examples/websockets_api_example.py script_examples/websockets_api_example_ws_images.py`
- `py -m pytest tests/execution/test_jobs.py -q` (`48 passed`)

An end-to-end image generation run was not performed because this environment does not contain the checkpoint used by the examples.