### PR TITLE
ci: dispatch to cloud with a scoped App token instead of a PAT

### DIFF
--- a/.github/workflows/tag-dispatch-cloud.yml
+++ b/.github/workflows/tag-dispatch-cloud.yml
@@ -36,6 +36,10 @@ jobs:
           # default; this dispatch targets another repo.
           owner: Comfy-Org
           repositories: cloud
+          # Without this, the minted token carries every permission the
+          # installation holds. Pinning it to the one scope repository_dispatch
+          # needs keeps that true even if the App is later granted more.
+          permission-contents: write
 
       - name: Send repository dispatch to cloud
         env:
@@ -43,11 +47,6 @@ jobs:
           RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-
-          if [ -z "${DISPATCH_TOKEN:-}" ]; then
-            echo "::error::App token generation produced an empty token."
-            exit 1
-          fi
 
           RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/${RELEASE_TAG}"
 

--- a/.github/workflows/tag-dispatch-cloud.yml
+++ b/.github/workflows/tag-dispatch-cloud.yml
@@ -22,10 +22,14 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         with:
-          app-id: ${{ secrets.FEN_RELEASE_APP_ID }}
-          private-key: ${{ secrets.FEN_RELEASE_PRIVATE_KEY }}
-          # Cross-repo dispatch: without these the token is scoped to this
-          # repository and the POST to cloud would 403.
+          # cloud-code-bot is the same App the cloud receiver already runs on:
+          # it authored the bump PRs, so its write access there is established
+          # rather than assumed.
+          app-id: ${{ vars.CLOUD_CODE_BOT_APP_ID }}
+          private-key: ${{ secrets.CLOUD_CODE_BOT_PRIVATE_KEY }}
+          # Cross-repo dispatch: create-github-app-token scopes to the current
+          # repository by default, so the org installation must be named
+          # explicitly or the POST to cloud would 403.
           owner: Comfy-Org
           repositories: cloud
 

--- a/.github/workflows/tag-dispatch-cloud.yml
+++ b/.github/workflows/tag-dispatch-cloud.yml
@@ -22,14 +22,18 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         with:
-          # cloud-code-bot is the same App the cloud receiver already runs on:
-          # it authored the bump PRs, so its write access there is established
-          # rather than assumed.
-          app-id: ${{ vars.CLOUD_CODE_BOT_APP_ID }}
-          private-key: ${{ secrets.CLOUD_CODE_BOT_PRIVATE_KEY }}
-          # Cross-repo dispatch: create-github-app-token scopes to the current
-          # repository by default, so the org installation must be named
-          # explicitly or the POST to cloud would 403.
+          # A single-purpose App: installed only on Comfy-Org/cloud, holding
+          # only contents:write. Deliberately NOT cloud-code-bot, which is also
+          # entitled to cloud's production release and migration workflows --
+          # an App private key is not scoped, so any key stored here can mint a
+          # token for everything its App is entitled to, on every repo it is
+          # installed on. The owner/repositories inputs below are arguments,
+          # not a security boundary. Keeping this App minimal is what makes it
+          # safe to hold in a public repository.
+          app-id: ${{ vars.CORE_TO_CLOUD_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.CORE_TO_CLOUD_DISPATCH_PRIVATE_KEY }}
+          # create-github-app-token scopes to the current repository by
+          # default; this dispatch targets another repo.
           owner: Comfy-Org
           repositories: cloud
 

--- a/.github/workflows/tag-dispatch-cloud.yml
+++ b/.github/workflows/tag-dispatch-cloud.yml
@@ -8,16 +8,36 @@ on:
 jobs:
   dispatch-cloud:
     runs-on: ubuntu-latest
+    # No checkout and no use of GITHUB_TOKEN; the dispatch goes out on the App
+    # token generated below, which is scoped to Comfy-Org/cloud only.
+    permissions:
+      contents: read
     steps:
+      # A PAT was used here previously. It was silently regenerated upstream
+      # without the Actions secret being updated, so every tag from v0.25.0
+      # (2026-06-16) through v0.29.0 dispatched a 401 and no cloud bump PR was
+      # opened for six weeks. App installation tokens are minted per run and
+      # cannot drift out of sync with a stored copy.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        with:
+          app-id: ${{ secrets.FEN_RELEASE_APP_ID }}
+          private-key: ${{ secrets.FEN_RELEASE_PRIVATE_KEY }}
+          # Cross-repo dispatch: without these the token is scoped to this
+          # repository and the POST to cloud would 403.
+          owner: Comfy-Org
+          repositories: cloud
+
       - name: Send repository dispatch to cloud
         env:
-          DISPATCH_TOKEN: ${{ secrets.CLOUD_REPO_DISPATCH_TOKEN }}
+          DISPATCH_TOKEN: ${{ steps.app-token.outputs.token }}
           RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
 
           if [ -z "${DISPATCH_TOKEN:-}" ]; then
-            echo "::error::CLOUD_REPO_DISPATCH_TOKEN is required but not set."
+            echo "::error::App token generation produced an empty token."
             exit 1
           fi
 


### PR DESCRIPTION
The cloud-side ComfyUI bump automation has been dead since 2026-06-16 and nobody noticed, because the bump PRs were quietly filed by hand instead.

## What broke

`tag-dispatch-cloud.yml` fires correctly on every `v*` tag push, then dies at the `curl`:

```
curl: (22) The requested URL returned error: 401
```

The PAT behind `CLOUD_REPO_DISPATCH_TOKEN` ("Core to Cloud Tag Release Automation") was regenerated on the GitHub side without the Actions secret being updated, so the stored copy went stale. Evidence: the secret's `updated_at` is still `2026-05-11`, the day it was first set, while the token page reports an expiry of Jun 2027. The two values simply stopped matching.

**Last success:** v0.24.1 (2026-06-04). **First 401:** v0.25.0 (2026-06-16).

12 consecutive tags dispatched nothing: v0.25.0, v0.25.1, v0.26.0, v0.26.1, v0.26.2, v0.27.0, v0.27.1, v0.28.0, v0.28.1, v0.28.2, v0.28.3, v0.29.0.

Note what was **not** wrong: the PAT's scope. It targeted `Comfy-Org/cloud` with read+write on code, which is the documented minimum for `repository_dispatch` — GitHub offers no narrower "dispatch-only" permission. The failure was lifecycle, not scope.

## What this changes

Mint a GitHub App installation token per run instead of reading a stored PAT. Nothing is left saved that can drift out of sync or silently expire.

The App is deliberately **single-purpose**: installed only on `Comfy-Org/cloud`, holding only `contents: write`. That preserves the outgoing PAT's scope discipline while removing its renewal step.

Also narrows the job to `permissions: contents: read` — it does no checkout and never uses `GITHUB_TOKEN`.

### Why a new App rather than an existing one

Two existing Apps were considered and rejected.

**`FEN_RELEASE_*`** are environment secrets on the `backport release` environment, not repo or org secrets, so a job that does not declare that environment reads them as empty. That environment is also gated on **required reviewers** (`comfyanonymous`, `Kosinkadink`), so declaring it would park every tag push waiting for a human to approve a deployment — reintroducing the exact silent stall this PR removes.

**`cloud-code-bot`** would work, and its write access to cloud is proven, but it is the wrong scope to store here. An App private key is not scoped: it authenticates as the App and can mint tokens for every repo that App is installed on, carrying the App's full entitlement. The `owner` / `repositories` inputs below are step arguments, not a security boundary. cloud-code-bot is wired into 13 cloud workflows including `release-production.yml`, `release-production-migrate.yml`, and `release-devplatform-production.yml`, so its key grants far more than this dispatch needs.

Storing it in this repository would join two different trust boundaries at the weaker one: `Comfy-Org/cloud` has a controlled contributor set, while this repo is public with a much larger maintainer population and workflow surface. Fork PRs cannot read secrets, which is a real mitigation, but it does not cover `pull_request_target` workflows, unpinned third-party actions in a job holding the secret, or the broader write-access set.

A single-purpose App gives both properties instead of forcing a choice: no expiry, and a key whose worst case is the one capability this workflow already legitimately needs.

## Required before this merges

Neither value exists in this repo yet. One-time setup:

- [ ] Create a GitHub App (suggested name: **Core to Cloud Tag Dispatch**) with repository permission **Contents: Read and write**, and nothing else
- [ ] Install it on **`Comfy-Org/cloud` only** — not org-wide, not on this repo
- [ ] Add variable `CORE_TO_CLOUD_DISPATCH_APP_ID` = the App's ID (not sensitive)
- [ ] Add secret `CORE_TO_CLOUD_DISPATCH_PRIVATE_KEY` = the App's generated private key
- [ ] After the first successful tag dispatch, delete the now-unused `CLOUD_REPO_DISPATCH_TOKEN` secret and revoke the PAT

`create-github-app-token` resolves the installation via the `owner` input, so the App does not need to be installed on this repository.

## How has this been tested?

- `yaml.safe_load` parses the workflow; job permissions, absence of an `environment:` gate, and token scope (`Comfy-Org/cloud`) asserted
- Action pinned to `bcd2ba49218906704ab6c1aa796996da409d3eb1`, the same SHA already used by `backport_release.yaml`
- The receiver side is verified working: a manual `repository_dispatch` for `v0.29.0` ran `bump-comfyui-on-tag.yml` green and opened Comfy-Org/cloud#5679. The cloud half was never at fault.
- Not verifiable pre-merge: the live dispatch. It only exercises on a real tag push, so the first tag after merge is the proof.

## Follow-up worth filing separately

This PR removes the credential that broke. It does not add alerting — 12 failures over six weeks produced zero signal, because the failure surfaces only in this repo's Actions tab while the people expecting the PR are watching `cloud`. Whichever credential is used, that gap is what turned a two-minute problem into a six-week one.

## Documentation

- [x] No documentation changes needed