### PR TITLE
feat(assets): extract video metadata into system_metadata on ingest and scan

### DIFF
--- a/app/assets/scanner.py
+++ b/app/assets/scanner.py
@@ -33,7 +33,7 @@ from app.assets.services.file_utils import (
     verify_file_unchanged,
 )
 from app.assets.services.hashing import HashCheckpoint, compute_blake3_hash
-from app.assets.services.image_dimensions import extract_image_dimensions
+from app.assets.services.media_metadata import extract_media_metadata
 from app.assets.services.metadata_extract import extract_file_metadata
 from app.assets.services.path_utils import (
     compute_loader_path,
@@ -507,10 +507,9 @@ def enrich_asset(
 
     if extract_metadata and metadata:
         system_metadata = metadata.to_user_metadata()
-        if mime_type and mime_type.startswith("image/"):
-            dims = extract_image_dimensions(file_path, mime_type=mime_type)
-            if dims:
-                system_metadata.update(dims)
+        dims = extract_media_metadata(file_path, mime_type=mime_type)
+        if dims:
+            system_metadata.update(dims)
         set_reference_system_metadata(session, reference_id, system_metadata)
 
     if full_hash:

--- a/app/assets/services/ingest.py
+++ b/app/assets/services/ingest.py
@@ -31,7 +31,10 @@ from app.assets.database.queries import (
 from app.assets.helpers import get_utc_now, normalize_tags
 from app.assets.services.bulk_ingest import batch_insert_seed_assets
 from app.assets.services.file_utils import get_size_and_mtime_ns
-from app.assets.services.image_dimensions import extract_image_dimensions
+from app.assets.services.media_metadata import (
+    MEDIA_METADATA_KEYS,
+    extract_media_metadata,
+)
 from app.assets.services.path_utils import (
     compute_loader_path,
     get_name_and_tags_from_asset_path,
@@ -138,7 +141,7 @@ def _ingest_file_from_path(
                 user_metadata=user_metadata,
             )
 
-            _maybe_store_image_dimensions(
+            _maybe_store_media_metadata(
                 session,
                 reference_id=reference_id,
                 file_path=locator,
@@ -316,7 +319,7 @@ def _register_existing_asset(
                 user_metadata=new_meta,
             )
 
-        _backfill_image_dimensions_from_siblings(
+        _backfill_media_metadata_from_siblings(
             session,
             asset_id=asset.id,
             new_reference_id=ref.id,
@@ -369,25 +372,22 @@ def _update_metadata_with_filename(
         )
 
 
-_IMAGE_DIMENSION_KEYS = ("kind", "width", "height")
+_MEDIA_KINDS = ("image", "video")
 
 
-def _maybe_store_image_dimensions(
+def _maybe_store_media_metadata(
     session: Session,
     reference_id: str,
     file_path: str,
     mime_type: str | None,
     current_system_metadata: dict | None,
 ) -> None:
-    """Populate ``kind``/``width``/``height`` on system_metadata for image refs.
+    """Populate media keys on system_metadata for image and video refs.
 
-    Non-image MIME types are a no-op. Pre-existing keys (e.g. enricher-written
+    Non-media MIME types are a no-op. Pre-existing keys (e.g. enricher-written
     safetensors metadata, download provenance) are preserved by merge.
     """
-    if not mime_type or not mime_type.startswith("image/"):
-        return
-
-    dims = extract_image_dimensions(file_path, mime_type=mime_type)
+    dims = extract_media_metadata(file_path, mime_type=mime_type)
     if not dims:
         return
 
@@ -402,31 +402,35 @@ def _maybe_store_image_dimensions(
         )
 
 
-def _backfill_image_dimensions_from_siblings(
+def _backfill_media_metadata_from_siblings(
     session: Session,
     asset_id: str,
     new_reference_id: str,
     current_system_metadata: dict | None,
 ) -> None:
-    """Copy image dimension keys from any sibling reference of the same asset.
+    """Copy media metadata keys from any sibling reference of the same asset.
 
-    The from-hash path doesn't read the file bytes, so dimensions can't be
+    The from-hash path doesn't read the file bytes, so metadata can't be
     extracted there directly. When another reference of the same asset already
-    carries image dimensions, copy them onto the new reference so consumers
-    see consistent metadata regardless of how the asset was registered.
+    carries media metadata, copy it onto the new reference so consumers see
+    consistent metadata regardless of how the asset was registered.
 
-    Best-effort: missing siblings, non-image siblings, or absent dimension
+    Best-effort: missing siblings, non-media siblings, or absent metadata
     keys leave the target reference unchanged.
     """
     current = current_system_metadata or {}
-    if current.get("kind") == "image" and "width" in current and "height" in current:
+    if (
+        current.get("kind") in _MEDIA_KINDS
+        and "width" in current
+        and "height" in current
+    ):
         return
 
     for sibling in list_references_by_asset_id(session, asset_id):
         if sibling.id == new_reference_id:
             continue
         meta = sibling.system_metadata or {}
-        if meta.get("kind") != "image":
+        if meta.get("kind") not in _MEDIA_KINDS:
             continue
         width = meta.get("width")
         height = meta.get("height")
@@ -438,9 +442,9 @@ def _backfill_image_dimensions_from_siblings(
         ):
             continue
         merged = dict(current)
-        merged["kind"] = "image"
-        merged["width"] = width
-        merged["height"] = height
+        for key in MEDIA_METADATA_KEYS:
+            if key in meta:
+                merged[key] = meta[key]
         if merged != current:
             set_reference_system_metadata(
                 session,

--- a/app/assets/services/media_metadata.py
+++ b/app/assets/services/media_metadata.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.assets.services.image_dimensions import extract_image_dimensions
+from app.assets.services.video_metadata import extract_video_metadata
+
+MEDIA_METADATA_KEYS = (
+    "kind",
+    "width",
+    "height",
+    "duration",
+    "fps",
+    "frame_count",
+)
+
+
+def extract_media_metadata(
+    file_path: str, mime_type: str | None = None
+) -> dict[str, Any] | None:
+    """Extract media metadata for the file, dispatched on the MIME prefix.
+
+    Returns ``None`` for non-media MIME types or unreadable files.
+    """
+    if not mime_type:
+        return None
+    if mime_type.startswith("image/"):
+        return extract_image_dimensions(file_path, mime_type=mime_type)
+    if mime_type.startswith("video/"):
+        return extract_video_metadata(file_path, mime_type=mime_type)
+    return None

--- a/app/assets/services/video_metadata.py
+++ b/app/assets/services/video_metadata.py
@@ -1,0 +1,81 @@
+"""Video metadata extraction for asset ingest.
+
+Reads only the container/stream headers via PyAV to capture dimensions,
+duration, fps and frame count cheaply, without decoding frames. Returns a
+metadata dict suitable for merging into ``AssetReference.system_metadata``.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def extract_video_metadata(
+    file_path: str, mime_type: str | None = None
+) -> dict[str, Any] | None:
+    """Extract video stream metadata for the file at ``file_path``.
+
+    Args:
+        file_path: Absolute path to a file on disk.
+        mime_type: Optional MIME type hint. When provided and not prefixed
+            with ``video/``, extraction is skipped without touching the file.
+
+    Returns:
+        ``{"kind": "video", "width": W, "height": H, ...}`` with optional
+        ``duration`` (seconds), ``fps`` and ``frame_count`` keys when the
+        file has a recognizable video stream, otherwise ``None``.
+    """
+    if mime_type is not None and not mime_type.startswith("video/"):
+        return None
+
+    try:
+        import av
+    except ImportError:
+        logger.debug(
+            "PyAV not available; skipping video metadata extraction for %s",
+            file_path,
+        )
+        return None
+
+    try:
+        with av.open(file_path) as container:
+            stream = next(
+                (s for s in container.streams if s.type == "video"), None
+            )
+            if stream is None:
+                return None
+
+            fps = float(stream.average_rate) if stream.average_rate else None
+            duration = None
+            if stream.duration is not None and stream.time_base is not None:
+                duration = float(stream.duration * stream.time_base)
+            elif container.duration is not None:
+                duration = float(container.duration * av.time_base)
+            frame_count = stream.frames or None
+            if frame_count is None and duration is not None and fps is not None:
+                frame_count = round(duration * fps)
+
+            width = stream.codec_context.width
+            height = stream.codec_context.height
+    except (OSError, ValueError, av.error.FFmpegError) as exc:
+        logger.debug("Failed to read video metadata from %s: %s", file_path, exc)
+        return None
+
+    if (
+        not isinstance(width, int)
+        or not isinstance(height, int)
+        or width <= 0
+        or height <= 0
+    ):
+        return None
+
+    metadata: dict[str, Any] = {"kind": "video", "width": width, "height": height}
+    if duration is not None:
+        metadata["duration"] = duration
+    if fps is not None:
+        metadata["fps"] = fps
+    if frame_count is not None:
+        metadata["frame_count"] = frame_count
+    return metadata

--- a/app/assets/services/video_metadata.py
+++ b/app/assets/services/video_metadata.py
@@ -54,8 +54,6 @@ def extract_video_metadata(
             elif container.duration is not None:
                 duration = float(container.duration / av.time_base)
             frame_count = stream.frames or None
-            if frame_count is None and duration is not None and fps is not None:
-                frame_count = round(duration * fps)
 
             width = stream.codec_context.width
             height = stream.codec_context.height

--- a/app/assets/services/video_metadata.py
+++ b/app/assets/services/video_metadata.py
@@ -52,7 +52,7 @@ def extract_video_metadata(
             if stream.duration is not None and stream.time_base is not None:
                 duration = float(stream.duration * stream.time_base)
             elif container.duration is not None:
-                duration = float(container.duration * av.time_base)
+                duration = float(container.duration / av.time_base)
             frame_count = stream.frames or None
             if frame_count is None and duration is not None and fps is not None:
                 frame_count = round(duration * fps)

--- a/comfy_execution/asset_enrichment.py
+++ b/comfy_execution/asset_enrichment.py
@@ -1,6 +1,7 @@
 """Enrich executed-node output entries with asset id."""
 import logging
-import os
+
+from comfy_execution.media_enrichment import resolve_output_entry_path
 
 
 def enrich_output_with_assets(output_ui: dict) -> dict:
@@ -15,7 +16,6 @@ def enrich_output_with_assets(output_ui: dict) -> dict:
     if not args.enable_assets:
         return output_ui
 
-    import folder_paths
     from app.assets.services.ingest import register_file_in_place, DependencyMissingError
 
     enriched = {}
@@ -29,20 +29,8 @@ def enrich_output_with_assets(output_ui: dict) -> dict:
                 new_entries.append(entry)
                 continue
             try:
-                base = folder_paths.get_directory_by_type(entry["type"])
-                if base is None:
-                    new_entries.append(entry)
-                    continue
-                base_abs = os.path.abspath(base)
-                abs_path = os.path.abspath(os.path.join(base_abs, entry.get("subfolder") or "", entry["filename"]))
-                try:
-                    if os.path.commonpath([base_abs, abs_path]) != base_abs:
-                        raise ValueError("escapes base")
-                except ValueError:
-                    logging.warning("Asset enrichment skipped (path escapes base): %s", entry.get("filename"))
-                    new_entries.append(entry)
-                    continue
-                if not os.path.isfile(abs_path):
+                abs_path = resolve_output_entry_path(entry)
+                if abs_path is None:
                     new_entries.append(entry)
                     continue
 

--- a/comfy_execution/media_enrichment.py
+++ b/comfy_execution/media_enrichment.py
@@ -12,6 +12,8 @@ import logging
 import mimetypes
 import os
 
+import folder_paths
+
 
 def resolve_output_entry_path(entry) -> str | None:
     """Resolve a file-type output entry to an absolute path inside its base dir.
@@ -21,12 +23,10 @@ def resolve_output_entry_path(entry) -> str | None:
     folder-type base directory (symlinks are resolved before the containment
     check), and paths with no file on disk.
     """
-    import folder_paths
-
     if not isinstance(entry, dict) or "filename" not in entry or "type" not in entry:
         return None
     filename = entry["filename"]
-    subfolder = entry.get("subfolder") or ""
+    subfolder = entry.get("subfolder", "")
     if not isinstance(filename, str) or not isinstance(subfolder, str) or not isinstance(entry["type"], str):
         return None
     base = folder_paths.get_directory_by_type(entry["type"])

--- a/comfy_execution/media_enrichment.py
+++ b/comfy_execution/media_enrichment.py
@@ -1,0 +1,94 @@
+"""Enrich executed-node output entries with media metadata.
+
+Attaches a ``metadata`` object (``kind``/``width``/``height``, plus
+``duration``/``fps``/``frame_count`` for videos) to each file-type output
+entry at output-processing time, so consumers of the ``executed`` message
+and ``/history`` can read media properties without probing the files
+themselves. Unlike asset enrichment this is NOT gated on ``--enable-assets``:
+the properties serve history/websocket consumers that don't run the assets
+system at all.
+"""
+import logging
+import mimetypes
+import os
+
+
+def resolve_output_entry_path(entry) -> str | None:
+    """Resolve a file-type output entry to an absolute path inside its base dir.
+
+    Returns ``None`` for non-file entries (no ``filename``/``type``, or
+    non-string fields), unknown folder types, paths that escape the
+    folder-type base directory (symlinks are resolved before the containment
+    check), and paths with no file on disk.
+    """
+    import folder_paths
+
+    if not isinstance(entry, dict) or "filename" not in entry or "type" not in entry:
+        return None
+    filename = entry["filename"]
+    subfolder = entry.get("subfolder") or ""
+    if not isinstance(filename, str) or not isinstance(subfolder, str) or not isinstance(entry["type"], str):
+        return None
+    base = folder_paths.get_directory_by_type(entry["type"])
+    if base is None:
+        return None
+    # realpath (not abspath) so a symlink planted inside the base directory
+    # can't smuggle an outside target past the containment check; the base is
+    # resolved too since output/temp dirs are themselves commonly symlinks.
+    base_real = os.path.realpath(base)
+    real_path = os.path.realpath(os.path.join(base_real, subfolder, filename))
+    try:
+        if os.path.commonpath([base_real, real_path]) != base_real:
+            logging.warning("Output entry path escapes base directory: %s", filename)
+            return None
+    except ValueError:
+        logging.warning("Output entry path escapes base directory: %s", filename)
+        return None
+    if not os.path.isfile(real_path):
+        return None
+    return real_path
+
+
+def enrich_output_with_media_metadata(output_ui: dict) -> dict:
+    """Attach a ``metadata`` media-properties object to file output entries.
+
+    Runs once per produced output at output-processing time. Returns a new
+    dict; entries are copied before modification, and an entry that already
+    carries a ``metadata`` key is left untouched. Best-effort: unreadable
+    files, non-media types, and per-entry errors leave that entry unchanged
+    and never block execution.
+    """
+    try:
+        from app.assets.services.media_metadata import extract_media_metadata
+    except Exception:
+        # Broad on purpose: this enrichment is best-effort and is called
+        # unguarded from the output-processing path, so a dependency failing
+        # to import for any reason must degrade to a no-op, not block outputs.
+        logging.warning("Media metadata extraction unavailable; skipping enrichment", exc_info=True)
+        return output_ui
+
+    enriched = {}
+    for key, entries in output_ui.items():
+        if not isinstance(entries, list):
+            enriched[key] = entries
+            continue
+        new_entries = []
+        for entry in entries:
+            try:
+                if isinstance(entry, dict) and "metadata" not in entry:
+                    abs_path = resolve_output_entry_path(entry)
+                    if abs_path is not None:
+                        mime_type = mimetypes.guess_type(entry["filename"], strict=False)[0]
+                        media = extract_media_metadata(abs_path, mime_type=mime_type)
+                        if media:
+                            entry = dict(entry)
+                            entry["metadata"] = media
+            except Exception:
+                filename = entry.get("filename") if isinstance(entry, dict) else None
+                logging.warning(
+                    "Failed to enrich output entry with media metadata: %s",
+                    filename, exc_info=True,
+                )
+            new_entries.append(entry)
+        enriched[key] = new_entries
+    return enriched

--- a/execution.py
+++ b/execution.py
@@ -44,6 +44,7 @@ from comfy_execution.validation import validate_node_input
 from comfy_execution.progress import get_progress_state, reset_progress_state, add_progress_handler, WebUIProgressHandler
 from comfy_execution.utils import CurrentNodeContext
 from comfy_execution.asset_enrichment import enrich_output_with_assets
+from comfy_execution.media_enrichment import enrich_output_with_media_metadata
 from comfy_api.internal import _ComfyNodeInternal, _NodeOutputInternal, first_real_override, is_class, make_locked_method_func
 from comfy_api.latest import io, _io
 from comfy_execution.cache_provider import _has_cache_providers, _get_cache_providers, _logger as _cache_logger
@@ -561,9 +562,11 @@ async def execute(server, dynprompt, caches, current_item, extra_data, executed,
                 asyncio.create_task(await_completion())
                 return (ExecutionResult.PENDING, None, None)
         if len(output_ui) > 0:
-            # Enrich at output-processing time (not in the send path) so assets
-            # are registered even when no client is connected, and the asset id
-            # flows into ui_outputs and the cache alongside the raw entries.
+            # Enrich at output-processing time (not in the send path) so the
+            # added fields flow into ui_outputs and the cache alongside the
+            # raw entries, even when no client is connected. Media metadata is
+            # attached unconditionally; asset ids only under --enable-assets.
+            output_ui = enrich_output_with_media_metadata(output_ui)
             output_ui = enrich_output_with_assets(output_ui)
             ui_outputs[unique_id] = {
                 "meta": {

--- a/tests-unit/assets_test/services/test_video_metadata.py
+++ b/tests-unit/assets_test/services/test_video_metadata.py
@@ -1,0 +1,138 @@
+"""Tests for the video_metadata service."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from app.assets.services.media_metadata import extract_media_metadata
+from app.assets.services.video_metadata import extract_video_metadata
+
+av = pytest.importorskip("av")
+
+
+def _make_mp4(
+    path: Path, width: int = 64, height: int = 48, frames: int = 12, fps: int = 8
+) -> Path:
+    with av.open(str(path), "w") as container:
+        stream = container.add_stream("libx264", rate=fps)
+        stream.width = width
+        stream.height = height
+        stream.pix_fmt = "yuv420p"
+        for _ in range(frames):
+            frame = av.VideoFrame.from_ndarray(
+                np.zeros((height, width, 3), dtype=np.uint8), format="rgb24"
+            )
+            for packet in stream.encode(frame):
+                container.mux(packet)
+        for packet in stream.encode():
+            container.mux(packet)
+    return path
+
+
+class TestExtractVideoMetadata:
+    def test_extracts_stream_metadata(self, tmp_path: Path):
+        f = _make_mp4(tmp_path / "clip.mp4", width=64, height=48, frames=12, fps=8)
+
+        result = extract_video_metadata(str(f), mime_type="video/mp4")
+
+        assert result is not None
+        assert result["kind"] == "video"
+        assert result["width"] == 64
+        assert result["height"] == 48
+        assert result["frame_count"] == 12
+        assert result["fps"] == pytest.approx(8.0)
+        assert result["duration"] == pytest.approx(12 / 8, abs=0.1)
+
+    def test_works_when_mime_type_is_none(self, tmp_path: Path):
+        f = _make_mp4(tmp_path / "no_mime.mp4")
+
+        result = extract_video_metadata(str(f), mime_type=None)
+
+        assert result is not None
+        assert result["kind"] == "video"
+
+    @pytest.mark.parametrize(
+        "mime",
+        ["application/json", "text/plain", "image/png", "audio/mpeg"],
+    )
+    def test_skips_non_video_mime_types(self, tmp_path: Path, mime: str):
+        result = extract_video_metadata(
+            str(tmp_path / "untouched.mp4"), mime_type=mime
+        )
+
+        assert result is None
+
+    def test_returns_none_for_missing_file(self, tmp_path: Path):
+        result = extract_video_metadata(
+            str(tmp_path / "does_not_exist.mp4"), mime_type="video/mp4"
+        )
+
+        assert result is None
+
+    def test_returns_none_for_corrupt_video(self, tmp_path: Path):
+        f = tmp_path / "corrupt.mp4"
+        f.write_bytes(b"not actually an mp4 file")
+
+        result = extract_video_metadata(str(f), mime_type="video/mp4")
+
+        assert result is None
+
+
+class TestExtractMediaMetadata:
+    def test_dispatches_video_mime_to_video_extractor(self, tmp_path: Path):
+        f = _make_mp4(tmp_path / "clip.mp4")
+
+        result = extract_media_metadata(str(f), mime_type="video/mp4")
+
+        assert result is not None
+        assert result["kind"] == "video"
+
+    def test_dispatches_image_mime_to_image_extractor(self, tmp_path: Path):
+        from PIL import Image
+
+        f = tmp_path / "img.png"
+        Image.new("RGB", (32, 16)).save(f, format="PNG")
+
+        result = extract_media_metadata(str(f), mime_type="image/png")
+
+        assert result == {"kind": "image", "width": 32, "height": 16}
+
+    def test_returns_none_without_mime_type(self, tmp_path: Path):
+        f = _make_mp4(tmp_path / "clip.mp4")
+
+        assert extract_media_metadata(str(f), mime_type=None) is None
+
+    def test_returns_none_for_non_media_mime(self, tmp_path: Path):
+        f = tmp_path / "file.bin"
+        f.write_bytes(b"\x00")
+
+        assert extract_media_metadata(str(f), mime_type="text/plain") is None
+
+
+class TestIngestStoresVideoMetadata:
+    def test_register_file_in_place_stores_video_metadata(
+        self, mock_create_session, temp_dir: Path, session
+    ):
+        from app.assets.database.models import AssetReference
+        from app.assets.services.ingest import _ingest_file_from_path
+
+        f = _make_mp4(temp_dir / "clip.mp4", width=64, height=48)
+
+        result = _ingest_file_from_path(
+            abs_path=str(f),
+            asset_hash="blake3:video123",
+            size_bytes=f.stat().st_size,
+            mtime_ns=1234567890000000000,
+            mime_type="video/mp4",
+        )
+
+        assert result.reference_id is not None
+        ref = session.query(AssetReference).one()
+        meta = ref.system_metadata or {}
+        assert meta["kind"] == "video"
+        assert meta["width"] == 64
+        assert meta["height"] == 48
+        assert meta["frame_count"] == 12
+        assert meta["fps"] == pytest.approx(8.0)

--- a/tests-unit/assets_test/services/test_video_metadata.py
+++ b/tests-unit/assets_test/services/test_video_metadata.py
@@ -9,14 +9,18 @@ import pytest
 from app.assets.services.media_metadata import extract_media_metadata
 from app.assets.services.video_metadata import extract_video_metadata
 
-av = pytest.importorskip("av")
 
-
-def _make_mp4(
-    path: Path, width: int = 64, height: int = 48, frames: int = 12, fps: int = 8
+def _make_video(
+    path: Path,
+    width: int = 64,
+    height: int = 48,
+    frames: int = 12,
+    fps: int = 8,
+    codec: str = "libx264",
 ) -> Path:
+    av = pytest.importorskip("av")
     with av.open(str(path), "w") as container:
-        stream = container.add_stream("libx264", rate=fps)
+        stream = container.add_stream(codec, rate=fps)
         stream.width = width
         stream.height = height
         stream.pix_fmt = "yuv420p"
@@ -29,6 +33,12 @@ def _make_mp4(
         for packet in stream.encode():
             container.mux(packet)
     return path
+
+
+def _make_mp4(
+    path: Path, width: int = 64, height: int = 48, frames: int = 12, fps: int = 8
+) -> Path:
+    return _make_video(path, width=width, height=height, frames=frames, fps=fps)
 
 
 class TestExtractVideoMetadata:
@@ -79,6 +89,15 @@ class TestExtractVideoMetadata:
 
         assert result is None
 
+    def test_webm_duration_from_container_without_frame_count(self, tmp_path: Path):
+        f = _make_video(tmp_path / "clip.webm", frames=12, fps=8, codec="libvpx-vp9")
+
+        result = extract_video_metadata(str(f), mime_type="video/webm")
+
+        assert result is not None
+        assert result["duration"] == pytest.approx(12 / 8, abs=0.2)
+        assert "frame_count" not in result
+
 
 class TestExtractMediaMetadata:
     def test_dispatches_video_mime_to_video_extractor(self, tmp_path: Path):
@@ -90,7 +109,7 @@ class TestExtractMediaMetadata:
         assert result["kind"] == "video"
 
     def test_dispatches_image_mime_to_image_extractor(self, tmp_path: Path):
-        from PIL import Image
+        Image = pytest.importorskip("PIL.Image")
 
         f = tmp_path / "img.png"
         Image.new("RGB", (32, 16)).save(f, format="PNG")
@@ -136,3 +155,38 @@ class TestIngestStoresVideoMetadata:
         assert meta["height"] == 48
         assert meta["frame_count"] == 12
         assert meta["fps"] == pytest.approx(8.0)
+
+    def test_register_existing_asset_backfills_metadata_from_sibling(
+        self, mock_create_session, temp_dir: Path, session
+    ):
+        from app.assets.database.models import AssetReference
+        from app.assets.services.ingest import (
+            _ingest_file_from_path,
+            _register_existing_asset,
+        )
+
+        f = _make_mp4(temp_dir / "clip.mp4", width=64, height=48)
+        _ingest_file_from_path(
+            abs_path=str(f),
+            asset_hash="blake3:videosibling",
+            size_bytes=f.stat().st_size,
+            mtime_ns=1234567890000000000,
+            mime_type="video/mp4",
+        )
+
+        result = _register_existing_asset(
+            asset_hash="blake3:videosibling",
+            name="copy.mp4",
+            mime_type="video/mp4",
+        )
+
+        assert result.created is True
+        session.expire_all()
+        ref = session.query(AssetReference).filter_by(name="copy.mp4").one()
+        meta = ref.system_metadata or {}
+        assert meta["kind"] == "video"
+        assert meta["width"] == 64
+        assert meta["height"] == 48
+        assert meta["frame_count"] == 12
+        assert meta["fps"] == pytest.approx(8.0)
+        assert "duration" in meta

--- a/tests-unit/execution_test/test_media_enrichment.py
+++ b/tests-unit/execution_test/test_media_enrichment.py
@@ -1,0 +1,220 @@
+"""Tests for enrich_output_with_media_metadata in comfy_execution/media_enrichment.py."""
+import mimetypes
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Initialize the mimetypes registry before any test patches os.path.isfile —
+# its lazy init consults os.path.isfile to pick candidate files, and a
+# patched-True isfile makes it try to open files that don't exist.
+mimetypes.init()
+
+# Platform-appropriate absolute base. tempfile.gettempdir() returns C:\... on
+# Windows and /tmp on POSIX, so containment via commonpath behaves naturally.
+_DEFAULT_BASE = os.path.join(__import__("tempfile").gettempdir(), "media-enrichment-test-base")
+
+_VIDEO_META = {
+    "kind": "video",
+    "width": 1280,
+    "height": 720,
+    "duration": 4.0,
+    "fps": 24.0,
+    "frame_count": 96,
+}
+
+
+def _mocked_modules(*, extract=None, directory=_DEFAULT_BASE):
+    return {
+        "folder_paths": MagicMock(get_directory_by_type=MagicMock(return_value=directory)),
+        "app.assets.services.media_metadata": MagicMock(
+            extract_media_metadata=extract or MagicMock(return_value=dict(_VIDEO_META)),
+        ),
+    }
+
+
+def _call(output_ui, *, extract=None, file_exists=True, directory=_DEFAULT_BASE):
+    extract_mock = extract or MagicMock(return_value=dict(_VIDEO_META))
+    mocked = _mocked_modules(extract=extract_mock, directory=directory)
+
+    # Only os.path.isfile is patched — abspath/join must run natively so the
+    # containment check sees real platform paths.
+    with patch.dict("sys.modules", mocked), \
+         patch("os.path.isfile", return_value=file_exists):
+        import comfy_execution.media_enrichment as mod
+        return mod.enrich_output_with_media_metadata(output_ui), extract_mock
+
+
+class TestEnrichOutputWithMediaMetadata(unittest.TestCase):
+
+    def test_attaches_metadata_object(self):
+        output = {"images": [{"filename": "clip.mp4", "subfolder": "", "type": "output"}]}
+        result, _ = _call(output)
+        self.assertEqual(result["images"][0]["metadata"], _VIDEO_META)
+
+    def test_passes_guessed_mime_type(self):
+        output = {"images": [{"filename": "clip.mp4", "subfolder": "", "type": "output"}]}
+        _, extract_mock = _call(output)
+        _, kwargs = extract_mock.call_args
+        self.assertEqual(kwargs["mime_type"], "video/mp4")
+
+    def test_original_entry_not_mutated(self):
+        orig = {"filename": "clip.mp4", "subfolder": "", "type": "output"}
+        _call({"images": [orig]})
+        self.assertNotIn("metadata", orig)
+
+    def test_non_media_extractor_none_leaves_entry_unchanged(self):
+        extract = MagicMock(return_value=None)
+        output = {"latent": [{"filename": "a.latent", "subfolder": "", "type": "output"}]}
+        result, _ = _call(output, extract=extract)
+        self.assertNotIn("metadata", result["latent"][0])
+
+    def test_existing_metadata_key_untouched(self):
+        entry = {"filename": "clip.mp4", "subfolder": "", "type": "output", "metadata": {"kind": "other"}}
+        result, extract_mock = _call({"images": [entry]})
+        self.assertEqual(result["images"][0]["metadata"], {"kind": "other"})
+        extract_mock.assert_not_called()
+
+    def test_non_list_value_passed_through(self):
+        result, _ = _call({"text": "hello"})
+        self.assertEqual(result["text"], "hello")
+
+    def test_none_entry_in_list_unchanged(self):
+        output = {"images": [None, {"filename": "a.mp4", "subfolder": "", "type": "output"}]}
+        result, _ = _call(output)
+        self.assertIsNone(result["images"][0])
+        self.assertIn("metadata", result["images"][1])
+
+    def test_entry_without_filename_unchanged(self):
+        output = {"latent": [{"subfolder": "", "type": "output"}]}
+        result, extract_mock = _call(output)
+        self.assertNotIn("metadata", result["latent"][0])
+        extract_mock.assert_not_called()
+
+    def test_file_not_on_disk_unchanged(self):
+        output = {"images": [{"filename": "missing.mp4", "subfolder": "", "type": "output"}]}
+        result, extract_mock = _call(output, file_exists=False)
+        self.assertNotIn("metadata", result["images"][0])
+        extract_mock.assert_not_called()
+
+    def test_unknown_type_directory_unchanged(self):
+        output = {"images": [{"filename": "a.mp4", "subfolder": "", "type": "unknown"}]}
+        result, extract_mock = _call(output, directory=None)
+        self.assertNotIn("metadata", result["images"][0])
+        extract_mock.assert_not_called()
+
+    def test_path_traversal_subfolder_skipped(self):
+        output = {"images": [{"filename": "passwd", "subfolder": "../../etc", "type": "output"}]}
+        result, extract_mock = _call(output)
+        self.assertNotIn("metadata", result["images"][0])
+        extract_mock.assert_not_called()
+
+    def test_absolute_filename_skipped(self):
+        absolute_filename = os.path.abspath(os.sep + "etc" + os.sep + "passwd")
+        output = {"images": [{"filename": absolute_filename, "subfolder": "", "type": "output"}]}
+        result, extract_mock = _call(output)
+        self.assertNotIn("metadata", result["images"][0])
+        extract_mock.assert_not_called()
+
+    def test_extractor_unavailable_returns_unchanged(self):
+        output = {"images": [{"filename": "a.mp4", "subfolder": "", "type": "output"}]}
+        mocked = {
+            "folder_paths": MagicMock(get_directory_by_type=MagicMock(return_value=_DEFAULT_BASE)),
+            # A None sys.modules entry makes the lazy import raise ImportError.
+            "app.assets.services.media_metadata": None,
+        }
+        with patch.dict("sys.modules", mocked), \
+             patch("os.path.isfile", return_value=True):
+            import comfy_execution.media_enrichment as mod
+            result = mod.enrich_output_with_media_metadata(output)
+        self.assertNotIn("metadata", result["images"][0])
+
+    def test_extractor_import_failure_beyond_importerror_degrades(self):
+        class ExplodingModule:
+            def __getattr__(self, name):
+                raise RuntimeError("dependency init failed")
+
+        output = {"images": [{"filename": "a.mp4", "subfolder": "", "type": "output"}]}
+        mocked = {
+            "folder_paths": MagicMock(get_directory_by_type=MagicMock(return_value=_DEFAULT_BASE)),
+            "app.assets.services.media_metadata": ExplodingModule(),
+        }
+        with patch.dict("sys.modules", mocked), \
+             patch("os.path.isfile", return_value=True):
+            import comfy_execution.media_enrichment as mod
+            result = mod.enrich_output_with_media_metadata(output)
+        self.assertNotIn("metadata", result["images"][0])
+
+    def test_non_string_fields_skipped(self):
+        output = {
+            "images": [
+                {"filename": 42, "subfolder": "", "type": "output"},
+                {"filename": "a.mp4", "subfolder": ["nested"], "type": "output"},
+                {"filename": "b.mp4", "subfolder": "", "type": 7},
+            ]
+        }
+        result, extract_mock = _call(output)
+        for entry in result["images"]:
+            self.assertNotIn("metadata", entry)
+        extract_mock.assert_not_called()
+
+    def test_symlink_escape_rejected_real_fs(self):
+        import shutil
+        import tempfile
+
+        root = tempfile.mkdtemp(prefix="media-enrichment-symlink-")
+        try:
+            base = os.path.join(root, "output")
+            os.makedirs(base)
+            secret = os.path.join(root, "secret.txt")
+            with open(secret, "w") as f:
+                f.write("outside")
+            os.symlink(secret, os.path.join(base, "clip.mp4"))
+            inside = os.path.join(base, "real.mp4")
+            with open(inside, "w") as f:
+                f.write("inside")
+
+            mocked = {"folder_paths": MagicMock(get_directory_by_type=MagicMock(return_value=base))}
+            # No isfile patching — this test runs against the real filesystem.
+            with patch.dict("sys.modules", mocked):
+                import comfy_execution.media_enrichment as mod
+                escaped = mod.resolve_output_entry_path(
+                    {"filename": "clip.mp4", "subfolder": "", "type": "output"})
+                contained = mod.resolve_output_entry_path(
+                    {"filename": "real.mp4", "subfolder": "", "type": "output"})
+            self.assertIsNone(escaped, "symlink pointing outside the base must be rejected")
+            self.assertEqual(contained, os.path.realpath(inside))
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_extractor_error_does_not_block_sibling_entries(self):
+        call_count = [0]
+
+        def extract_side_effect(abs_path, mime_type=None):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise RuntimeError("boom")
+            return dict(_VIDEO_META)
+
+        extract = MagicMock(side_effect=extract_side_effect)
+        output = {
+            "images": [
+                {"filename": "bad.mp4", "subfolder": "", "type": "output"},
+                {"filename": "good.mp4", "subfolder": "", "type": "output"},
+            ]
+        }
+        result, _ = _call(output, extract=extract)
+        self.assertNotIn("metadata", result["images"][0])
+        self.assertEqual(result["images"][1]["metadata"], _VIDEO_META)
+
+    def test_multiple_output_keys_all_enriched(self):
+        output = {
+            "images": [{"filename": "a.png", "subfolder": "", "type": "output"}],
+            "videos": [{"filename": "b.mp4", "subfolder": "", "type": "output"}],
+        }
+        result, _ = _call(output)
+        self.assertIn("metadata", result["images"][0])
+        self.assertIn("metadata", result["videos"][0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests-unit/execution_test/test_media_enrichment.py
+++ b/tests-unit/execution_test/test_media_enrichment.py
@@ -1,17 +1,22 @@
 """Tests for enrich_output_with_media_metadata in comfy_execution/media_enrichment.py."""
-import mimetypes
 import os
+import shutil
+import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
+from utils.mime_types import init_mime_types
+
 # Initialize the mimetypes registry before any test patches os.path.isfile —
 # its lazy init consults os.path.isfile to pick candidate files, and a
-# patched-True isfile makes it try to open files that don't exist.
-mimetypes.init()
+# patched-True isfile makes it try to open files that don't exist. Use the
+# project initializer, not mimetypes.init(), which would wipe the custom
+# registrations other test modules rely on.
+init_mime_types()
 
 # Platform-appropriate absolute base. tempfile.gettempdir() returns C:\... on
 # Windows and /tmp on POSIX, so containment via commonpath behaves naturally.
-_DEFAULT_BASE = os.path.join(__import__("tempfile").gettempdir(), "media-enrichment-test-base")
+_DEFAULT_BASE = os.path.join(tempfile.gettempdir(), "media-enrichment-test-base")
 
 _VIDEO_META = {
     "kind": "video",
@@ -23,25 +28,25 @@ _VIDEO_META = {
 }
 
 
-def _mocked_modules(*, extract=None, directory=_DEFAULT_BASE):
-    return {
-        "folder_paths": MagicMock(get_directory_by_type=MagicMock(return_value=directory)),
-        "app.assets.services.media_metadata": MagicMock(
-            extract_media_metadata=extract or MagicMock(return_value=dict(_VIDEO_META)),
-        ),
-    }
+import comfy_execution.media_enrichment as media_enrichment
+
+
+def _folder_paths_mock(directory=_DEFAULT_BASE):
+    return MagicMock(get_directory_by_type=MagicMock(return_value=directory))
 
 
 def _call(output_ui, *, extract=None, file_exists=True, directory=_DEFAULT_BASE):
     extract_mock = extract or MagicMock(return_value=dict(_VIDEO_META))
-    mocked = _mocked_modules(extract=extract_mock, directory=directory)
+    extractor_module = MagicMock(extract_media_metadata=extract_mock)
 
-    # Only os.path.isfile is patched — abspath/join must run natively so the
+    # folder_paths is bound at media_enrichment module scope, so it is patched
+    # as an attribute; the extractor is looked up lazily via sys.modules. Only
+    # os.path.isfile is patched — abspath/join must run natively so the
     # containment check sees real platform paths.
-    with patch.dict("sys.modules", mocked), \
+    with patch.object(media_enrichment, "folder_paths", _folder_paths_mock(directory)), \
+         patch.dict("sys.modules", {"app.assets.services.media_metadata": extractor_module}), \
          patch("os.path.isfile", return_value=file_exists):
-        import comfy_execution.media_enrichment as mod
-        return mod.enrich_output_with_media_metadata(output_ui), extract_mock
+        return media_enrichment.enrich_output_with_media_metadata(output_ui), extract_mock
 
 
 class TestEnrichOutputWithMediaMetadata(unittest.TestCase):
@@ -117,15 +122,11 @@ class TestEnrichOutputWithMediaMetadata(unittest.TestCase):
 
     def test_extractor_unavailable_returns_unchanged(self):
         output = {"images": [{"filename": "a.mp4", "subfolder": "", "type": "output"}]}
-        mocked = {
-            "folder_paths": MagicMock(get_directory_by_type=MagicMock(return_value=_DEFAULT_BASE)),
-            # A None sys.modules entry makes the lazy import raise ImportError.
-            "app.assets.services.media_metadata": None,
-        }
-        with patch.dict("sys.modules", mocked), \
+        # A None sys.modules entry makes the lazy import raise ImportError.
+        with patch.object(media_enrichment, "folder_paths", _folder_paths_mock()), \
+             patch.dict("sys.modules", {"app.assets.services.media_metadata": None}), \
              patch("os.path.isfile", return_value=True):
-            import comfy_execution.media_enrichment as mod
-            result = mod.enrich_output_with_media_metadata(output)
+            result = media_enrichment.enrich_output_with_media_metadata(output)
         self.assertNotIn("metadata", result["images"][0])
 
     def test_extractor_import_failure_beyond_importerror_degrades(self):
@@ -134,15 +135,29 @@ class TestEnrichOutputWithMediaMetadata(unittest.TestCase):
                 raise RuntimeError("dependency init failed")
 
         output = {"images": [{"filename": "a.mp4", "subfolder": "", "type": "output"}]}
-        mocked = {
-            "folder_paths": MagicMock(get_directory_by_type=MagicMock(return_value=_DEFAULT_BASE)),
-            "app.assets.services.media_metadata": ExplodingModule(),
-        }
-        with patch.dict("sys.modules", mocked), \
+        with patch.object(media_enrichment, "folder_paths", _folder_paths_mock()), \
+             patch.dict("sys.modules", {"app.assets.services.media_metadata": ExplodingModule()}), \
              patch("os.path.isfile", return_value=True):
-            import comfy_execution.media_enrichment as mod
-            result = mod.enrich_output_with_media_metadata(output)
+            result = media_enrichment.enrich_output_with_media_metadata(output)
         self.assertNotIn("metadata", result["images"][0])
+
+    def test_missing_subfolder_key_defaults_to_base_dir(self):
+        output = {"images": [{"filename": "clip.mp4", "type": "output"}]}
+        result, _ = _call(output)
+        self.assertIn("metadata", result["images"][0])
+
+    def test_falsy_non_string_subfolder_skipped(self):
+        output = {
+            "images": [
+                {"filename": "a.mp4", "subfolder": None, "type": "output"},
+                {"filename": "b.mp4", "subfolder": False, "type": "output"},
+                {"filename": "c.mp4", "subfolder": 0, "type": "output"},
+            ]
+        }
+        result, extract_mock = _call(output)
+        for entry in result["images"]:
+            self.assertNotIn("metadata", entry)
+        extract_mock.assert_not_called()
 
     def test_non_string_fields_skipped(self):
         output = {
@@ -158,9 +173,6 @@ class TestEnrichOutputWithMediaMetadata(unittest.TestCase):
         extract_mock.assert_not_called()
 
     def test_symlink_escape_rejected_real_fs(self):
-        import shutil
-        import tempfile
-
         root = tempfile.mkdtemp(prefix="media-enrichment-symlink-")
         try:
             base = os.path.join(root, "output")
@@ -168,18 +180,19 @@ class TestEnrichOutputWithMediaMetadata(unittest.TestCase):
             secret = os.path.join(root, "secret.txt")
             with open(secret, "w") as f:
                 f.write("outside")
-            os.symlink(secret, os.path.join(base, "clip.mp4"))
+            try:
+                os.symlink(secret, os.path.join(base, "clip.mp4"))
+            except OSError as e:
+                self.skipTest(f"cannot create symlinks on this platform: {e}")
             inside = os.path.join(base, "real.mp4")
             with open(inside, "w") as f:
                 f.write("inside")
 
-            mocked = {"folder_paths": MagicMock(get_directory_by_type=MagicMock(return_value=base))}
             # No isfile patching — this test runs against the real filesystem.
-            with patch.dict("sys.modules", mocked):
-                import comfy_execution.media_enrichment as mod
-                escaped = mod.resolve_output_entry_path(
+            with patch.object(media_enrichment, "folder_paths", _folder_paths_mock(base)):
+                escaped = media_enrichment.resolve_output_entry_path(
                     {"filename": "clip.mp4", "subfolder": "", "type": "output"})
-                contained = mod.resolve_output_entry_path(
+                contained = media_enrichment.resolve_output_entry_path(
                     {"filename": "real.mp4", "subfolder": "", "type": "output"})
             self.assertIsNone(escaped, "symlink pointing outside the base must be rejected")
             self.assertEqual(contained, os.path.realpath(inside))


### PR DESCRIPTION
Extends the asset media-metadata pipeline (previously image-only) to video:

- video_metadata.py: PyAV header-only probe producing {kind: video, width, height, duration, fps, frame_count}
- media_metadata.py: MIME-dispatched extraction shared by ingest and the scanner enrichment pass
- ingest: _maybe_store_image_dimensions generalized to _maybe_store_media_metadata; sibling backfill copies all media keys
- scanner: enrichment merges media metadata for both image/ and video/

Uploaded and executed video files now carry duration/fps/frame_count/ width/height on the asset record, surfaced through the Assets API metadata field.