### PR TITLE
ops: keep FP8 LoRA biases in compute dtype

### DIFF
--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -286,6 +286,7 @@ def resolve_cast_module_with_vbar(s, dtype, device, bias_dtype, compute_dtype, w
     def post_cast(s, param_key, x, dtype, resident, update_weight):
         lowvram_fn = getattr(s, param_key + "_lowvram_function", None)
         fns = getattr(s, param_key + "_function", [])
+        requant = want_requant and param_key == "weight"
 
         if x is None:
             return None
@@ -303,13 +304,13 @@ def resolve_cast_module_with_vbar(s, dtype, device, bias_dtype, compute_dtype, w
         if not resident and lowvram_fn is not None:
             x = to_dequant(x, dtype if compute_dtype is None else compute_dtype)
             x = lowvram_fn(x)
-            if (want_requant and len(fns) == 0 or update_weight):
+            if (requant and len(fns) == 0 or update_weight):
                 seed = comfy.utils.string_to_seed(s.seed_key)
                 if isinstance(orig, QuantizedTensor):
                     y = orig.requantize_from_float(x, scale="recalculate", stochastic_rounding=seed)
                 else:
                     y = comfy.float.stochastic_rounding(x, orig.dtype, seed=seed)
-            if want_requant and len(fns) == 0:
+            if requant and len(fns) == 0:
                 x = y
             if update_weight:
                 orig.copy_(y)

--- a/tests-unit/comfy_quant/test_fp8_ops.py
+++ b/tests-unit/comfy_quant/test_fp8_ops.py
@@ -1,0 +1,74 @@
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from comfy.cli_args import args
+
+if not torch.cuda.is_available():
+    args.cpu = True
+
+from comfy import ops
+
+
+class TestFP8Ops(unittest.TestCase):
+    def test_vbar_requantizes_weight_but_not_bias(self):
+        weight = torch.zeros((16, 16), dtype=torch.float8_e4m3fn)
+        bias = torch.zeros(16, dtype=torch.float8_e4m3fn)
+        patch = lambda tensor: tensor
+        layer = SimpleNamespace(
+            weight=weight,
+            bias=bias,
+            weight_function=[],
+            bias_function=[],
+            weight_lowvram_function=patch,
+            bias_lowvram_function=patch,
+            seed_key="layer",
+            _prefetch={
+                "resident": False,
+                "xfer_dest": torch.empty(1, dtype=torch.uint8),
+                "needs_cast": False,
+                "cast_geometry": None,
+                "signature": (1,),
+            },
+        )
+
+        with (
+            mock.patch.object(ops.comfy.memory_management, "interpret_gathered_like", return_value=[weight, bias]),
+            mock.patch.object(ops.comfy.float, "stochastic_rounding", side_effect=lambda tensor, dtype, seed: tensor.to(dtype)) as rounding,
+        ):
+            cast_weight, cast_bias = ops.resolve_cast_module_with_vbar(
+                layer,
+                torch.float8_e4m3fn,
+                torch.device("cpu"),
+                torch.float16,
+                torch.float16,
+                True,
+            )
+
+        self.assertEqual(cast_weight.dtype, torch.float8_e4m3fn)
+        self.assertEqual(cast_bias.dtype, torch.float16)
+        self.assertEqual(rounding.call_count, 2)
+
+    def test_fp8_linear_unpins_vbar_when_linear_fails(self):
+        weight = torch.zeros((16, 16), dtype=torch.float8_e4m3fn)
+        bias = torch.zeros(16, dtype=torch.float8_e4m3fn)
+        vbar = object()
+        layer = SimpleNamespace(weight=weight, _v=vbar)
+        input_tensor = torch.zeros((2, 16), dtype=torch.float16)
+        offload_info = (None, torch.device("cpu"), None)
+
+        with (
+            mock.patch.object(ops, "cast_bias_weight", return_value=(weight, bias, offload_info)),
+            mock.patch.object(ops.comfy_aimdo.model_vbar, "vbar_unpin") as unpin,
+            mock.patch.object(torch.nn.functional, "linear", side_effect=RuntimeError("FP8 linear failed")),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "FP8 linear failed"):
+                ops.fp8_linear(layer, input_tensor)
+
+        unpin.assert_called_once_with(vbar)


### PR DESCRIPTION
Fixes #14952.

When DynamicVRAM applies LoRA patches to an FP8 checkpoint, it requantizes both the weight and bias to FP8. The optimized linear operation does not accept an FP8 bias, so it falls back after raising an error. That error path also leaves the VBAR allocation pinned.

This change limits requantization to weights and keeps patched biases in the compute dtype. It preserves the current `CastBiasWeightContext` cleanup path and retains regression coverage for exception cleanup.

The issue was reproduced with the reported checkpoint and LoRA using DynamicVRAM and native AIMDO VBAR on Linux ROCm. The exact Windows/RTX 4090 environment was not available.

Tests: both focused regressions and all 9 quantization tests pass; Ruff passes.

---
AI usage disclosure: this change was prepared with AI assistance.