### PR TITLE
Reserve the memory required by MiniMaxH3TEModel to encode images

### DIFF
--- a/comfy/text_encoders/minimax.py
+++ b/comfy/text_encoders/minimax.py
@@ -122,9 +122,9 @@ class MiniMaxH3TEModel(comfy.sd1_clip.SD1ClipModel):
                          clip_model=MiniMaxH3ClipModel, model_options=model_options)
 
     def memory_estimation_function(self, token_weight_pairs, device=None):
-        text = 1024 * 1024 * 1024
+        text = 2.0 * 1024 * 1024 * 1024  # ~2 GB
 
-        constant = 0.25
+        constant = 0.14  # ~400 MB per RGB Megapixel
         image_dim = 0
 
         token_weight_pairs: list[list[tuple[int | dict, float]]] = token_weight_pairs.get("qwen3vl_32b", [])
@@ -134,7 +134,7 @@ class MiniMaxH3TEModel(comfy.sd1_clip.SD1ClipModel):
                     continue
                 if token["type"] == "image":
                     tensor: torch.Tensor = token["data"]
-                    image_dim += tensor.numel()
+                    image_dim += tensor.numel()  # B, H, W, C
 
         return image_dim * constant * 1024 + text
 

--- a/comfy/text_encoders/minimax.py
+++ b/comfy/text_encoders/minimax.py
@@ -121,6 +121,21 @@ class MiniMaxH3TEModel(comfy.sd1_clip.SD1ClipModel):
         super().__init__(device=device, dtype=dtype, name="qwen3vl_32b",
                          clip_model=MiniMaxH3ClipModel, model_options=model_options)
 
+    def memory_estimation_function(self, token_weight_pairs, device=None):
+        constant = 0.6
+        image_dim = 0
+
+        token_weight_pairs: list[list[tuple[int | dict, float]]] = token_weight_pairs.get("qwen3vl_32b", [])
+        for batch in token_weight_pairs:
+            for token, weight in batch:
+                if not isinstance(token, dict):
+                    continue
+                if token["type"] == "image":
+                    tensor: torch.Tensor = token["data"]
+                    image_dim += tensor.numel()
+
+        return image_dim * constant * 1024
+
 
 class MiniMaxH3Tokenizer(comfy.sd1_clip.SD1Tokenizer):
     def __init__(self, embedding_directory=None, tokenizer_data={}):

--- a/comfy/text_encoders/minimax.py
+++ b/comfy/text_encoders/minimax.py
@@ -122,7 +122,9 @@ class MiniMaxH3TEModel(comfy.sd1_clip.SD1ClipModel):
                          clip_model=MiniMaxH3ClipModel, model_options=model_options)
 
     def memory_estimation_function(self, token_weight_pairs, device=None):
-        constant = 0.72
+        text = 1024 * 1024 * 1024
+
+        constant = 0.25
         image_dim = 0
 
         token_weight_pairs: list[list[tuple[int | dict, float]]] = token_weight_pairs.get("qwen3vl_32b", [])
@@ -134,7 +136,7 @@ class MiniMaxH3TEModel(comfy.sd1_clip.SD1ClipModel):
                     tensor: torch.Tensor = token["data"]
                     image_dim += tensor.numel()
 
-        return image_dim * constant * 1024
+        return image_dim * constant * 1024 + text
 
 
 class MiniMaxH3Tokenizer(comfy.sd1_clip.SD1Tokenizer):

--- a/comfy/text_encoders/minimax.py
+++ b/comfy/text_encoders/minimax.py
@@ -122,7 +122,7 @@ class MiniMaxH3TEModel(comfy.sd1_clip.SD1ClipModel):
                          clip_model=MiniMaxH3ClipModel, model_options=model_options)
 
     def memory_estimation_function(self, token_weight_pairs, device=None):
-        constant = 0.6
+        constant = 0.72
         image_dim = 0
 
         token_weight_pairs: list[list[tuple[int | dict, float]]] = token_weight_pairs.get("qwen3vl_32b", [])


### PR DESCRIPTION
#### Problem

When using **MiniMax H3** to do **I2V**, the system often hangs (`1+ min`) at the `MiniMax H3 Image to Video` node. But when doing simple **T2V**, the node finishes instantly (`~5 sec`) instead. This is because the `load_model` only checks for the size of the model, it did not account for the images. So after the model is loaded, encoding the images exceeds the VRAM budget, hence the slow down. 

*(**tip:** using `--reserve-vram 2.5` does help with this problem)*

#### Solution

Use the existing `memory_estimation_function` framework to allocate the memory needed to encode the images *(the `constant` was manually calculated and tested)*

*(**note:** audio and video are not handled)*

#### Result

With this change, when doing **FI2VA**, the `MiniMax H3 Image to Video` node also finishes instantly (`~10 sec`) without having to rely on `--reserve-vram` 

#### Testing Environment

- **GPU:** RTX 4070 Ti S (`16 GB VRAM`)
- **RAM:** 96 GB
- **OS:** Windows 10
- `--disable-dynamic-vram`