### PR TITLE
Catch aimdo transfer fails and retry with mem free

### DIFF
--- a/comfy/memory_management.py
+++ b/comfy/memory_management.py
@@ -15,12 +15,13 @@ class TensorFileSlice(NamedTuple):
     size: int
 
 
-def read_tensor_file_slice_into(tensor, destination, stream=None, destination2=None):
+def read_tensor_file_slice_into(tensor, destination, stream=None, destination2=None, recover_memory=None):
 
     if isinstance(tensor, QuantizedTensor):
         if not read_tensor_file_slice_into(tensor._qdata,
                                            destination._qdata if destination is not None else None, stream=stream,
-                                           destination2=(destination2._qdata if destination2 is not None else None)):
+                                           destination2=(destination2._qdata if destination2 is not None else None),
+                                           recover_memory=recover_memory):
             return False
 
         if destination is not None:
@@ -56,22 +57,37 @@ def read_tensor_file_slice_into(tensor, destination, stream=None, destination2=N
 
     if destination is None:
         stream_ptr = getattr(stream, "cuda_stream", 0) if stream is not None else 0
-        comfy_aimdo.host_buffer.read_file_to_device(file_obj, info.offset, info.size,
-                                                    stream_ptr, destination2.data_ptr(),
-                                                    destination2.device.index,
-                                                    mark_cold=False)
+        for attempt in range(0, 2):
+            try:
+                comfy_aimdo.host_buffer.read_file_to_device(file_obj, info.offset, info.size,
+                                                            stream_ptr, destination2.data_ptr(),
+                                                            destination2.device.index,
+                                                            mark_cold=False)
+                break
+            except RuntimeError:
+                if attempt == 1 or recover_memory is None:
+                    raise
+                recover_memory(destination2.device)
         return True
 
     hostbuf = getattr(destination.untyped_storage(), "_comfy_hostbuf", None)
     if hostbuf is not None:
         stream_ptr = getattr(stream, "cuda_stream", 0) if stream is not None else 0
         device_ptr = destination2.data_ptr() if destination2 is not None else 0
-        with info.lock:
-            hostbuf.read_file_slice(file_obj, info.offset, info.size,
-                                    offset=destination.data_ptr() - hostbuf.get_raw_address(),
-                                    stream=stream_ptr,
-                                    device_ptr=device_ptr,
-                                    device=None if destination2 is None else destination2.device.index)
+        device = destination.device if destination2 is None else destination2.device
+        for attempt in range(0, 2):
+            try:
+                with info.lock:
+                    hostbuf.read_file_slice(file_obj, info.offset, info.size,
+                                            offset=destination.data_ptr() - hostbuf.get_raw_address(),
+                                            stream=stream_ptr,
+                                            device_ptr=device_ptr,
+                                            device=None if destination2 is None else destination2.device.index)
+                break
+            except RuntimeError:
+                if attempt == 1 or recover_memory is None:
+                    raise
+                recover_memory(device)
         return True
 
     if not hasattr(file_obj, "seek") or not hasattr(file_obj, "readinto"):

--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -1486,7 +1486,7 @@ FILE_READ_PANIC_RELEASE_MEMORY = 1024 * 1024 * 1024
 
 def panic_recover_memory(device):
     discard_cuda_async_error()
-    free_memory(FILE_READ_PANIC_RELEASE_MEMORY, device)
+    free_pins(FILE_READ_PANIC_RELEASE_MEMORY, evict_active=True)
     ensure_pin_registerable(FILE_READ_PANIC_RELEASE_MEMORY)
 
 

--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -1482,6 +1482,14 @@ def sync_stream(device, stream):
     current_stream(device).wait_stream(stream)
 
 
+FILE_READ_PANIC_RELEASE_MEMORY = 1024 * 1024 * 1024
+
+def panic_recover_memory(device):
+    discard_cuda_async_error()
+    free_memory(FILE_READ_PANIC_RELEASE_MEMORY, device)
+    ensure_pin_registerable(FILE_READ_PANIC_RELEASE_MEMORY)
+
+
 def cast_to_gathered(tensors, r, non_blocking=False, stream=None, r2=None):
     wf_context = nullcontext()
     if stream is not None:
@@ -1497,7 +1505,7 @@ def cast_to_gathered(tensors, r, non_blocking=False, stream=None, r2=None):
             dest2_view = dest2_views.pop(0) if dest2_views is not None else None
             if tensor is None:
                 continue
-            if comfy.memory_management.read_tensor_file_slice_into(tensor, dest_view, stream=stream, destination2=dest2_view):
+            if comfy.memory_management.read_tensor_file_slice_into(tensor, dest_view, stream=stream, destination2=dest2_view, recover_memory=panic_recover_memory):
                 continue
             storage = tensor._qdata.untyped_storage() if isinstance(tensor, comfy.quant_ops.QuantizedTensor) else tensor.untyped_storage()
             mark_mmap_dirty(storage)

--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -1593,7 +1593,10 @@ def discard_cuda_async_error():
         synchronize()
     except RuntimeError:
         #Dump it! We already know about it from the synchronous return
-        pass
+        try:
+            synchronize()
+        except RuntimeError:
+            pass
 
 def pin_memory(tensor):
     global TOTAL_PINNED_MEMORY

--- a/comfy/pinned_memory.py
+++ b/comfy/pinned_memory.py
@@ -60,7 +60,10 @@ def get_pin(module, subset="weights"):
 
     if torch.cuda.cudart().cudaHostRegister(pin.data_ptr(), size, 1) != 0:
         comfy.model_management.discard_cuda_async_error()
-        return pin
+        comfy.model_management.free_registrations(size)
+        if torch.cuda.cudart().cudaHostRegister(pin.data_ptr(), size, 1) != 0:
+            comfy.model_management.discard_cuda_async_error()
+            return pin
 
     module_pin["registered"] = True
     stack_split[0] = max(stack_split[0], module_pin["stack_index"])


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI/issues/15255

I have never reproduced the issue yet but this is a symptomatic fix to the traces shown that might fit.

This specifically addresses the memory-pressure presentation of the bug.

There is a theory that it can occur in multi-gpu setups under low ram, which would not be addressed (although its entirely possible the retry unsticks them just in dumb luck).