### PR TITLE
docs: document Linux bz2/lzma Python build requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,27 @@ Install the dependencies by opening your terminal inside the ComfyUI folder and:
 
 ```pip install -r requirements.txt```
 
+#### Linux Python standard-library modules (`_bz2`, `_lzma`)
+
+Some ComfyUI dependencies need Python builds with the `_bz2` and `_lzma` modules enabled.
+On a fresh Linux install those modules may be missing if the corresponding system libraries
+were not present when Python was built.
+
+Debian/Ubuntu/Pop!_OS:
+
+```bash
+sudo apt-get install libbz2-dev liblzma-dev
+```
+
+RHEL/Fedora/CentOS:
+
+```bash
+sudo dnf install bzip2-devel xz-devel
+```
+
+If you still see import errors for `_bz2` or `_lzma`, rebuild or reinstall Python after
+installing those packages (for example with `asdf`, `pyenv`, or your distro packages).
+
 After this you should have everything installed and can proceed to running ComfyUI.
 
 ### Others:


### PR DESCRIPTION
## Summary

Fresh Linux installs (e.g. Pop!_OS 22.04) can fail low-level imports of `_bz2` / `_lzma` when Python was built without the corresponding system libraries.

## Fix

Document the Debian (`libbz2-dev`, `liblzma-dev`) and RHEL (`bzip2-devel`, `xz-devel`) packages, and note that Python may need to be reinstalled/rebuilt after installing them.

Fixes #3219