### PR TITLE
fix(server): add disposition type to Content-Disposition per RFC 6266

### DIFF
--- a/server.py
+++ b/server.py
@@ -574,7 +574,7 @@ class PromptServer():
                             buffer.seek(0)
 
                             return web.Response(body=buffer.read(), content_type=f'image/{image_format}',
-                                                headers={"Content-Disposition": f"filename=\"{filename}\""})
+                                                headers={"Content-Disposition": f"inline; filename=\"{filename}\""})
 
                     if 'channel' not in request.rel_url.query:
                         channel = 'rgba'
@@ -594,7 +594,7 @@ class PromptServer():
                             buffer.seek(0)
 
                             return web.Response(body=buffer.read(), content_type='image/png',
-                                                headers={"Content-Disposition": f"filename=\"{filename}\""})
+                                                headers={"Content-Disposition": f"inline; filename=\"{filename}\""})
 
                     elif channel == 'a':
                         with Image.open(file) as img:
@@ -611,7 +611,7 @@ class PromptServer():
                             alpha_buffer.seek(0)
 
                             return web.Response(body=alpha_buffer.read(), content_type='image/png',
-                                                headers={"Content-Disposition": f"filename=\"{filename}\""})
+                                                headers={"Content-Disposition": f"inline; filename=\"{filename}\""})
                     else:
                         # Use the content type from asset resolution if available,
                         # otherwise guess from the filename.
@@ -634,7 +634,7 @@ class PromptServer():
                         # ".."/leading-slash filter above) can't break out of the
                         # header's quoted-string and malform the disposition.
                         safe_filename = filename.replace("\\", "\\\\").replace('"', '\\"')
-                        disposition = f"filename=\"{safe_filename}\""
+                        disposition = f"inline; filename=\"{safe_filename}\""
                         if folder_paths.is_dangerous_content_type(content_type):
                             content_type = 'application/octet-stream'
                             disposition = f"attachment; filename=\"{safe_filename}\""


### PR DESCRIPTION
## Summary

The `/view` endpoint emitted a bare `filename="..."` Content-Disposition header without a disposition type. RFC 6266 requires a type token (`inline` or `attachment`) before the parameters.

Strict parsers such as Go's `mime.ParseMediaType` reject the bare form, so third-party download libraries (e.g. `cavaliergopher/grab`) fall back to the URL path and save files as `view` instead of the real filename.

## Change

Prefix every `/view` response with `inline;` (the dangerous-content-type branch already uses `attachment;`). Inline preserves the existing browser behaviour of rendering images/media in the tab.

## Before

```
Content-Disposition: filename="output.png"
```

## After

```
Content-Disposition: inline; filename="output.png"
```

Closes #8914