### PR TITLE
fix: don't default the Stable Audio 3 VAE to bf16 on MPS

### DIFF
--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -988,6 +988,10 @@ class VAE:
                 self.process_output = lambda audio: audio
                 self.process_input = lambda audio: audio
                 self.working_dtypes = [torch.bfloat16, torch.float16, torch.float32]
+                if model_management.is_device_mps(device if device is not None else model_management.vae_device()):
+                    #bf16 decodes to broadband noise on mps: its 8-bit mantissa is too
+                    #coarse for the attention logits the DyT qk norms produce. fp16 is fine.
+                    self.working_dtypes = [torch.float16, torch.float32]
                 #This VAE has Parameters and Buffers the non-dynamic caster cannot handle
                 #Force cast it for --disable-dynamic-vram users until there is a true core fix.
                 if not comfy.memory_management.aimdo_enabled:

--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -932,6 +932,14 @@ class VAE:
                 self.process_output = lambda audio: audio
                 self.process_input = lambda audio: audio
                 self.working_dtypes = [torch.bfloat16, torch.float16, torch.float32]
+                if model_management.is_device_mps(device if device is not None else model_management.vae_device()):
+                    #bf16 decodes to broadband noise on backends whose sdpa runs the
+                    #softmax in the input dtype (measured on mps and cpu): the DyT
+                    #qk norms emit +-30..50 so attention logits land where bf16's
+                    #8-bit mantissa quantizes in steps of ~0.25-0.5, and the output
+                    #decorrelates completely (corr ~0 vs fp32). fp16 matches fp32
+                    #(corr 0.9997), so prefer it on mps.
+                    self.working_dtypes = [torch.float16, torch.float32]
                 #This VAE has Parameters and Buffers the non-dynamic caster cannot handle
                 #Force cast it for --disable-dynamic-vram users until there is a true core fix.
                 if not comfy.memory_management.aimdo_enabled:

--- a/tests-unit/comfy_test/audio_vae_mps_test.py
+++ b/tests-unit/comfy_test/audio_vae_mps_test.py
@@ -1,0 +1,86 @@
+"""Stable Audio 3 VAE dtype selection on Apple Silicon (MPS).
+
+The SA3 audio decoder cannot run in bf16 on backends whose attention
+softmax runs in the input dtype (mps, cpu): its DyT qk norms emit values
+around +-30..50, attention logits land where bf16's 8-bit mantissa
+quantizes in steps of ~0.25-0.5, and the decoded audio is broadband
+noise, fully decorrelated from the fp32 decode (corr ~0). fp16 matches
+fp32 (corr 0.9997). The VAE must therefore not default to bf16 on mps,
+while CUDA keeps its bf16 default.
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+
+from comfy.cli_args import args as cli_args
+
+if not (torch.cuda.is_available() or torch.backends.mps.is_available()):
+    cli_args.cpu = True
+
+import comfy.ldm.audio.vae_sa3  # noqa: E402
+import comfy.memory_management  # noqa: E402
+import comfy.model_management as mm  # noqa: E402
+import comfy.sd  # noqa: E402
+
+mps_only = pytest.mark.skipif(
+    not (torch.backends.mps.is_available() and mm.is_device_mps(mm.get_torch_device())),
+    reason="requires an Apple Silicon MPS device",
+)
+
+
+def sa3_state_dict():
+    # Routes VAE() into the Stable Audio 3 branch (small config).
+    return {"decoder.layers.3.transformers.0.pre_norm.alpha": torch.zeros(1)}
+
+
+class StubSA3AudioVAE(nn.Module):
+    # Stands in for SA3AudioVAE so tests don't build the full 100M+ param
+    # module; dtype selection under test happens outside the model class.
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+        self.linear = nn.Linear(2, 2)
+
+
+@pytest.fixture
+def sa3_vae_factory(monkeypatch):
+    def build(device):
+        monkeypatch.setattr(comfy.ldm.audio.vae_sa3, "SA3AudioVAE", StubSA3AudioVAE)
+        monkeypatch.setattr(comfy.memory_management, "aimdo_enabled", False)
+        monkeypatch.setattr(mm, "vae_device", lambda: device)
+        return comfy.sd.VAE(sd=sa3_state_dict())
+
+    return build
+
+
+def test_sa3_audio_vae_does_not_default_to_bf16_on_mps(monkeypatch, sa3_vae_factory):
+    # On macOS >= 14 should_use_bf16() approves bf16 for mps, which is the
+    # dtype the audio decode corrupts under; pin the version so the test
+    # exercises that path on any host.
+    monkeypatch.setattr(mm, "mac_version", lambda: (15, 0))
+    vae = sa3_vae_factory(torch.device("mps"))
+    assert vae.vae_dtype != torch.bfloat16
+    assert vae.vae_dtype == torch.float16
+
+
+def test_sa3_audio_vae_keeps_bf16_default_on_cuda(monkeypatch, sa3_vae_factory):
+    # The mps exclusion must not leak: CUDA-like devices (bf16 approved)
+    # keep preferring bf16.
+    monkeypatch.setattr(mm, "should_use_fp16", lambda device=None, **kwargs: True)
+    monkeypatch.setattr(mm, "should_use_bf16", lambda device=None, **kwargs: True)
+    vae = sa3_vae_factory(torch.device("cuda"))
+    assert vae.vae_dtype == torch.bfloat16
+
+
+def test_sa3_audio_vae_explicit_dtype_still_wins(sa3_vae_factory, monkeypatch):
+    # --bf16-vae style overrides bypass working_dtypes entirely.
+    monkeypatch.setattr(comfy.ldm.audio.vae_sa3, "SA3AudioVAE", StubSA3AudioVAE)
+    monkeypatch.setattr(comfy.memory_management, "aimdo_enabled", False)
+    vae = comfy.sd.VAE(sd=sa3_state_dict(), device=torch.device("cpu"), dtype=torch.bfloat16)
+    assert vae.vae_dtype == torch.bfloat16
+
+
+@mps_only
+def test_sa3_audio_vae_picks_fp16_on_mps_hardware(monkeypatch, sa3_vae_factory):
+    vae = sa3_vae_factory(mm.get_torch_device())
+    assert vae.vae_dtype == torch.float16


### PR DESCRIPTION
On Apple Silicon, Stable Audio 3 generations are silently corrupted: the pipeline reports success and writes files of the right length, but the decoded audio is broadband noise. The cause is the VAE decode running in bf16 — `working_dtypes` for the SA3 audio VAE lists bf16 first and `should_use_bf16()` approves it for mps on macOS ≥ 14, so bf16 is the default. fp16 and fp32 decodes of the same latent are correct.

This PR excludes bf16 from the SA3 audio VAE's working dtypes on mps (fp16 becomes the default there) and adds regression tests.

## Reproduction

`stable_audio_3_small_sfx.safetensors` + `t5gemma_b_b_ul2.safetensors`, seed 12345, steps 8, cfg 1.0, lcm/simple, 2.0 s, on an Apple Silicon Mac (macOS 26.5.2, torch 2.10.0). Everything below decodes the **same sampled latent**, so the VAE dtype is the only variable. Repro assets (standalone script, pinned latent, workflow JSON, wav/spectrograms) are attached to [this release on my fork](https://github.com/ChrisLundquist/ComfyUI/releases/tag/sa3-vae-bf16-evidence) and browsable on its [`evidence/sa3-vae-bf16`](https://github.com/ChrisLundquist/ComfyUI/tree/evidence/sa3-vae-bf16) branch:

```
python repro.py --comfy-root /path/to/ComfyUI \
    --ckpt /path/to/stable_audio_3_small_sfx.safetensors --latent latent_s12345.pt
```

| decode | crest | rms | corr vs cpu-fp32 |
|---|---|---|---|
| cpu-fp32 (reference) | 15.49 | 0.060 | 1.0000 |
| cpu-bf16 | 13.13 | 0.197 | **-0.0044** |
| **mps default before (= bf16)** | 13.07 | 0.197 | **-0.0099** |
| mps-fp32 | 15.50 | 0.060 | 1.0000 |
| **mps default after (= fp16)** | 15.69 | 0.060 | **0.9997** |

corr ≈ 1.0 means the decode produces the same sound as the fp32 reference; corr ≈ 0 means the output is unrelated noise. Note the failure is dtype-driven, not device-driven: **cpu-bf16 is equally corrupted**.

| before: bf16 (old mps default) | after: fp16 (new mps default) |
|---|---|
| ![before](https://github.com/ChrisLundquist/ComfyUI/releases/download/sa3-vae-bf16-evidence/before_default_bf16_spectrogram.png) | ![after](https://github.com/ChrisLundquist/ComfyUI/releases/download/sa3-vae-bf16-evidence/after_default_fp16_spectrogram.png) |

Audio decoded from the same latent: [before_default_bf16.wav](https://github.com/ChrisLundquist/ComfyUI/releases/download/sa3-vae-bf16-evidence/before_default_bf16.wav) · [after_default_fp16.wav](https://github.com/ChrisLundquist/ComfyUI/releases/download/sa3-vae-bf16-evidence/after_default_fp16.wav) · [reference_cpu_fp32.wav](https://github.com/ChrisLundquist/ComfyUI/releases/download/sa3-vae-bf16-evidence/reference_cpu_fp32.wav)

## Root cause

The SA3 decoder (`comfy/ldm/audio/vae_sa3.py`) can't run in bf16 on backends whose sdpa computes the softmax in the input dtype:

- The DyT qk "norms" don't normalize magnitude — they emit values around ±30..50 (`gamma * tanh(alpha*x) + beta` with large gamma), so attention logits land in a range where bf16's 8-bit mantissa quantizes in steps of ~0.25–0.5.
- Per-module tracing against an fp32 run shows q/k entering the **first** attention matching fp32 to 0.2%, while that attention's output already diverges ~56%. The error compounds through the 6 transformer blocks, and the final `mapping` conv extracts a small signal (|x| ≈ 0.9) from a large residual stream (|x| ≈ 70), amplifying it to ~950% relative error — hence fully decorrelated output.
- fp16's 3 extra mantissa bits are enough: corr 0.9997 vs fp32. It's a precision failure, not a range failure.

CUDA is believed unaffected because flash/cuDNN sdpa kernels compute the softmax in fp32 internally, which is consistent with no bf16 complaints from CUDA users since #14010. cpu never picks bf16 by default (`vae_dtype()` falls through to fp32). mps uses the math sdpa path, so it hits the bf16 softmax — and the same corruption reproduces on cpu when bf16 is forced, confirming the mechanism is dtype math, not an MPS kernel bug. (Related precedent: #14148 disabled sage attention for this model family for quality reasons.)

## Scope of the change

- **mps + SA3 audio VAE (small and medium configs): default changes bf16 → fp16.** That's the entire behavior change.
- CUDA keeps bf16 (exclusion is gated on `is_device_mps`), cpu keeps fp32, other accelerators unchanged.
- `--bf16-vae` / `--fp16-vae` / `--fp32-vae` overrides still win over `working_dtypes` as before.
- Other audio VAEs are unaffected (oobleck already prefers fp16; LTXV/mmaudio are fp32-only).

## Tests

`tests-unit/comfy_test/audio_vae_mps_test.py`, following the shape of the existing `text_encoder_mps_test.py`:

- `test_sa3_audio_vae_does_not_default_to_bf16_on_mps` — runs on any host (mps device + mac_version mocked).
- `test_sa3_audio_vae_keeps_bf16_default_on_cuda` — guards that the exclusion doesn't leak to CUDA.
- `test_sa3_audio_vae_explicit_dtype_still_wins` — explicit dtype overrides bypass `working_dtypes`.
- `test_sa3_audio_vae_picks_fp16_on_mps_hardware` — mps-only, real device.

Verified the tests fail against unfixed code for the right reason (both mps tests fail with `assert torch.bfloat16 != torch.bfloat16` / `assert torch.bfloat16 == torch.float16`; the CUDA-scope and override tests pass unfixed, as those behaviors are unchanged). Full `tests-unit/` suite: 1130 passed, 11 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
