### PR TITLE
fix: run text encoders on MPS instead of CPU on Apple Silicon

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -1193,7 +1193,7 @@ def text_encoder_offload_device():
 def text_encoder_device():
     if args.gpu_only:
         return get_torch_device()
-    elif vram_state in (VRAMState.HIGH_VRAM, VRAMState.NORMAL_VRAM) or comfy.memory_management.aimdo_enabled:
+    elif vram_state in (VRAMState.HIGH_VRAM, VRAMState.NORMAL_VRAM, VRAMState.SHARED) or comfy.memory_management.aimdo_enabled:
         if should_use_fp16(prioritize_performance=False):
             return get_torch_device()
         else:

--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -247,6 +247,18 @@ class CLIP:
         if dtype is None:
             dtype = model_management.text_encoder_dtype(load_device)
 
+        if not model_management.supports_cast(load_device, dtype):
+            load_device = offload_device
+
+        if load_device != offload_device and not model_management.supports_cast(load_device, torch.float8_e4m3fn):
+            # Quantized state dicts can contain weights in dtypes the declared
+            # model dtypes never reflect (e.g. fp8 layers behind comfy_quant
+            # metadata), which devices like mps cannot cast.
+            for c in (state_dict if isinstance(state_dict, list) else [state_dict]):
+                if any(k.endswith("comfy_quant") or (isinstance(w, torch.Tensor) and w.dtype in (torch.float8_e4m3fn, torch.float8_e5m2)) for k, w in c.items()):
+                    load_device = offload_device
+                    break
+
         params['dtype'] = dtype
         params['device'] = model_options.get("initial_device", model_management.text_encoder_initial_device(load_device, offload_device, parameters * model_management.dtype_size(dtype)))
         params['model_options'] = model_options
@@ -258,6 +270,7 @@ class CLIP:
                 load_device = offload_device
                 if params['device'] != offload_device:
                     self.cond_stage_model.to(offload_device)
+                    params['device'] = offload_device
                     logging.warning("Had to shift TE back.")
 
         model_management.archive_model_dtypes(self.cond_stage_model)

--- a/tests-unit/comfy_test/text_encoder_mps_test.py
+++ b/tests-unit/comfy_test/text_encoder_mps_test.py
@@ -1,0 +1,131 @@
+"""Text encoder device placement on Apple Silicon (MPS).
+
+MPS machines run in VRAMState.SHARED. Text encoders the device supports
+(fp16/bf16/fp32) should load on the GPU, while fp8/quantized ones must
+stay on the CPU because MPS cannot cast float8 dtypes.
+"""
+
+import pytest
+import torch
+
+import comfy.model_management as mm
+import comfy.ops
+import comfy.sd
+
+mps_only = pytest.mark.skipif(
+    not (torch.backends.mps.is_available() and mm.is_device_mps(mm.get_torch_device())),
+    reason="requires an Apple Silicon MPS device",
+)
+
+FP8_DTYPES = [torch.float8_e4m3fn, torch.float8_e5m2]
+
+# Big enough that text_encoder_initial_device() picks the load device.
+LARGE_PARAM_COUNT = 2 * 1024 * 1024 * 1024
+
+
+class DummyTokenizer:
+    def __init__(self, embedding_directory=None, tokenizer_data={}):
+        pass
+
+
+class DummyTEModel(torch.nn.Module):
+    def __init__(self, device=None, dtype=None, model_options={}):
+        super().__init__()
+        operations = model_options.get("custom_operations", comfy.ops.manual_cast)
+        self.linear = operations.Linear(8, 8, dtype=dtype, device=device)
+        self.dtypes = set([dtype])
+        self.construct_device = torch.device(device) if device is not None else None
+
+    def load_sd(self, sd):
+        return ([], [])
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+def make_clip(dtype, state_dict=[], clip_class=DummyTEModel):
+    class Target:
+        params = {}
+        clip = clip_class
+        tokenizer = DummyTokenizer
+
+    return comfy.sd.CLIP(
+        target=Target(),
+        parameters=LARGE_PARAM_COUNT,
+        model_options={"dtype": dtype},
+        state_dict=state_dict,
+        disable_dynamic=True,
+    )
+
+
+@pytest.fixture(autouse=True)
+def unload_models():
+    yield
+    mm.unload_all_models()
+
+
+@mps_only
+class TestTextEncoderDeviceMPS:
+    def test_vram_state_is_shared(self):
+        assert mm.vram_state == mm.VRAMState.SHARED
+
+    def test_text_encoder_device_is_mps(self):
+        assert mm.is_device_mps(mm.text_encoder_device())
+
+    def test_fp16_clip_loads_on_mps(self):
+        clip = make_clip(torch.float16)
+        assert mm.is_device_mps(clip.patcher.load_device)
+        weight = clip.cond_stage_model.linear.weight
+        assert weight.device.type == "mps"
+        x = torch.ones((1, 8), dtype=torch.float16, device=weight.device)
+        assert clip.cond_stage_model(x).device.type == "mps"
+
+    @pytest.mark.parametrize("fp8_dtype", FP8_DTYPES)
+    def test_fp8_clip_falls_back_to_cpu(self, fp8_dtype):
+        clip = make_clip(fp8_dtype)
+        assert clip.patcher.load_device == clip.patcher.offload_device
+        assert clip.cond_stage_model.construct_device.type == "cpu"
+        weight = clip.cond_stage_model.linear.weight
+        assert weight.device.type == "cpu"
+        x = torch.ones((1, 8), dtype=torch.float16, device=weight.device)
+        assert clip.cond_stage_model(x).device.type == "cpu"
+
+    @pytest.mark.parametrize("fp8_dtype", FP8_DTYPES)
+    def test_fp8_state_dict_falls_back_to_cpu(self, fp8_dtype):
+        # fp8 weights in the state dict aren't reflected in the declared
+        # model dtypes, e.g. quantized checkpoints with fp16 norm layers.
+        sd = {"linear.weight": torch.zeros((8, 8), dtype=fp8_dtype)}
+        clip = make_clip(torch.float16, state_dict=[sd])
+        assert not mm.is_device_mps(clip.patcher.load_device)
+        assert clip.cond_stage_model.construct_device.type == "cpu"
+
+    def test_comfy_quant_state_dict_falls_back_to_cpu(self):
+        sd = {
+            "linear.weight": torch.zeros((8, 8), dtype=torch.uint8),
+            "linear.comfy_quant": torch.zeros(16, dtype=torch.uint8),
+        }
+        clip = make_clip(torch.float16, state_dict=[sd])
+        assert not mm.is_device_mps(clip.patcher.load_device)
+        assert clip.cond_stage_model.construct_device.type == "cpu"
+
+    @pytest.mark.parametrize("fp8_dtype", FP8_DTYPES)
+    def test_mixed_declared_dtypes_fall_back_to_cpu(self, fp8_dtype):
+        # A secondary declared dtype (e.g. dtype_llama) can be fp8 while the
+        # primary dtype is fp16.
+        class MixedDtypeTEModel(DummyTEModel):
+            def __init__(self, device=None, dtype=None, model_options={}):
+                super().__init__(device=device, dtype=dtype, model_options=model_options)
+                self.dtypes = set([dtype, fp8_dtype])
+
+        clip = make_clip(torch.float16, clip_class=MixedDtypeTEModel)
+        assert not mm.is_device_mps(clip.patcher.load_device)
+        assert clip.cond_stage_model.linear.weight.device.type == "cpu"
+
+    @pytest.mark.parametrize("fp8_dtype", FP8_DTYPES)
+    def test_fp8_cast_still_unsupported_on_mps(self, fp8_dtype):
+        # If a torch release adds fp8 casts on MPS, supports_cast() can be
+        # updated to let fp8 text encoders onto the GPU (pytorch#132624).
+        assert not mm.supports_cast(mm.get_torch_device(), fp8_dtype)
+        t = torch.zeros(4, dtype=fp8_dtype, device="mps")
+        with pytest.raises((RuntimeError, TypeError)):
+            t.to(torch.float16)

--- a/tests-unit/comfy_test/text_encoder_mps_test.py
+++ b/tests-unit/comfy_test/text_encoder_mps_test.py
@@ -72,12 +72,13 @@ class TestTextEncoderDeviceMPS:
     def test_text_encoder_device_is_mps(self):
         assert mm.is_device_mps(mm.text_encoder_device())
 
-    def test_fp16_clip_loads_on_mps(self):
-        clip = make_clip(torch.float16)
+    @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+    def test_castable_dtype_clip_loads_on_mps(self, dtype):
+        clip = make_clip(dtype)
         assert mm.is_device_mps(clip.patcher.load_device)
         weight = clip.cond_stage_model.linear.weight
         assert weight.device.type == "mps"
-        x = torch.ones((1, 8), dtype=torch.float16, device=weight.device)
+        x = torch.ones((1, 8), dtype=dtype, device=weight.device)
         assert clip.cond_stage_model(x).device.type == "mps"
 
     @pytest.mark.parametrize("fp8_dtype", FP8_DTYPES)
@@ -103,8 +104,16 @@ class TestTextEncoderDeviceMPS:
         sd = {
             "linear.weight": torch.zeros((8, 8), dtype=torch.uint8),
             "linear.comfy_quant": torch.zeros(16, dtype=torch.uint8),
+            "spiece_model": b"not a tensor",
         }
         clip = make_clip(torch.float16, state_dict=[sd])
+        assert not mm.is_device_mps(clip.patcher.load_device)
+        assert clip.cond_stage_model.construct_device.type == "cpu"
+
+    def test_fp8_full_model_state_dict_falls_back_to_cpu(self):
+        # Full checkpoints pass a single dict instead of a list.
+        sd = {"linear.weight": torch.zeros((8, 8), dtype=torch.float8_e4m3fn)}
+        clip = make_clip(torch.float16, state_dict=sd)
         assert not mm.is_device_mps(clip.patcher.load_device)
         assert clip.cond_stage_model.construct_device.type == "cpu"
 
@@ -129,3 +138,16 @@ class TestTextEncoderDeviceMPS:
         t = torch.zeros(4, dtype=fp8_dtype, device="mps")
         with pytest.raises((RuntimeError, TypeError)):
             t.to(torch.float16)
+
+
+@pytest.mark.parametrize("fp8_dtype", FP8_DTYPES)
+def test_fp8_capable_devices_skip_the_quant_fallback(fp8_dtype):
+    # The state dict scan in CLIP.__init__ is gated on this, so devices
+    # that can cast fp8 keep loading quantized text encoders on the GPU.
+    assert mm.supports_cast(torch.device("cuda"), fp8_dtype)
+
+
+@pytest.mark.parametrize("state", [mm.VRAMState.LOW_VRAM, mm.VRAMState.NO_VRAM])
+def test_low_vram_states_keep_text_encoders_on_cpu(monkeypatch, state):
+    monkeypatch.setattr(mm, "vram_state", state)
+    assert mm.text_encoder_device() == torch.device("cpu")

--- a/tests-unit/comfy_test/text_encoder_mps_test.py
+++ b/tests-unit/comfy_test/text_encoder_mps_test.py
@@ -8,9 +8,14 @@ stay on the CPU because MPS cannot cast float8 dtypes.
 import pytest
 import torch
 
-import comfy.model_management as mm
-import comfy.ops
-import comfy.sd
+from comfy.cli_args import args as cli_args
+
+if not (torch.cuda.is_available() or torch.backends.mps.is_available()):
+    cli_args.cpu = True
+
+import comfy.model_management as mm  # noqa: E402
+import comfy.ops  # noqa: E402
+import comfy.sd  # noqa: E402
 
 mps_only = pytest.mark.skipif(
     not (torch.backends.mps.is_available() and mm.is_device_mps(mm.get_torch_device())),
@@ -24,13 +29,15 @@ LARGE_PARAM_COUNT = 2 * 1024 * 1024 * 1024
 
 
 class DummyTokenizer:
-    def __init__(self, embedding_directory=None, tokenizer_data={}):
+    def __init__(self, embedding_directory=None, tokenizer_data=None):
         pass
 
 
 class DummyTEModel(torch.nn.Module):
-    def __init__(self, device=None, dtype=None, model_options={}):
+    def __init__(self, device=None, dtype=None, model_options=None):
         super().__init__()
+        if model_options is None:
+            model_options = {}
         operations = model_options.get("custom_operations", comfy.ops.manual_cast)
         self.linear = operations.Linear(8, 8, dtype=dtype, device=device)
         self.dtypes = set([dtype])
@@ -43,7 +50,10 @@ class DummyTEModel(torch.nn.Module):
         return self.linear(x)
 
 
-def make_clip(dtype, state_dict=[], clip_class=DummyTEModel):
+def make_clip(dtype, state_dict=None, clip_class=DummyTEModel):
+    if state_dict is None:
+        state_dict = []
+
     class Target:
         params = {}
         clip = clip_class
@@ -122,7 +132,7 @@ class TestTextEncoderDeviceMPS:
         # A secondary declared dtype (e.g. dtype_llama) can be fp8 while the
         # primary dtype is fp16.
         class MixedDtypeTEModel(DummyTEModel):
-            def __init__(self, device=None, dtype=None, model_options={}):
+            def __init__(self, device=None, dtype=None, model_options=None):
                 super().__init__(device=device, dtype=dtype, model_options=model_options)
                 self.dtypes = set([dtype, fp8_dtype])
 
@@ -135,8 +145,8 @@ class TestTextEncoderDeviceMPS:
         # If a torch release adds fp8 casts on MPS, supports_cast() can be
         # updated to let fp8 text encoders onto the GPU (pytorch#132624).
         assert not mm.supports_cast(mm.get_torch_device(), fp8_dtype)
-        t = torch.zeros(4, dtype=fp8_dtype, device="mps")
         with pytest.raises((RuntimeError, TypeError)):
+            t = torch.zeros(4, dtype=fp8_dtype, device="mps")
             t.to(torch.float16)
 
 


### PR DESCRIPTION
Re-lands #12809 (reverted in #13070) with guards that keep fp8/quantized text encoders on the CPU.

## Problem

On Apple Silicon `vram_state` is `VRAMState.SHARED`, so `text_encoder_device()` never returns the GPU and text encoders always run on the CPU. For LM-style encoders this dominates generation time: ACE-Step 1.5 on an M5 Max spends 6m19s in LM sampling on CPU vs ~40s on MPS (measured via `--gpu-only`, which takes the same placement path). Reported for MPS in #12271.

## Why #12809 was reverted, and how this addresses it

PyTorch's MPS backend has no float8 support beyond raw storage — any op touching an fp8 MPS tensor, including the `.to(fp16)` dequantization cast, raises `TypeError` (pytorch/pytorch#132624, still open, not fixed in nightly). The existing `supports_cast()` fallback in `CLIP.__init__` only inspects declared model dtypes, which never reflect fp8 weights behind `comfy_quant` metadata (`QuantizedTensor` reports the compute dtype, not the fp8 storage dtype). So #12809 let quantized text encoders load onto MPS and crash at encode time.

## Changes

- add `VRAMState.SHARED` to `text_encoder_device()` — `SHARED` is only ever set on MPS, so other platforms are unaffected
- `CLIP.__init__` decides the device before any weights are allocated: it checks `supports_cast()` on the resolved dtype, and when the load device cannot cast fp8 it scans the incoming state dict for fp8 tensors or `comfy_quant` markers and keeps those text encoders on the offload device; devices that can cast fp8 (cuda etc.) skip the scan entirely
- the pre-existing "Had to shift TE back" path now updates the current device so the load log stays accurate

## Tests

`tests-unit/comfy_test/text_encoder_mps_test.py` (skipped off-MPS; runs on macOS CI runners): fp16 placement on the GPU, fp8 fallback via declared dtype / secondary dtype (`dtype_llama` style) / state-dict fp8 weights / `comfy_quant` markers, and a canary that fails when a torch release adds fp8 casts on MPS so `supports_cast()` can be relaxed.

Verified with real checkpoints on an M5 Max (torch 2.10.0): the ACE-Step qwen 0.6b+4b text encoders load on `mps` (`CLIP/text encoder model load device: mps`); the same LM checkpoint cast to fp8 stays on `cpu`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [ ] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [ ] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [ ] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**

