### PR TITLE
fix(api-nodes): disambiguate deprecated partner-node display names

### DIFF
--- a/comfy_api_nodes/nodes_bytedance.py
+++ b/comfy_api_nodes/nodes_bytedance.py
@@ -545,9 +545,14 @@ class ByteDanceSeedreamNode(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="ByteDanceSeedreamNode",
-            display_name="ByteDance Seedream 4.5 & 5.0",
+            display_name="ByteDance Seedream 4.5 & 5.0 (legacy)",
             category="partner/image/ByteDance",
-            description="Unified text-to-image generation and precise single-sentence editing at up to 4K resolution.",
+            description=(
+                "Unified text-to-image generation and precise single-sentence editing at up to 4K resolution. "
+                "This class name is historical and is kept only for compatibility with existing workflows; "
+                "it supports the current models, "
+                "so prefer the ByteDanceSeedreamNodeV2 ('ByteDance Seedream 4.5 & 5.0') node for new workflows."
+            ),
             inputs=[
                 IO.Combo.Input(
                     "model",

--- a/comfy_api_nodes/nodes_gemini.py
+++ b/comfy_api_nodes/nodes_gemini.py
@@ -459,11 +459,14 @@ class GeminiNode(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="GeminiNode",
-            display_name="Google Gemini",
+            display_name="Google Gemini (legacy)",
             category="partner/text/Gemini",
             description="Generate text responses with Google's Gemini AI model. "
             "You can provide multiple types of inputs (text, images, audio, video) "
-            "as context for generating more relevant and meaningful responses.",
+            "as context for generating more relevant and meaningful responses. "
+            "This class name is historical and is kept only for compatibility with existing workflows; "
+            "it supports the current Gemini models, "
+            "so prefer the GeminiNodeV2 ('Google Gemini') node for new workflows.",
             inputs=[
                 IO.String.Input(
                     "prompt",
@@ -475,11 +478,11 @@ class GeminiNode(IO.ComfyNode):
                 IO.Combo.Input(
                     "model",
                     options=[
+                        "gemini-3-1-pro",
+                        "gemini-3-1-flash-lite",
                         "gemini-2.5-pro",
                         "gemini-2.5-flash",
                         "gemini-3-pro-preview",
-                        "gemini-3-1-pro",
-                        "gemini-3-1-flash-lite",
                     ],
                     default="gemini-3-1-pro",
                     tooltip="The Gemini model to use for generating responses.",
@@ -1193,9 +1196,14 @@ class GeminiNanoBanana2(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="GeminiNanoBanana2",
-            display_name="Nano Banana 2",
+            display_name="Nano Banana 2 (legacy)",
             category="partner/image/Gemini",
-            description="Generate or edit images synchronously via Google Vertex API.",
+            description=(
+                "Generate or edit images synchronously via Google Vertex API. "
+                "This class name is historical and is kept only for compatibility with existing workflows; "
+                "it supports the current models, "
+                "so prefer the GeminiNanoBanana2V2 ('Nano Banana 2') node for new workflows."
+            ),
             inputs=[
                 IO.String.Input(
                     "prompt",

--- a/comfy_api_nodes/nodes_grok.py
+++ b/comfy_api_nodes/nodes_grok.py
@@ -227,9 +227,14 @@ class GrokImageEditNode(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="GrokImageEditNode",
-            display_name="Grok Image Edit",
+            display_name="Grok Image Edit (legacy)",
             category="partner/image/Grok",
-            description="Modify an existing image based on a text prompt",
+            description=(
+                "Modify an existing image based on a text prompt. "
+                "This class name is historical and is kept only for compatibility with existing workflows; "
+                "it supports the current models, "
+                "so prefer the GrokImageEditNodeV2 ('Grok Image Edit') node for new workflows."
+            ),
             inputs=[
                 IO.Combo.Input(
                     "model",

--- a/comfy_api_nodes/nodes_openai.py
+++ b/comfy_api_nodes/nodes_openai.py
@@ -383,9 +383,14 @@ class OpenAIGPTImage1(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="OpenAIGPTImage1",
-            display_name="OpenAI GPT Image 2",
+            display_name="OpenAI GPT Image 2 (legacy)",
             category="partner/image/OpenAI",
-            description="Generates images synchronously via OpenAI's GPT Image endpoint.",
+            description=(
+                "Generates images synchronously via OpenAI's GPT Image endpoint. "
+                "This class name is historical and is kept only for compatibility with existing workflows; "
+                "the node is not limited to GPT Image 1 and defaults to the current gpt-image-2 model, "
+                "so prefer the OpenAIGPTImageNodeV2 ('OpenAI GPT Image 2') node for new workflows."
+            ),
             is_deprecated=True,
             inputs=[
                 IO.String.Input(
@@ -459,7 +464,7 @@ class OpenAIGPTImage1(IO.ComfyNode):
                 ),
                 IO.Combo.Input(
                     "model",
-                    options=["gpt-image-1", "gpt-image-1.5", "gpt-image-2"],
+                    options=["gpt-image-2", "gpt-image-1.5", "gpt-image-1"],
                     default="gpt-image-2",
                     optional=True,
                 ),


### PR DESCRIPTION
## ELI-5

Five old "V1" partner nodes had the **exact same display name** as their newer "V2" replacements — e.g. both the deprecated `OpenAIGPTImage1` and the live `OpenAIGPTImageNodeV2` were called **"OpenAI GPT Image 2"**. In the node picker you saw two identical names, and people (and agents) kept landing on the deprecated one. Worse, the deprecated OpenAI node listed `gpt-image-1` first in its model dropdown, so a "just pick the first option" nudge quietly downgraded users to an older model even though the node already defaults to `gpt-image-2`.

This PR renames each deprecated twin with a **" (legacy)"** suffix so the names no longer collide, adds a short note to each one explaining it's kept only for old-workflow compatibility (and pointing at the live node to use instead), and reorders the model dropdowns that led with a stale option so the current model comes first. **No class names change**, so existing workflows keep loading and running exactly as before.

## What changed

For each of the 5 deprecated/live partner pairs where the deprecated node shared an exact `display_name` with its live replacement:

| Deprecated node | Old display name | New display name | Live replacement |
|---|---|---|---|
| `OpenAIGPTImage1` | OpenAI GPT Image 2 | OpenAI GPT Image 2 (legacy) | `OpenAIGPTImageNodeV2` |
| `GeminiNode` | Google Gemini | Google Gemini (legacy) | `GeminiNodeV2` |
| `GrokImageEditNode` | Grok Image Edit | Grok Image Edit (legacy) | `GrokImageEditNodeV2` |
| `GeminiNanoBanana2` | Nano Banana 2 | Nano Banana 2 (legacy) | `GeminiNanoBanana2V2` |
| `ByteDanceSeedreamNode` | ByteDance Seedream 4.5 & 5.0 | ByteDance Seedream 4.5 & 5.0 (legacy) | `ByteDanceSeedreamNodeV2` |

For every one of the five:
1. **`display_name`** gets a `" (legacy)"` suffix — resolves the collision.
2. **`description`** gains one factual sentence: the class name is historical, kept only for existing-workflow compatibility, supports the current models, and names the live V2 class to prefer for new workflows.
3. **Model combo order** — reordered to lead with the current model **only where it was stale-first**:
   - `OpenAIGPTImage1`: `["gpt-image-1", "gpt-image-1.5", "gpt-image-2"]` → `["gpt-image-2", "gpt-image-1.5", "gpt-image-1"]` (now matches the V2 node; the explicit default was already `gpt-image-2`).
   - `GeminiNode`: the `gemini-3.1` generation now leads, matching the live V2 node and the node's own default (`gemini-3-1-pro`).
   - `GrokImageEditNode`, `GeminiNanoBanana2`, `ByteDanceSeedreamNode` already led with the current model, so their combos are **unchanged**.

## Why this is safe

- **Class names (`node_id` / `class_type`) are untouched** — existing workflows referencing these nodes still load and run. Only `display_name`, `description`, and combo *order* move.
- **Combo reorder is presentational only.** Both execute paths consume the `model` widget by string value (`model: str`, then `if model == "..."`), never by index, and the explicit `default=` is unchanged — so reordering options cannot change execution or break saved workflows (combo selections are stored by value, not position).
- **No `object_info` schema change** — only literal field values within the existing schema were edited.

## Judgment calls

- **Naming convention.** Applied `" (legacy)"` as an append to each deprecated `display_name` (per the agreed convention), which cleanly resolves all five collisions and stays stable against future partner renames.
- **`GeminiNode` combo reorder.** It's the one non-OpenAI twin that was genuinely stale-first (led with `gemini-2.5-pro` while defaulting to the current `gemini-3-1-pro`), so I hoisted the current `gemini-3.1` generation to the front to match the live V2 node. All model options are preserved and the default is unchanged.
- **ControlNet collisions out of scope.** The wider analysis noted 6 additional ControlNet `display_name` collisions; those live in core nodes, not `comfy_api_nodes/`, and are left for a follow-up.

## Verification

- `python -m py_compile` on all four changed files — pass.
- `ruff check` (repo config) on all four changed files — pass.
- AST sweep of `comfy_api_nodes/`: **0** remaining deprecated/live `display_name` collisions (was 5).
- The API-node modules require external SDKs / the full ML runtime to import, so the full pytest suite runs in CI rather than locally; this change is limited to string literals and one list reorder with no logic or schema-structure change.

<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [x] **Is API Node Change**

### Pricing & Billing
- [x] **No pricing update**

### QA
- [ ] **QA done**
- [x] **QA not required** — metadata-only (display name, description, combo order); no functional/API/billing change.

### Comms
- [ ] Informed **Kosinkadink**