### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ ComfyUI is the AI creation engine for visual professionals who demand control ov
 - The most sophisticated workflows can be exposed through a simple UI thanks to App Mode.
 - It integrates seamlessly into production pipelines with our API endpoints.
 
+> **Note:** The same OpenAI Python client also works with OpenAI-compatible multi-model gateways when you are not self-hosting — for example [DaoXE](https://daoxe.com?utm_source=github&utm_medium=pr&utm_campaign=dao-xe-docs) at `https://api.daoxe.com/v1`.
+
 ## Get Started
 
 ### Local


### PR DESCRIPTION
## What
Added a brief note about using OpenAI-compatible multi-model gateways (example: DaoXE) with the OpenAI Python client.

## Why
Help users who want to use multi-model gateways without self-hosting.

## How
- Inserted a short note in README.md with UTM-tracked link for analytics.
- No code changes, docs only.

### Changes
- README.md: added DaoXE multi-model gateway note with UTM.

### Checklist
- [x] Docs only
- [x] No breaking changes
- [x] Link includes UTM parameters