### PR TITLE
model_patcher: skip synthetic quant keys in get_key_patches

### DIFF
--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -165,6 +165,19 @@ def low_vram_patch_estimate_vram(model, key):
 
     return weight.numel() * model_dtype.itemsize * LOWVRAM_PATCH_ESTIMATE_MATH_FACTOR
 
+def _collect_quantized_weight_state_dict_keys(model):
+    """Return state-dict keys owned by each module's QuantizedTensor weight."""
+    keys = set()
+    for module_name, module in model.named_modules(remove_duplicate=False):
+        weight = getattr(module, "weight", None)
+        if not isinstance(weight, QuantizedTensor):
+            continue
+        prefix = f"{module_name}." if module_name else ""
+        weight_key = f"{prefix}weight"
+        keys.update(k for k in weight.state_dict(weight_key) if k != weight_key)
+        keys.add(f"{prefix}comfy_quant")
+    return keys
+
 def get_key_weight(model, key):
     set_func = None
     convert_func = None
@@ -812,11 +825,14 @@ class ModelPatcher:
 
     def get_key_patches(self, filter_prefix=None):
         model_sd = self.model_state_dict()
+        quantized_weight_state_dict_keys = _collect_quantized_weight_state_dict_keys(self.model)
         p = {}
         for k in model_sd:
             if filter_prefix is not None:
                 if not k.startswith(filter_prefix):
                     continue
+            if k in quantized_weight_state_dict_keys:
+                continue
             bk = self.backup.get(k, None)
             hbk = self.hook_backup.get(k, None)
             weight, set_func, convert_func = get_key_weight(self.model, k)

--- a/tests-unit/comfy_quant/test_mixed_precision.py
+++ b/tests-unit/comfy_quant/test_mixed_precision.py
@@ -14,7 +14,7 @@ from comfy.cli_args import args
 if not has_gpu():
     args.cpu = True
 
-from comfy import ops
+from comfy import hooks, ops
 from comfy.model_patcher import ModelPatcher
 from comfy.quant_ops import QUANT_ALGOS, QuantizedTensor, TensorCoreFP8E4M3Layout
 import comfy.utils
@@ -338,7 +338,7 @@ class TestMixedPrecisionOps(unittest.TestCase):
         self.assertEqual(saved_conf["linear_dtype"], "int8")
         self.assertNotIn("quant_group_size", saved_conf)
 
-    def test_get_key_patches_skips_only_quantized_weight_pieces(self):
+    def test_hook_patches_skip_only_quantized_weight_pieces(self):
         operations = ops.mixed_precision_ops(compute_dtype=torch.float32)
         model = torch.nn.Module()
         model.linear = operations.Linear(4, 4, bias=False, device="cpu")
@@ -355,8 +355,32 @@ class TestMixedPrecisionOps(unittest.TestCase):
             torch.tensor(0.125), requires_grad=False
         )
         model.linear_alias = model.linear
+        model.patch_target = torch.nn.Linear(4, 4, bias=False)
+        torch.nn.init.zeros_(model.patch_target.weight)
 
         patcher = ModelPatcher(model, torch.device("cpu"), torch.device("cpu"))
+        weight = model.linear.weight
+        input_scale = model.linear.input_scale
+        hook = hooks.WeightHook()
+        hook.need_weight_init = False
+        hook.weights = {
+            "patch_target.weight": (torch.ones_like(model.patch_target.weight),)
+        }
+        hook_group = hooks.HookGroup()
+        hook_group.add(hook)
+        patcher.register_all_hook_patches(
+            hook_group, hooks.create_target_dict(hooks.EnumWeightTarget.Model)
+        )
+        patcher.patch_hooks(hook_group)
+
+        self.assertIs(model.linear.weight, weight)
+        self.assertIs(model.linear.input_scale, input_scale)
+        self.assertTrue(
+            torch.equal(
+                model.patch_target.weight,
+                torch.ones_like(model.patch_target.weight),
+            )
+        )
 
         self.assertEqual(
             set(patcher.get_key_patches()),
@@ -365,6 +389,7 @@ class TestMixedPrecisionOps(unittest.TestCase):
                 "linear.input_scale",
                 "linear_alias.weight",
                 "linear_alias.input_scale",
+                "patch_target.weight",
             },
         )
 

--- a/tests-unit/comfy_quant/test_mixed_precision.py
+++ b/tests-unit/comfy_quant/test_mixed_precision.py
@@ -15,7 +15,8 @@ if not has_gpu():
     args.cpu = True
 
 from comfy import ops
-from comfy.quant_ops import QUANT_ALGOS, QuantizedTensor
+from comfy.model_patcher import ModelPatcher
+from comfy.quant_ops import QUANT_ALGOS, QuantizedTensor, TensorCoreFP8E4M3Layout
 import comfy.utils
 
 
@@ -336,6 +337,36 @@ class TestMixedPrecisionOps(unittest.TestCase):
         self.assertEqual(saved_conf["convrot_groupsize"], 256)
         self.assertEqual(saved_conf["linear_dtype"], "int8")
         self.assertNotIn("quant_group_size", saved_conf)
+
+    def test_get_key_patches_skips_only_quantized_weight_pieces(self):
+        operations = ops.mixed_precision_ops(compute_dtype=torch.float32)
+        model = torch.nn.Module()
+        model.linear = operations.Linear(4, 4, bias=False, device="cpu")
+        qdata, params = TensorCoreFP8E4M3Layout.quantize(
+            torch.ones(4, 4), scale="recalculate"
+        )
+        model.linear.quant_format = "float8_e4m3fn"
+        model.linear.layout_type = "TensorCoreFP8E4M3Layout"
+        model.linear.weight = torch.nn.Parameter(
+            QuantizedTensor(qdata, model.linear.layout_type, params),
+            requires_grad=False,
+        )
+        model.linear.input_scale = torch.nn.Parameter(
+            torch.tensor(0.125), requires_grad=False
+        )
+        model.linear_alias = model.linear
+
+        patcher = ModelPatcher(model, torch.device("cpu"), torch.device("cpu"))
+
+        self.assertEqual(
+            set(patcher.get_key_patches()),
+            {
+                "linear.weight",
+                "linear.input_scale",
+                "linear_alias.weight",
+                "linear_alias.input_scale",
+            },
+        )
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Summary

Skip synthetic state-dict entries owned by `QuantizedTensor` weights when
`ModelPatcher` collects patchable model keys.

### Problem

Quantized weights expose entries such as `weight_scale` and `comfy_quant`
through `state_dict()`, but those entries are not regular module attributes.
`get_key_patches()` attempted to resolve them as attributes and raised errors
such as:

```text
'Linear' object has no attribute 'weight_scale'
```

### Change

Collect the exact state-dict entries owned by each actual `QuantizedTensor`
weight and exclude only those synthetic entries. Real `weight` and
`input_scale` parameters remain patchable, including modules shared under
multiple aliases.

This intentionally avoids a global suffix blacklist or a broad missing-
attribute fallback.

### Validation

The focused `WeightHook -> patch_hooks -> get_key_patches` regression fails with
the reported `weight_scale` exception on the exact base and passes with this
PR. It also verifies that:

- a normal Hook target is still applied;
- real quantized `weight` and `input_scale` parameters remain available;
- only the `QuantizedTensor`-owned pieces are skipped;
- shared module aliases remain correct.

The complete mixed-precision test file passes on both the PR-pinned dependency
set and current `comfy-kitchen==0.2.28` / `comfy-aimdo==0.4.13`. The full
CPU-only unit suite adds this regression without introducing a new failure.

Addresses #14382.

### Scope

This PR fixes the synthetic quantized state-key lookup failure. The later
setter-backed `inplace_update` traceback exposed by reporter retesting is a
separate follow-up and is not included here. The ModelSave/reload issue remains
tracked independently in PR #15104.

---

*AI usage disclosure: this change was prepared with AI assistance; a human reviewed and verified it and can explain every line. (Reviewed by AMD engineers before submission.)*
