### PR TITLE
Add MiniMax H3 pruned complete LoRA support to official LoraLoader

### DIFF
--- a/comfy/ldm/minimax/pruned_lora.py
+++ b/comfy/ldm/minimax/pruned_lora.py
@@ -43,6 +43,27 @@ def has_pruned_adaln(lora):
     )
 
 
+def has_legacy_dora(lora):
+    """Detect the node package's legacy ``diff_b`` DoRA convention.
+
+    ComfyUI's official ``diff_b`` handling is a 1-D bias diff.  A 2-D
+    ``diff_b``, or a ``diff_b`` paired with ``lora_A`` on the same base, means
+    the LoRA was produced with the legacy LyCORIS-style DoRA convention used by
+    the MiniMax node package.  Loading it through the official LoraLoader
+    would silently treat it as a bias diff.
+    """
+    for k in lora:
+        if k.endswith(".lora_A.weight"):
+            base = k[: -len(".lora_A.weight")]
+        elif k.endswith(".lora_down.weight"):
+            base = k[: -len(".lora_down.weight")]
+        else:
+            continue
+        if base + ".diff_b" in lora:
+            return True
+    return False
+
+
 def adaln_adapter_compatible(patch, target_shape):
     if isinstance(patch, tuple):
         if len(patch) == 2 and patch[0] == "diff":

--- a/comfy/ldm/minimax/pruned_lora.py
+++ b/comfy/ldm/minimax/pruned_lora.py
@@ -1,0 +1,163 @@
+"""MiniMax H3 pruned AdaLN LoRA helpers.
+
+These helpers are model-specific and live in the MiniMax module instead of
+``comfy/sd.py``.  ``sd.py`` only calls them from ``load_lora_for_models``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import torch
+
+
+def set_patch_value(patch):
+    if not isinstance(patch, tuple) or len(patch) != 2:
+        return None
+    if patch[0] != "set" or not isinstance(patch[1], tuple) or len(patch[1]) != 1:
+        return None
+    return patch[1][0]
+
+
+def existing_set(model, key):
+    for p in model.patches.get(key, []):
+        value = set_patch_value(p[1])
+        if value is not None:
+            return value
+    return None
+
+
+def has_pruned_adaln(lora):
+    return (
+        "adaln_t_table" in lora
+        or "diffusion_model.adaln_t_table" in lora
+        or "adaln_t_table.set_weight" in lora
+        or "diffusion_model.adaln_t_table.set_weight" in lora
+        or any(
+            ".adaln_proj.linear.weight" in k
+            or ".adaln_proj.linear.bias" in k
+            or ".adaln_proj.linear.weight.set_weight" in k
+            or ".adaln_proj.linear.bias.set_weight" in k
+            for k in lora
+        )
+    )
+
+
+def adaln_adapter_compatible(patch, target_shape):
+    if isinstance(patch, tuple):
+        return True
+    weights = getattr(patch, "weights", None)
+    if not weights or len(weights) < 2:
+        return False
+    return (
+        weights[0].shape[0] == target_shape[0]
+        and weights[1].shape[-1] == target_shape[-1]
+    )
+
+
+def apply_merged_adaln_patches(patcher, merged):
+    for key, patch in merged:
+        existing = patcher.patches.get(key, [])
+        preserved = [(1.0, patch, 1.0, None, None)]
+        preserved.extend([
+            p for p in existing
+            if set_patch_value(p[1]) is None
+        ])
+        patcher.patches[key] = preserved
+
+
+def merge_adaln_patches(model, loaded, model_sd, strength_model):
+    """Merge stacked complete pruned AdaLN set patches at the loader boundary.
+
+    Standard ``set`` patches replace the target weight, so loading two complete
+    pruned LoRAs through separate LoraLoader nodes would otherwise overwrite the
+    first LoRA's AdaLN projection.  This helper converts the incoming set patch
+    into a delta relative to the original model weight and combines it with the
+    existing full replacement:
+
+        combined = current_full + strength * (new_full - base)
+
+    The table itself is kept from the existing/base model.  If the incoming
+    LoRA carries a different table, the merge still runs but is approximate.
+    """
+    current_table = None
+    new_table = None
+    for key in model_sd:
+        if key.endswith("adaln_t_table"):
+            current_table = existing_set(model, key)
+            if current_table is None:
+                current_table = model_sd[key]
+            break
+    for key in loaded:
+        if key.endswith("adaln_t_table"):
+            new_table = set_patch_value(loaded[key])
+            break
+
+    table_warned = False
+    if current_table is not None and new_table is not None:
+        if current_table.shape != new_table.shape:
+            table_warned = True
+        else:
+            target_device = current_table.device
+            current_table = current_table.to(target_device)
+            new_table = new_table.to(target_device)
+            if (current_table.float() - new_table.float()).abs().max().item() > 1e-3:
+                table_warned = True
+    if table_warned:
+        logging.warning(
+            "MiniMax H3 pruned LoRA merge: adaln_t_table differs between "
+            "stacked LoRAs. Projection deltas are still merged, but results "
+            "are approximate; use a shared fixed table or generate a combined "
+            "complete pruned LoRA."
+        )
+
+    merged = []
+    for key in list(loaded):
+        if not (
+            key.endswith("adaln_t_table")
+            or key.endswith(".adaln_proj.linear.weight")
+            or key.endswith(".adaln_proj.linear.bias")
+        ):
+            continue
+        new_full = set_patch_value(loaded[key])
+        if new_full is None:
+            continue
+
+        if key.endswith("adaln_t_table"):
+            base = model_sd.get(key)
+            if base is not None:
+                merged.append((key, ("set", (base,))))
+            else:
+                merged.append((key, ("set", (new_full,))))
+            loaded.pop(key)
+            continue
+
+        base = model_sd.get(key)
+        if base is None:
+            continue
+        current_full = existing_set(model, key)
+        if current_full is None:
+            current_full = base
+        if current_full.shape != new_full.shape or current_full.shape != base.shape:
+            loaded.pop(key)
+            logging.warning(
+                "MiniMax H3 pruned LoRA merge skipped for %s: shape mismatch "
+                "current=%s new=%s base=%s",
+                key,
+                tuple(current_full.shape),
+                tuple(new_full.shape),
+                tuple(base.shape),
+            )
+            continue
+        target_device = base.device
+        current_full = current_full.to(target_device)
+        new_full = new_full.to(target_device)
+        base = base.to(target_device)
+        combined = (
+            current_full.float()
+            + strength_model * (new_full.float() - base.float())
+        ).to(base.dtype)
+        merged.append((key, ("set", (combined,))))
+        loaded.pop(key)
+
+    return merged

--- a/comfy/ldm/minimax/pruned_lora.py
+++ b/comfy/ldm/minimax/pruned_lora.py
@@ -52,7 +52,13 @@ def has_legacy_dora(lora):
     the MiniMax node package.  Loading it through the official LoraLoader
     would silently treat it as a bias diff.
     """
-    for k in lora:
+    for k, v in lora.items():
+        if (
+            isinstance(v, torch.Tensor)
+            and k.endswith(".diff_b")
+            and v.dim() == 2
+        ):
+            return True
         if k.endswith(".lora_A.weight"):
             base = k[: -len(".lora_A.weight")]
         elif k.endswith(".lora_down.weight"):

--- a/comfy/ldm/minimax/pruned_lora.py
+++ b/comfy/ldm/minimax/pruned_lora.py
@@ -46,7 +46,7 @@ def has_pruned_adaln(lora):
 def adaln_adapter_compatible(patch, target_shape):
     if isinstance(patch, tuple):
         return True
-    weights = getattr(patch, "weights", None)
+    weights = patch.weights
     if not weights or len(weights) < 2:
         return False
     return (
@@ -99,7 +99,6 @@ def merge_adaln_patches(model, loaded, model_sd, strength_model):
             table_warned = True
         else:
             target_device = current_table.device
-            current_table = current_table.to(target_device)
             new_table = new_table.to(target_device)
             if (current_table.float() - new_table.float()).abs().max().item() > 1e-3:
                 table_warned = True
@@ -125,9 +124,7 @@ def merge_adaln_patches(model, loaded, model_sd, strength_model):
 
         if key.endswith("adaln_t_table"):
             base = model_sd.get(key)
-            if base is not None:
-                merged.append((key, ("set", (base,))))
-            else:
+            if base is None:
                 merged.append((key, ("set", (new_full,))))
             loaded.pop(key)
             continue
@@ -152,7 +149,6 @@ def merge_adaln_patches(model, loaded, model_sd, strength_model):
         target_device = base.device
         current_full = current_full.to(target_device)
         new_full = new_full.to(target_device)
-        base = base.to(target_device)
         combined = (
             current_full.float()
             + strength_model * (new_full.float() - base.float())

--- a/comfy/ldm/minimax/pruned_lora.py
+++ b/comfy/ldm/minimax/pruned_lora.py
@@ -45,6 +45,10 @@ def has_pruned_adaln(lora):
 
 def adaln_adapter_compatible(patch, target_shape):
     if isinstance(patch, tuple):
+        if len(patch) == 2 and patch[0] == "diff":
+            data = patch[1]
+            if isinstance(data, tuple) and data:
+                return data[0].shape == target_shape
         return True
     weights = patch.weights
     if not weights or len(weights) < 2:

--- a/comfy/lora.py
+++ b/comfy/lora.py
@@ -37,7 +37,40 @@ LORA_CLIP_MAP = {
 def load_lora(lora, to_load, log_missing=True):
     patch_dict = {}
     loaded_keys = set()
+    adaln_skip_warned = set()
     for x in to_load:
+        is_adaln_full = (
+            ".adaln_proj.linear" in x
+            or x in ("adaln_t_table", "diffusion_model.adaln_t_table")
+            or "final_layer.adaln_proj.linear" in x
+        )
+        direct_weight_name = "{}.weight".format(x)
+        if is_adaln_full and direct_weight_name in lora:
+            patch_dict[to_load[x]] = ("set", (lora[direct_weight_name],))
+            loaded_keys.add(direct_weight_name)
+        direct_bias_name = "{}.bias".format(x)
+        if (is_adaln_full and direct_bias_name in lora
+                and to_load[x].endswith(".weight")):
+            bias_target = to_load[x][:-len(".weight")] + ".bias"
+            patch_dict[bias_target] = ("set", (lora[direct_bias_name],))
+            loaded_keys.add(direct_bias_name)
+        if is_adaln_full and x in lora:
+            patch_dict[to_load[x]] = ("set", (lora[x],))
+            loaded_keys.add(x)
+        if is_adaln_full and not (
+            direct_weight_name in lora
+            or direct_bias_name in lora
+            or x in lora
+        ):
+            warn_key = x.split("diffusion_model.", 1)[-1]
+            if ".adaln_proj.linear" in warn_key and warn_key not in adaln_skip_warned:
+                adaln_skip_warned.add(warn_key)
+                logging.warning(
+                    "MiniMax H3 pruned: AdaLN LoRA key %s skipped; "
+                    "use a complete pruned LoRA or bake it into table/projection.",
+                    x)
+            continue
+
         alpha_name = "{}.alpha".format(x)
         alpha = None
         if alpha_name in lora.keys():
@@ -196,6 +229,22 @@ def model_lora_keys_unet(model, key_map={}):
                 key_map["{}".format(k[:-len(".weight")])] = k #generic lora format without any weird key names
             else:
                 key_map["{}".format(k)] = k #generic lora format for not .weight without any weird key names
+
+    if isinstance(model, comfy.model_base.MiniMaxH3):
+        use_curves = bool(getattr(model.diffusion_model, "use_adaln_curves", False))
+        for k in sdk:
+            if k.startswith("diffusion_model."):
+                unprefixed = k[len("diffusion_model."):]
+                if k.endswith(".weight"):
+                    lora_base = unprefixed[:-len(".weight")]
+                    if use_curves or not (
+                        ".adaln_proj.linear" in lora_base
+                        or lora_base == "final_layer.adaln_proj.linear"
+                    ):
+                        key_map[lora_base] = k
+                else:
+                    if use_curves or unprefixed != "adaln_t_table":
+                        key_map[unprefixed] = k
 
     diffusers_keys = comfy.utils.unet_to_diffusers(model.model_config.unet_config)
     for k in diffusers_keys:

--- a/comfy/lora.py
+++ b/comfy/lora.py
@@ -37,38 +37,24 @@ LORA_CLIP_MAP = {
 def load_lora(lora, to_load, log_missing=True):
     patch_dict = {}
     loaded_keys = set()
-    adaln_skip_warned = set()
     for x in to_load:
-        is_adaln_full = (
-            ".adaln_proj.linear" in x
-            or x in ("adaln_t_table", "diffusion_model.adaln_t_table")
-            or "final_layer.adaln_proj.linear" in x
-        )
         direct_weight_name = "{}.weight".format(x)
-        if is_adaln_full and direct_weight_name in lora:
+        if direct_weight_name in lora:
             patch_dict[to_load[x]] = ("set", (lora[direct_weight_name],))
             loaded_keys.add(direct_weight_name)
         direct_bias_name = "{}.bias".format(x)
-        if (is_adaln_full and direct_bias_name in lora
-                and to_load[x].endswith(".weight")):
+        if direct_bias_name in lora and to_load[x].endswith(".weight"):
             bias_target = to_load[x][:-len(".weight")] + ".bias"
             patch_dict[bias_target] = ("set", (lora[direct_bias_name],))
             loaded_keys.add(direct_bias_name)
-        if is_adaln_full and x in lora:
+        if x in lora:
             patch_dict[to_load[x]] = ("set", (lora[x],))
             loaded_keys.add(x)
-        if is_adaln_full and not (
+        if (
             direct_weight_name in lora
             or direct_bias_name in lora
             or x in lora
         ):
-            warn_key = x.split("diffusion_model.", 1)[-1]
-            if ".adaln_proj.linear" in warn_key and warn_key not in adaln_skip_warned:
-                adaln_skip_warned.add(warn_key)
-                logging.warning(
-                    "MiniMax H3 pruned: AdaLN LoRA key %s skipped; "
-                    "use a complete pruned LoRA or bake it into table/projection.",
-                    x)
             continue
 
         alpha_name = "{}.alpha".format(x)
@@ -231,7 +217,7 @@ def model_lora_keys_unet(model, key_map={}):
                 key_map["{}".format(k)] = k #generic lora format for not .weight without any weird key names
 
     if isinstance(model, comfy.model_base.MiniMaxH3):
-        use_curves = bool(getattr(model.diffusion_model, "use_adaln_curves", False))
+        use_curves = bool(model.diffusion_model.use_adaln_curves)
         for k in sdk:
             if k.startswith("diffusion_model."):
                 unprefixed = k[len("diffusion_model."):]

--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -240,7 +240,7 @@ def _merge_minimax_h3_adaln_patches(model, loaded, model_sd, strength_model):
         combined = (
             current_full.float()
             + strength_model * (new_full.float() - base.float())
-        ).to(new_full.dtype)
+        ).to(base.dtype)
         merged.append((key, ("set", (combined,))))
         loaded.pop(key)
 

--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -100,9 +100,10 @@ def load_lora_for_models(model, clip, lora, strength_model, strength_clip, lora_
     if model is not None:
         key_map = comfy.lora.model_lora_keys_unet(model.model, key_map)
         if isinstance(model.model, comfy.model_base.MiniMaxH3):
-            use_curves = bool(getattr(model.model.diffusion_model, "use_adaln_curves", False))
+            use_curves = bool(model.model.diffusion_model.use_adaln_curves)
             has_pruned_adaln = (
                 "adaln_t_table" in lora
+                or "diffusion_model.adaln_t_table" in lora
                 or any(
                     ".adaln_proj.linear.weight" in k
                     or ".adaln_proj.linear.bias" in k
@@ -118,6 +119,21 @@ def load_lora_for_models(model, clip, lora, strength_model, strength_clip, lora_
 
     lora = comfy.lora_convert.convert_lora(lora)
     loaded = comfy.lora.load_lora(lora, key_map)
+    if model is not None and isinstance(model.model, comfy.model_base.MiniMaxH3):
+        if model.model.diffusion_model.use_adaln_curves:
+            incompatible_adaln = {}
+            for target, patch in loaded.items():
+                if target.endswith(".adaln_proj.linear.weight") and not (
+                    isinstance(patch, tuple) and patch and patch[0] == "set"
+                ):
+                    incompatible_adaln[target] = patch
+            if incompatible_adaln:
+                for target in incompatible_adaln:
+                    loaded.pop(target)
+                logging.warning(
+                    "MiniMax H3 pruned: incompatible 2688-dim AdaLN LoRA "
+                    "patches skipped; use a complete pruned LoRA or bake it "
+                    "into table/projection.")
     if model is not None:
         new_modelpatcher = model.clone()
         k = new_modelpatcher.add_patches(loaded, strength_model)

--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -95,156 +95,7 @@ import comfy.latent_formats
 
 import comfy.ldm.flux.redux
 
-def _mini_max_h3_set_patch_value(patch):
-    if not isinstance(patch, tuple) or len(patch) != 2:
-        return None
-    if patch[0] != "set" or not isinstance(patch[1], tuple) or len(patch[1]) != 1:
-        return None
-    return patch[1][0]
-
-
-def _mini_max_h3_existing_set(model, key):
-    for p in model.patches.get(key, []):
-        value = _mini_max_h3_set_patch_value(p[1])
-        if value is not None:
-            return value
-    return None
-
-
-def _mini_max_h3_has_pruned_adaln(lora):
-    return (
-        "adaln_t_table" in lora
-        or "diffusion_model.adaln_t_table" in lora
-        or "adaln_t_table.set_weight" in lora
-        or "diffusion_model.adaln_t_table.set_weight" in lora
-        or any(
-            ".adaln_proj.linear.weight" in k
-            or ".adaln_proj.linear.bias" in k
-            or ".adaln_proj.linear.weight.set_weight" in k
-            or ".adaln_proj.linear.bias.set_weight" in k
-            for k in lora
-        )
-    )
-
-
-def _mini_max_h3_adaln_adapter_compatible(patch, target_shape):
-    if isinstance(patch, tuple):
-        return True
-    weights = getattr(patch, "weights", None)
-    if not weights or len(weights) < 2:
-        return False
-    return (
-        weights[0].shape[0] == target_shape[0]
-        and weights[1].shape[-1] == target_shape[-1]
-    )
-
-
-def _apply_merged_minimax_h3_adaln_patches(patcher, merged):
-    for key, patch in merged:
-        existing = patcher.patches.get(key, [])
-        preserved = [(1.0, patch, 1.0, None, None)]
-        preserved.extend([
-            p for p in existing
-            if _mini_max_h3_set_patch_value(p[1]) is None
-        ])
-        patcher.patches[key] = preserved
-
-
-def _merge_minimax_h3_adaln_patches(model, loaded, model_sd, strength_model):
-    """Merge stacked complete pruned AdaLN set patches at the loader boundary.
-
-    Standard ``set`` patches replace the target weight, so loading two complete
-    pruned LoRAs through separate LoraLoader nodes would otherwise overwrite the
-    first LoRA's AdaLN projection.  This helper converts the incoming set patch
-    into a delta relative to the original model weight and combines it with the
-    existing full replacement:
-
-        combined = current_full + strength * (new_full - base)
-
-    The table itself is kept from the existing/base model.  If the incoming
-    LoRA carries a different table, the merge still runs but is approximate.
-    """
-    current_table = None
-    new_table = None
-    for key in model_sd:
-        if key.endswith("adaln_t_table"):
-            current_table = _mini_max_h3_existing_set(model, key)
-            if current_table is None:
-                current_table = model_sd[key]
-            break
-    for key in loaded:
-        if key.endswith("adaln_t_table"):
-            new_table = _mini_max_h3_set_patch_value(loaded[key])
-            break
-
-    table_warned = False
-    if current_table is not None and new_table is not None:
-        if current_table.shape != new_table.shape:
-            table_warned = True
-        else:
-            target_device = current_table.device
-            current_table = current_table.to(target_device)
-            new_table = new_table.to(target_device)
-            if (current_table.float() - new_table.float()).abs().max().item() > 1e-3:
-                table_warned = True
-    if table_warned:
-        logging.warning(
-            "MiniMax H3 pruned LoRA merge: adaln_t_table differs between "
-            "stacked LoRAs. Projection deltas are still merged, but results "
-            "are approximate; use a shared fixed table or generate a combined "
-            "complete pruned LoRA."
-        )
-
-    merged = []
-    for key in list(loaded):
-        if not (
-            key.endswith("adaln_t_table")
-            or key.endswith(".adaln_proj.linear.weight")
-            or key.endswith(".adaln_proj.linear.bias")
-        ):
-            continue
-        new_full = _mini_max_h3_set_patch_value(loaded[key])
-        if new_full is None:
-            continue
-
-        if key.endswith("adaln_t_table"):
-            base = model_sd.get(key)
-            if base is not None:
-                merged.append((key, ("set", (base,))))
-            else:
-                merged.append((key, ("set", (new_full,))))
-            loaded.pop(key)
-            continue
-
-        base = model_sd.get(key)
-        if base is None:
-            continue
-        current_full = _mini_max_h3_existing_set(model, key)
-        if current_full is None:
-            current_full = base
-        if current_full.shape != new_full.shape or current_full.shape != base.shape:
-            loaded.pop(key)
-            logging.warning(
-                "MiniMax H3 pruned LoRA merge skipped for %s: shape mismatch "
-                "current=%s new=%s base=%s",
-                key,
-                tuple(current_full.shape),
-                tuple(new_full.shape),
-                tuple(base.shape),
-            )
-            continue
-        target_device = base.device
-        current_full = current_full.to(target_device)
-        new_full = new_full.to(target_device)
-        base = base.to(target_device)
-        combined = (
-            current_full.float()
-            + strength_model * (new_full.float() - base.float())
-        ).to(base.dtype)
-        merged.append((key, ("set", (combined,))))
-        loaded.pop(key)
-
-    return merged
+from comfy.ldm.minimax import pruned_lora
 
 
 def load_lora_for_models(model, clip, lora, strength_model, strength_clip, lora_metadata=None):
@@ -253,7 +104,7 @@ def load_lora_for_models(model, clip, lora, strength_model, strength_clip, lora_
         key_map = comfy.lora.model_lora_keys_unet(model.model, key_map)
         if isinstance(model.model, comfy.model_base.MiniMaxH3):
             use_curves = bool(model.model.diffusion_model.use_adaln_curves)
-            has_pruned_adaln = _mini_max_h3_has_pruned_adaln(lora)
+            has_pruned_adaln = pruned_lora.has_pruned_adaln(lora)
             if has_pruned_adaln and not use_curves:
                 logging.warning(
                     "MiniMax H3 non-pruned model: complete pruned AdaLN "
@@ -280,7 +131,7 @@ def load_lora_for_models(model, clip, lora, strength_model, strength_clip, lora_
                     loaded.pop(target)
                     removed_incompatible = True
             elif target.endswith(".adaln_proj.linear.weight") and target in model_sd:
-                if not _mini_max_h3_adaln_adapter_compatible(
+                if not pruned_lora.adaln_adapter_compatible(
                     patch, model_sd[target].shape
                 ):
                     loaded.pop(target)
@@ -294,12 +145,12 @@ def load_lora_for_models(model, clip, lora, strength_model, strength_clip, lora_
     if model is not None and isinstance(model.model, comfy.model_base.MiniMaxH3):
         use_curves = bool(model.model.diffusion_model.use_adaln_curves)
         if use_curves:
-            merged_adaln = _merge_minimax_h3_adaln_patches(
+            merged_adaln = pruned_lora.merge_adaln_patches(
                 model, loaded, model_sd, strength_model
             )
     if model is not None:
         new_modelpatcher = model.clone()
-        _apply_merged_minimax_h3_adaln_patches(new_modelpatcher, merged_adaln)
+        pruned_lora.apply_merged_adaln_patches(new_modelpatcher, merged_adaln)
         k = new_modelpatcher.add_patches(loaded, strength_model)
         if lora_metadata:
             new_modelpatcher.set_attachments("lora_metadata", lora_metadata)

--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -4,6 +4,7 @@ from enum import Enum
 import logging
 
 from comfy import model_management
+import comfy.model_base
 from comfy.utils import ProgressBar
 from .ldm.models.autoencoder import AutoencoderKL, AutoencodingEngine
 from .ldm.cascade.stage_a import StageA
@@ -98,6 +99,20 @@ def load_lora_for_models(model, clip, lora, strength_model, strength_clip, lora_
     key_map = {}
     if model is not None:
         key_map = comfy.lora.model_lora_keys_unet(model.model, key_map)
+        if isinstance(model.model, comfy.model_base.MiniMaxH3):
+            use_curves = bool(getattr(model.model.diffusion_model, "use_adaln_curves", False))
+            has_pruned_adaln = (
+                "adaln_t_table" in lora
+                or any(
+                    ".adaln_proj.linear.weight" in k
+                    or ".adaln_proj.linear.bias" in k
+                    for k in lora
+                )
+            )
+            if has_pruned_adaln and not use_curves:
+                logging.warning(
+                    "MiniMax H3 non-pruned model: complete pruned AdaLN "
+                    "replacement keys will be skipped.")
     if clip is not None:
         key_map = comfy.lora.model_lora_keys_clip(clip.cond_stage_model, key_map)
 

--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -167,7 +167,7 @@ def _merge_minimax_h3_adaln_patches(model, loaded, model_sd, strength_model):
         if key.endswith("adaln_t_table"):
             base = model_sd.get(key)
             if base is not None:
-                merged.append((key, ("set", (base.float().to(new_full.dtype),))))
+                merged.append((key, ("set", (base,))))
             else:
                 merged.append((key, ("set", (new_full,))))
             loaded.pop(key)
@@ -180,6 +180,7 @@ def _merge_minimax_h3_adaln_patches(model, loaded, model_sd, strength_model):
         if current_full is None:
             current_full = base
         if current_full.shape != new_full.shape or current_full.shape != base.shape:
+            loaded.pop(key)
             logging.warning(
                 "MiniMax H3 pruned LoRA merge skipped for %s: shape mismatch "
                 "current=%s new=%s base=%s",

--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -95,6 +95,110 @@ import comfy.latent_formats
 
 import comfy.ldm.flux.redux
 
+def _mini_max_h3_set_patch_value(patch):
+    if not isinstance(patch, tuple) or len(patch) != 2:
+        return None
+    if patch[0] != "set" or not isinstance(patch[1], tuple) or len(patch[1]) != 1:
+        return None
+    return patch[1][0]
+
+
+def _mini_max_h3_existing_set(model, key):
+    for p in model.patches.get(key, []):
+        value = _mini_max_h3_set_patch_value(p[1])
+        if value is not None:
+            return value
+    return None
+
+
+def _merge_minimax_h3_adaln_patches(model, loaded, model_sd, strength_model):
+    """Merge stacked complete pruned AdaLN set patches at the loader boundary.
+
+    Standard ``set`` patches replace the target weight, so loading two complete
+    pruned LoRAs through separate LoraLoader nodes would otherwise overwrite the
+    first LoRA's AdaLN projection.  This helper converts the incoming set patch
+    into a delta relative to the original model weight and combines it with the
+    existing full replacement:
+
+        combined = current_full + strength * (new_full - base)
+
+    The table itself is kept from the existing/base model.  If the incoming
+    LoRA carries a different table, the merge still runs but is approximate.
+    """
+    current_table = None
+    new_table = None
+    for key in model_sd:
+        if key.endswith("adaln_t_table"):
+            current_table = _mini_max_h3_existing_set(model, key)
+            if current_table is None:
+                current_table = model_sd[key]
+            break
+    for key in loaded:
+        if key.endswith("adaln_t_table"):
+            new_table = _mini_max_h3_set_patch_value(loaded[key])
+            break
+
+    table_warned = False
+    if current_table is not None and new_table is not None:
+        if current_table.shape != new_table.shape:
+            table_warned = True
+        elif (current_table.float() - new_table.float()).abs().max().item() > 1e-3:
+            table_warned = True
+    if table_warned:
+        logging.warning(
+            "MiniMax H3 pruned LoRA merge: adaln_t_table differs between "
+            "stacked LoRAs. Projection deltas are still merged, but results "
+            "are approximate; use a shared fixed table or generate a combined "
+            "complete pruned LoRA."
+        )
+
+    merged = []
+    for key in list(loaded):
+        if not (
+            key.endswith("adaln_t_table")
+            or key.endswith(".adaln_proj.linear.weight")
+            or key.endswith(".adaln_proj.linear.bias")
+        ):
+            continue
+        new_full = _mini_max_h3_set_patch_value(loaded[key])
+        if new_full is None:
+            continue
+
+        if key.endswith("adaln_t_table"):
+            base = model_sd.get(key)
+            if base is not None:
+                merged.append((key, ("set", (base.float().to(new_full.dtype),))))
+            else:
+                merged.append((key, ("set", (new_full,))))
+            loaded.pop(key)
+            continue
+
+        base = model_sd.get(key)
+        if base is None:
+            continue
+        current_full = _mini_max_h3_existing_set(model, key)
+        if current_full is None:
+            current_full = base
+        if current_full.shape != new_full.shape or current_full.shape != base.shape:
+            logging.warning(
+                "MiniMax H3 pruned LoRA merge skipped for %s: shape mismatch "
+                "current=%s new=%s base=%s",
+                key,
+                tuple(current_full.shape),
+                tuple(new_full.shape),
+                tuple(base.shape),
+            )
+            continue
+        combined = (
+            current_full.float()
+            + strength_model * (new_full.float() - base.float())
+        ).to(new_full.dtype)
+        merged.append((key, ("set", (combined,))))
+        loaded.pop(key)
+
+    return merged
+
+
 def load_lora_for_models(model, clip, lora, strength_model, strength_clip, lora_metadata=None):
     key_map = {}
     if model is not None:
@@ -146,8 +250,18 @@ def load_lora_for_models(model, clip, lora, strength_model, strength_clip, lora_
                 "MiniMax H3 pruned: incompatible 2688-dim AdaLN LoRA "
                 "patches skipped; use a complete pruned LoRA or bake it "
                 "into table/projection.")
+    merged_adaln = []
+    if model is not None and isinstance(model.model, comfy.model_base.MiniMaxH3):
+        use_curves = bool(model.model.diffusion_model.use_adaln_curves)
+        if use_curves:
+            merged_adaln = _merge_minimax_h3_adaln_patches(
+                model, loaded, model_sd, strength_model
+            )
     if model is not None:
         new_modelpatcher = model.clone()
+        for key, patch in merged_adaln:
+            new_modelpatcher.patches.pop(key, None)
+            new_modelpatcher.patches[key] = [(1.0, patch, 1.0, None, None)]
         k = new_modelpatcher.add_patches(loaded, strength_model)
         if lora_metadata:
             new_modelpatcher.set_attachments("lora_metadata", lora_metadata)

--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -99,25 +99,29 @@ from comfy.ldm.minimax import pruned_lora
 
 
 def load_lora_for_models(model, clip, lora, strength_model, strength_clip, lora_metadata=None):
+    is_minimax_h3 = (
+        model is not None
+        and isinstance(model.model, comfy.model_base.MiniMaxH3)
+    )
+    raw_lora = lora
     key_map = {}
     if model is not None:
         key_map = comfy.lora.model_lora_keys_unet(model.model, key_map)
-        if isinstance(model.model, comfy.model_base.MiniMaxH3):
-            use_curves = bool(model.model.diffusion_model.use_adaln_curves)
-            has_pruned_adaln = pruned_lora.has_pruned_adaln(lora)
-            if has_pruned_adaln and not use_curves:
-                logging.warning(
-                    "MiniMax H3 non-pruned model: complete pruned AdaLN "
-                    "replacement keys will be skipped.")
     if clip is not None:
         key_map = comfy.lora.model_lora_keys_clip(clip.cond_stage_model, key_map)
 
     lora = comfy.lora_convert.convert_lora(lora)
     loaded = comfy.lora.load_lora(lora, key_map)
-    if model is not None and isinstance(model.model, comfy.model_base.MiniMaxH3):
+    merged_adaln = []
+    if is_minimax_h3:
         use_curves = bool(model.model.diffusion_model.use_adaln_curves)
+        has_pruned_adaln = pruned_lora.has_pruned_adaln(raw_lora)
         model_sd = model.model.state_dict()
         removed_incompatible = False
+        if has_pruned_adaln and not use_curves:
+            logging.warning(
+                "MiniMax H3 non-pruned model: complete pruned AdaLN "
+                "replacement keys will be skipped.")
         for target, patch in list(loaded.items()):
             is_adaln_replacement = (
                 target.endswith(".adaln_proj.linear.weight")
@@ -141,9 +145,6 @@ def load_lora_for_models(model, clip, lora, strength_model, strength_clip, lora_
                 "MiniMax H3 pruned: incompatible 2688-dim AdaLN LoRA "
                 "patches skipped; use a complete pruned LoRA or bake it "
                 "into table/projection.")
-    merged_adaln = []
-    if model is not None and isinstance(model.model, comfy.model_base.MiniMaxH3):
-        use_curves = bool(model.model.diffusion_model.use_adaln_curves)
         if use_curves:
             merged_adaln = pruned_lora.merge_adaln_patches(
                 model, loaded, model_sd, strength_model

--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -142,11 +142,11 @@ def _mini_max_h3_adaln_adapter_compatible(patch, target_shape):
 def _apply_merged_minimax_h3_adaln_patches(patcher, merged):
     for key, patch in merged:
         existing = patcher.patches.get(key, [])
-        preserved = [
+        preserved = [(1.0, patch, 1.0, None, None)]
+        preserved.extend([
             p for p in existing
             if _mini_max_h3_set_patch_value(p[1]) is None
-        ]
-        preserved.append((1.0, patch, 1.0, None, None))
+        ])
         patcher.patches[key] = preserved
 
 

--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -114,6 +114,12 @@ def load_lora_for_models(model, clip, lora, strength_model, strength_clip, lora_
     loaded = comfy.lora.load_lora(lora, key_map)
     merged_adaln = []
     if is_minimax_h3:
+        if pruned_lora.has_legacy_dora(raw_lora):
+            raise ValueError(
+                "MiniMax H3 pruned LoRA uses legacy 2D diff_b DoRA keys. "
+                "The official LoraLoader does not apply this DoRA convention. "
+                "Bake the DoRA into weights or convert it to dora_scale first."
+            )
         use_curves = bool(model.model.diffusion_model.use_adaln_curves)
         has_pruned_adaln = pruned_lora.has_pruned_adaln(raw_lora)
         model_sd = model.model.state_dict()

--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -120,20 +120,32 @@ def load_lora_for_models(model, clip, lora, strength_model, strength_clip, lora_
     lora = comfy.lora_convert.convert_lora(lora)
     loaded = comfy.lora.load_lora(lora, key_map)
     if model is not None and isinstance(model.model, comfy.model_base.MiniMaxH3):
-        if model.model.diffusion_model.use_adaln_curves:
-            incompatible_adaln = {}
-            for target, patch in loaded.items():
-                if target.endswith(".adaln_proj.linear.weight") and not (
-                    isinstance(patch, tuple) and patch and patch[0] == "set"
-                ):
-                    incompatible_adaln[target] = patch
-            if incompatible_adaln:
-                for target in incompatible_adaln:
+        use_curves = bool(model.model.diffusion_model.use_adaln_curves)
+        model_sd = model.model.state_dict()
+        removed_incompatible = False
+        for target, patch in list(loaded.items()):
+            is_adaln_replacement = (
+                target.endswith(".adaln_proj.linear.weight")
+                or target.endswith(".adaln_proj.linear.bias")
+                or target.endswith("adaln_t_table")
+            )
+            if not use_curves:
+                if (is_adaln_replacement
+                        and isinstance(patch, tuple)
+                        and patch and patch[0] == "set"):
                     loaded.pop(target)
-                logging.warning(
-                    "MiniMax H3 pruned: incompatible 2688-dim AdaLN LoRA "
-                    "patches skipped; use a complete pruned LoRA or bake it "
-                    "into table/projection.")
+                    removed_incompatible = True
+            elif target.endswith(".adaln_proj.linear.weight") and target in model_sd:
+                weights = getattr(patch, "weights", None)
+                if (weights and len(weights) >= 2
+                        and weights[1].shape[-1] != model_sd[target].shape[-1]):
+                    loaded.pop(target)
+                    removed_incompatible = True
+        if use_curves and removed_incompatible:
+            logging.warning(
+                "MiniMax H3 pruned: incompatible 2688-dim AdaLN LoRA "
+                "patches skipped; use a complete pruned LoRA or bake it "
+                "into table/projection.")
     if model is not None:
         new_modelpatcher = model.clone()
         k = new_modelpatcher.add_patches(loaded, strength_model)

--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -111,6 +111,45 @@ def _mini_max_h3_existing_set(model, key):
     return None
 
 
+def _mini_max_h3_has_pruned_adaln(lora):
+    return (
+        "adaln_t_table" in lora
+        or "diffusion_model.adaln_t_table" in lora
+        or "adaln_t_table.set_weight" in lora
+        or "diffusion_model.adaln_t_table.set_weight" in lora
+        or any(
+            ".adaln_proj.linear.weight" in k
+            or ".adaln_proj.linear.bias" in k
+            or ".adaln_proj.linear.weight.set_weight" in k
+            or ".adaln_proj.linear.bias.set_weight" in k
+            for k in lora
+        )
+    )
+
+
+def _mini_max_h3_adaln_adapter_compatible(patch, target_shape):
+    if isinstance(patch, tuple):
+        return True
+    weights = getattr(patch, "weights", None)
+    if not weights or len(weights) < 2:
+        return False
+    return (
+        weights[0].shape[0] == target_shape[0]
+        and weights[1].shape[-1] == target_shape[-1]
+    )
+
+
+def _apply_merged_minimax_h3_adaln_patches(patcher, merged):
+    for key, patch in merged:
+        existing = patcher.patches.get(key, [])
+        preserved = [
+            p for p in existing
+            if _mini_max_h3_set_patch_value(p[1]) is None
+        ]
+        preserved.append((1.0, patch, 1.0, None, None))
+        patcher.patches[key] = preserved
+
+
 def _merge_minimax_h3_adaln_patches(model, loaded, model_sd, strength_model):
     """Merge stacked complete pruned AdaLN set patches at the loader boundary.
 
@@ -142,8 +181,12 @@ def _merge_minimax_h3_adaln_patches(model, loaded, model_sd, strength_model):
     if current_table is not None and new_table is not None:
         if current_table.shape != new_table.shape:
             table_warned = True
-        elif (current_table.float() - new_table.float()).abs().max().item() > 1e-3:
-            table_warned = True
+        else:
+            target_device = current_table.device
+            current_table = current_table.to(target_device)
+            new_table = new_table.to(target_device)
+            if (current_table.float() - new_table.float()).abs().max().item() > 1e-3:
+                table_warned = True
     if table_warned:
         logging.warning(
             "MiniMax H3 pruned LoRA merge: adaln_t_table differs between "
@@ -190,6 +233,10 @@ def _merge_minimax_h3_adaln_patches(model, loaded, model_sd, strength_model):
                 tuple(base.shape),
             )
             continue
+        target_device = base.device
+        current_full = current_full.to(target_device)
+        new_full = new_full.to(target_device)
+        base = base.to(target_device)
         combined = (
             current_full.float()
             + strength_model * (new_full.float() - base.float())
@@ -206,15 +253,7 @@ def load_lora_for_models(model, clip, lora, strength_model, strength_clip, lora_
         key_map = comfy.lora.model_lora_keys_unet(model.model, key_map)
         if isinstance(model.model, comfy.model_base.MiniMaxH3):
             use_curves = bool(model.model.diffusion_model.use_adaln_curves)
-            has_pruned_adaln = (
-                "adaln_t_table" in lora
-                or "diffusion_model.adaln_t_table" in lora
-                or any(
-                    ".adaln_proj.linear.weight" in k
-                    or ".adaln_proj.linear.bias" in k
-                    for k in lora
-                )
-            )
+            has_pruned_adaln = _mini_max_h3_has_pruned_adaln(lora)
             if has_pruned_adaln and not use_curves:
                 logging.warning(
                     "MiniMax H3 non-pruned model: complete pruned AdaLN "
@@ -241,9 +280,9 @@ def load_lora_for_models(model, clip, lora, strength_model, strength_clip, lora_
                     loaded.pop(target)
                     removed_incompatible = True
             elif target.endswith(".adaln_proj.linear.weight") and target in model_sd:
-                weights = getattr(patch, "weights", None)
-                if (weights and len(weights) >= 2
-                        and weights[1].shape[-1] != model_sd[target].shape[-1]):
+                if not _mini_max_h3_adaln_adapter_compatible(
+                    patch, model_sd[target].shape
+                ):
                     loaded.pop(target)
                     removed_incompatible = True
         if use_curves and removed_incompatible:
@@ -260,9 +299,7 @@ def load_lora_for_models(model, clip, lora, strength_model, strength_clip, lora_
             )
     if model is not None:
         new_modelpatcher = model.clone()
-        for key, patch in merged_adaln:
-            new_modelpatcher.patches.pop(key, None)
-            new_modelpatcher.patches[key] = [(1.0, patch, 1.0, None, None)]
+        _apply_merged_minimax_h3_adaln_patches(new_modelpatcher, merged_adaln)
         k = new_modelpatcher.add_patches(loaded, strength_model)
         if lora_metadata:
             new_modelpatcher.set_attachments("lora_metadata", lora_metadata)

--- a/tests-unit/comfy_test/test_lora_merge.py
+++ b/tests-unit/comfy_test/test_lora_merge.py
@@ -117,6 +117,22 @@ def test_merge_normalizes_cross_device_tensors():
     assert merged[wk][1][0].device == base_w.device
 
 
+def test_merge_retains_base_dtype():
+    torch.manual_seed(8)
+    table = torch.randn(4, 4, dtype=torch.float32)
+    base_w = torch.randn(6, 4, dtype=torch.float16)
+    new_w = torch.randn(6, 4, dtype=torch.float32)
+
+    tk = "diffusion_model.adaln_t_table"
+    wk = "diffusion_model.blocks.0.adaln_proj.linear.weight"
+    sd = {tk: table, wk: base_w}
+    patcher = _FakePatcher()
+    loaded = {tk: ("set", (table,)), wk: ("set", (new_w,))}
+
+    merged = dict(_merge(sd, patcher, loaded))
+    assert merged[wk][1][0].dtype == base_w.dtype
+
+
 def test_stacked_pruned_adaln_merges_linearly():
     torch.manual_seed(0)
     table = torch.randn(4, 4)

--- a/tests-unit/comfy_test/test_lora_merge.py
+++ b/tests-unit/comfy_test/test_lora_merge.py
@@ -1,4 +1,5 @@
 import logging
+from types import SimpleNamespace
 
 import torch
 
@@ -32,6 +33,88 @@ def _apply_set_patch(value, base):
         base.clone(),
         "diffusion_model.blocks.0.adaln_proj.linear.weight",
     )
+
+
+def test_pruned_adaln_detection_covers_set_weight():
+    assert comfy.sd._mini_max_h3_has_pruned_adaln(
+        {"adaln_t_table.set_weight": torch.ones(4, 4)}
+    )
+    assert comfy.sd._mini_max_h3_has_pruned_adaln(
+        {"diffusion_model.adaln_t_table.set_weight": torch.ones(4, 4)}
+    )
+    assert comfy.sd._mini_max_h3_has_pruned_adaln(
+        {"blocks.0.adaln_proj.linear.weight.set_weight": torch.ones(6, 4)}
+    )
+
+
+def test_adapter_output_dimension_is_checked():
+    target_shape = (6, 4)
+    bad_patch = SimpleNamespace(
+        weights=(torch.randn(7, 2), torch.randn(2, 4))
+    )
+    good_patch = SimpleNamespace(
+        weights=(torch.randn(6, 2), torch.randn(2, 4))
+    )
+    direct_set = ("set", (torch.randn(6, 4),))
+
+    assert not comfy.sd._mini_max_h3_adaln_adapter_compatible(
+        bad_patch, target_shape
+    )
+    assert comfy.sd._mini_max_h3_adaln_adapter_compatible(
+        good_patch, target_shape
+    )
+    assert comfy.sd._mini_max_h3_adaln_adapter_compatible(
+        direct_set, target_shape
+    )
+
+
+def test_apply_merged_preserves_existing_non_set_patch():
+    patcher = _FakePatcher()
+    wk = "diffusion_model.blocks.0.adaln_proj.linear.weight"
+    diff_patch = (
+        1.0,
+        ("diff", (torch.randn(6, 4),)),
+        1.0,
+        None,
+        None,
+    )
+    old_set = (
+        1.0,
+        ("set", (torch.randn(6, 4),)),
+        1.0,
+        None,
+        None,
+    )
+    new_value = torch.randn(6, 4)
+    patcher.patches[wk] = [diff_patch, old_set]
+
+    comfy.sd._apply_merged_minimax_h3_adaln_patches(
+        patcher, [(wk, ("set", (new_value,)))]
+    )
+
+    patches = patcher.patches[wk]
+    assert patches[0] is diff_patch
+    assert len(patches) == 2
+    assert comfy.sd._mini_max_h3_set_patch_value(patches[1][1]) is new_value
+
+
+def test_merge_normalizes_cross_device_tensors():
+    if not torch.cuda.is_available():
+        return
+    torch.manual_seed(7)
+    table = torch.randn(4, 4)
+    other_table = torch.randn(4, 4, device="cuda")
+    base_w = torch.randn(6, 4)
+    new_w = torch.randn(6, 4, device="cuda")
+
+    tk = "diffusion_model.adaln_t_table"
+    wk = "diffusion_model.blocks.0.adaln_proj.linear.weight"
+    sd = {tk: table, wk: base_w}
+    patcher = _FakePatcher()
+    loaded = {tk: ("set", (other_table,)), wk: ("set", (new_w,))}
+
+    merged = dict(_merge(sd, patcher, loaded))
+    assert merged[wk][1][0].device == base_w.device
 
 
 def test_stacked_pruned_adaln_merges_linearly():

--- a/tests-unit/comfy_test/test_lora_merge.py
+++ b/tests-unit/comfy_test/test_lora_merge.py
@@ -68,6 +68,19 @@ def test_adapter_output_dimension_is_checked():
     )
 
 
+def test_mismatched_direct_diff_patch_is_rejected():
+    target_shape = (6, 4)
+    bad_diff = ("diff", (torch.randn(7, 4),))
+    good_diff = ("diff", (torch.randn(6, 4),))
+
+    assert not comfy.ldm.minimax.pruned_lora.adaln_adapter_compatible(
+        bad_diff, target_shape
+    )
+    assert comfy.ldm.minimax.pruned_lora.adaln_adapter_compatible(
+        good_diff, target_shape
+    )
+
+
 def test_apply_merged_preserves_existing_non_set_patch():
     patcher = _FakePatcher()
     wk = "diffusion_model.blocks.0.adaln_proj.linear.weight"

--- a/tests-unit/comfy_test/test_lora_merge.py
+++ b/tests-unit/comfy_test/test_lora_merge.py
@@ -47,6 +47,18 @@ def test_pruned_adaln_detection_covers_set_weight():
     )
 
 
+def test_legacy_dora_detection():
+    assert comfy.ldm.minimax.pruned_lora.has_legacy_dora(
+        {
+            "blocks.0.attn.qkv_proj.lora_A.weight": torch.randn(2, 6),
+            "blocks.0.attn.qkv_proj.diff_b": torch.randn(8, 1),
+        }
+    )
+    assert not comfy.ldm.minimax.pruned_lora.has_legacy_dora(
+        {"blocks.0.attn.qkv_proj.bias.diff_b": torch.randn(8)}
+    )
+
+
 def test_adapter_output_dimension_is_checked():
     target_shape = (6, 4)
     bad_patch = SimpleNamespace(
@@ -278,3 +290,80 @@ def test_table_mismatch_warns_but_merges(caplog):
     expected = w1 + (w2 - base_w)
     applied = _apply_set_patch(dict(merged)[wk][1][0], base_w)
     assert torch.allclose(applied.float(), expected.float())
+
+
+def test_combined_standard_lora_dora_adaln():
+    torch.manual_seed(9)
+    out, in_, rank = 8, 6, 4
+    model_sd = {
+        "adaln_t_table": torch.randn(4, 4),
+        "blocks.0.adaln_proj.linear.weight": torch.randn(8, 4),
+        "blocks.0.adaln_proj.linear.bias": torch.randn(8),
+        "blocks.0.attn.qkv_proj.weight": torch.randn(out, in_),
+        "blocks.0.mlp.fc1.weight": torch.randn(out, in_),
+    }
+
+    a_d = torch.randn(rank, in_)
+    b_d = torch.randn(out, rank) * 0.1
+    diff_b = torch.randn(out, 1) * 0.02
+    wq = model_sd["blocks.0.attn.qkv_proj.weight"]
+    w_temp = wq + b_d @ a_d
+    n0 = wq.norm(dim=1, keepdim=True).clamp(min=1e-8)
+    nt = w_temp.norm(dim=1, keepdim=True).clamp(min=1e-8)
+    dora_scale = (n0 + diff_b) / nt * n0
+
+    a_s = torch.randn(rank, in_)
+    b_s = torch.randn(out, rank) * 0.2
+    lora_sd = {
+        "adaln_t_table": model_sd["adaln_t_table"],
+        "blocks.0.adaln_proj.linear.weight": (
+            model_sd["blocks.0.adaln_proj.linear.weight"]
+            + torch.randn(8, 4) * 0.1
+        ),
+        "blocks.0.adaln_proj.linear.bias": (
+            model_sd["blocks.0.adaln_proj.linear.bias"]
+            + torch.randn(8) * 0.1
+        ),
+        "blocks.0.attn.qkv_proj.lora_A.weight": a_d,
+        "blocks.0.attn.qkv_proj.lora_B.weight": b_d,
+        "blocks.0.attn.qkv_proj.dora_scale": dora_scale,
+        "blocks.0.mlp.fc1.lora_A.weight": a_s,
+        "blocks.0.mlp.fc1.lora_B.weight": b_s,
+    }
+    to_load = {
+        "adaln_t_table": "adaln_t_table",
+        "blocks.0.adaln_proj.linear": "blocks.0.adaln_proj.linear.weight",
+        "blocks.0.attn.qkv_proj": "blocks.0.attn.qkv_proj.weight",
+        "blocks.0.mlp.fc1": "blocks.0.mlp.fc1.weight",
+    }
+
+    loaded = comfy.lora.load_lora(lora_sd, to_load)
+    patcher = _FakePatcher()
+    merged = dict(comfy.ldm.minimax.pruned_lora.merge_adaln_patches(
+        patcher, loaded, model_sd, 1.0
+    ))
+
+    qkv = comfy.lora.calculate_weight(
+        [(1.0, loaded["blocks.0.attn.qkv_proj.weight"], 1.0, None, None)],
+        model_sd["blocks.0.attn.qkv_proj.weight"].clone(),
+        "qkv",
+    )
+    expected_qkv = (n0 + diff_b) * w_temp / nt
+
+    mlp = comfy.lora.calculate_weight(
+        [(1.0, loaded["blocks.0.mlp.fc1.weight"], 1.0, None, None)],
+        model_sd["blocks.0.mlp.fc1.weight"].clone(),
+        "mlp",
+    )
+    expected_mlp = model_sd["blocks.0.mlp.fc1.weight"] + b_s @ a_s
+
+    wk = "blocks.0.adaln_proj.linear.weight"
+    adaln = comfy.lora.calculate_weight(
+        [(1.0, merged[wk], 1.0, None, None)],
+        model_sd[wk].clone(),
+        "adaln",
+    )
+
+    assert torch.allclose(qkv.float(), expected_qkv.float(), atol=1e-6)
+    assert torch.allclose(mlp.float(), expected_mlp.float())
+    assert torch.allclose(adaln.float(), lora_sd[wk].float())

--- a/tests-unit/comfy_test/test_lora_merge.py
+++ b/tests-unit/comfy_test/test_lora_merge.py
@@ -222,7 +222,7 @@ def test_table_branch_retains_base_tensor():
 
     merged = dict(_merge(sd, patcher, loaded))
     assert tk not in loaded
-    assert dict(merged)[tk][1][0] is table
+    assert tk not in merged
 
 
 def test_shape_mismatch_removes_incompatible_patch(caplog):

--- a/tests-unit/comfy_test/test_lora_merge.py
+++ b/tests-unit/comfy_test/test_lora_merge.py
@@ -1,0 +1,128 @@
+import logging
+
+import torch
+
+import comfy.lora
+import comfy.sd
+
+
+class _FakeModel:
+    def __init__(self, sd):
+        self._sd = sd
+
+    def state_dict(self):
+        return self._sd
+
+
+class _FakePatcher:
+    def __init__(self, patches=None):
+        self.patches = patches or {}
+
+
+def _merge(sd, patcher, loaded, strength=1.0):
+    return comfy.sd._merge_minimax_h3_adaln_patches(
+        patcher, loaded, sd, strength
+    )
+
+
+def _apply_set_patch(value, base):
+    patches = [(1.0, ("set", (value,)), 1.0, None, None)]
+    return comfy.lora.calculate_weight(
+        patches,
+        base.clone(),
+        "diffusion_model.blocks.0.adaln_proj.linear.weight",
+    )
+
+
+def test_stacked_pruned_adaln_merges_linearly():
+    torch.manual_seed(0)
+    table = torch.randn(4, 4)
+    base_w = torch.randn(6, 4)
+    base_b = torch.randn(6)
+    w1 = base_w + torch.randn(6, 4) * 0.1
+    w2 = base_w + torch.randn(6, 4) * 0.1
+
+    wk = "diffusion_model.blocks.0.adaln_proj.linear.weight"
+    bk = "diffusion_model.blocks.0.adaln_proj.linear.bias"
+    tk = "diffusion_model.adaln_t_table"
+    sd = {tk: table, wk: base_w, bk: base_b}
+    patcher = _FakePatcher({wk: [(1.0, ("set", (w1,)), 1.0, None, None)]})
+    loaded = {
+        tk: ("set", (table,)),
+        wk: ("set", (w2,)),
+        bk: ("set", (base_b + torch.randn(6) * 0.05,)),
+    }
+
+    merged = dict(_merge(sd, patcher, loaded, strength=0.5))
+    assert wk not in loaded
+    merged_w = merged[wk][1][0]
+    expected = w1 + 0.5 * (w2 - base_w)
+    assert torch.allclose(merged_w.float(), expected.float())
+
+
+def test_sequential_weight_application_is_linear():
+    torch.manual_seed(2)
+    table = torch.randn(4, 4)
+    base_w = torch.randn(6, 4)
+    d1 = torch.randn(6, 4) * 0.05
+    d2 = torch.randn(6, 4) * 0.05
+    d3 = torch.randn(6, 4) * 0.05
+
+    wk = "diffusion_model.blocks.0.adaln_proj.linear.weight"
+    tk = "diffusion_model.adaln_t_table"
+    sd = {tk: table, wk: base_w}
+    patcher = _FakePatcher()
+
+    for delta in (d1, d2, d3):
+        loaded = {
+            tk: ("set", (table,)),
+            wk: ("set", (base_w + delta,)),
+        }
+        merged = dict(_merge(sd, patcher, loaded, strength=1.0))
+        patcher.patches[wk] = [
+            (1.0, merged[wk], 1.0, None, None)
+        ]
+
+    applied = _apply_set_patch(patcher.patches[wk][0][1][1][0], base_w)
+    expected = base_w + d1 + d2 + d3
+    assert torch.allclose(applied.float(), expected.float())
+
+
+def test_strength_is_applied_to_adaln_delta():
+    torch.manual_seed(3)
+    table = torch.randn(4, 4)
+    base_w = torch.randn(6, 4)
+    delta = torch.randn(6, 4) * 0.05
+
+    wk = "diffusion_model.blocks.0.adaln_proj.linear.weight"
+    tk = "diffusion_model.adaln_t_table"
+    sd = {tk: table, wk: base_w}
+    patcher = _FakePatcher()
+    loaded = {tk: ("set", (table,)), wk: ("set", (base_w + delta,))}
+    merged = dict(_merge(sd, patcher, loaded, strength=0.5))
+
+    applied = _apply_set_patch(merged[wk][1][0], base_w)
+    assert torch.allclose(applied.float(), (base_w + 0.5 * delta).float())
+
+
+def test_table_mismatch_warns_but_merges(caplog):
+    torch.manual_seed(1)
+    table = torch.randn(4, 4)
+    other_table = table + torch.randn(4, 4) * 0.1
+    base_w = torch.randn(6, 4)
+    w1 = base_w + torch.randn(6, 4) * 0.1
+    w2 = base_w + torch.randn(6, 4) * 0.1
+
+    wk = "diffusion_model.blocks.0.adaln_proj.linear.weight"
+    tk = "diffusion_model.adaln_t_table"
+    sd = {tk: table, wk: base_w}
+    patcher = _FakePatcher({wk: [(1.0, ("set", (w1,)), 1.0, None, None)]})
+    loaded = {tk: ("set", (other_table,)), wk: ("set", (w2,))}
+
+    with caplog.at_level(logging.WARNING):
+        merged = _merge(sd, patcher, loaded)
+    assert wk not in loaded
+    assert any("adaln_t_table differs" in r.message for r in caplog.records)
+    expected = w1 + (w2 - base_w)
+    applied = _apply_set_patch(dict(merged)[wk][1][0], base_w)
+    assert torch.allclose(applied.float(), expected.float())

--- a/tests-unit/comfy_test/test_lora_merge.py
+++ b/tests-unit/comfy_test/test_lora_merge.py
@@ -105,6 +105,40 @@ def test_strength_is_applied_to_adaln_delta():
     assert torch.allclose(applied.float(), (base_w + 0.5 * delta).float())
 
 
+def test_table_branch_retains_base_tensor():
+    torch.manual_seed(4)
+    table = torch.randn(4, 4)
+    other_table = torch.randn(4, 4)
+    base_w = torch.randn(6, 4)
+
+    tk = "diffusion_model.adaln_t_table"
+    wk = "diffusion_model.blocks.0.adaln_proj.linear.weight"
+    sd = {tk: table, wk: base_w}
+    patcher = _FakePatcher()
+    loaded = {tk: ("set", (other_table,)), wk: ("set", (base_w,))}
+
+    merged = dict(_merge(sd, patcher, loaded))
+    assert dict(merged)[tk][1][0] is table
+
+
+def test_shape_mismatch_removes_incompatible_patch(caplog):
+    torch.manual_seed(5)
+    table = torch.randn(4, 4)
+    base_w = torch.randn(6, 4)
+    bad_w = torch.randn(7, 4)
+
+    tk = "diffusion_model.adaln_t_table"
+    wk = "diffusion_model.blocks.0.adaln_proj.linear.weight"
+    sd = {tk: table, wk: base_w}
+    patcher = _FakePatcher()
+    loaded = {tk: ("set", (table,)), wk: ("set", (bad_w,))}
+
+    with caplog.at_level(logging.WARNING):
+        _merge(sd, patcher, loaded)
+    assert wk not in loaded
+    assert any("shape mismatch" in r.message for r in caplog.records)
+
+
 def test_table_mismatch_warns_but_merges(caplog):
     torch.manual_seed(1)
     table = torch.randn(4, 4)

--- a/tests-unit/comfy_test/test_lora_merge.py
+++ b/tests-unit/comfy_test/test_lora_merge.py
@@ -71,9 +71,11 @@ def test_adapter_output_dimension_is_checked():
 def test_apply_merged_preserves_existing_non_set_patch():
     patcher = _FakePatcher()
     wk = "diffusion_model.blocks.0.adaln_proj.linear.weight"
+    base_w = torch.randn(6, 4)
+    diff_value = torch.randn(6, 4) * 0.1
     diff_patch = (
         1.0,
-        ("diff", (torch.randn(6, 4),)),
+        ("diff", (diff_value,)),
         1.0,
         None,
         None,
@@ -93,9 +95,11 @@ def test_apply_merged_preserves_existing_non_set_patch():
     )
 
     patches = patcher.patches[wk]
-    assert patches[0] is diff_patch
+    assert comfy.sd._mini_max_h3_set_patch_value(patches[0][1]) is new_value
+    assert patches[1] is diff_patch
     assert len(patches) == 2
-    assert comfy.sd._mini_max_h3_set_patch_value(patches[1][1]) is new_value
+    applied = comfy.lora.calculate_weight(patches, base_w.clone(), wk)
+    assert torch.allclose(applied.float(), (new_value + diff_value).float())
 
 
 def test_merge_normalizes_cross_device_tensors():

--- a/tests-unit/comfy_test/test_lora_merge.py
+++ b/tests-unit/comfy_test/test_lora_merge.py
@@ -54,6 +54,9 @@ def test_legacy_dora_detection():
             "blocks.0.attn.qkv_proj.diff_b": torch.randn(8, 1),
         }
     )
+    assert comfy.ldm.minimax.pruned_lora.has_legacy_dora(
+        {"blocks.0.attn.qkv_proj.diff_b": torch.randn(8, 1)}
+    )
     assert not comfy.ldm.minimax.pruned_lora.has_legacy_dora(
         {"blocks.0.attn.qkv_proj.bias.diff_b": torch.randn(8)}
     )

--- a/tests-unit/comfy_test/test_lora_merge.py
+++ b/tests-unit/comfy_test/test_lora_merge.py
@@ -118,6 +118,7 @@ def test_table_branch_retains_base_tensor():
     loaded = {tk: ("set", (other_table,)), wk: ("set", (base_w,))}
 
     merged = dict(_merge(sd, patcher, loaded))
+    assert tk not in loaded
     assert dict(merged)[tk][1][0] is table
 
 
@@ -134,8 +135,9 @@ def test_shape_mismatch_removes_incompatible_patch(caplog):
     loaded = {tk: ("set", (table,)), wk: ("set", (bad_w,))}
 
     with caplog.at_level(logging.WARNING):
-        _merge(sd, patcher, loaded)
+        merged = _merge(sd, patcher, loaded)
     assert wk not in loaded
+    assert wk not in dict(merged)
     assert any("shape mismatch" in r.message for r in caplog.records)
 
 

--- a/tests-unit/comfy_test/test_lora_merge.py
+++ b/tests-unit/comfy_test/test_lora_merge.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 import torch
 
 import comfy.lora
-import comfy.sd
+import comfy.ldm.minimax.pruned_lora
 
 
 class _FakeModel:
@@ -21,7 +21,7 @@ class _FakePatcher:
 
 
 def _merge(sd, patcher, loaded, strength=1.0):
-    return comfy.sd._merge_minimax_h3_adaln_patches(
+    return comfy.ldm.minimax.pruned_lora.merge_adaln_patches(
         patcher, loaded, sd, strength
     )
 
@@ -36,13 +36,13 @@ def _apply_set_patch(value, base):
 
 
 def test_pruned_adaln_detection_covers_set_weight():
-    assert comfy.sd._mini_max_h3_has_pruned_adaln(
+    assert comfy.ldm.minimax.pruned_lora.has_pruned_adaln(
         {"adaln_t_table.set_weight": torch.ones(4, 4)}
     )
-    assert comfy.sd._mini_max_h3_has_pruned_adaln(
+    assert comfy.ldm.minimax.pruned_lora.has_pruned_adaln(
         {"diffusion_model.adaln_t_table.set_weight": torch.ones(4, 4)}
     )
-    assert comfy.sd._mini_max_h3_has_pruned_adaln(
+    assert comfy.ldm.minimax.pruned_lora.has_pruned_adaln(
         {"blocks.0.adaln_proj.linear.weight.set_weight": torch.ones(6, 4)}
     )
 
@@ -57,13 +57,13 @@ def test_adapter_output_dimension_is_checked():
     )
     direct_set = ("set", (torch.randn(6, 4),))
 
-    assert not comfy.sd._mini_max_h3_adaln_adapter_compatible(
+    assert not comfy.ldm.minimax.pruned_lora.adaln_adapter_compatible(
         bad_patch, target_shape
     )
-    assert comfy.sd._mini_max_h3_adaln_adapter_compatible(
+    assert comfy.ldm.minimax.pruned_lora.adaln_adapter_compatible(
         good_patch, target_shape
     )
-    assert comfy.sd._mini_max_h3_adaln_adapter_compatible(
+    assert comfy.ldm.minimax.pruned_lora.adaln_adapter_compatible(
         direct_set, target_shape
     )
 
@@ -90,12 +90,12 @@ def test_apply_merged_preserves_existing_non_set_patch():
     new_value = torch.randn(6, 4)
     patcher.patches[wk] = [diff_patch, old_set]
 
-    comfy.sd._apply_merged_minimax_h3_adaln_patches(
+    comfy.ldm.minimax.pruned_lora.apply_merged_adaln_patches(
         patcher, [(wk, ("set", (new_value,)))]
     )
 
     patches = patcher.patches[wk]
-    assert comfy.sd._mini_max_h3_set_patch_value(patches[0][1]) is new_value
+    assert comfy.ldm.minimax.pruned_lora.set_patch_value(patches[0][1]) is new_value
     assert patches[1] is diff_patch
     assert len(patches) == 2
     applied = comfy.lora.calculate_weight(patches, base_w.clone(), wk)


### PR DESCRIPTION
**Title**

Add MiniMax H3 pruned complete LoRA support to official LoraLoader

**Summary**

MiniMax H3 pruned checkpoints replace the full 2688-dim time embedder and AdaLN branch with a shared 8-dim adaln_t_table plus per-block projections.

This PR lets the official LoraLoader/LoraLoaderModelOnly load a complete pruned LoRA directly. The format contains standard backbone LoRA keys plus full AdaLN replacement keys:

- adaln_t_table
- blocks.*.adaln_proj.linear.weight/bias
- final_layer.adaln_proj.linear.weight/bias

Backbone keys are merged through the existing LoRA adapter path. AdaLN keys are applied as full set patches so pruned models can use the adapted table and projections without 2688-dim runtime injection.

**Source LoRA**

The acceleration LoRA used for generating the pruned adapters:

https://huggingface.co/larryvrh/MiniMax-H3-Turbo-Lora

**Tooling**

The complete pruned LoRA files are generated by:

https://github.com/xiaolibai-sys/MiniMax-H3-Pruned-Lora-Adapter

Inputs:
- Full MiniMax H3 BF16 model
- Acceleration LoRA from: https://huggingface.co/larryvrh/MiniMax-H3-Turbo-Lora
- Optional official h3_silu_temb_grid

**Lightning Sampling / shift_audio Note**

This PR only makes the complete pruned LoRA loadable. It does not by itself prepare ComfyUI for lightning sampling.

For the 4-step Turbo LoRA, audio must not be stepped on the same sigma grid as video. The model uses two flow schedules:

- video sigma shift = 12
- audio sigma shift = 3

Using a stock single-schedule sampler over-steps audio at low step counts, which can make the audio distorted or broken. This is the same shift_audio/lightning-sampling issue raised in the MiniMax-H3-Turbo-Lora repository:

https://huggingface.co/larryvrh/MiniMax-H3-Turbo-Lora

To prepare for lightning sampling, ComfyUI also needs a dual-clock sampler or an exposed shift_audio path so video and audio advance on their own sigma schedules.

**Recommendation: Shared Table for Combining LoRAs**

For multiple LoRAs that must be combined, use a shared fixed table:

- optimize_table: false
- init_table: builtin:fl2va or builtin:ref2va
- only projection/bias are optimized

P_combined = P_base + sum(strength_j * (P_j - P_base))
b_combined = b_base + sum(strength_j * (b_j - b_base))
T_combined = T_common

This preserves a common T, so separate LoRA projections can be stacked without re-fitting a new table or aligning different bases.

**Recommendation: Alternating Least Squares for Accuracy**

For a single high-accuracy adapter, the tool also supports joint optimization:

- optimize_table: true
- init_table: optional pruned table or PCA initialization
- als_iters: number of alternating least squares iterations

The ALS loop alternates:

fix T -> solve P_i, b_i for every block
fix P_i, b_i -> update T

**Accuracy Comparison**

The accuracy numbers compare the fitted AdaLN modulation against the exact modulation matrix of the BF16 full model with the LoRA applied:

M_i = E @ W_i.T + b_i + E @ (B_i @ A_i).T

where:
- E  = silu(time_embedder(t)) from the BF16 model
- W_i, b_i = full BF16 AdaLN weight/bias
- A, B = LoRA AdaLN matrices

This is an AdaLN modulation reconstruction error, not a final video/audio output error. End-to-end quality still needs a pruned-model sampling comparison.

Measured with the 4-step Turbo LoRA:

ALS:
  block max/mean = 1.5e-5 / 6e-6
  final = 4.5e-5

Fixed projection:
  block max/mean = 8.8e-5 / 6e-5
  final = 1.27e-4

**Changes**

comfy/lora.py
- Add MiniMaxH3-specific unprefixed key mapping.
- Map full AdaLN/table replacement keys only for pruned curve models.
- Treat complete AdaLN replacement keys as set patches.
- Skip incompatible 2688-dim AdaLN LoRA keys on pruned models with a warning.
- Keep standard LoRA adapter behavior for backbone and other models.

comfy/sd.py
- Warn when a complete pruned LoRA is loaded on a non-pruned MiniMax H3 model.
- Skip AdaLN/table replacement safely in that case.

**Backward Compatibility**

Standard LoRA loading behavior is unchanged. The new full-replacement path only activates when:
- the model is MiniMaxH3
- the LoRA contains adaln_t_table or blocks.*.adaln_proj.linear.weight/bias

**Validation**

- Complete LoRA: 103 set patches + backbone adapter generated.
- AdaLN table/weight/bias patch application max_abs_diff = 0.0.
- Backbone real merge verified with LoRAAdapter.calculate_weight.
- Pruned/non-pruned key mapping verified.
- Original Turbo LoRA on pruned model now skips AdaLN and warns.
- Shared-table linear-combination math verified with random LoRA deltas.

**Files Changed**

comfy/lora.py
comfy/sd.py