### PR TITLE
Hold a reference to the pending-node completion waiter

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -228,6 +228,12 @@ def get_input_data(inputs, class_def, unique_id, execution_list=None, dynprompt=
 
 map_node_over_list = None #Don't hook this please
 
+# The event loop only keeps weak references to tasks. The completion waiter
+# created below is not awaited by anyone, so without a strong reference it can
+# be garbage collected before it calls unblock() — which leaves the execution
+# list blocked on that node forever.
+_completion_waiters: set[asyncio.Task] = set()
+
 async def resolve_map_node_over_list_results(results):
     remaining = [x for x in results if isinstance(x, asyncio.Task) and not x.done()]
     if len(remaining) == 0:
@@ -558,7 +564,9 @@ async def execute(server, dynprompt, caches, current_item, extra_data, executed,
                     tasks = [x for x in output_data if isinstance(x, asyncio.Task)]
                     await asyncio.gather(*tasks, return_exceptions=True)
                     unblock()
-                asyncio.create_task(await_completion())
+                waiter = asyncio.create_task(await_completion())
+                _completion_waiters.add(waiter)
+                waiter.add_done_callback(_completion_waiters.discard)
                 return (ExecutionResult.PENDING, None, None)
         if len(output_ui) > 0:
             # Enrich at output-processing time (not in the send path) so assets


### PR DESCRIPTION
## The bug

When a node reports pending async work, `execution.py` blocks the execution list on that node and spawns a waiter to release it:

```python
if has_pending_tasks:
    pending_async_nodes[unique_id] = output_data
    unblock = execution_list.add_external_block(unique_id)
    async def await_completion():
        tasks = [x for x in output_data if isinstance(x, asyncio.Task)]
        await asyncio.gather(*tasks, return_exceptions=True)
        unblock()
    asyncio.create_task(await_completion())
    return (ExecutionResult.PENDING, None, None)
```

The waiter's task is thrown away. Nobody awaits it, and the event loop only keeps a **weak** reference — [the asyncio docs are explicit about this](https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task):

> Important: Save a reference to the result of this function, to avoid a task disappearing mid-execution. The event loop only keeps weak references to tasks. A task that isn't referenced elsewhere may get garbage collected at any time, even before it's done.

If that happens, `unblock()` is never called and the execution list stays blocked on the node — the workflow hangs rather than failing with an error, which is the hardest kind of bug to report.

Note that `pending_async_nodes[unique_id] = output_data` keeps the *inner* tasks alive, but nothing holds the `await_completion()` wrapper — and that wrapper is the only thing that ever calls `unblock()`.

## The change

```python
waiter = asyncio.create_task(await_completion())
_completion_waiters.add(waiter)
waiter.add_done_callback(_completion_waiters.discard)
```

with a module-level `_completion_waiters: set[asyncio.Task]` declared next to the other module-level state. `discard` rather than `remove` so a double callback can't raise. The set stays bounded by the number of in-flight pending nodes.

Nothing else changes: no control flow, no scheduling order, no awaited behaviour. The waiter was fire-and-forget before and remains so — it simply can no longer be collected while still running.

## Verification

```console
$ ruff check execution.py
All checks passed!
$ python -m py_compile execution.py
```

No test: the failure is a garbage-collection race, so a test would have to force a GC at a chosen moment and assert the task did *not* vanish — flaky by construction. Happy to add one if you have a shape in mind.

Found with an AST scan for `create_task` / `ensure_future` results discarded as bare expression statements (excluding `TaskGroup.create_task`, which does hold strong references). This was the only hit in the repo, and after the change the scan is clean.
