### PR TITLE
model_management: fix free_memory race with cleanup_models finalizer

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -767,7 +767,8 @@ class LoadedModel:
             self._patcher_finalizer.detach()
 
     def is_dead(self):
-        return self.real_model() is not None and self.model is None
+        real_model = self.real_model
+        return real_model is not None and (real_model() is None or self.model is None)
 
 
 def use_more_memory(extra_memory, loaded_models, device):
@@ -810,23 +811,27 @@ def free_memory(memory_required, device, keep_loaded=[], for_dynamic=False, pins
 
     for shift_model in list(current_loaded_models):
         if device is None or shift_model.device == device:
-            if shift_model not in keep_loaded and not shift_model.is_dead():
-                can_unload.append((-shift_model.model_offloaded_memory(), sys.getrefcount(shift_model.model), shift_model.model_memory(), shift_model))
+            model = shift_model.model
+            if model is not None and shift_model not in keep_loaded and not shift_model.is_dead():
+                can_unload.append((-shift_model.model_offloaded_memory(), sys.getrefcount(model), shift_model.model_memory(), shift_model))
                 shift_model.currently_used = False
 
     can_unload_sorted = sorted(can_unload, key=lambda a: a[:3])
     for x in can_unload_sorted:
         shift_model = x[-1]
+        model = shift_model.model
+        if model is None:
+            continue
         memory_to_free = 1e32
         if not DISABLE_SMART_MEMORY or device is None:
             memory_to_free = 0 if device is None else memory_required - get_free_memory(device)
-            if shift_model.model.is_dynamic() and for_dynamic:
+            if model.is_dynamic() and for_dynamic:
                 #don't actually unload dynamic models for the sake of other dynamic models
                 #as that works on-demand.
-                memory_required -= shift_model.model.loaded_size()
+                memory_required -= model.loaded_size()
                 memory_to_free = 0
         if memory_to_free > 0 and shift_model.model_unload(memory_to_free):
-            logging.debug(f"Unloading {shift_model.model.model.__class__.__name__}")
+            logging.debug(f"Unloading {model.model.__class__.__name__}")
             unloaded_model.append(shift_model)
 
     for shift_model in unloaded_model:
@@ -992,13 +997,16 @@ def archive_model_dtypes(model):
 
 def cleanup_models():
     to_delete = []
-    for i in range(len(current_loaded_models)):
-        if current_loaded_models[i].real_model() is None:
-            to_delete = [i] + to_delete
+    for loaded_model in list(current_loaded_models):
+        real_model = loaded_model.real_model
+        if real_model is not None and real_model() is None:
+            to_delete.append(loaded_model)
 
-    for i in to_delete:
-        x = current_loaded_models.pop(i)
-        del x
+    for loaded_model in to_delete:
+        for i in range(len(current_loaded_models) - 1, -1, -1):
+            if current_loaded_models[i] is loaded_model:
+                del current_loaded_models[i]
+                break
 
 def dtype_size(dtype):
     dtype_size = 4

--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -808,30 +808,37 @@ def free_memory(memory_required, device, keep_loaded=[], for_dynamic=False, pins
     can_unload = []
     unloaded_models = []
 
-    for i in range(len(current_loaded_models) -1, -1, -1):
-        shift_model = current_loaded_models[i]
+    # Iterate a snapshot: free_memory can re-enter itself on this thread when a
+    # weakref finalizer (cleanup_models) fires during GC mid-loop and pops from
+    # current_loaded_models. Carry the LoadedModel object (not a stale absolute
+    # index) and remove unloaded entries by identity so a concurrent pop is tolerated.
+    for shift_model in list(current_loaded_models):
         if device is None or shift_model.device == device:
             if shift_model not in keep_loaded and not shift_model.is_dead():
-                can_unload.append((-shift_model.model_offloaded_memory(), sys.getrefcount(shift_model.model), shift_model.model_memory(), i))
+                can_unload.append((-shift_model.model_offloaded_memory(), sys.getrefcount(shift_model.model), shift_model.model_memory(), shift_model))
                 shift_model.currently_used = False
 
-    can_unload_sorted = sorted(can_unload)
+    can_unload_sorted = sorted(can_unload, key=lambda a: a[:3])
     for x in can_unload_sorted:
-        i = x[-1]
+        shift_model = x[-1]
         memory_to_free = 1e32
         if not DISABLE_SMART_MEMORY or device is None:
             memory_to_free = 0 if device is None else memory_required - get_free_memory(device)
-            if current_loaded_models[i].model.is_dynamic() and for_dynamic:
+            if shift_model.model.is_dynamic() and for_dynamic:
                 #don't actually unload dynamic models for the sake of other dynamic models
                 #as that works on-demand.
-                memory_required -= current_loaded_models[i].model.loaded_size()
+                memory_required -= shift_model.model.loaded_size()
                 memory_to_free = 0
-        if memory_to_free > 0 and current_loaded_models[i].model_unload(memory_to_free):
-            logging.debug(f"Unloading {current_loaded_models[i].model.model.__class__.__name__}")
-            unloaded_model.append(i)
+        if memory_to_free > 0 and shift_model.model_unload(memory_to_free):
+            logging.debug(f"Unloading {shift_model.model.model.__class__.__name__}")
+            unloaded_model.append(shift_model)
 
-    for i in sorted(unloaded_model, reverse=True):
-        unloaded_models.append(current_loaded_models.pop(i))
+    for shift_model in unloaded_model:
+        unloaded_models.append(shift_model)
+        for _idx in range(len(current_loaded_models) - 1, -1, -1):
+            if current_loaded_models[_idx] is shift_model:
+                current_loaded_models.pop(_idx)
+                break
 
     if not for_dynamic and pins_required > 0:
         ensure_pin_budget(pins_required)

--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -808,10 +808,6 @@ def free_memory(memory_required, device, keep_loaded=[], for_dynamic=False, pins
     can_unload = []
     unloaded_models = []
 
-    # Iterate a snapshot: free_memory can re-enter itself on this thread when a
-    # weakref finalizer (cleanup_models) fires during GC mid-loop and pops from
-    # current_loaded_models. Carry the LoadedModel object (not a stale absolute
-    # index) and remove unloaded entries by identity so a concurrent pop is tolerated.
     for shift_model in list(current_loaded_models):
         if device is None or shift_model.device == device:
             if shift_model not in keep_loaded and not shift_model.is_dead():


### PR DESCRIPTION
### Summary

`LoadedModel.model` dereferences a weak reference on every access. During
`free_memory()`, cyclic GC can run a `cleanup_models()` finalizer re-entrantly
and either mutate `current_loaded_models` or collect a patcher between two
property reads.

The current PR fixes the stale-list-index face, but still exposes the reported
`NoneType.model_size`, `NoneType.is_dynamic`, and finalizer
`NoneType is not callable` faces.

### Change

- Iterate snapshots, carry `LoadedModel` objects, and remove them by identity.
- Pin `model = shift_model.model` once in each `free_memory()` loop and skip a
  collected patcher.
- Make `LoadedModel.is_dead()` preserve its existing leaked-model check while
  also recognizing a collected real model.
- Make `cleanup_models()` guard an unset `real_model` field and remove dead
  wrappers by identity over a snapshot.

No locks, threads, memory-policy changes, or broad accessor fallbacks are added.

### Validation

Against both current PR head `3711b4d01f` and current master `3216c62e99`, the
deterministic scope oracle reproduces:

- first-loop weakref loss: `AttributeError`;
- second-loop weakref loss: `AttributeError`;
- unset `real_model` in `is_dead()`: `TypeError`;
- unset `real_model` in `cleanup_models()`: `TypeError`.

With this candidate all four arms pass. The real single-threaded,
automatic-GC harness also completes 500 iterations without a crash.

```text
published branch tests-unit: 919 passed, 10 skipped
current-master merge candidate tests-unit: 1485 passed, 10 skipped
Ruff: passed
py_compile: passed
```

Fixes #14365