### PR TITLE
fix: allow Load Image symlinks into temp/output media roots

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -321,11 +321,6 @@ def is_within_directory(directory: str, target: str) -> bool:
         return False
 
 
-def _trusted_media_directories() -> tuple[str, ...]:
-    """Directories users are allowed to load media from via annotated paths."""
-    return (get_input_directory(), get_output_directory(), get_temp_directory())
-
-
 def is_safe_annotated_filepath(base_dir: str, filepath: str) -> bool:
     """Validate an annotated media path, allowing symlinks into trusted dirs.
 
@@ -335,22 +330,22 @@ def is_safe_annotated_filepath(base_dir: str, filepath: str) -> bool:
     `input/link.png -> ../temp/image.png` works for Load Image (#14990), while
     symlinks that escape outside those media roots remain rejected.
     """
-    try:
-        base = os.path.realpath(base_dir)
-        parent = os.path.realpath(os.path.dirname(filepath))
-        if os.path.commonpath((base, parent)) != base:
-            return False
-        target = os.path.realpath(filepath)
-        for media_dir in _trusted_media_directories():
-            try:
-                root = os.path.realpath(media_dir)
-                if os.path.commonpath((root, target)) == root:
-                    return True
-            except ValueError:
-                continue
+    base = os.path.realpath(base_dir)
+    parent = os.path.realpath(os.path.dirname(filepath))
+    # Windows: different drives cannot share a common path root.
+    if os.path.splitdrive(base)[0].lower() != os.path.splitdrive(parent)[0].lower():
         return False
-    except ValueError:
+    if os.path.commonpath((base, parent)) != base:
         return False
+
+    target = os.path.realpath(filepath)
+    for media_dir in (get_input_directory(), get_output_directory(), get_temp_directory()):
+        root = os.path.realpath(media_dir)
+        if os.path.splitdrive(root)[0].lower() != os.path.splitdrive(target)[0].lower():
+            continue
+        if os.path.commonpath((root, target)) == root:
+            return True
+    return False
 
 
 def get_annotated_filepath(name: str, default_dir: str | None=None) -> str:

--- a/folder_paths.py
+++ b/folder_paths.py
@@ -321,6 +321,38 @@ def is_within_directory(directory: str, target: str) -> bool:
         return False
 
 
+def _trusted_media_directories() -> tuple[str, ...]:
+    """Directories users are allowed to load media from via annotated paths."""
+    return (get_input_directory(), get_output_directory(), get_temp_directory())
+
+
+def is_safe_annotated_filepath(base_dir: str, filepath: str) -> bool:
+    """Validate an annotated media path, allowing symlinks into trusted dirs.
+
+    The path entry itself (its parent after resolving intermediate components)
+    must live under `base_dir`, so `../` traversal still fails. The ultimate
+    realpath target may be any of input/output/temp so that e.g.
+    `input/link.png -> ../temp/image.png` works for Load Image (#14990), while
+    symlinks that escape outside those media roots remain rejected.
+    """
+    try:
+        base = os.path.realpath(base_dir)
+        parent = os.path.realpath(os.path.dirname(filepath))
+        if os.path.commonpath((base, parent)) != base:
+            return False
+        target = os.path.realpath(filepath)
+        for media_dir in _trusted_media_directories():
+            try:
+                root = os.path.realpath(media_dir)
+                if os.path.commonpath((root, target)) == root:
+                    return True
+            except ValueError:
+                continue
+        return False
+    except ValueError:
+        return False
+
+
 def get_annotated_filepath(name: str, default_dir: str | None=None) -> str:
     name, base_dir = annotated_filepath(name)
 
@@ -331,9 +363,9 @@ def get_annotated_filepath(name: str, default_dir: str | None=None) -> str:
             base_dir = get_input_directory()  # fallback path
 
     filepath = os.path.abspath(os.path.join(base_dir, name))
-    # Prevent path traversal: the resolved path must stay within base_dir.
+    # Prevent path traversal / escape outside trusted media roots.
     # repr() the name in the message so a crafted value can't inject log lines.
-    if not is_within_directory(base_dir, filepath):
+    if not is_safe_annotated_filepath(base_dir, filepath):
         raise ValueError("Invalid file path: {!r}".format(name))
     return filepath
 
@@ -345,8 +377,8 @@ def exists_annotated_filepath(name) -> bool:
         base_dir = get_input_directory()  # fallback path
 
     filepath = os.path.abspath(os.path.join(base_dir, name))
-    # Treat traversal attempts as non-existent rather than probing the filesystem.
-    if not is_within_directory(base_dir, filepath):
+    # Treat traversal / unsafe symlink targets as non-existent.
+    if not is_safe_annotated_filepath(base_dir, filepath):
         return False
     return os.path.exists(filepath)
 

--- a/tests-unit/folder_paths_test/symlink_media_test.py
+++ b/tests-unit/folder_paths_test/symlink_media_test.py
@@ -1,6 +1,8 @@
 import os
 from pathlib import Path
 
+import pytest
+
 import folder_paths
 
 
@@ -46,12 +48,8 @@ def test_symlink_escaping_media_roots_is_rejected(tmp_path: Path):
     link.symlink_to(outside)
 
     assert folder_paths.exists_annotated_filepath("evil.png") is False
-    try:
+    with pytest.raises(ValueError):
         folder_paths.get_annotated_filepath("evil.png")
-        raised = False
-    except ValueError:
-        raised = True
-    assert raised
 
 
 def test_path_traversal_is_still_rejected(tmp_path: Path):

--- a/tests-unit/folder_paths_test/symlink_media_test.py
+++ b/tests-unit/folder_paths_test/symlink_media_test.py
@@ -1,0 +1,59 @@
+import os
+from pathlib import Path
+
+import folder_paths
+
+
+def _setup_media_dirs(tmp_path: Path):
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    temp_dir = tmp_path / "temp"
+    input_dir.mkdir()
+    output_dir.mkdir()
+    temp_dir.mkdir()
+    folder_paths.set_input_directory(str(input_dir))
+    folder_paths.set_output_directory(str(output_dir))
+    folder_paths.set_temp_directory(str(temp_dir))
+    return input_dir, output_dir, temp_dir
+
+
+def test_symlink_from_input_to_temp_is_allowed(tmp_path: Path):
+    input_dir, _output_dir, temp_dir = _setup_media_dirs(tmp_path)
+    target = temp_dir / "image.png"
+    target.write_bytes(b"png")
+    link = input_dir / "link.png"
+    link.symlink_to(target)
+
+    assert folder_paths.exists_annotated_filepath("link.png") is True
+    assert folder_paths.get_annotated_filepath("link.png") == os.path.abspath(str(link))
+
+
+def test_symlink_from_input_to_output_is_allowed(tmp_path: Path):
+    input_dir, output_dir, _temp_dir = _setup_media_dirs(tmp_path)
+    target = output_dir / "image.png"
+    target.write_bytes(b"png")
+    link = input_dir / "link.png"
+    link.symlink_to(target)
+
+    assert folder_paths.exists_annotated_filepath("link.png") is True
+
+
+def test_symlink_escaping_media_roots_is_rejected(tmp_path: Path):
+    input_dir, _output_dir, _temp_dir = _setup_media_dirs(tmp_path)
+    outside = tmp_path / "secret.png"
+    outside.write_bytes(b"nope")
+    link = input_dir / "evil.png"
+    link.symlink_to(outside)
+
+    assert folder_paths.exists_annotated_filepath("evil.png") is False
+    try:
+        folder_paths.get_annotated_filepath("evil.png")
+        raised = False
+    except ValueError:
+        raised = True
+    assert raised
+
+
+def test_path_traversal_is_still_rejected(tmp_path: Path):
+    _setup_media_dirs(tmp_path)
+    assert folder_paths.exists_annotated_filepath("../secret.png") is False


### PR DESCRIPTION
## Summary

`Load Image` rejects images that are symlinks from `input/` into `temp/` or `output/` (e.g. `ln -s ../temp/image.png link.png`) with “Image not loaded” / invalid path (#14990).

Root cause: `exists_annotated_filepath` / `get_annotated_filepath` used `realpath` containment only against the base directory, so a symlink whose target is outside that base failed even when the target is still a trusted Comfy media root.

### Fix

- Add `is_safe_annotated_filepath`: the path entry’s parent must stay under the base dir (blocks `../` traversal), but the resolved target may live in **input / output / temp**.
- Symlinks that escape those media roots still fail.
- Unit tests for temp/output symlinks, escape rejection, and traversal.

## Testing

```bash
pytest tests-unit/folder_paths_test/symlink_media_test.py -q
# 4 passed
```

Fixes #14990
