### PR TITLE
fix: stop get_full_path raising ValueError for another drive on Windows

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -447,7 +447,9 @@ def get_full_path(folder_name: str, filename: str) -> str | None:
     if folder_name not in folder_names_and_paths:
         return None
     folders = folder_names_and_paths[folder_name]
-    filename = os.path.relpath(os.path.join("/", filename), "/")
+    # Drop any drive or UNC prefix first. On Windows such a filename shares no
+    # mount with "/", so relpath raises ValueError instead of normalizing.
+    filename = os.path.relpath(os.path.join("/", os.path.splitdrive(filename)[1]), "/")
     for x in folders[0]:
         full_path = os.path.join(x, filename)
         if os.path.isfile(full_path):

--- a/tests-unit/comfy_test/folder_path_test.py
+++ b/tests-unit/comfy_test/folder_path_test.py
@@ -180,3 +180,38 @@ def test_models_directory_cli_and_getters(temp_dir):
             reload(comfy.cli_args)
             reload(folder_paths)
 
+
+
+def test_get_full_path_rejects_absolute_filename(temp_dir):
+    # A filename is always treated as relative to the registered folders, so an
+    # absolute one must resolve to "not found" rather than escaping the folder.
+    folder_paths.folder_names_and_paths["test_folder"] = ([temp_dir], {".safetensors"})
+    try:
+        assert folder_paths.get_full_path("test_folder", "/etc/passwd") is None
+        assert folder_paths.get_full_path("test_folder", "../../etc/passwd") is None
+    finally:
+        del folder_paths.folder_names_and_paths["test_folder"]
+
+
+def test_get_full_path_with_filename_on_another_drive(temp_dir):
+    # os.path.relpath raises ValueError when the two paths share no mount, which
+    # on Windows is any filename carrying a different drive letter or a UNC
+    # prefix. get_full_path should report "not found", not raise.
+    folder_paths.folder_names_and_paths["test_folder"] = ([temp_dir], {".safetensors"})
+    try:
+        assert folder_paths.get_full_path("test_folder", "D:/models/model.safetensors") is None
+        assert folder_paths.get_full_path("test_folder", r"Z:\models\model.safetensors") is None
+        assert folder_paths.get_full_path("test_folder", r"\\server\share\model.safetensors") is None
+    finally:
+        del folder_paths.folder_names_and_paths["test_folder"]
+
+
+def test_get_full_path_or_raise_on_another_drive(temp_dir):
+    # The documented failure mode is FileNotFoundError; a ValueError from the
+    # path normalization would bypass callers that catch the former.
+    folder_paths.folder_names_and_paths["test_folder"] = ([temp_dir], {".safetensors"})
+    try:
+        with pytest.raises(FileNotFoundError):
+            folder_paths.get_full_path_or_raise("test_folder", "D:/models/model.safetensors")
+    finally:
+        del folder_paths.folder_names_and_paths["test_folder"]

--- a/tests-unit/comfy_test/folder_path_test.py
+++ b/tests-unit/comfy_test/folder_path_test.py
@@ -206,6 +206,24 @@ def test_get_full_path_with_filename_on_another_drive(temp_dir):
         del folder_paths.folder_names_and_paths["test_folder"]
 
 
+def test_get_full_path_with_drive_relative_filename(temp_dir):
+    # "C:models/x" (no separator after the colon) is drive-relative on Windows.
+    # It used to resolve against the process working directory, so the lookup
+    # became <folder>/<cwd-without-drive>/models/x, which never matched. A
+    # filename is only ever relative to a registered folder, so drop the drive.
+    folder_paths.folder_names_and_paths["test_folder"] = ([temp_dir], {".safetensors"})
+    try:
+        os.makedirs(os.path.join(temp_dir, "models"), exist_ok=True)
+        target = os.path.join(temp_dir, "models", "model.safetensors")
+        with open(target, "w") as f:
+            f.write("")
+
+        assert folder_paths.get_full_path("test_folder", "models/model.safetensors") == target
+        assert folder_paths.get_full_path("test_folder", "C:models/model.safetensors") == target
+    finally:
+        del folder_paths.folder_names_and_paths["test_folder"]
+
+
 def test_get_full_path_or_raise_on_another_drive(temp_dir):
     # The documented failure mode is FileNotFoundError; a ValueError from the
     # path normalization would bypass callers that catch the former.

--- a/tests-unit/comfy_test/folder_path_test.py
+++ b/tests-unit/comfy_test/folder_path_test.py
@@ -193,14 +193,23 @@ def test_get_full_path_rejects_absolute_filename(temp_dir):
         del folder_paths.folder_names_and_paths["test_folder"]
 
 
+def _other_drive(path) -> str:
+    # A drive letter the given path is definitely not on, so the cross-mount
+    # branch is exercised rather than an ordinary "file is missing" miss. On
+    # POSIX splitdrive() finds no drive and any letter qualifies.
+    on = os.path.splitdrive(str(path))[0].rstrip(":").upper()
+    return "E" if on == "D" else "D"
+
+
 def test_get_full_path_with_filename_on_another_drive(temp_dir):
     # os.path.relpath raises ValueError when the two paths share no mount, which
     # on Windows is any filename carrying a different drive letter or a UNC
     # prefix. get_full_path should report "not found", not raise.
     folder_paths.folder_names_and_paths["test_folder"] = ([temp_dir], {".safetensors"})
+    other = _other_drive(temp_dir)
     try:
-        assert folder_paths.get_full_path("test_folder", "D:/models/model.safetensors") is None
-        assert folder_paths.get_full_path("test_folder", r"Z:\models\model.safetensors") is None
+        assert folder_paths.get_full_path("test_folder", f"{other}:/models/model.safetensors") is None
+        assert folder_paths.get_full_path("test_folder", rf"{other}:\models\model.safetensors") is None
         assert folder_paths.get_full_path("test_folder", r"\\server\share\model.safetensors") is None
     finally:
         del folder_paths.folder_names_and_paths["test_folder"]
@@ -228,8 +237,9 @@ def test_get_full_path_or_raise_on_another_drive(temp_dir):
     # The documented failure mode is FileNotFoundError; a ValueError from the
     # path normalization would bypass callers that catch the former.
     folder_paths.folder_names_and_paths["test_folder"] = ([temp_dir], {".safetensors"})
+    other = _other_drive(temp_dir)
     try:
         with pytest.raises(FileNotFoundError):
-            folder_paths.get_full_path_or_raise("test_folder", "D:/models/model.safetensors")
+            folder_paths.get_full_path_or_raise("test_folder", f"{other}:/models/model.safetensors")
     finally:
         del folder_paths.folder_names_and_paths["test_folder"]


### PR DESCRIPTION
## Problem

`folder_paths.get_full_path()` normalizes the caller-supplied filename to a relative path before joining it onto each registered folder:

```python
filename = os.path.relpath(os.path.join("/", filename), "/")
```

`os.path.join` discards the `"/"` when the second argument is drive-absolute, so on Windows a filename carrying a different drive letter arrives at `relpath` unchanged. `relpath` then raises, because the two paths share no mount:

```
>>> folder_paths.get_full_path("checkpoints", "D:/models/model.safetensors")
ValueError: path is on mount 'D:', start on mount 'C:'
```

Same for a mapped drive (`Z:\...`) and for a UNC path (`\\server\share\...`).

`get_full_path` is documented to return `None` when it cannot find the file, and `get_full_path_or_raise` turns that `None` into a `FileNotFoundError`. The `ValueError` bypasses both, so callers that correctly handle a missing model still see an unhandled exception. Storing models on a second drive is common on Windows, so a workflow or API request naming one that way fails with a confusing error instead of a clean "not found".

Reproduced on Windows 11 against `master`, with the current drive as `C:`:

| filename | before | after |
|---|---|---|
| `model.safetensors` | `None` | `None` |
| `../../etc/passwd` | `None` | `None` |
| `/absolute/model.safetensors` | `None` | `None` |
| `C:/models/model.safetensors` | `None` | `None` |
| `D:/models/model.safetensors` | **ValueError** | `None` |
| `Z:\models\model.safetensors` | **ValueError** | `None` |
| `\\server\share\model.safetensors` | **ValueError** | `None` |

## Fix

Split the drive or UNC prefix off before normalizing. `os.path.splitdrive` returns an empty prefix on POSIX and for relative input, so behaviour is unchanged everywhere it already worked, including the traversal stripping that line exists for.

## Scope

This is the same family as #1488, but a different call site. That issue is about `os.path.commonpath`, and the open PR #13146 replaces those `commonpath` call sites with a guarded helper. Neither touches this `relpath` line, so this stays a separate one-line change and should not conflict.

## Tests

Added three cases to `tests-unit/comfy_test/folder_path_test.py`, which runs without torch:

- absolute and traversal filenames still resolve to `None` (guards the existing behaviour that line provides)
- a filename on another drive, a mapped drive, and a UNC path all return `None`
- `get_full_path_or_raise` raises `FileNotFoundError` rather than `ValueError`

Verified the tests catch this: with the one-line change reverted and the tests kept, the two new drive tests fail with the original `ValueError: path is on mount 'D:', start on mount 'C:'`.

`ruff check .` is clean. Torch-free unit suites pass locally on Windows: `comfy_test/folder_path_test.py` 17, `folder_paths_test` 34, `utils` 15, `prompt_server_test` 32, `server_test` 40, `jobs_cancel_test` 22.
