### PR TITLE
[Partner Nodes] feat(bria): add Transparent option to Remove Video Background

### DIFF
--- a/comfy_api_nodes/nodes_bria.py
+++ b/comfy_api_nodes/nodes_bria.py
@@ -251,12 +251,17 @@ class BriaRemoveVideoBackground(IO.ComfyNode):
             node_id="BriaRemoveVideoBackground",
             display_name="Bria Remove Video Background",
             category="partner/video/Bria",
-            description="Remove the background from a video using Bria. ",
+            description="Remove the background from a video using Bria. Pick a color to composite "
+            "the foreground over a solid background (returns an MP4), or pick 'Transparent' to "
+            "get a WebM/VP9 video with a real alpha channel. Connect Transparent output directly "
+            "to Save Video to write the alpha-channel WebM to disk; for per-frame compositing "
+            "(images + mask sockets), use 'Bria Remove Video Background (Transparent)' instead.",
             inputs=[
                 IO.Video.Input("video"),
                 IO.Combo.Input(
                     "background_color",
                     options=[
+                        "Transparent",
                         "Black",
                         "White",
                         "Gray",
@@ -268,7 +273,11 @@ class BriaRemoveVideoBackground(IO.ComfyNode):
                         "Magenta",
                         "Orange",
                     ],
-                    tooltip="Background color for the output video.",
+                    tooltip="Background color for the output video. 'Transparent' returns a "
+                    "WebM/VP9 video with an alpha channel (best paired with Save Video); other "
+                    "options composite the foreground over the chosen solid color and return an MP4. "
+                    "For per-frame compositing (images + mask sockets) use 'Bria Remove Video "
+                    "Background (Transparent)' instead.",
                 ),
                 IO.Int.Input(
                     "seed",
@@ -301,13 +310,17 @@ class BriaRemoveVideoBackground(IO.ComfyNode):
         seed: int,
     ) -> IO.NodeOutput:
         validate_video_duration(video, max_duration=60.0)
+        # Bria returns 422 if background_color="Transparent" is paired with mp4_h264
+        # (no alpha plane). VP9-in-WebM carries the alpha; downstream VIDEO handling
+        # preserves it as long as Save Video uses auto/auto (stream-copy) settings.
+        output_container_and_codec = "webm_vp9" if background_color == "Transparent" else "mp4_h264"
         response = await sync_op(
             cls,
             ApiEndpoint(path="/proxy/bria/v2/video/edit/remove_background", method="POST"),
             data=BriaRemoveVideoBackgroundRequest(
                 video=await upload_video_to_comfyapi(cls, video),
                 background_color=background_color,
-                output_container_and_codec="mp4_h264",
+                output_container_and_codec=output_container_and_codec,
                 seed=seed,
             ),
             response_model=BriaStatusResponse,
@@ -504,8 +517,9 @@ class BriaTransparentVideoBackground(IO.ComfyNode):
             display_name="Bria Remove Video Background (Transparent)",
             category="partner/video/Bria",
             description="Remove the background from a video using Bria and return the cut-out frames "
-            "plus an alpha mask. Connect both to a compositing node, or feed them to Save WEBM to "
-            "write a transparent video.",
+            "plus an alpha mask, ready for per-frame compositing or feeding into Save WEBM. Use this "
+            "when you need IMAGE + MASK sockets; if you only need to save a transparent video file, "
+            "use 'Bria Remove Video Background' with background_color='Transparent' instead.",
             inputs=[
                 IO.Video.Input("video"),
                 IO.Int.Input(

--- a/comfy_api_nodes/nodes_bria.py
+++ b/comfy_api_nodes/nodes_bria.py
@@ -519,9 +519,10 @@ class BriaTransparentVideoBackground(IO.ComfyNode):
             display_name="Bria Remove Video Background (Transparent)",
             category="partner/video/Bria",
             description="Remove the background from a video using Bria and return the cut-out frames "
-            "plus an alpha mask, ready for per-frame compositing or feeding into Save WEBM. Use this "
-            "when you need IMAGE + MASK sockets; if you only need to save a transparent video file, "
-            "use 'Bria Remove Video Background' with background_color='Transparent' instead.",
+            "plus an alpha mask, ready for per-frame compositing or feeding into Save WEBM to "
+            "persist a transparent video to disk. This is currently the only way to save the "
+            "alpha channel: Save Video on the consolidated 'Bria Remove Video Background' node's "
+            "Transparent output writes a .mp4 by default and drops the VP9 alpha plane on mux.",
             inputs=[
                 IO.Video.Input("video"),
                 IO.Int.Input(

--- a/comfy_api_nodes/nodes_bria.py
+++ b/comfy_api_nodes/nodes_bria.py
@@ -252,16 +252,16 @@ class BriaRemoveVideoBackground(IO.ComfyNode):
             display_name="Bria Remove Video Background",
             category="partner/video/Bria",
             description="Remove the background from a video using Bria. Pick a color to composite "
-            "the foreground over a solid background (returns an MP4), or pick 'Transparent' to "
-            "get a WebM/VP9 video with a real alpha channel. Connect Transparent output directly "
-            "to Save Video to write the alpha-channel WebM to disk; for per-frame compositing "
-            "(images + mask sockets), use 'Bria Remove Video Background (Transparent)' instead.",
+            "the foreground over a solid background (returns an MP4), or pick 'Transparent' to get "
+            "a WebM/VP9 video with a real alpha channel. For per-frame compositing (images + mask "
+            "sockets) or saving the transparent result to disk with alpha preserved, use 'Bria "
+            "Remove Video Background (Transparent)' instead -- Save Video currently writes to .mp4 "
+            "by default, which drops the VP9 alpha plane.",
             inputs=[
                 IO.Video.Input("video"),
                 IO.Combo.Input(
                     "background_color",
                     options=[
-                        "Transparent",
                         "Black",
                         "White",
                         "Gray",
@@ -272,12 +272,13 @@ class BriaRemoveVideoBackground(IO.ComfyNode):
                         "Cyan",
                         "Magenta",
                         "Orange",
+                        "Transparent",
                     ],
-                    tooltip="Background color for the output video. 'Transparent' returns a "
-                    "WebM/VP9 video with an alpha channel (best paired with Save Video); other "
-                    "options composite the foreground over the chosen solid color and return an MP4. "
-                    "For per-frame compositing (images + mask sockets) use 'Bria Remove Video "
-                    "Background (Transparent)' instead.",
+                    default="Black",
+                    tooltip="Background color for the output video. Colors composite the "
+                    "foreground over a solid background and return an MP4. 'Transparent' returns "
+                    "a WebM/VP9 video with an alpha channel; for per-frame compositing or saving "
+                    "the alpha to disk, use 'Bria Remove Video Background (Transparent)' instead.",
                 ),
                 IO.Int.Input(
                     "seed",
@@ -311,8 +312,9 @@ class BriaRemoveVideoBackground(IO.ComfyNode):
     ) -> IO.NodeOutput:
         validate_video_duration(video, max_duration=60.0)
         # Bria returns 422 if background_color="Transparent" is paired with mp4_h264
-        # (no alpha plane). VP9-in-WebM carries the alpha; downstream VIDEO handling
-        # preserves it as long as Save Video uses auto/auto (stream-copy) settings.
+        # (no alpha plane), so request webm_vp9 instead. VP9 carries the alpha in a side
+        # layer; the bytes pass through ComfyUI's VIDEO type as a file reference but
+        # SaveVideo's default .mp4 extension currently drops it on mux -- see PR notes.
         output_container_and_codec = "webm_vp9" if background_color == "Transparent" else "mp4_h264"
         response = await sync_op(
             cls,

--- a/tests-unit/comfy_api_test/video_types_test.py
+++ b/tests-unit/comfy_api_test/video_types_test.py
@@ -5,10 +5,13 @@ import os
 import av
 import io
 from fractions import Fraction
+import numpy as np
+
 from comfy_api.input_impl.video_types import VideoFromFile, VideoFromComponents
-from comfy_api.util.video_types import VideoComponents
+from comfy_api.util.video_types import VideoComponents, VideoContainer, VideoCodec
 from comfy_api.input.basic_types import AudioInput
 from av.error import InvalidDataError
+from av.codec import CodecContext
 
 EPSILON = 0.0001
 
@@ -237,3 +240,63 @@ def test_duration_consistency(video_components):
     manual_duration = float(components.images.shape[0] / components.frame_rate)
 
     assert duration == pytest.approx(manual_duration)
+
+
+def _make_webm_vp9_with_alpha(width=32, height=32, frames=5, fps=10) -> bytes:
+    buf = io.BytesIO()
+    with av.open(buf, mode="w", format="webm") as container:
+        stream = container.add_stream("libvpx-vp9", rate=fps)
+        stream.width = width
+        stream.height = height
+        stream.pix_fmt = "yuva420p"
+        for i in range(frames):
+            rgba = np.zeros((height, width, 4), dtype=np.uint8)
+            rgba[..., 0] = 200
+            rgba[..., 1] = 50 + i * 30
+            rgba[..., 2] = 80
+            rgba[..., 3] = (i + 1) * 50
+            frame = av.VideoFrame.from_ndarray(rgba, format="rgba")
+            frame = frame.reformat(format="yuva420p")
+            for packet in stream.encode(frame):
+                container.mux(packet)
+        for packet in stream.encode(None):
+            container.mux(packet)
+    return buf.getvalue()
+
+
+def _per_frame_alpha_means_libvpx(source) -> list:
+    means = []
+    with av.open(source, mode="r") as container:
+        stream = container.streams.video[0]
+        decoder = CodecContext.create("libvpx-vp9", "r")
+        for packet in container.demux(stream):
+            for frame in decoder.decode(packet):
+                rgba = frame.to_ndarray(format="rgba")
+                means.append(float(rgba[..., 3].mean()))
+    return means
+
+
+def test_save_to_auto_preserves_vp9_alpha_via_stream_copy():
+    """Save Video with format=auto, codec=auto stream-copies a WebM/VP9+alpha file
+    without touching the alpha plane. This is the assumption that the consolidated
+    'Bria Remove Video Background' node relies on when background_color='Transparent'
+    (which makes Bria return a webm_vp9 url with a real alpha channel)."""
+    raw = _make_webm_vp9_with_alpha()
+    original_means = _per_frame_alpha_means_libvpx(io.BytesIO(raw))
+    assert len(original_means) > 0, "test fixture failed to produce frames"
+    assert original_means == sorted(original_means), (
+        "test fixture alpha did not encode as monotonically increasing"
+    )
+
+    video = VideoFromFile(io.BytesIO(raw))
+    out_buf = io.BytesIO()
+    video.save_to(out_buf, format=VideoContainer.AUTO, codec=VideoCodec.AUTO)
+
+    out_buf.seek(0)
+    saved_means = _per_frame_alpha_means_libvpx(out_buf)
+
+    assert len(saved_means) == len(original_means)
+    for original, saved in zip(original_means, saved_means):
+        assert original == pytest.approx(saved, abs=EPSILON), (
+            f"alpha lost across stream-copy round-trip: {original} -> {saved}"
+        )

--- a/tests-unit/comfy_api_test/video_types_test.py
+++ b/tests-unit/comfy_api_test/video_types_test.py
@@ -273,14 +273,21 @@ def _per_frame_alpha_means_libvpx(source) -> list:
             for frame in decoder.decode(packet):
                 rgba = frame.to_ndarray(format="rgba")
                 means.append(float(rgba[..., 3].mean()))
+        try:
+            for frame in decoder.decode(None):
+                rgba = frame.to_ndarray(format="rgba")
+                means.append(float(rgba[..., 3].mean()))
+        except EOFError:
+            pass
     return means
 
 
-def test_save_to_auto_preserves_vp9_alpha_via_stream_copy():
-    """Save Video with format=auto, codec=auto stream-copies a WebM/VP9+alpha file
-    without touching the alpha plane. This is the assumption that the consolidated
-    'Bria Remove Video Background' node relies on when background_color='Transparent'
-    (which makes Bria return a webm_vp9 url with a real alpha channel)."""
+def test_video_from_file_save_to_bytesio_stream_copies_vp9_alpha():
+    """VideoFromFile.save_to(BytesIO, format=AUTO, codec=AUTO) stream-copies the source
+    container/codec without re-encoding, so a WebM/VP9 file with an alpha plane
+    round-trips unchanged. Note: this covers ONLY the in-memory BytesIO path. Saving
+    to a .mp4 file (SaveVideo's default extension) muxes VP9 into MP4 and drops the
+    alpha plane -- intentionally not covered here; see PR notes."""
     raw = _make_webm_vp9_with_alpha()
     original_means = _per_frame_alpha_means_libvpx(io.BytesIO(raw))
     assert len(original_means) > 0, "test fixture failed to produce frames"


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

## Why

Bria asked for the "Transparent" output to live inside the `Bria Remove Video Background` node as just another `background_color` dropdown value, rather than a separate `Bria Remove Video Background (Transparent)` node. This PR is the smallest change that adds it.

**Draft on purpose** — there is a UX caveat we should decide how to handle before merging. See "Open question" below.

## What changed

`comfy_api_nodes/nodes_bria.py`:
- `BriaRemoveVideoBackground` now exposes `Transparent` in the `background_color` dropdown.
- When `background_color == "Transparent"`, the node sends `output_container_and_codec="webm_vp9"` to Bria (Bria returns 422 if you pair `Transparent` with `mp4_h264`). Everything else still sends `mp4_h264`.
- Dropdown default explicitly pinned to `"Black"` to preserve the prior implicit default; `Transparent` is at the end of the list.
- Descriptions/tooltips on both `BriaRemoveVideoBackground` and `BriaTransparentVideoBackground` reworked to make the division of labor explicit and call out the Save Video alpha-drop issue.
- `BriaTransparentVideoBackground` (the IMAGE + MASK node) is **unchanged and not deprecated** — see "Why both still exist".

`tests-unit/comfy_api_test/video_types_test.py`:
- New `test_video_from_file_save_to_bytesio_stream_copies_vp9_alpha`: builds a synthetic WebM/VP9 video with a deliberately varying alpha plane, runs it through `VideoFromFile.save_to(BytesIO, format=AUTO, codec=AUTO)`, and confirms alpha decodes back identically via `libvpx-vp9`. Test name and docstring scope it precisely to the in-memory BytesIO path; the .mp4 file-path case (SaveVideo's default) is intentionally not covered because it drops alpha (see PR notes).

## Why both nodes still exist (and the new node isn't a full replacement)

I tested the end-to-end flow on a synthetic VP9 + alpha file, and there are two ComfyUI-core gaps that mean the consolidated node is not yet equivalent to the dedicated transparent node:

1. **`Get Video Components` cannot expose the alpha plane for VP9.** `VideoFromFile.get_components_internal` decodes with PyAV's default `vp9` decoder, which drops the side alpha layer before the alpha-detection code at `comfy_api/latest/_input_impl/video_types.py:291-321` runs. The existing `BriaTransparentVideoBackground` works around this by manually constructing `CodecContext.create("libvpx-vp9", "r")` (see `_video_to_images_and_mask`). Until core grows VP9-alpha decoding, anyone who wants `images + mask` sockets has to use the dedicated node.
2. **`Save Video` with default `auto/auto` writes a `.mp4` file**, and muxing a VP9 stream into MP4 drops the alpha plane. Confirmed locally: source `[50, 100, 151, 201, 251]` per-frame alpha decodes back as `[255, 255, 255, 255, 255]` after a round-trip through a `.mp4` path. `VideoContainer` doesn't have a WebM option today, so users can't simply pick a different format either.

So `BriaTransparentVideoBackground` is the only path that actually delivers an alpha-channel result to disk today. The PR makes that explicit in both nodes' descriptions.

## Open question for review

The consolidated "Transparent" option *technically works* — Bria returns the right file, the file passes through the graph carrying alpha bytes — but the only thing the user can do with it today is feed it back into the graph in memory or write it to disk losing alpha. Options:

- **Ship as-is (this PR)**: honest descriptions, no surprises. The consolidated node is mostly useful as a forward-looking entry point once core video alpha support lands.
- **Extend scope**: add `WebM` to `VideoContainer`, teach `SaveVideo` to pick the right extension based on source codec/container, optionally surface `VideoComponents.alpha` from `GetVideoComponents`. Bigger blast radius (touches core video code that every node uses).
- **Defer**: don't add Transparent to the consolidated node yet; just clean up the descriptions of the two existing nodes to clarify the split.

I lean toward shipping this PR as-is and filing follow-ups for the two core issues — but it's your call. Not marking ready-for-review until that's decided.

## Verification

- `ruff check comfy_api_nodes/nodes_bria.py tests-unit/comfy_api_test/video_types_test.py` — clean.
- `python -m pytest tests-unit/comfy_api_test/video_types_test.py` — `16 passed`, including the new VP9-alpha round-trip test.
- Manual: synthetic VP9 + alpha encode → `VideoFromFile` → `save_to` confirmed (a) byte-exact alpha preservation when target is `BytesIO`/`.webm`, (b) **alpha-dropping** when target is `.mp4` (which is what `SaveVideo` does by default — the caveat we're being honest about).
- No live Bria API testing in this environment (no API key, no GPU).

## Follow-ups (not in this PR)

- Patch `VideoFromFile.get_components_internal` to fall back to `libvpx-vp9` when the stream codec is `vp9` so alpha decoding works for every VP9 input, then surface an optional `mask` output on `GetVideoComponents`.
- Add `webm_vp9` to `VideoContainer`/`VideoCodec` and teach `SaveVideo` to choose the extension based on the source's container/codec when in `auto` mode.
- Once both land, `BriaTransparentVideoBackground` can actually be deprecated.


<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [ ] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [ ] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [ ] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**

