### PR TITLE
Transcode when the output container cannot store the source codec

### DIFF
--- a/comfy_api/latest/_input/video_types.py
+++ b/comfy_api/latest/_input/video_types.py
@@ -30,14 +30,23 @@ class VideoInput(ABC):
         metadata: Optional[dict] = None,
         bit_depth: int | None = None,
         crf: float | None = None,
+        color_space: str | None = None,
     ):
         """
         Abstract method to save the video input to a file.
 
         bit_depth selects the encoded bit depth; None keeps the video's native depth.
-        crf selects the H.264 constant rate factor; None uses the encoder default.
+        crf selects the H.264 or AV1 constant rate factor; None uses the encoder default.
+        color_space="sRGB" writes SDR BT.709/sRGB video. "HDR" writes 10-bit BT.2020/HLG video;
+        "HDR PQ" selects BT.2020/PQ.
+        Tensor-created videos default to sRGB when color_space is None. Loaded videos keep matching recognized native color
+        properties; other input pixels must already use the selected color space.
         """
         pass
+
+    def get_color_space(self) -> str:
+        """Return the video's color space as sRGB, HDR, HDR PQ, or auto when unspecified."""
+        return "auto"
 
     @abstractmethod
     def as_trimmed(

--- a/comfy_api/latest/_input_impl/video_types.py
+++ b/comfy_api/latest/_input_impl/video_types.py
@@ -1,6 +1,6 @@
 from av.container import InputContainer
 from av.subtitles.stream import SubtitleStream
-from av.video.reformatter import ColorRange
+from av.video.reformatter import ColorPrimaries, ColorRange, ColorTrc
 from fractions import Fraction
 from typing import Optional
 from .._input import AudioInput, VideoInput
@@ -14,6 +14,38 @@ import os
 import torch
 from .._util import VideoContainer, VideoCodec, VideoComponents
 import logging
+
+
+VIDEO_ENCODERS = {
+    VideoCodec.H264: "h264",
+    VideoCodec.AV1: "libsvtav1",
+}
+VIDEO_CONTAINER_FORMATS = {
+    VideoContainer.MP4: "mp4",
+    VideoContainer.MKV: "matroska",
+    VideoContainer.WEBM: "webm",
+}
+WEBM_STREAM_CODECS = {
+    "video": {"av1", "vp8", "vp9"},
+    "audio": {"opus", "vorbis"},
+    "subtitle": {"webvtt"},
+}
+BT2020_NCL = 9
+BT709_NCL = 1
+HDR_COLOR_TRANSFERS = {
+    "HDR": ColorTrc.ARIB_STD_B67,
+    "HDR PQ": ColorTrc.SMPTE2084,
+}
+VIDEO_COLOR_TRANSFERS = {
+    "sRGB": ColorTrc.IEC61966_2_1,
+    **HDR_COLOR_TRANSFERS,
+}
+VIDEO_TRANSFER_COLOR_SPACES = {
+    ColorTrc.BT709: "sRGB",
+    ColorTrc.IEC61966_2_1: "sRGB",
+    ColorTrc.ARIB_STD_B67: "HDR",
+    ColorTrc.SMPTE2084: "HDR PQ",
+}
 
 
 def container_to_output_format(container_format: str | None) -> str | None:
@@ -37,21 +69,23 @@ def get_open_write_kwargs(
 ) -> dict:
     """Get kwargs for writing a `VideoFromFile` to a file/stream with `av.open`"""
     is_write_to_buffer = isinstance(dest, io.BytesIO)
-    is_mp4_file = not is_write_to_buffer and os.path.splitext(dest)[1].lower() == ".mp4"
-    movflags = "use_metadata_tags+faststart" if is_mp4_file else "use_metadata_tags"
-    open_kwargs = {
-        "mode": "w",
-        # If isobmff, preserve custom metadata tags (workflow, prompt, extra_pnginfo)
-        "options": {"movflags": movflags},
-    }
+    open_kwargs = {"mode": "w"}
 
     if is_write_to_buffer:
         # Set output format explicitly, since it cannot be inferred from file extension
         if to_format == VideoContainer.AUTO:
             to_format = container_format.lower()
+        elif isinstance(to_format, VideoContainer):
+            to_format = VIDEO_CONTAINER_FORMATS[to_format]
         elif isinstance(to_format, str):
             to_format = to_format.lower()
         open_kwargs["format"] = container_to_output_format(to_format)
+
+    output_format = open_kwargs["format"] if is_write_to_buffer else os.path.splitext(dest)[1].lower().lstrip(".")
+    if output_format in ("mov", "mp4"):
+        # Preserve custom metadata tags (workflow, prompt, extra_pnginfo) in isobmff.
+        movflags = "use_metadata_tags" if is_write_to_buffer else "use_metadata_tags+faststart"
+        open_kwargs["options"] = {"movflags": movflags}
 
     return open_kwargs
 
@@ -100,19 +134,66 @@ def write_output_metadata(container: InputContainer, output, metadata: dict | No
             output.metadata[key] = value if isinstance(value, str) else json.dumps(value)
 
 
-def mp4_output_open_kwargs(path: str | io.BytesIO, format: VideoContainer, codec: VideoCodec) -> dict:
-    if format != VideoContainer.AUTO and format != VideoContainer.MP4:
-        raise ValueError("Only MP4 format is supported for now")
-    if codec != VideoCodec.AUTO and codec != VideoCodec.H264:
-        raise ValueError("Only H264 codec is supported for now")
+def video_output_config(path: str | io.BytesIO, format: VideoContainer, codec: VideoCodec) -> tuple[dict, VideoContainer, VideoCodec]:
+    if isinstance(format, str):
+        format = VideoContainer(format)
+    if isinstance(codec, str):
+        codec = VideoCodec(codec)
+
+    if format == VideoContainer.AUTO:
+        extension = os.path.splitext(os.fspath(path))[1].lower() if isinstance(path, (str, os.PathLike)) else ""
+        format = {
+            ".mkv": VideoContainer.MKV,
+            ".webm": VideoContainer.WEBM,
+        }.get(extension, VideoContainer.MP4)
+    if codec == VideoCodec.AUTO:
+        codec = VideoCodec.AV1 if format == VideoContainer.WEBM else VideoCodec.H264
+    if format == VideoContainer.WEBM and codec != VideoCodec.AV1:
+        raise ValueError("WebM output requires the AV1 codec")
+
     # FFmpeg's faststart pass reopens the output by filename, so it cannot be used with file-like objects.
-    movflags = "use_metadata_tags+faststart" if isinstance(path, (str, os.PathLike)) else "use_metadata_tags"
-    open_kwargs = {"mode": "w", "options": {"movflags": movflags}}
-    if isinstance(format, VideoContainer) and format != VideoContainer.AUTO:
-        open_kwargs["format"] = format.value
-    elif isinstance(path, io.BytesIO):
-        open_kwargs["format"] = "mp4"  # no file extension to infer the format from
-    return open_kwargs
+    open_kwargs = {"mode": "w", "format": VIDEO_CONTAINER_FORMATS[format]}
+    if format == VideoContainer.MP4:
+        movflags = "use_metadata_tags+faststart" if isinstance(path, (str, os.PathLike)) else "use_metadata_tags"
+        open_kwargs["options"] = {"movflags": movflags}
+    return open_kwargs, format, codec
+
+
+def set_video_color_properties(target, color_space):
+    is_hdr = color_space in HDR_COLOR_TRANSFERS
+    target.color_primaries = ColorPrimaries.BT2020 if is_hdr else ColorPrimaries.BT709
+    target.color_trc = VIDEO_COLOR_TRANSFERS[color_space]
+    target.colorspace = BT2020_NCL if is_hdr else BT709_NCL
+    target.color_range = ColorRange.MPEG
+
+
+def copy_color_properties(source, target):
+    target.color_primaries = source.color_primaries
+    target.color_trc = source.color_trc
+    target.colorspace = source.colorspace
+    target.color_range = source.color_range
+
+
+def video_stream_color_space(stream) -> str | None:
+    if stream is None:
+        return None
+    return VIDEO_TRANSFER_COLOR_SPACES.get(stream.color_trc)
+
+
+def video_encoder_options(codec: VideoCodec, crf: float | None) -> dict[str, str]:
+    if crf is None:
+        return {}
+    if codec == VideoCodec.AV1 and crf == 0:
+        return {"svtav1-params": "lossless=1"}
+    return {"crf": str(crf)}
+
+
+def webm_streams_compatible(streams) -> bool:
+    for stream in streams:
+        allowed_codecs = WEBM_STREAM_CODECS.get(stream.type)
+        if allowed_codecs is not None and stream.codec_context is not None and stream.codec.canonical_name not in allowed_codecs:
+            return False
+    return True
 
 
 class VideoFromFile(VideoInput):
@@ -166,6 +247,13 @@ class VideoFromFile(VideoInput):
         with av.open(self.__file, mode="r") as container:
             video_stream = container.streams.video[0] if len(container.streams.video) > 0 else None
             return video_stream_bit_depth(video_stream)
+
+    def get_color_space(self) -> str:
+        if isinstance(self.__file, io.BytesIO):
+            self.__file.seek(0)
+        with av.open(self.__file, mode="r") as container:
+            video_stream = container.streams.video[0] if len(container.streams.video) > 0 else None
+            return video_stream_color_space(video_stream) or "sRGB"
 
     def get_duration(self) -> float:
         """
@@ -465,16 +553,28 @@ class VideoFromFile(VideoInput):
         metadata: Optional[dict] = None,
         bit_depth: int | None = None,
         crf: float | None = None,
+        color_space: str | None = None,
     ):
+        if color_space is not None and color_space not in VIDEO_COLOR_TRANSFERS:
+            raise ValueError(f"Unsupported video color space: {color_space}")
+        _, output_format, _ = video_output_config(path, format, codec)
         if isinstance(self.__file, io.BytesIO):
             self.__file.seek(0)  # Reset the BytesIO object to the beginning
         with av.open(self.__file, mode='r') as container:
             container_format = container.format.name
             video_stream = container.streams.video[0] if len(container.streams.video) > 0 else None
-            video_encoding = video_stream.codec.name if video_stream is not None else None
+            video_encoding = video_stream.codec.canonical_name if video_stream is not None else None
             source_bit_depth = video_stream_bit_depth(video_stream)
+            source_color_space = video_stream_color_space(video_stream)
+            if source_color_space is not None and color_space is not None and source_color_space != color_space:
+                raise ValueError(
+                    f"Cannot save {source_color_space} video as {color_space} without color conversion; "
+                    f"use auto or {source_color_space}"
+                )
             reuse_streams = True
-            if format != VideoContainer.AUTO and format not in container_format.split(","):
+            if format != VideoContainer.AUTO and VIDEO_CONTAINER_FORMATS[VideoContainer(format)] not in container_format.split(","):
+                reuse_streams = False
+            if output_format == VideoContainer.WEBM and not webm_streams_compatible(container.streams):
                 reuse_streams = False
             if codec != VideoCodec.AUTO and codec != video_encoding and video_encoding is not None:
                 reuse_streams = False
@@ -482,13 +582,15 @@ class VideoFromFile(VideoInput):
                 reuse_streams = False
             if crf is not None:
                 reuse_streams = False
+            if color_space is not None:
+                reuse_streams = False
             if self.__start_time or self.__duration:
                 reuse_streams = False
 
             if not reuse_streams:
                 if bit_depth is None:
                     bit_depth = source_bit_depth
-                return self._save_transcoded(container, path, format=format, codec=codec, metadata=metadata, bit_depth=bit_depth, crf=crf)
+                return self._save_transcoded(container, path, format=format, codec=codec, metadata=metadata, bit_depth=bit_depth, crf=crf, color_space=color_space)
 
             streams = container.streams
 
@@ -522,9 +624,10 @@ class VideoFromFile(VideoInput):
         metadata: dict | None,
         bit_depth: int,
         crf: float | None = None,
+        color_space: str | None = None,
     ):
-        """Re-encode to H.264/AAC one frame at a time; peak memory does not scale with video length."""
-        open_kwargs = mp4_output_open_kwargs(path, format, codec)
+        """Re-encode one frame at a time; peak memory does not scale with video length."""
+        open_kwargs, output_format, output_codec = video_output_config(path, format, codec)
         video_stream = self._get_first_video_stream(container)
         start_time, duration = self.get_active_trim_window()
         start_pts = int(start_time / video_stream.time_base)
@@ -539,6 +642,10 @@ class VideoFromFile(VideoInput):
             container.seek(start_pts, stream=video_stream)
 
         audio_stream = last_decodable_audio_stream(container)
+        source_color_space = video_stream_color_space(video_stream)
+        preserve_source_color = source_color_space is not None
+        if color_space in HDR_COLOR_TRANSFERS or source_color_space in HDR_COLOR_TRANSFERS:
+            bit_depth = max(bit_depth, 10)
         pix_fmt = "yuv420p10le" if bit_depth >= 10 else "yuv420p"
         rate = Fraction(video_stream.average_rate) if video_stream.average_rate else Fraction(1)
 
@@ -558,6 +665,8 @@ class VideoFromFile(VideoInput):
                     logging.warning("Audio stream parameters could not be determined; ignoring audio.")
                     audio_stream = None
         if audio_stream is not None:
+            if output_format == VideoContainer.WEBM:
+                sample_rate = 48000
             audio_time_base = Fraction(1, sample_rate)
             layout = {1: "mono", 2: "stereo", 6: "5.1"}.get(channels, "stereo")
             resampler = av.audio.resampler.AudioResampler(format="fltp", layout=layout, rate=sample_rate)
@@ -655,24 +764,28 @@ class VideoFromFile(VideoInput):
                             else:
                                 out_width, out_height = frame.width, frame.height
                             if out_width % 2 or out_height % 2:
-                                raise ValueError(f"H.264 output requires even dimensions, got {out_width}x{out_height}")
+                                raise ValueError(f"{output_codec.value.upper()} output requires even dimensions, got {out_width}x{out_height}")
                             source_size = (frame.width, frame.height)
                             output = av.open(path, **open_kwargs)
                             # Add metadata before writing any streams
                             write_output_metadata(container, output, metadata)
-                            out_video = output.add_stream("h264", rate=rate)
+                            out_video = output.add_stream(VIDEO_ENCODERS[output_codec], rate=rate)
                             # no B-frames: reordering makes mp4 sample durations follow decode order,
                             # so irregular-VFR spans and trim windows land wrong
                             out_video.codec_context.max_b_frames = 0
                             out_video.width = out_width
                             out_video.height = out_height
                             out_video.pix_fmt = pix_fmt
-                            if crf is not None:
-                                out_video.options = {"crf": str(crf)}
+                            out_video.options = video_encoder_options(output_codec, crf)
+                            if preserve_source_color:
+                                copy_color_properties(video_stream, out_video.codec_context)
+                            elif color_space is not None:
+                                set_video_color_properties(out_video.codec_context, color_space)
                             # source pts pass through (rebased to 0), so variable frame rate survives
                             out_video.codec_context.time_base = video_stream.time_base
                             if audio_stream is not None:
-                                out_audio = output.add_stream("aac", rate=sample_rate, layout=layout)
+                                audio_codec = "libopus" if output_format == VideoContainer.WEBM else "aac"
+                                out_audio = output.add_stream(audio_codec, rate=sample_rate, layout=layout)
                         if (frame.width, frame.height) != source_size:
                             # encoding would silently rescale the new geometry into the old one
                             raise ValueError(
@@ -697,11 +810,15 @@ class VideoFromFile(VideoInput):
                                 rotation_filter = (g_src, g_sink)
                             rotation_filter[0].push(frame)
                             frame = rotation_filter[1].pull()
-                        if frame.color_range == ColorRange.JPEG:
+                        if frame.color_range == ColorRange.JPEG and not preserve_source_color:
                             # compress full-range sources (yuvj/MJPEG) to limited range
                             frame = frame.reformat(format=pix_fmt, src_color_range="JPEG", dst_color_range="MPEG")
                         else:
                             frame = frame.reformat(format=pix_fmt)
+                        if preserve_source_color:
+                            copy_color_properties(video_stream, frame)
+                        elif color_space is not None:
+                            set_video_color_properties(frame, color_space)
                         frame_output_end = None
                         if frame.pts is not None:
                             if video_pts_offset is None:
@@ -830,6 +947,9 @@ class VideoFromComponents(VideoInput):
     def get_bit_depth(self) -> int:
         return self.__bit_depth
 
+    def get_color_space(self) -> str:
+        return "sRGB"
+
     def save_to(
         self,
         path: str,
@@ -838,12 +958,19 @@ class VideoFromComponents(VideoInput):
         metadata: Optional[dict] = None,
         bit_depth: int | None = None,
         crf: float | None = None,
+        color_space: str | None = None,
     ):
         """Save the video to a file path or BytesIO buffer."""
-        open_kwargs = mp4_output_open_kwargs(path, format, codec)
+        if color_space is None:
+            color_space = "sRGB"
+        if color_space is not None and color_space not in VIDEO_COLOR_TRANSFERS:
+            raise ValueError(f"Unsupported video color space: {color_space}")
+        open_kwargs, output_format, output_codec = video_output_config(path, format, codec)
         # None means "use the depth this video was created with" (CreateVideo's choice).
         if bit_depth is None:
             bit_depth = self.__bit_depth
+        if color_space in HDR_COLOR_TRANSFERS:
+            bit_depth = max(bit_depth, 10)
         is_10bit = bit_depth >= 10
         with av.open(path, **open_kwargs) as output:
             # Add metadata before writing any streams
@@ -854,22 +981,28 @@ class VideoFromComponents(VideoInput):
             frame_rate = Fraction(round(self.__components.frame_rate * 1000), 1000)
             # Create a video stream
             pix_fmt = "yuv420p10le" if is_10bit else "yuv420p"
-            video_stream = output.add_stream('h264', rate=frame_rate)
+            video_stream = output.add_stream(VIDEO_ENCODERS[output_codec], rate=frame_rate)
             video_stream.width = self.__components.images.shape[2]
             video_stream.height = self.__components.images.shape[1]
             video_stream.pix_fmt = pix_fmt
-            if crf is not None:
-                video_stream.options = {"crf": str(crf)}
+            video_stream.options = video_encoder_options(output_codec, crf)
+            if color_space is not None:
+                set_video_color_properties(video_stream.codec_context, color_space)
 
             # Create an audio stream
             audio_sample_rate = 1
+            audio_resampler = None
             audio_stream: Optional[av.AudioStream] = None
             if self.__components.audio:
-                audio_sample_rate = int(self.__components.audio['sample_rate'])
+                source_audio_sample_rate = int(self.__components.audio['sample_rate'])
+                audio_sample_rate = 48000 if output_format == VideoContainer.WEBM else source_audio_sample_rate
                 waveform = self.__components.audio['waveform']
-                waveform = waveform[0, :, :math.ceil((audio_sample_rate / frame_rate) * self.__components.images.shape[0])]
+                waveform = waveform[0, :, :math.ceil((source_audio_sample_rate / frame_rate) * self.__components.images.shape[0])]
                 layout = {1: 'mono', 2: 'stereo', 6: '5.1'}.get(waveform.shape[0], 'stereo')
-                audio_stream = output.add_stream('aac', rate=audio_sample_rate, layout=layout)
+                audio_codec = "libopus" if output_format == VideoContainer.WEBM else "aac"
+                audio_stream = output.add_stream(audio_codec, rate=audio_sample_rate, layout=layout)
+                if audio_sample_rate != source_audio_sample_rate:
+                    audio_resampler = av.audio.resampler.AudioResampler(format="fltp", layout=layout, rate=audio_sample_rate)
 
             # Encode video
             for i, frame in enumerate(self.__components.images):
@@ -880,7 +1013,14 @@ class VideoFromComponents(VideoInput):
                 else:
                     img = (frame * 255).clamp(0, 255).byte().cpu().numpy() # shape: (H, W, 3)
                     frame = av.VideoFrame.from_ndarray(img, format='rgb24')
-                frame = frame.reformat(format=pix_fmt)
+                dst_colorspace = None
+                if color_space == "sRGB":
+                    dst_colorspace = BT709_NCL
+                elif color_space in HDR_COLOR_TRANSFERS:
+                    dst_colorspace = BT2020_NCL
+                frame = frame.reformat(format=pix_fmt, dst_colorspace=dst_colorspace)
+                if color_space is not None:
+                    set_video_color_properties(frame, color_space)
                 packet = video_stream.encode(frame)
                 output.mux(packet)
 
@@ -890,9 +1030,14 @@ class VideoFromComponents(VideoInput):
 
             if audio_stream and self.__components.audio:
                 frame = av.AudioFrame.from_ndarray(waveform.float().cpu().contiguous().numpy(), format='fltp', layout=layout)
-                frame.sample_rate = audio_sample_rate
+                frame.sample_rate = source_audio_sample_rate
                 frame.pts = 0
-                output.mux(audio_stream.encode(frame))
+                frames = [frame] if audio_resampler is None else audio_resampler.resample(frame)
+                for frame in frames:
+                    output.mux(audio_stream.encode(frame))
+                if audio_resampler is not None:
+                    for frame in audio_resampler.resample(None):
+                        output.mux(audio_stream.encode(frame))
 
                 # Flush encoder
                 output.mux(audio_stream.encode(None))

--- a/comfy_api/latest/_input_impl/video_types.py
+++ b/comfy_api/latest/_input_impl/video_types.py
@@ -134,6 +134,17 @@ def write_output_metadata(container: InputContainer, output, metadata: dict | No
             output.metadata[key] = value if isinstance(value, str) else json.dumps(value)
 
 
+def unsupported_remux_codecs(streams, output_container) -> list[str]:
+    supported = output_container.supported_codecs
+    return [
+        stream.codec_context.name
+        for stream in streams
+        if isinstance(stream, (av.VideoStream, av.AudioStream, SubtitleStream))
+        and stream.codec_context is not None
+        and stream.codec_context.name not in supported
+    ]
+
+
 def video_output_config(path: str | io.BytesIO, format: VideoContainer, codec: VideoCodec) -> tuple[dict, VideoContainer, VideoCodec]:
     if isinstance(format, str):
         format = VideoContainer(format)
@@ -592,28 +603,54 @@ class VideoFromFile(VideoInput):
                     bit_depth = source_bit_depth
                 return self._save_transcoded(container, path, format=format, codec=codec, metadata=metadata, bit_depth=bit_depth, crf=crf, color_space=color_space)
 
-            streams = container.streams
-
             open_kwargs = get_open_write_kwargs(path, container_format, format)
-            with av.open(path, **open_kwargs) as output_container:
-                # Add metadata before writing any streams
-                write_output_metadata(container, output_container, metadata)
+            if self._save_remuxed(container, path, open_kwargs, metadata):
+                return
 
-                # Add streams to the new container. Streams with no codec context cannot be used as an output template.
-                stream_map = {}
-                for stream in streams:
-                    if isinstance(stream, (av.VideoStream, av.AudioStream, SubtitleStream)):
-                        if stream.codec_context is None:
-                            logging.warning("Skipping %s stream %d with unsupported codec", stream.type, stream.index)
-                            continue
-                        out_stream = output_container.add_stream_from_template(template=stream, opaque=True)
-                        stream_map[stream] = out_stream
+            if bit_depth is None:
+                bit_depth = source_bit_depth
+            if isinstance(path, io.BytesIO):
+                path.seek(0)
+                path.truncate()
+            return self._save_transcoded(container, path, format=format, codec=codec, metadata=metadata, bit_depth=bit_depth, crf=crf, color_space=color_space)
 
-                # Write packets to the new container
-                for packet in container.demux():
-                    if packet.stream in stream_map and packet.dts is not None:
-                        packet.stream = stream_map[packet.stream]
-                        output_container.mux(packet)
+    def _save_remuxed(
+        self,
+        container: InputContainer,
+        path: str | io.BytesIO,
+        open_kwargs: dict,
+        metadata: dict | None,
+    ) -> bool:
+        streams = container.streams
+        with av.open(path, **open_kwargs) as output_container:
+            unsupported = unsupported_remux_codecs(streams, output_container)
+            if unsupported:
+                logging.info(
+                    "Cannot copy %s into a %s container; re-encoding instead.",
+                    ", ".join(sorted(set(unsupported))),
+                    output_container.format.name,
+                )
+                return False
+
+            # Add metadata before writing any streams
+            write_output_metadata(container, output_container, metadata)
+
+            # Add streams to the new container. Streams with no codec context cannot be used as an output template.
+            stream_map = {}
+            for stream in streams:
+                if isinstance(stream, (av.VideoStream, av.AudioStream, SubtitleStream)):
+                    if stream.codec_context is None:
+                        logging.warning("Skipping %s stream %d with unsupported codec", stream.type, stream.index)
+                        continue
+                    out_stream = output_container.add_stream_from_template(template=stream, opaque=True)
+                    stream_map[stream] = out_stream
+
+            # Write packets to the new container
+            for packet in container.demux():
+                if packet.stream in stream_map and packet.dts is not None:
+                    packet.stream = stream_map[packet.stream]
+                    output_container.mux(packet)
+        return True
 
     def _save_transcoded(
         self,

--- a/comfy_api/latest/_input_impl/video_types.py
+++ b/comfy_api/latest/_input_impl/video_types.py
@@ -596,6 +596,11 @@ class VideoFromFile(VideoInput):
             if self._save_remuxed(container, path, open_kwargs, metadata):
                 return
 
+            if video_stream is None:
+                raise ValueError(
+                    f"Cannot store the audio of '{self.__file}' in this container, and there is no video "
+                    "stream to re-encode it alongside."
+                )
             if bit_depth is None:
                 bit_depth = source_bit_depth
             if isinstance(path, io.BytesIO):

--- a/comfy_api/latest/_input_impl/video_types.py
+++ b/comfy_api/latest/_input_impl/video_types.py
@@ -134,17 +134,6 @@ def write_output_metadata(container: InputContainer, output, metadata: dict | No
             output.metadata[key] = value if isinstance(value, str) else json.dumps(value)
 
 
-def unsupported_remux_codecs(streams, output_container) -> list[str]:
-    supported = output_container.supported_codecs
-    return [
-        stream.codec_context.name
-        for stream in streams
-        if isinstance(stream, (av.VideoStream, av.AudioStream, SubtitleStream))
-        and stream.codec_context is not None
-        and stream.codec_context.name not in supported
-    ]
-
-
 def video_output_config(path: str | io.BytesIO, format: VideoContainer, codec: VideoCodec) -> tuple[dict, VideoContainer, VideoCodec]:
     if isinstance(format, str):
         format = VideoContainer(format)
@@ -623,15 +612,6 @@ class VideoFromFile(VideoInput):
     ) -> bool:
         streams = container.streams
         with av.open(path, **open_kwargs) as output_container:
-            unsupported = unsupported_remux_codecs(streams, output_container)
-            if unsupported:
-                logging.info(
-                    "Cannot copy %s into a %s container; re-encoding instead.",
-                    ", ".join(sorted(set(unsupported))),
-                    output_container.format.name,
-                )
-                return False
-
             # Add metadata before writing any streams
             write_output_metadata(container, output_container, metadata)
 
@@ -642,7 +622,23 @@ class VideoFromFile(VideoInput):
                     if stream.codec_context is None:
                         logging.warning("Skipping %s stream %d with unsupported codec", stream.type, stream.index)
                         continue
-                    out_stream = output_container.add_stream_from_template(template=stream, opaque=True)
+                    try:
+                        out_stream = output_container.add_stream_from_template(template=stream, opaque=True)
+                    except ValueError:
+                        codec_name = stream.codec_context.name
+                        format_name = output_container.format.name
+                        if isinstance(stream, SubtitleStream):
+                            logging.warning(
+                                "Dropping %s subtitle stream %d: the %s container cannot store it.",
+                                codec_name, stream.index, format_name,
+                            )
+                            continue
+                        logging.warning(
+                            "The %s container cannot store %s, so the whole file is being re-encoded to H.264/AAC. "
+                            "Any additional audio or subtitle streams will be dropped.",
+                            format_name, codec_name,
+                        )
+                        return False
                     stream_map[stream] = out_stream
 
             # Write packets to the new container

--- a/comfy_api/latest/_input_impl/video_types.py
+++ b/comfy_api/latest/_input_impl/video_types.py
@@ -71,8 +71,7 @@ def get_open_write_kwargs(
     is_write_to_buffer = isinstance(dest, io.BytesIO)
     open_kwargs = {"mode": "w"}
 
-    if is_write_to_buffer:
-        # Set output format explicitly, since it cannot be inferred from file extension
+    if is_write_to_buffer or to_format != VideoContainer.AUTO:
         if to_format == VideoContainer.AUTO:
             to_format = container_format.lower()
         elif isinstance(to_format, VideoContainer):
@@ -81,7 +80,7 @@ def get_open_write_kwargs(
             to_format = to_format.lower()
         open_kwargs["format"] = container_to_output_format(to_format)
 
-    output_format = open_kwargs["format"] if is_write_to_buffer else os.path.splitext(dest)[1].lower().lstrip(".")
+    output_format = open_kwargs["format"] if "format" in open_kwargs else os.path.splitext(dest)[1].lower().lstrip(".")
     if output_format in ("mov", "mp4"):
         # Preserve custom metadata tags (workflow, prompt, extra_pnginfo) in isobmff.
         movflags = "use_metadata_tags" if is_write_to_buffer else "use_metadata_tags+faststart"
@@ -617,10 +616,8 @@ class VideoFromFile(VideoInput):
     ) -> bool:
         streams = container.streams
         with av.open(path, **open_kwargs) as output_container:
-            # Add metadata before writing any streams
             write_output_metadata(container, output_container, metadata)
 
-            # Add streams to the new container. Streams with no codec context cannot be used as an output template.
             stream_map = {}
             for stream in streams:
                 if isinstance(stream, (av.VideoStream, av.AudioStream, SubtitleStream)):
@@ -647,7 +644,6 @@ class VideoFromFile(VideoInput):
                         return False
                     stream_map[stream] = out_stream
 
-            # Write packets to the new container
             for packet in container.demux():
                 if packet.stream in stream_map and packet.dts is not None:
                     packet.stream = stream_map[packet.stream]
@@ -683,6 +679,7 @@ class VideoFromFile(VideoInput):
         audio_stream = last_decodable_audio_stream(container)
         source_color_space = video_stream_color_space(video_stream)
         preserve_source_color = source_color_space is not None
+        normalize_color_range = video_stream.color_range == ColorRange.JPEG and source_color_space not in HDR_COLOR_TRANSFERS
         if color_space in HDR_COLOR_TRANSFERS or source_color_space in HDR_COLOR_TRANSFERS:
             bit_depth = max(bit_depth, 10)
         pix_fmt = "yuv420p10le" if bit_depth >= 10 else "yuv420p"
@@ -712,15 +709,10 @@ class VideoFromFile(VideoInput):
             if duration:
                 duration_cap = math.ceil(duration * sample_rate)
 
-        # Subtitles are remuxed untouched: there is no subtitle encoder binding, so a stream the
-        # output container cannot store as-is is dropped with a warning naming it, exactly like
-        # the remux path does. Streams FFmpeg has no decoder for cannot template a new stream.
         subtitle_streams = [s for s in container.streams.subtitles if s.codec_context is not None]
         streams = [video_stream] if audio_stream is None else [video_stream, audio_stream]
         streams += subtitle_streams
         subtitle_map = {}
-        # Subtitle packets that arrive before the first kept video frame: the output is not open
-        # yet and the pts rebase offset is not known, so they wait here rather than being lost.
         pending_subtitles = []
         pts_step = max(1, int(round((1 / rate) / video_stream.time_base)))
         video_done = False
@@ -780,15 +772,12 @@ class VideoFromFile(VideoInput):
             return cap
 
         def mux_subtitle(packet):
-            """Remux one subtitle packet, rebased onto the trimmed timeline the video was rebased to."""
             out_stream = subtitle_map.get(packet.stream)
             if out_stream is None or packet.dts is None or packet.pts is None or packet.time_base is None:
                 return
             start = float(packet.pts * packet.time_base)
             if start < start_time or (duration and start >= start_time + duration):
                 return
-            # the video's own rebase offset, so subtitles stay in sync with it rather than
-            # with the requested start (a seek lands on the preceding keyframe)
             offset_ticks = video_pts_offset if video_pts_offset is not None else start_pts
             shift = int(round(float(offset_ticks * video_stream.time_base) / packet.time_base))
             packet.pts -= shift
@@ -799,7 +788,6 @@ class VideoFromFile(VideoInput):
             output.mux(packet)
 
         def flush_subtitles():
-            # only once the first video frame fixed the rebase offset
             if output is None or not pending_subtitles or last_video_pts is None:
                 return
             while pending_subtitles:
@@ -853,6 +841,8 @@ class VideoFromFile(VideoInput):
                             out_video.options = video_encoder_options(output_codec, crf)
                             if preserve_source_color:
                                 copy_color_properties(video_stream, out_video.codec_context)
+                                if normalize_color_range:
+                                    out_video.codec_context.color_range = ColorRange.MPEG
                             elif color_space is not None:
                                 set_video_color_properties(out_video.codec_context, color_space)
                             # source pts pass through (rebased to 0), so variable frame rate survives
@@ -897,13 +887,14 @@ class VideoFromFile(VideoInput):
                                 rotation_filter = (g_src, g_sink)
                             rotation_filter[0].push(frame)
                             frame = rotation_filter[1].pull()
-                        if frame.color_range == ColorRange.JPEG and not preserve_source_color:
-                            # compress full-range sources (yuvj/MJPEG) to limited range
+                        if frame.color_range == ColorRange.JPEG and normalize_color_range:
                             frame = frame.reformat(format=pix_fmt, src_color_range="JPEG", dst_color_range="MPEG")
                         else:
                             frame = frame.reformat(format=pix_fmt)
                         if preserve_source_color:
                             copy_color_properties(video_stream, frame)
+                            if normalize_color_range:
+                                frame.color_range = ColorRange.MPEG
                         elif color_space is not None:
                             set_video_color_properties(frame, color_space)
                         frame_output_end = None

--- a/comfy_api/latest/_input_impl/video_types.py
+++ b/comfy_api/latest/_input_impl/video_types.py
@@ -640,7 +640,8 @@ class VideoFromFile(VideoInput):
                             continue
                         logging.warning(
                             "The %s container cannot store %s, so the whole file is being re-encoded to H.264/AAC. "
-                            "Any additional audio or subtitle streams will be dropped.",
+                            "Any additional audio streams will be dropped; subtitles the output container "
+                            "can store are kept.",
                             format_name, codec_name,
                         )
                         return False
@@ -711,7 +712,16 @@ class VideoFromFile(VideoInput):
             if duration:
                 duration_cap = math.ceil(duration * sample_rate)
 
+        # Subtitles are remuxed untouched: there is no subtitle encoder binding, so a stream the
+        # output container cannot store as-is is dropped with a warning naming it, exactly like
+        # the remux path does. Streams FFmpeg has no decoder for cannot template a new stream.
+        subtitle_streams = [s for s in container.streams.subtitles if s.codec_context is not None]
         streams = [video_stream] if audio_stream is None else [video_stream, audio_stream]
+        streams += subtitle_streams
+        subtitle_map = {}
+        # Subtitle packets that arrive before the first kept video frame: the output is not open
+        # yet and the pts rebase offset is not known, so they wait here rather than being lost.
+        pending_subtitles = []
         pts_step = max(1, int(round((1 / rate) / video_stream.time_base)))
         video_done = False
         audio_done = audio_stream is None
@@ -769,6 +779,32 @@ class VideoFromFile(VideoInput):
                 audio_done = True
             return cap
 
+        def mux_subtitle(packet):
+            """Remux one subtitle packet, rebased onto the trimmed timeline the video was rebased to."""
+            out_stream = subtitle_map.get(packet.stream)
+            if out_stream is None or packet.dts is None or packet.pts is None or packet.time_base is None:
+                return
+            start = float(packet.pts * packet.time_base)
+            if start < start_time or (duration and start >= start_time + duration):
+                return
+            # the video's own rebase offset, so subtitles stay in sync with it rather than
+            # with the requested start (a seek lands on the preceding keyframe)
+            offset_ticks = video_pts_offset if video_pts_offset is not None else start_pts
+            shift = int(round(float(offset_ticks * video_stream.time_base) / packet.time_base))
+            packet.pts -= shift
+            packet.dts -= shift
+            if packet.pts < 0:
+                return
+            packet.stream = out_stream
+            output.mux(packet)
+
+        def flush_subtitles():
+            # only once the first video frame fixed the rebase offset
+            if output is None or not pending_subtitles or last_video_pts is None:
+                return
+            while pending_subtitles:
+                mux_subtitle(pending_subtitles.pop(0))
+
         try:
             for packet in container.demux(*streams):
                 if video_done and audio_done:
@@ -824,6 +860,19 @@ class VideoFromFile(VideoInput):
                             if audio_stream is not None:
                                 audio_codec = "libopus" if output_format == VideoContainer.WEBM else "aac"
                                 out_audio = output.add_stream(audio_codec, rate=sample_rate, layout=layout)
+                            for subtitle_stream in subtitle_streams:
+                                try:
+                                    subtitle_map[subtitle_stream] = output.add_stream_from_template(
+                                        template=subtitle_stream, opaque=True
+                                    )
+                                except ValueError:
+                                    logging.warning(
+                                        "Dropping %s subtitle stream %d: the %s container cannot store it, "
+                                        "and subtitles cannot be re-encoded.",
+                                        subtitle_stream.codec_context.name,
+                                        subtitle_stream.index,
+                                        output.format.name,
+                                    )
                         if (frame.width, frame.height) != source_size:
                             # encoding would silently rescale the new geometry into the old one
                             raise ValueError(
@@ -889,6 +938,7 @@ class VideoFromFile(VideoInput):
                         for out_packet in out_video.encode(frame):
                             out_packet.duration = video_frame_durations.pop(out_packet.pts, 0)
                             output.mux(out_packet)
+                        flush_subtitles()
                         drain_audio()
 
                 elif packet.stream == audio_stream and not audio_done:
@@ -924,6 +974,12 @@ class VideoFromFile(VideoInput):
                                 audio_done = True
                                 break
 
+                elif packet.stream in subtitle_map:
+                    mux_subtitle(packet)
+                elif packet.stream in subtitle_streams and output is None:
+                    pending_subtitles.append(packet)
+
+            flush_subtitles()
             if output is None:
                 raise ValueError(f"No decodable video frames found in file '{self.__file}'")
             if out_audio is not None and not audio_done:

--- a/comfy_api/latest/_input_impl/video_types.py
+++ b/comfy_api/latest/_input_impl/video_types.py
@@ -636,7 +636,7 @@ class VideoFromFile(VideoInput):
                             )
                             continue
                         logging.warning(
-                            "The %s container cannot store %s, so the whole file is being re-encoded to H.264/AAC. "
+                            "The %s container cannot store %s, so the whole file is being re-encoded. "
                             "Any additional audio streams will be dropped; subtitles the output container "
                             "can store are kept.",
                             format_name, codec_name,

--- a/comfy_api/latest/_input_impl/video_types.py
+++ b/comfy_api/latest/_input_impl/video_types.py
@@ -100,6 +100,17 @@ def write_output_metadata(container: InputContainer, output, metadata: dict | No
             output.metadata[key] = value if isinstance(value, str) else json.dumps(value)
 
 
+def unsupported_remux_codecs(streams, output_container) -> list[str]:
+    supported = output_container.supported_codecs
+    return [
+        stream.codec_context.name
+        for stream in streams
+        if isinstance(stream, (av.VideoStream, av.AudioStream, SubtitleStream))
+        and stream.codec_context is not None
+        and stream.codec_context.name not in supported
+    ]
+
+
 def mp4_output_open_kwargs(path: str | io.BytesIO, format: VideoContainer, codec: VideoCodec) -> dict:
     if format != VideoContainer.AUTO and format != VideoContainer.MP4:
         raise ValueError("Only MP4 format is supported for now")
@@ -490,28 +501,54 @@ class VideoFromFile(VideoInput):
                     bit_depth = source_bit_depth
                 return self._save_transcoded(container, path, format=format, codec=codec, metadata=metadata, bit_depth=bit_depth, crf=crf)
 
-            streams = container.streams
-
             open_kwargs = get_open_write_kwargs(path, container_format, format)
-            with av.open(path, **open_kwargs) as output_container:
-                # Add metadata before writing any streams
-                write_output_metadata(container, output_container, metadata)
+            if self._save_remuxed(container, path, open_kwargs, metadata):
+                return
 
-                # Add streams to the new container. Streams with no codec context cannot be used as an output template.
-                stream_map = {}
-                for stream in streams:
-                    if isinstance(stream, (av.VideoStream, av.AudioStream, SubtitleStream)):
-                        if stream.codec_context is None:
-                            logging.warning("Skipping %s stream %d with unsupported codec", stream.type, stream.index)
-                            continue
-                        out_stream = output_container.add_stream_from_template(template=stream, opaque=True)
-                        stream_map[stream] = out_stream
+            if bit_depth is None:
+                bit_depth = source_bit_depth
+            if isinstance(path, io.BytesIO):
+                path.seek(0)
+                path.truncate()
+            return self._save_transcoded(container, path, format=format, codec=codec, metadata=metadata, bit_depth=bit_depth, crf=crf)
 
-                # Write packets to the new container
-                for packet in container.demux():
-                    if packet.stream in stream_map and packet.dts is not None:
-                        packet.stream = stream_map[packet.stream]
-                        output_container.mux(packet)
+    def _save_remuxed(
+        self,
+        container: InputContainer,
+        path: str | io.BytesIO,
+        open_kwargs: dict,
+        metadata: dict | None,
+    ) -> bool:
+        streams = container.streams
+        with av.open(path, **open_kwargs) as output_container:
+            unsupported = unsupported_remux_codecs(streams, output_container)
+            if unsupported:
+                logging.info(
+                    "Cannot copy %s into a %s container; re-encoding instead.",
+                    ", ".join(sorted(set(unsupported))),
+                    output_container.format.name,
+                )
+                return False
+
+            # Add metadata before writing any streams
+            write_output_metadata(container, output_container, metadata)
+
+            # Add streams to the new container. Streams with no codec context cannot be used as an output template.
+            stream_map = {}
+            for stream in streams:
+                if isinstance(stream, (av.VideoStream, av.AudioStream, SubtitleStream)):
+                    if stream.codec_context is None:
+                        logging.warning("Skipping %s stream %d with unsupported codec", stream.type, stream.index)
+                        continue
+                    out_stream = output_container.add_stream_from_template(template=stream, opaque=True)
+                    stream_map[stream] = out_stream
+
+            # Write packets to the new container
+            for packet in container.demux():
+                if packet.stream in stream_map and packet.dts is not None:
+                    packet.stream = stream_map[packet.stream]
+                    output_container.mux(packet)
+        return True
 
     def _save_transcoded(
         self,

--- a/comfy_api/latest/_util/video_types.py
+++ b/comfy_api/latest/_util/video_types.py
@@ -7,6 +7,7 @@ from .._input import ImageInput, AudioInput, MaskInput
 class VideoCodec(str, Enum):
     AUTO = "auto"
     H264 = "h264"
+    AV1 = "av1"
 
     @classmethod
     def as_input(cls) -> list[str]:
@@ -18,6 +19,8 @@ class VideoCodec(str, Enum):
 class VideoContainer(str, Enum):
     AUTO = "auto"
     MP4 = "mp4"
+    MKV = "mkv"
+    WEBM = "webm"
 
     @classmethod
     def as_input(cls) -> list[str]:
@@ -35,6 +38,10 @@ class VideoContainer(str, Enum):
             value = cls(value)
         if value == VideoContainer.MP4 or value == VideoContainer.AUTO:
             return "mp4"
+        if value == VideoContainer.MKV:
+            return "mkv"
+        if value == VideoContainer.WEBM:
+            return "webm"
         return ""
 
 @dataclass

--- a/comfy_extras/nodes_video.py
+++ b/comfy_extras/nodes_video.py
@@ -167,7 +167,7 @@ class SaveVideo(io.ComfyNode):
         )
 
     @classmethod
-    def execute(cls, video: Input.Video, filename_prefix, format: io.DynamicCombo.Type | str, codec: io.DynamicCombo.Type | None = None) -> io.NodeOutput:
+    def execute(cls, video: Input.Video, filename_prefix, format: io.DynamicCombo.Type | str, codec: io.DynamicCombo.Type | str | None = None) -> io.NodeOutput:
         if isinstance(format, dict):
             format_name = format["format"]
             codec = format.get("codec") or codec
@@ -175,6 +175,8 @@ class SaveVideo(io.ComfyNode):
             format_name = format
         if codec is None:
             codec = {"codec": "auto"}
+        elif isinstance(codec, str):
+            codec = {"codec": codec}
         codec_name = codec["codec"]
         encoding = codec.get("encoding") or {}
         color_space = encoding.get("color_space")
@@ -197,14 +199,15 @@ class SaveVideo(io.ComfyNode):
             if len(metadata) > 0:
                 saved_metadata = metadata
         file = f"{filename}_{counter:05}_.{Types.VideoContainer.get_extension(format_name)}"
-        video.save_to(
-            os.path.join(full_output_folder, file),
-            format=Types.VideoContainer(format_name),
-            codec=Types.VideoCodec(codec_name),
-            metadata=saved_metadata,
-            crf=encoding.get("crf"),
-            color_space=color_space,
-        )
+        save_options = {
+            "format": Types.VideoContainer(format_name),
+            "codec": Types.VideoCodec(codec_name),
+            "metadata": saved_metadata,
+            "crf": encoding.get("crf"),
+        }
+        if color_space is not None:
+            save_options["color_space"] = color_space
+        video.save_to(os.path.join(full_output_folder, file), **save_options)
 
         return io.NodeOutput(video, ui=ui.PreviewVideo([ui.SavedResult(file, subfolder, io.FolderType.output)]))
 

--- a/comfy_extras/nodes_video.py
+++ b/comfy_extras/nodes_video.py
@@ -72,6 +72,70 @@ class SaveWEBM(io.ComfyNode):
 
         return io.NodeOutput(images, ui=ui.PreviewVideo([ui.SavedResult(file, subfolder, io.FolderType.output)]))
 
+def _save_video_codec_input(supported_codecs: list[str], *, optional=False, hidden=False):
+    codec_options = []
+    if "auto" in supported_codecs:
+        codec_options.append(io.DynamicCombo.Option("auto", []))
+    if "h264" in supported_codecs:
+        codec_options.append(
+            io.DynamicCombo.Option(
+                "h264",
+                [
+                    io.DynamicCombo.Input(
+                        "encoding",
+                        display_name="encoding mode",
+                        options=[
+                            io.DynamicCombo.Option("auto", []),
+                            io.DynamicCombo.Option(
+                                "re-encode",
+                                [io.Float.Input("crf", default=23.0, min=0.0, max=51.0, step=1.0, tooltip="Lower values produce higher quality and larger files.")],
+                            ),
+                        ],
+                        optional=True,
+                        tooltip="Automatic preserves compatible H.264 streams. Re-encode applies a custom CRF.",
+                    ),
+                ],
+            )
+        )
+    if "av1" in supported_codecs:
+        codec_options.append(
+            io.DynamicCombo.Option(
+                "av1",
+                [
+                    io.DynamicCombo.Input(
+                        "encoding",
+                        display_name="encoding mode",
+                        options=[
+                            io.DynamicCombo.Option("auto", []),
+                            io.DynamicCombo.Option(
+                                "re-encode",
+                                [
+                                    io.Float.Input("crf", default=30.0, min=0.0, max=63.0, step=1.0, tooltip="Lower values produce higher quality and larger files."),
+                                    io.Combo.Input(
+                                        "color_space",
+                                        options=["auto", "sRGB", "HDR", "HDR PQ"],
+                                        default="auto",
+                                        display_name="color space",
+                                        tooltip="Auto uses sRGB for videos created from images and preserves recognized colors on loaded videos. sRGB writes SDR BT.709/sRGB. HDR writes 10-bit BT.2020/HLG; HDR PQ writes BT.2020/PQ. Other input pixels must already use the selected color space.",
+                                    ),
+                                ],
+                            ),
+                        ],
+                        optional=True,
+                        tooltip="Automatic preserves compatible AV1 streams. Re-encode applies custom encoding options.",
+                    ),
+                ],
+            )
+        )
+    return io.DynamicCombo.Input(
+        "codec",
+        options=codec_options,
+        optional=optional,
+        tooltip="The codec to use for the video.",
+        extra_dict={"hidden": True} if hidden else None,
+    )
+
+
 class SaveVideo(io.ComfyNode):
     @classmethod
     def define_schema(cls):
@@ -85,32 +149,17 @@ class SaveVideo(io.ComfyNode):
             inputs=[
                 io.Video.Input("video", tooltip="The video to save."),
                 io.String.Input("filename_prefix", default="video/ComfyUI", tooltip="The prefix for the file to save. This may include formatting information such as %date:yyyy-MM-dd% or %Empty Latent Image.width% to include values from nodes."),
-                io.Combo.Input("format", options=Types.VideoContainer.as_input(), default="auto", tooltip="The format to save the video as."),
                 io.DynamicCombo.Input(
-                    "codec",
+                    "format",
                     options=[
-                        io.DynamicCombo.Option("auto", []),
-                        io.DynamicCombo.Option(
-                            "h264",
-                            [
-                                io.DynamicCombo.Input(
-                                    "encoding",
-                                    display_name="encoding mode",
-                                    options=[
-                                        io.DynamicCombo.Option("auto", []),
-                                        io.DynamicCombo.Option(
-                                            "re-encode",
-                                            [io.Float.Input("crf", default=23.0, min=0.0, max=51.0, step=1.0, tooltip="Lower values produce higher quality and larger files.")],
-                                        ),
-                                    ],
-                                    optional=True,
-                                    tooltip="Automatic preserves compatible H.264 streams. Re-encode applies a custom CRF.",
-                                ),
-                            ],
-                        ),
+                        io.DynamicCombo.Option("auto", [_save_video_codec_input(["auto", "h264", "av1"])]),
+                        io.DynamicCombo.Option("mp4", [_save_video_codec_input(["auto", "h264", "av1"])]),
+                        io.DynamicCombo.Option("mkv", [_save_video_codec_input(["auto", "h264", "av1"])]),
+                        io.DynamicCombo.Option("webm", [_save_video_codec_input(["auto", "av1"])]),
                     ],
-                    tooltip="The codec to use for the video.",
+                    tooltip="The format to save the video as.",
                 ),
+                _save_video_codec_input(["auto", "h264", "av1"], optional=True, hidden=True),
             ],
             hidden=[io.Hidden.prompt, io.Hidden.extra_pnginfo],
             is_output_node=True,
@@ -118,9 +167,19 @@ class SaveVideo(io.ComfyNode):
         )
 
     @classmethod
-    def execute(cls, video: Input.Video, filename_prefix, format: str, codec: io.DynamicCombo.Type) -> io.NodeOutput:
+    def execute(cls, video: Input.Video, filename_prefix, format: io.DynamicCombo.Type | str, codec: io.DynamicCombo.Type | None = None) -> io.NodeOutput:
+        if isinstance(format, dict):
+            format_name = format["format"]
+            codec = format.get("codec") or codec
+        else:
+            format_name = format
+        if codec is None:
+            codec = {"codec": "auto"}
         codec_name = codec["codec"]
         encoding = codec.get("encoding") or {}
+        color_space = encoding.get("color_space")
+        if color_space == "auto":
+            color_space = None
         width, height = video.get_dimensions()
         full_output_folder, filename, counter, subfolder, filename_prefix = folder_paths.get_save_image_path(
             filename_prefix,
@@ -137,13 +196,14 @@ class SaveVideo(io.ComfyNode):
                 metadata["prompt"] = cls.hidden.prompt
             if len(metadata) > 0:
                 saved_metadata = metadata
-        file = f"{filename}_{counter:05}_.{Types.VideoContainer.get_extension(format)}"
+        file = f"{filename}_{counter:05}_.{Types.VideoContainer.get_extension(format_name)}"
         video.save_to(
             os.path.join(full_output_folder, file),
-            format=Types.VideoContainer(format),
-            codec=codec_name,
+            format=Types.VideoContainer(format_name),
+            codec=Types.VideoCodec(codec_name),
             metadata=saved_metadata,
             crf=encoding.get("crf"),
+            color_space=color_space,
         )
 
         return io.NodeOutput(video, ui=ui.PreviewVideo([ui.SavedResult(file, subfolder, io.FolderType.output)]))
@@ -199,7 +259,7 @@ class GetVideoComponents(io.ComfyNode):
             search_aliases=["extract frames", "split video", "video to images", "demux"],
             display_name="Get Video Components",
             category="video",
-            description="Extracts all components from a video: frames, audio, framerate, and bit depth.",
+            description="Extracts video frames, audio, frame rate, bit depth, and color space.",
             inputs=[
                 io.Video.Input("video", tooltip="The video to extract components from."),
             ],
@@ -208,13 +268,20 @@ class GetVideoComponents(io.ComfyNode):
                 io.Audio.Output(display_name="audio"),
                 io.Float.Output(display_name="fps"),
                 io.Int.Output(display_name="bit_depth"),
+                io.Combo.Output(display_name="color_space"),
             ],
         )
 
     @classmethod
     def execute(cls, video: Input.Video) -> io.NodeOutput:
         components = video.get_components()
-        return io.NodeOutput(components.images, components.audio, float(components.frame_rate), video.get_bit_depth())
+        return io.NodeOutput(
+            components.images,
+            components.audio,
+            float(components.frame_rate),
+            video.get_bit_depth(),
+            video.get_color_space(),
+        )
 
 
 class LoadVideo(io.ComfyNode):

--- a/tests-unit/comfy_api_test/input_impl_test.py
+++ b/tests-unit/comfy_api_test/input_impl_test.py
@@ -2,8 +2,9 @@ import io
 from comfy_api.input_impl.video_types import (
     container_to_output_format,
     get_open_write_kwargs,
+    video_encoder_options,
 )
-from comfy_api.util import VideoContainer
+from comfy_api.util import VideoCodec, VideoContainer
 
 
 def test_container_to_output_format_empty_string():
@@ -36,7 +37,7 @@ def test_get_open_write_kwargs_filepath_no_format():
     kwargs_specific = get_open_write_kwargs("output.avi", "mp4", "avi")
     fail_msg = "Format should not be set for file paths (Specific)"
     assert "format" not in kwargs_specific, fail_msg
-    assert kwargs_specific["options"]["movflags"] == "use_metadata_tags"
+    assert "options" not in kwargs_specific
 
 
 def test_get_open_write_kwargs_base_options_mode():
@@ -90,3 +91,16 @@ def test_get_open_write_kwargs_bytesio_specific_format_list():
 
     fail_msg = "Format should be a valid format from the specified format list when output format is not AUTO"
     assert kwargs["format"] in to_fmt, fail_msg
+
+
+def test_get_open_write_kwargs_does_not_pass_movflags_to_matroska_or_webm():
+    for format, suffix in ((VideoContainer.MKV, "mkv"), (VideoContainer.WEBM, "webm")):
+        assert "options" not in get_open_write_kwargs(f"output.{suffix}", "mp4", format)
+        assert "options" not in get_open_write_kwargs(io.BytesIO(), "mp4", format)
+
+
+def test_av1_zero_crf_uses_lossless_mode():
+    assert video_encoder_options(VideoCodec.AV1, 0) == {"svtav1-params": "lossless=1"}
+    assert video_encoder_options(VideoCodec.AV1, 30.0) == {"crf": "30.0"}
+    assert video_encoder_options(VideoCodec.H264, 0) == {"crf": "0"}
+    assert video_encoder_options(VideoCodec.AV1, None) == {}

--- a/tests-unit/comfy_api_test/input_impl_test.py
+++ b/tests-unit/comfy_api_test/input_impl_test.py
@@ -29,14 +29,12 @@ def test_container_to_output_format_single():
     assert container_to_output_format("mp4") == "mp4"
 
 
-def test_get_open_write_kwargs_filepath_no_format():
-    """Test that 'format' kwarg is NOT set when dest is a file path."""
+def test_get_open_write_kwargs_filepath_format():
     kwargs_auto = get_open_write_kwargs("output.mp4", "mp4", VideoContainer.AUTO)
-    assert "format" not in kwargs_auto, "Format should not be set for file paths (AUTO)"
+    assert "format" not in kwargs_auto
 
     kwargs_specific = get_open_write_kwargs("output.avi", "mp4", "avi")
-    fail_msg = "Format should not be set for file paths (Specific)"
-    assert "format" not in kwargs_specific, fail_msg
+    assert kwargs_specific["format"] == "avi"
     assert "options" not in kwargs_specific
 
 

--- a/tests-unit/comfy_api_test/video_types_test.py
+++ b/tests-unit/comfy_api_test/video_types_test.py
@@ -727,6 +727,85 @@ def test_save_to_mp4_writes_metadata_before_media(video_components, tmp_path):
         assert data.index(b"moov") < data.index(b"mdat")
 
 
+def create_matroska_source(
+    tmp_path, video_codec="libvpx", audio_codec=None, frames=6, fps=10, container_format="webm"
+):
+    path = str(tmp_path / f"source_{video_codec}.{container_format}")
+    with av.open(path, mode="w", format=container_format) as container:
+        video_stream = container.add_stream(video_codec, rate=fps)
+        video_stream.width = 32
+        video_stream.height = 32
+        video_stream.pix_fmt = "yuv420p"
+        audio_stream = None
+        if audio_codec is not None:
+            audio_stream = container.add_stream(audio_codec, rate=48000)
+            audio_stream.sample_rate = 48000
+
+        for i in range(frames):
+            frame = av.VideoFrame.from_ndarray(
+                torch.full((32, 32, 3), (i * 40) % 256, dtype=torch.uint8).numpy(),
+                format="rgb24",
+            )
+            container.mux(video_stream.encode(frame.reformat(format="yuv420p")))
+        if audio_stream is not None:
+            for offset in range(0, 48000 * frames // fps, 960):
+                audio_frame = av.AudioFrame.from_ndarray(
+                    torch.zeros(1, 960, dtype=torch.int16).numpy(), format="s16", layout="mono"
+                )
+                audio_frame.sample_rate = 48000
+                audio_frame.pts = offset
+                container.mux(audio_stream.encode(audio_frame))
+        for stream in [video_stream, audio_stream]:
+            if stream is not None:
+                container.mux(stream.encode(None))
+    return path
+
+
+def test_save_to_auto_transcodes_codec_the_container_cannot_store(tmp_path):
+    source = create_matroska_source(tmp_path)
+    destination = str(tmp_path / "saved.mp4")
+
+    VideoFromFile(source).save_to(destination)
+
+    with av.open(destination) as container:
+        assert container.format.name == "mov,mp4,m4a,3gp,3g2,mj2"
+        assert container.streams.video[0].codec.name == "h264"
+
+
+def test_save_to_auto_transcodes_when_only_audio_is_unsupported(tmp_path):
+    source = create_matroska_source(
+        tmp_path, video_codec="libx264", audio_codec="pcm_u8", container_format="matroska"
+    )
+    destination = str(tmp_path / "saved.mp4")
+
+    VideoFromFile(source).save_to(destination)
+
+    with av.open(destination) as container:
+        assert container.streams.video[0].codec.name == "h264"
+        assert container.streams.audio[0].codec.name == "aac"
+
+
+def test_save_to_auto_still_remuxes_a_compatible_codec(tmp_path):
+    source = create_matroska_source(tmp_path, video_codec="libvpx-vp9")
+    destination = str(tmp_path / "saved.mp4")
+
+    VideoFromFile(source).save_to(destination)
+
+    with av.open(destination) as container:
+        assert container.streams.video[0].codec.name == "vp9"
+
+
+def test_save_to_buffer_transcodes_codec_the_container_cannot_store(tmp_path):
+    source = create_matroska_source(tmp_path)
+    buffer = io.BytesIO()
+
+    VideoFromFile(source).save_to(buffer, format=VideoContainer.MP4)
+
+    buffer.seek(0)
+    with av.open(buffer) as container:
+        assert container.streams.video[0].codec.name == "h264"
+
+
 def create_transcode_source(
     width=64, height=64, frames=30, fps=30, audio_streams=1, undecodable_audio=0, rotation=False,
     container_format="mov", audio_codec="pcm_s16le",

--- a/tests-unit/comfy_api_test/video_types_test.py
+++ b/tests-unit/comfy_api_test/video_types_test.py
@@ -355,6 +355,48 @@ def create_hdr_av1_video(path, transfer, color_range):
         container.mux(stream.encode(None))
 
 
+def create_full_range_srgb_video(path):
+    images = np.random.default_rng(29).integers(0, 256, (3, 64, 64, 3), dtype=np.uint8)
+    with av.open(path, mode="w") as container:
+        stream = container.add_stream("mjpeg", rate=30)
+        stream.width = 64
+        stream.height = 64
+        stream.pix_fmt = "yuvj420p"
+        stream.color_primaries = ColorPrimaries.BT709
+        stream.color_trc = ColorTrc.BT709
+        stream.colorspace = 1
+        stream.color_range = ColorRange.JPEG
+        for image in images:
+            frame = av.VideoFrame.from_ndarray(image, format="rgb24").reformat(format="yuvj420p")
+            frame.color_primaries = ColorPrimaries.BT709
+            frame.color_trc = ColorTrc.BT709
+            frame.colorspace = 1
+            frame.color_range = ColorRange.JPEG
+            container.mux(stream.encode(frame))
+        container.mux(stream.encode(None))
+
+
+def test_save_loaded_srgb_converts_full_range_to_limited(tmp_path):
+    source = str(tmp_path / "source.mov")
+    output = str(tmp_path / "output.mp4")
+    create_full_range_srgb_video(source)
+    with av.open(source) as container:
+        source_stream = container.streams.video[0]
+        source_color = (source_stream.color_primaries, source_stream.color_trc)
+
+    VideoFromFile(source).save_to(
+        output,
+        format=VideoContainer.MP4,
+        codec=VideoCodec.H264,
+        crf=0,
+    )
+
+    with av.open(output) as container:
+        stream = container.streams.video[0]
+        assert (stream.color_primaries, stream.color_trc) == source_color
+        assert stream.color_range == ColorRange.MPEG
+
+
 def test_save_to_av1_crf_controls_quality(tmp_path):
     generator = torch.Generator().manual_seed(11)
     components = VideoComponents(
@@ -822,6 +864,16 @@ def test_save_to_auto_still_remuxes_a_compatible_codec(tmp_path):
     with av.open(destination) as container:
         assert container.streams.video[0].codec.name == "vp9"
         assert decoded_counts(container)[0] == 6
+
+
+def test_save_to_explicit_format_overrides_destination_suffix(simple_video_file, tmp_path):
+    destination = str(tmp_path / "saved.mkv")
+
+    VideoFromFile(simple_video_file).save_to(destination, format=VideoContainer.MP4)
+
+    with av.open(destination) as container:
+        assert "mp4" in container.format.name.split(",")
+        assert decoded_counts(container)[0] == 3
 
 
 def test_save_to_buffer_transcodes_codec_the_container_cannot_store(tmp_path):
@@ -1348,13 +1400,11 @@ def test_save_to_transcode_bakes_rotation():
 
 
 def mov_text_payload(text: str) -> bytes:
-    """A mov_text sample is a 16-bit big-endian length followed by the UTF-8 text."""
     encoded = text.encode("utf-8")
     return len(encoded).to_bytes(2, "big") + encoded
 
 
 def create_subtitled_source(subtitle_codec="mov_text", container_format="mp4", frames=90, fps=30):
-    """mpeg4 video (so save_to must transcode) alongside a subtitle track carrying three cues."""
     buffer = io.BytesIO()
     with av.open(buffer, mode="w", format=container_format) as container:
         video_stream = container.add_stream("mpeg4", rate=fps)
@@ -1380,7 +1430,6 @@ def create_subtitled_source(subtitle_codec="mov_text", container_format="mp4", f
 
 
 def subtitle_cues(buffer):
-    """(seconds, text) for every non-empty cue; the mp4 muxer pads gaps with 2-byte empties."""
     buffer.seek(0)
     with av.open(buffer) as container:
         if not container.streams.subtitles:
@@ -1393,7 +1442,6 @@ def subtitle_cues(buffer):
 
 
 def test_save_to_transcode_keeps_subtitles_the_container_can_store():
-    """Transcoding video must not silently drop a subtitle track the output can hold."""
     output = io.BytesIO()
     VideoFromFile(create_subtitled_source()).save_to(
         output, format=VideoContainer.MP4, codec=VideoCodec.H264
@@ -1407,7 +1455,6 @@ def test_save_to_transcode_keeps_subtitles_the_container_can_store():
 
 
 def test_save_to_transcode_trims_subtitles_with_the_video():
-    """Kept cues rebase onto the trimmed timeline; cues outside the window are dropped."""
     output = io.BytesIO()
     VideoFromFile(create_subtitled_source(), start_time=1, duration=1).save_to(
         output, format=VideoContainer.MP4, codec=VideoCodec.H264
@@ -1417,8 +1464,6 @@ def test_save_to_transcode_trims_subtitles_with_the_video():
 
 
 def test_save_to_transcode_drops_unstorable_subtitles_with_a_warning(caplog):
-    """There is no subtitle encoder binding, so subrip cannot become mov_text: drop it, but
-    name the stream instead of letting the track vanish silently."""
     output = io.BytesIO()
     with caplog.at_level(logging.WARNING):
         VideoFromFile(create_subtitled_source(subtitle_codec="subrip", container_format="matroska")).save_to(
@@ -1437,7 +1482,6 @@ def test_save_to_transcode_drops_unstorable_subtitles_with_a_warning(caplog):
 
 
 def test_save_to_remux_fallback_keeps_subtitles():
-    """The audio-triggered fallback into the transcode path must keep subtitles too."""
     buffer = io.BytesIO()
     with av.open(buffer, mode="w", format="mov") as container:
         video_stream = container.add_stream("mpeg4", rate=30)

--- a/tests-unit/comfy_api_test/video_types_test.py
+++ b/tests-unit/comfy_api_test/video_types_test.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 import torch
 import tempfile
@@ -1201,6 +1202,7 @@ def test_save_to_transcode_clamps_final_pts_to_declared_stream_duration():
         def __init__(self, video_stream):
             self.video = [video_stream]
             self.audio = []
+            self.subtitles = []
 
     class _PacketProxy:
         def __init__(self, packet, stream):
@@ -1343,6 +1345,139 @@ def test_save_to_transcode_bakes_rotation():
         assert result["frames"] == 30
     finally:
         os.unlink(file_path)
+
+
+def mov_text_payload(text: str) -> bytes:
+    """A mov_text sample is a 16-bit big-endian length followed by the UTF-8 text."""
+    encoded = text.encode("utf-8")
+    return len(encoded).to_bytes(2, "big") + encoded
+
+
+def create_subtitled_source(subtitle_codec="mov_text", container_format="mp4", frames=90, fps=30):
+    """mpeg4 video (so save_to must transcode) alongside a subtitle track carrying three cues."""
+    buffer = io.BytesIO()
+    with av.open(buffer, mode="w", format=container_format) as container:
+        video_stream = container.add_stream("mpeg4", rate=fps)
+        video_stream.width = video_stream.height = 64
+        video_stream.pix_fmt = "yuv420p"
+        subtitle_stream = container.add_mux_stream(subtitle_codec)
+        subtitle_stream.time_base = Fraction(1, 1000)
+        for i in range(frames):
+            frame = av.VideoFrame.from_ndarray(
+                torch.full((64, 64, 3), (i * 7) % 256, dtype=torch.uint8).numpy(), format="rgb24"
+            ).reformat(format="yuv420p")
+            container.mux(video_stream.encode(frame))
+        container.mux(video_stream.encode(None))
+        for start_ms, text in ((0, "one"), (1000, "two"), (2000, "three")):
+            packet = av.Packet(mov_text_payload(text))
+            packet.stream = subtitle_stream
+            packet.pts = packet.dts = start_ms
+            packet.duration = 900
+            packet.time_base = Fraction(1, 1000)
+            container.mux(packet)
+    buffer.seek(0)
+    return buffer
+
+
+def subtitle_cues(buffer):
+    """(seconds, text) for every non-empty cue; the mp4 muxer pads gaps with 2-byte empties."""
+    buffer.seek(0)
+    with av.open(buffer) as container:
+        if not container.streams.subtitles:
+            return None
+        return [
+            (float(packet.pts * packet.time_base), bytes(packet)[2:].decode("utf-8"))
+            for packet in container.demux(container.streams.subtitles[0])
+            if packet.dts is not None and packet.size > 2
+        ]
+
+
+def test_save_to_transcode_keeps_subtitles_the_container_can_store():
+    """Transcoding video must not silently drop a subtitle track the output can hold."""
+    output = io.BytesIO()
+    VideoFromFile(create_subtitled_source()).save_to(
+        output, format=VideoContainer.MP4, codec=VideoCodec.H264
+    )
+
+    output.seek(0)
+    with av.open(output) as container:
+        assert container.streams.video[0].codec_context.name == "h264"
+        assert [s.codec_context.name for s in container.streams.subtitles] == ["mov_text"]
+    assert subtitle_cues(output) == [(0.0, "one"), (1.0, "two"), (2.0, "three")]
+
+
+def test_save_to_transcode_trims_subtitles_with_the_video():
+    """Kept cues rebase onto the trimmed timeline; cues outside the window are dropped."""
+    output = io.BytesIO()
+    VideoFromFile(create_subtitled_source(), start_time=1, duration=1).save_to(
+        output, format=VideoContainer.MP4, codec=VideoCodec.H264
+    )
+
+    assert subtitle_cues(output) == [(0.0, "two")]
+
+
+def test_save_to_transcode_drops_unstorable_subtitles_with_a_warning(caplog):
+    """There is no subtitle encoder binding, so subrip cannot become mov_text: drop it, but
+    name the stream instead of letting the track vanish silently."""
+    output = io.BytesIO()
+    with caplog.at_level(logging.WARNING):
+        VideoFromFile(create_subtitled_source(subtitle_codec="subrip", container_format="matroska")).save_to(
+            output, format=VideoContainer.MP4, codec=VideoCodec.H264
+        )
+
+    assert subtitle_cues(output) is None
+    assert any(
+        "subtitle stream" in record.message and "cannot store it" in record.message
+        for record in caplog.records
+    )
+    output.seek(0)
+    with av.open(output) as container:
+        assert container.streams.video[0].codec_context.name == "h264"
+        assert len([f for p in container.demux(container.streams.video[0]) for f in p.decode()]) == 90
+
+
+def test_save_to_remux_fallback_keeps_subtitles():
+    """The audio-triggered fallback into the transcode path must keep subtitles too."""
+    buffer = io.BytesIO()
+    with av.open(buffer, mode="w", format="mov") as container:
+        video_stream = container.add_stream("mpeg4", rate=30)
+        video_stream.width = video_stream.height = 64
+        video_stream.pix_fmt = "yuv420p"
+        audio_stream = container.add_stream("pcm_u8", rate=44100)
+        audio_stream.sample_rate = 44100
+        subtitle_stream = container.add_mux_stream("mov_text")
+        subtitle_stream.time_base = Fraction(1, 1000)
+        for i in range(30):
+            frame = av.VideoFrame.from_ndarray(
+                torch.full((64, 64, 3), (i * 7) % 256, dtype=torch.uint8).numpy(), format="rgb24"
+            ).reformat(format="yuv420p")
+            container.mux(video_stream.encode(frame))
+        for offset in range(0, 44100, 1024):
+            audio_frame = av.AudioFrame.from_ndarray(
+                torch.zeros(1, min(1024, 44100 - offset), dtype=torch.int16).numpy(),
+                format="s16", layout="mono",
+            )
+            audio_frame.sample_rate = 44100
+            audio_frame.pts = offset
+            container.mux(audio_stream.encode(audio_frame))
+        for stream in (video_stream, audio_stream):
+            container.mux(stream.encode(None))
+        packet = av.Packet(mov_text_payload("one"))
+        packet.stream = subtitle_stream
+        packet.pts = packet.dts = 0
+        packet.duration = 900
+        packet.time_base = Fraction(1, 1000)
+        container.mux(packet)
+
+    buffer.seek(0)
+    output = io.BytesIO()
+    VideoFromFile(buffer).save_to(output, format=VideoContainer.MP4)
+
+    output.seek(0)
+    with av.open(output) as container:
+        assert container.streams.video[0].codec_context.name == "h264"
+        assert container.streams.audio[0].codec_context.name == "aac"
+    assert subtitle_cues(output) == [(0.0, "one")]
 
 
 def test_save_to_transcode_skips_undecodable_audio():

--- a/tests-unit/comfy_api_test/video_types_test.py
+++ b/tests-unit/comfy_api_test/video_types_test.py
@@ -5,11 +5,13 @@ import os
 import sys
 import av
 import io
+import numpy as np
 from fractions import Fraction
 from comfy_api.input_impl.video_types import VideoFromFile, VideoFromComponents
 from comfy_api.util.video_types import VideoComponents, VideoContainer, VideoCodec
 from comfy_api.input.basic_types import AudioInput
 from av.error import InvalidDataError
+from av.video.reformatter import ColorPrimaries, ColorRange, ColorTrc
 
 EPSILON = 0.0001
 
@@ -130,6 +132,11 @@ def test_video_from_file_get_dimensions(simple_video_file):
     width, height = video.get_dimensions()
     assert width == 4
     assert height == 4
+
+
+def test_video_color_space_defaults_to_srgb(simple_video_file, video_components):
+    assert VideoFromFile(simple_video_file).get_color_space() == "sRGB"
+    assert VideoFromComponents(video_components).get_color_space() == "sRGB"
 
 
 def test_video_from_file_bytesio_input():
@@ -256,6 +263,456 @@ def test_save_to_h264_crf_controls_quality(tmp_path):
 
     VideoFromFile(high_quality).save_to(transcoded, codec=VideoCodec.H264, crf=51)
     assert os.path.getsize(transcoded) < os.path.getsize(high_quality)
+
+
+def video_packet_bytes(path):
+    with av.open(path) as container:
+        return [bytes(packet) for packet in container.demux(container.streams.video[0]) if packet.size]
+
+
+def decoded_video_frames(path):
+    with av.open(path) as container:
+        frames = []
+        for frame in container.decode(video=0):
+            bytes_per_sample = max(component.bits for component in frame.format.components)
+            bytes_per_sample = (bytes_per_sample + 7) // 8
+            plane_sizes = (
+                (frame.width * bytes_per_sample, frame.height),
+                ((frame.width // 2) * bytes_per_sample, frame.height // 2),
+                ((frame.width // 2) * bytes_per_sample, frame.height // 2),
+            )
+            frames.append(tuple(
+                b"".join(
+                    bytes(plane)[row * plane.line_size:row * plane.line_size + row_size]
+                    for row in range(rows)
+                )
+                for plane, (row_size, rows) in zip(frame.planes, plane_sizes)
+            ))
+        return frames
+
+
+@pytest.mark.parametrize(
+    "format,suffix,codec",
+    [
+        (VideoContainer.MP4, "mp4", VideoCodec.H264),
+        (VideoContainer.MKV, "mkv", VideoCodec.H264),
+        (VideoContainer.MKV, "mkv", VideoCodec.AV1),
+        (VideoContainer.WEBM, "webm", VideoCodec.AV1),
+    ],
+)
+def test_video_from_components_auto_color_space_matches_srgb(tmp_path, format, suffix, codec):
+    components = VideoComponents(
+        images=torch.rand(3, 64, 64, 3, generator=torch.Generator().manual_seed(23)),
+        frame_rate=Fraction(30),
+    )
+    auto = str(tmp_path / f"auto.{suffix}")
+    srgb = str(tmp_path / f"srgb.{suffix}")
+
+    VideoFromComponents(components).save_to(
+        auto,
+        format=format,
+        codec=codec,
+        crf=0,
+    )
+    VideoFromComponents(components).save_to(
+        srgb,
+        format=format,
+        codec=codec,
+        crf=0,
+        color_space="sRGB",
+    )
+
+    assert decoded_video_frames(auto) == decoded_video_frames(srgb)
+    for path in (auto, srgb):
+        with av.open(path) as container:
+            stream = container.streams.video[0]
+            assert stream.color_primaries == ColorPrimaries.BT709
+            assert stream.color_trc == ColorTrc.IEC61966_2_1
+            assert stream.colorspace == 1
+            assert stream.color_range == ColorRange.MPEG
+
+
+def create_hdr_av1_video(path, transfer, color_range):
+    images = np.random.default_rng(17).integers(0, 65536, (3, 64, 64, 3), dtype=np.uint16)
+    with av.open(path, mode="w") as container:
+        stream = container.add_stream("libsvtav1", rate=30)
+        stream.width = 64
+        stream.height = 64
+        stream.pix_fmt = "yuv420p10le"
+        stream.options = {"svtav1-params": "lossless=1"}
+        stream.color_primaries = ColorPrimaries.BT2020
+        stream.color_trc = transfer
+        stream.colorspace = 9
+        stream.color_range = color_range
+        for image in images:
+            frame = av.VideoFrame.from_ndarray(image, format="rgb48le").reformat(format="yuv420p10le")
+            frame.color_primaries = ColorPrimaries.BT2020
+            frame.color_trc = transfer
+            frame.colorspace = 9
+            frame.color_range = color_range
+            container.mux(stream.encode(frame))
+        container.mux(stream.encode(None))
+
+
+def test_save_to_av1_crf_controls_quality(tmp_path):
+    generator = torch.Generator().manual_seed(11)
+    components = VideoComponents(
+        images=torch.rand(12, 64, 64, 3, generator=generator),
+        frame_rate=Fraction(30),
+    )
+    high_quality = str(tmp_path / "high_quality.mkv")
+    low_quality = str(tmp_path / "low_quality.mkv")
+
+    VideoFromComponents(components).save_to(
+        high_quality,
+        format=VideoContainer.MKV,
+        codec=VideoCodec.AV1,
+        crf=0,
+    )
+    VideoFromComponents(components).save_to(
+        low_quality,
+        format=VideoContainer.MKV,
+        codec=VideoCodec.AV1,
+        crf=63,
+    )
+
+    assert os.path.getsize(high_quality) > os.path.getsize(low_quality)
+
+
+@pytest.mark.parametrize(
+    "format,suffix,codec,video_codec,audio_codec,audio_rate",
+    [
+        (VideoContainer.AUTO, "mp4", VideoCodec.AUTO, "h264", "aac", 44100),
+        (VideoContainer.MP4, "mp4", VideoCodec.H264, "h264", "aac", 44100),
+        (VideoContainer.MP4, "mp4", VideoCodec.AV1, "av1", "aac", 44100),
+        (VideoContainer.MKV, "mkv", VideoCodec.AUTO, "h264", "aac", 44100),
+        (VideoContainer.MKV, "mkv", VideoCodec.H264, "h264", "aac", 44100),
+        (VideoContainer.MKV, "mkv", VideoCodec.AV1, "av1", "aac", 44100),
+        (VideoContainer.WEBM, "webm", VideoCodec.AUTO, "av1", "opus", 48000),
+        (VideoContainer.WEBM, "webm", VideoCodec.AV1, "av1", "opus", 48000),
+    ],
+)
+def test_save_components_container_codec_and_audio_matrix(
+    tmp_path, format, suffix, codec, video_codec, audio_codec, audio_rate
+):
+    components = VideoComponents(
+        images=torch.rand(3, 64, 64, 3),
+        audio=AudioInput({
+            "waveform": torch.rand(1, 2, 4410),
+            "sample_rate": 44100,
+        }),
+        frame_rate=Fraction(30),
+    )
+    path = str(tmp_path / f"components.{suffix}")
+
+    VideoFromComponents(components).save_to(
+        path,
+        format=format,
+        codec=codec,
+        crf=30,
+        metadata={"prompt": {"test": "video"}},
+    )
+
+    with av.open(path) as container:
+        assert container.streams.video[0].codec.canonical_name == video_codec
+        assert container.streams.video[0].format.name == "yuv420p"
+        assert container.streams.audio[0].codec.canonical_name == audio_codec
+        assert container.streams.audio[0].sample_rate == audio_rate
+        prompt = container.metadata.get("PROMPT", container.metadata.get("prompt"))
+        assert prompt == '{"test": "video"}'
+        assert sum(1 for _ in container.decode(video=0)) == 3
+    with av.open(path) as container:
+        assert sum(frame.samples for frame in container.decode(audio=0)) > 0
+
+
+@pytest.mark.parametrize(
+    "color_space,transfer,pix_fmt,primaries,colorspace",
+    [
+        ("sRGB", ColorTrc.IEC61966_2_1, "yuv420p", ColorPrimaries.BT709, 1),
+        ("HDR", ColorTrc.ARIB_STD_B67, "yuv420p10le", ColorPrimaries.BT2020, 9),
+        ("HDR PQ", ColorTrc.SMPTE2084, "yuv420p10le", ColorPrimaries.BT2020, 9),
+    ],
+)
+def test_save_to_av1_mkv_color_space(tmp_path, color_space, transfer, pix_fmt, primaries, colorspace):
+    components = VideoComponents(
+        images=torch.rand(2, 64, 64, 3),
+        frame_rate=Fraction(30),
+    )
+    path = str(tmp_path / "hdr.mkv")
+    remuxed = str(tmp_path / "remuxed.mkv")
+
+    VideoFromComponents(components).save_to(
+        path,
+        format=VideoContainer.MKV,
+        codec=VideoCodec.AV1,
+        crf=30,
+        color_space=color_space,
+        metadata={"prompt": {"test": "hdr"}},
+    )
+
+    with av.open(path) as container:
+        stream = container.streams.video[0]
+        assert stream.codec.canonical_name == "av1"
+        assert stream.format.name == pix_fmt
+        assert stream.color_primaries == primaries
+        assert stream.color_trc == transfer
+        assert stream.colorspace == colorspace
+        assert stream.color_range == ColorRange.MPEG
+        assert container.metadata["PROMPT"] == '{"test": "hdr"}'
+    assert VideoFromFile(path).get_color_space() == color_space
+
+    source_packets = video_packet_bytes(path)
+    VideoFromFile(path).save_to(
+        remuxed,
+        format=VideoContainer.MKV,
+        codec=VideoCodec.AV1,
+    )
+    with av.open(remuxed) as container:
+        stream = container.streams.video[0]
+        assert stream.codec.canonical_name == "av1"
+        assert stream.format.name == pix_fmt
+        assert stream.color_primaries == primaries
+        assert stream.color_trc == transfer
+        assert container.metadata["PROMPT"] == '{"test": "hdr"}'
+    assert video_packet_bytes(remuxed) == source_packets
+
+
+@pytest.mark.parametrize(
+    "transfer,color_range,color_space",
+    [
+        (ColorTrc.SMPTE2084, ColorRange.MPEG, None),
+        (ColorTrc.SMPTE2084, ColorRange.MPEG, "HDR PQ"),
+        (ColorTrc.ARIB_STD_B67, ColorRange.MPEG, None),
+        (ColorTrc.ARIB_STD_B67, ColorRange.MPEG, "HDR"),
+        (ColorTrc.ARIB_STD_B67, ColorRange.JPEG, "HDR"),
+    ],
+)
+def test_save_to_loaded_hdr_preserves_color(tmp_path, transfer, color_range, color_space):
+    source = str(tmp_path / "source.mkv")
+    remuxed = str(tmp_path / "auto_encoding.mkv")
+    reencoded = str(tmp_path / "auto_color_space.webm")
+    create_hdr_av1_video(source, transfer, color_range)
+
+    video = VideoFromFile(source)
+    video.save_to(remuxed, format=VideoContainer.MKV, codec=VideoCodec.AV1)
+    video.save_to(
+        reencoded,
+        format=VideoContainer.WEBM,
+        codec=VideoCodec.AV1,
+        crf=0,
+        color_space=color_space,
+    )
+
+    assert video_packet_bytes(remuxed) == video_packet_bytes(source)
+    source_frames = decoded_video_frames(source)
+    reencoded_frames = decoded_video_frames(reencoded)
+    assert len(source_frames) == len(reencoded_frames)
+    assert all(np.array_equal(source_frame, output_frame) for source_frame, output_frame in zip(source_frames, reencoded_frames))
+
+    for path in (remuxed, reencoded):
+        with av.open(path) as container:
+            stream = container.streams.video[0]
+            assert stream.codec.canonical_name == "av1"
+            assert stream.format.name == "yuv420p10le"
+            assert stream.color_primaries == ColorPrimaries.BT2020
+            assert stream.color_trc == transfer
+            assert stream.colorspace == 9
+            assert stream.color_range == color_range
+
+
+@pytest.mark.parametrize("color_space", ["sRGB", "HDR PQ"])
+def test_save_to_loaded_hdr_rejects_color_conversion(tmp_path, color_space):
+    source = str(tmp_path / "source.mkv")
+    output = str(tmp_path / "wrong_transfer.webm")
+    create_hdr_av1_video(source, ColorTrc.ARIB_STD_B67, ColorRange.MPEG)
+
+    with pytest.raises(ValueError, match=f"Cannot save HDR video as {color_space} without color conversion"):
+        VideoFromFile(source).save_to(
+            output,
+            format=VideoContainer.WEBM,
+            codec=VideoCodec.AV1,
+            crf=30,
+            color_space=color_space,
+        )
+
+    assert not os.path.exists(output)
+
+
+def test_save_to_av1_webm_transcodes_audio(tmp_path):
+    components = VideoComponents(
+        images=torch.rand(2, 64, 64, 3),
+        audio=AudioInput({
+            "waveform": torch.rand(1, 2, 4410),
+            "sample_rate": 44100,
+        }),
+        frame_rate=Fraction(30),
+    )
+    source = str(tmp_path / "source.mp4")
+    path = str(tmp_path / "output.webm")
+    VideoFromComponents(components).save_to(source, color_space="HDR")
+
+    VideoFromFile(source).save_to(
+        path,
+        format=VideoContainer.WEBM,
+        codec=VideoCodec.AV1,
+        crf=30,
+        color_space="HDR",
+    )
+
+    with av.open(path) as container:
+        video_stream = container.streams.video[0]
+        assert video_stream.codec.canonical_name == "av1"
+        assert video_stream.format.name == "yuv420p10le"
+        assert video_stream.color_primaries == ColorPrimaries.BT2020
+        assert video_stream.color_trc == ColorTrc.ARIB_STD_B67
+        assert video_stream.colorspace == 9
+        assert container.streams.audio[0].codec.name == "opus"
+        assert container.streams.audio[0].sample_rate == 48000
+        assert sum(1 for _ in container.decode(video=0)) == 2
+    with av.open(path) as container:
+        assert sum(frame.samples for frame in container.decode(audio=0)) > 0
+
+
+@pytest.mark.parametrize("source_codec", [VideoCodec.H264, VideoCodec.AV1])
+def test_save_loaded_mkv_to_webm_auto_transcodes_incompatible_streams(tmp_path, source_codec):
+    components = VideoComponents(
+        images=torch.rand(3, 64, 64, 3),
+        audio=AudioInput({
+            "waveform": torch.rand(1, 2, 4410),
+            "sample_rate": 44100,
+        }),
+        frame_rate=Fraction(30),
+    )
+    source = str(tmp_path / "source.mkv")
+    output = str(tmp_path / "output.webm")
+    VideoFromComponents(components).save_to(
+        source,
+        format=VideoContainer.MKV,
+        codec=source_codec,
+        crf=63 if source_codec == VideoCodec.AV1 else 30,
+    )
+
+    VideoFromFile(source).save_to(
+        output,
+        format=VideoContainer.WEBM,
+        codec=VideoCodec.AUTO,
+    )
+
+    with av.open(output) as container:
+        assert container.streams.video[0].codec.canonical_name == "av1"
+        assert container.streams.audio[0].codec.canonical_name == "opus"
+        assert container.streams.audio[0].sample_rate == 48000
+        assert sum(1 for _ in container.decode(video=0)) == 3
+    with av.open(output) as container:
+        assert sum(frame.samples for frame in container.decode(audio=0)) > 0
+
+
+def test_save_loaded_h264_mkv_to_webm_h264_rejected_before_creating_output(tmp_path):
+    components = VideoComponents(
+        images=torch.rand(1, 64, 64, 3),
+        frame_rate=Fraction(30),
+    )
+    source = str(tmp_path / "source.mkv")
+    output = tmp_path / "output.webm"
+    VideoFromComponents(components).save_to(
+        source,
+        format=VideoContainer.MKV,
+        codec=VideoCodec.H264,
+    )
+
+    with pytest.raises(ValueError, match="WebM output requires the AV1 codec"):
+        VideoFromFile(source).save_to(
+            str(output),
+            format=VideoContainer.WEBM,
+            codec=VideoCodec.H264,
+        )
+
+    assert not output.exists()
+
+
+def test_save_loaded_webm_auto_remuxes_compatible_streams(tmp_path):
+    components = VideoComponents(
+        images=torch.rand(3, 64, 64, 3),
+        audio=AudioInput({
+            "waveform": torch.rand(1, 2, 4410),
+            "sample_rate": 44100,
+        }),
+        frame_rate=Fraction(30),
+    )
+    source = str(tmp_path / "source.webm")
+    output = str(tmp_path / "output.webm")
+    VideoFromComponents(components).save_to(
+        source,
+        format=VideoContainer.WEBM,
+        codec=VideoCodec.AV1,
+        crf=63,
+    )
+    source_packets = video_packet_bytes(source)
+
+    VideoFromFile(source).save_to(
+        output,
+        format=VideoContainer.WEBM,
+        codec=VideoCodec.AUTO,
+    )
+
+    assert video_packet_bytes(output) == source_packets
+    with av.open(output) as container:
+        assert container.streams.video[0].codec.canonical_name == "av1"
+        assert container.streams.audio[0].codec.canonical_name == "opus"
+        assert sum(1 for _ in container.decode(video=0)) == 3
+
+
+@pytest.mark.parametrize("format", [VideoContainer.MKV, VideoContainer.WEBM])
+def test_save_to_av1_file_like_output(format):
+    components = VideoComponents(
+        images=torch.rand(1, 64, 64, 3),
+        frame_rate=Fraction(30),
+    )
+    output = io.BytesIO()
+
+    VideoFromComponents(components).save_to(
+        output,
+        format=format,
+        codec=VideoCodec.AV1,
+        crf=63,
+    )
+
+    output.seek(0)
+    with av.open(output) as container:
+        assert container.streams.video[0].codec.canonical_name == "av1"
+        assert sum(1 for _ in container.decode(video=0)) == 1
+
+
+def test_save_to_rejects_h264_webm_before_creating_output(tmp_path):
+    components = VideoComponents(
+        images=torch.rand(1, 64, 64, 3),
+        frame_rate=Fraction(30),
+    )
+    path = tmp_path / "invalid.webm"
+
+    with pytest.raises(ValueError, match="WebM output requires the AV1 codec"):
+        VideoFromComponents(components).save_to(
+            str(path),
+            format=VideoContainer.WEBM,
+            codec=VideoCodec.H264,
+        )
+
+    assert not path.exists()
+
+
+def test_save_to_rejects_unknown_color_space(tmp_path):
+    components = VideoComponents(
+        images=torch.rand(1, 64, 64, 3),
+        frame_rate=Fraction(30),
+    )
+
+    with pytest.raises(ValueError, match="Unsupported video color space: HLG"):
+        VideoFromComponents(components).save_to(
+            str(tmp_path / "invalid.mkv"),
+            format=VideoContainer.MKV,
+            codec=VideoCodec.AV1,
+            color_space="HLG",
+        )
 
 
 def test_save_to_mp4_writes_metadata_before_media(video_components, tmp_path):

--- a/tests-unit/comfy_api_test/video_types_test.py
+++ b/tests-unit/comfy_api_test/video_types_test.py
@@ -1404,13 +1404,19 @@ def mov_text_payload(text: str) -> bytes:
     return len(encoded).to_bytes(2, "big") + encoded
 
 
+def add_test_subtitle_stream(container, codec):
+    if not hasattr(container, "add_mux_stream"):
+        pytest.skip("PyAV 17 or newer is required to synthesize subtitle packets")
+    return container.add_mux_stream(codec)
+
+
 def create_subtitled_source(subtitle_codec="mov_text", container_format="mp4", frames=90, fps=30):
     buffer = io.BytesIO()
     with av.open(buffer, mode="w", format=container_format) as container:
         video_stream = container.add_stream("mpeg4", rate=fps)
         video_stream.width = video_stream.height = 64
         video_stream.pix_fmt = "yuv420p"
-        subtitle_stream = container.add_mux_stream(subtitle_codec)
+        subtitle_stream = add_test_subtitle_stream(container, subtitle_codec)
         subtitle_stream.time_base = Fraction(1, 1000)
         for i in range(frames):
             frame = av.VideoFrame.from_ndarray(
@@ -1489,7 +1495,7 @@ def test_save_to_remux_fallback_keeps_subtitles():
         video_stream.pix_fmt = "yuv420p"
         audio_stream = container.add_stream("pcm_u8", rate=44100)
         audio_stream.sample_rate = 44100
-        subtitle_stream = container.add_mux_stream("mov_text")
+        subtitle_stream = add_test_subtitle_stream(container, "mov_text")
         subtitle_stream.time_base = Fraction(1, 1000)
         for i in range(30):
             frame = av.VideoFrame.from_ndarray(

--- a/tests-unit/comfy_api_test/video_types_test.py
+++ b/tests-unit/comfy_api_test/video_types_test.py
@@ -727,9 +727,32 @@ def test_save_to_mp4_writes_metadata_before_media(video_components, tmp_path):
         assert data.index(b"moov") < data.index(b"mdat")
 
 
+def require_encoder(name):
+    try:
+        av.codec.Codec(name, "w")
+    except av.codec.codec.UnknownCodecError:
+        pytest.skip(f"{name} encoder not available in this PyAV build")
+
+
+def decoded_counts(container):
+    video = sum(len(packet.decode()) for packet in container.demux(container.streams.video[0]))
+    audio = 0
+    if container.streams.audio:
+        container.seek(0)
+        audio = sum(
+            frame.samples
+            for packet in container.demux(container.streams.audio[0])
+            for frame in packet.decode()
+        )
+    return video, audio
+
+
 def create_matroska_source(
     tmp_path, video_codec="libvpx", audio_codec=None, frames=6, fps=10, container_format="webm"
 ):
+    require_encoder(video_codec)
+    if audio_codec is not None:
+        require_encoder(audio_codec)
     path = str(tmp_path / f"source_{video_codec}.{container_format}")
     with av.open(path, mode="w", format=container_format) as container:
         video_stream = container.add_stream(video_codec, rate=fps)
@@ -768,13 +791,14 @@ def test_save_to_auto_transcodes_codec_the_container_cannot_store(tmp_path):
     VideoFromFile(source).save_to(destination)
 
     with av.open(destination) as container:
-        assert container.format.name == "mov,mp4,m4a,3gp,3g2,mj2"
+        assert "mp4" in container.format.name.split(",")
         assert container.streams.video[0].codec.name == "h264"
+        assert decoded_counts(container)[0] == 6
 
 
 def test_save_to_auto_transcodes_when_only_audio_is_unsupported(tmp_path):
     source = create_matroska_source(
-        tmp_path, video_codec="libx264", audio_codec="pcm_u8", container_format="matroska"
+        tmp_path, video_codec="mpeg4", audio_codec="pcm_u8", container_format="matroska"
     )
     destination = str(tmp_path / "saved.mp4")
 
@@ -783,6 +807,9 @@ def test_save_to_auto_transcodes_when_only_audio_is_unsupported(tmp_path):
     with av.open(destination) as container:
         assert container.streams.video[0].codec.name == "h264"
         assert container.streams.audio[0].codec.name == "aac"
+        video_frames, audio_samples = decoded_counts(container)
+        assert video_frames == 6
+        assert audio_samples > 0
 
 
 def test_save_to_auto_still_remuxes_a_compatible_codec(tmp_path):
@@ -793,17 +820,23 @@ def test_save_to_auto_still_remuxes_a_compatible_codec(tmp_path):
 
     with av.open(destination) as container:
         assert container.streams.video[0].codec.name == "vp9"
+        assert decoded_counts(container)[0] == 6
 
 
 def test_save_to_buffer_transcodes_codec_the_container_cannot_store(tmp_path):
-    source = create_matroska_source(tmp_path)
+    source = create_matroska_source(
+        tmp_path, video_codec="mpeg4", audio_codec="pcm_u8", container_format="mov"
+    )
     buffer = io.BytesIO()
+    buffer.write(b"\x00" * 4096)
 
     VideoFromFile(source).save_to(buffer, format=VideoContainer.MP4)
 
     buffer.seek(0)
     with av.open(buffer) as container:
         assert container.streams.video[0].codec.name == "h264"
+        assert container.streams.audio[0].codec.name == "aac"
+        assert decoded_counts(container)[0] == 6
 
 
 def create_transcode_source(

--- a/tests-unit/comfy_api_test/video_types_test.py
+++ b/tests-unit/comfy_api_test/video_types_test.py
@@ -270,6 +270,85 @@ def test_save_to_mp4_writes_metadata_before_media(video_components, tmp_path):
         assert data.index(b"moov") < data.index(b"mdat")
 
 
+def create_matroska_source(
+    tmp_path, video_codec="libvpx", audio_codec=None, frames=6, fps=10, container_format="webm"
+):
+    path = str(tmp_path / f"source_{video_codec}.{container_format}")
+    with av.open(path, mode="w", format=container_format) as container:
+        video_stream = container.add_stream(video_codec, rate=fps)
+        video_stream.width = 32
+        video_stream.height = 32
+        video_stream.pix_fmt = "yuv420p"
+        audio_stream = None
+        if audio_codec is not None:
+            audio_stream = container.add_stream(audio_codec, rate=48000)
+            audio_stream.sample_rate = 48000
+
+        for i in range(frames):
+            frame = av.VideoFrame.from_ndarray(
+                torch.full((32, 32, 3), (i * 40) % 256, dtype=torch.uint8).numpy(),
+                format="rgb24",
+            )
+            container.mux(video_stream.encode(frame.reformat(format="yuv420p")))
+        if audio_stream is not None:
+            for offset in range(0, 48000 * frames // fps, 960):
+                audio_frame = av.AudioFrame.from_ndarray(
+                    torch.zeros(1, 960, dtype=torch.int16).numpy(), format="s16", layout="mono"
+                )
+                audio_frame.sample_rate = 48000
+                audio_frame.pts = offset
+                container.mux(audio_stream.encode(audio_frame))
+        for stream in [video_stream, audio_stream]:
+            if stream is not None:
+                container.mux(stream.encode(None))
+    return path
+
+
+def test_save_to_auto_transcodes_codec_the_container_cannot_store(tmp_path):
+    source = create_matroska_source(tmp_path)
+    destination = str(tmp_path / "saved.mp4")
+
+    VideoFromFile(source).save_to(destination)
+
+    with av.open(destination) as container:
+        assert container.format.name == "mov,mp4,m4a,3gp,3g2,mj2"
+        assert container.streams.video[0].codec.name == "h264"
+
+
+def test_save_to_auto_transcodes_when_only_audio_is_unsupported(tmp_path):
+    source = create_matroska_source(
+        tmp_path, video_codec="libx264", audio_codec="pcm_u8", container_format="matroska"
+    )
+    destination = str(tmp_path / "saved.mp4")
+
+    VideoFromFile(source).save_to(destination)
+
+    with av.open(destination) as container:
+        assert container.streams.video[0].codec.name == "h264"
+        assert container.streams.audio[0].codec.name == "aac"
+
+
+def test_save_to_auto_still_remuxes_a_compatible_codec(tmp_path):
+    source = create_matroska_source(tmp_path, video_codec="libvpx-vp9")
+    destination = str(tmp_path / "saved.mp4")
+
+    VideoFromFile(source).save_to(destination)
+
+    with av.open(destination) as container:
+        assert container.streams.video[0].codec.name == "vp9"
+
+
+def test_save_to_buffer_transcodes_codec_the_container_cannot_store(tmp_path):
+    source = create_matroska_source(tmp_path)
+    buffer = io.BytesIO()
+
+    VideoFromFile(source).save_to(buffer, format=VideoContainer.MP4)
+
+    buffer.seek(0)
+    with av.open(buffer) as container:
+        assert container.streams.video[0].codec.name == "h264"
+
+
 def create_transcode_source(
     width=64, height=64, frames=30, fps=30, audio_streams=1, undecodable_audio=0, rotation=False,
     container_format="mov", audio_codec="pcm_s16le",

--- a/tests-unit/comfy_extras_test/nodes_video_test.py
+++ b/tests-unit/comfy_extras_test/nodes_video_test.py
@@ -1,0 +1,50 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from comfy_api.latest import Types
+from comfy_extras import nodes_video
+
+
+@pytest.fixture
+def save_video(monkeypatch, tmp_path):
+    monkeypatch.setattr(nodes_video.folder_paths, "get_output_directory", lambda: str(tmp_path))
+    monkeypatch.setattr(
+        nodes_video.folder_paths,
+        "get_save_image_path",
+        lambda *args: (str(tmp_path), "output", 1, "", args[0]),
+    )
+    monkeypatch.setattr(nodes_video.SaveVideo, "hidden", SimpleNamespace(prompt=None, extra_pnginfo=None), raising=False)
+    video = Mock()
+    video.get_dimensions.return_value = (64, 64)
+    return video
+
+
+def test_save_video_accepts_legacy_codec_string(save_video):
+    nodes_video.SaveVideo.execute(save_video, "video", "mp4", "h264")
+
+    kwargs = save_video.save_to.call_args.kwargs
+    assert kwargs["format"] == Types.VideoContainer.MP4
+    assert kwargs["codec"] == Types.VideoCodec.H264
+    assert "color_space" not in kwargs
+
+
+def test_save_video_forwards_nested_encoding_options(save_video):
+    nodes_video.SaveVideo.execute(
+        save_video,
+        "video",
+        {
+            "format": "webm",
+            "codec": {
+                "codec": "av1",
+                "encoding": {"crf": 30, "color_space": "HDR"},
+            },
+        },
+    )
+
+    kwargs = save_video.save_to.call_args.kwargs
+    assert kwargs["format"] == Types.VideoContainer.WEBM
+    assert kwargs["codec"] == Types.VideoCodec.AV1
+    assert kwargs["crf"] == 30
+    assert kwargs["color_space"] == "HDR"


### PR DESCRIPTION
Load Video -> Save Video on a VP8 WebM crashes, because `format=auto` names the output after the destination extension (`.mp4`) but skips the container check that decides whether the source streams can be copied, so VP8 packets get aimed at a muxer that refuses them. Every stream is added before the first packet is muxed, so this attempts the copy and treats PyAV's own refusal as the answer: nothing has been written yet, and the save falls back to re-encoding. Handling the refusal per stream also means a subtitle track the destination cannot store is dropped on its own instead of dragging an otherwise copyable video into a needless re-encode, and codecs the destination does accept still remux losslessly. One caveat: when the refused stream is audio, the whole file is re-encoded and extra audio and subtitle tracks are dropped, since the transcode path carries one video and one audio stream; that is now logged at warning rather than passing silently. Repro is any VP8 WebM through Load Video into Save Video with the default `format=auto`:

```
  File "ComfyUI/comfy_extras/nodes_video.py", line 141, in execute
    video.save_to(
  File "ComfyUI/comfy_api/latest/_input_impl/video_types.py", line 507, in save_to
    out_stream = output_container.add_stream_from_template(template=stream, opaque=True)
  File "av/container/output.py", line 162, in av.container.output.OutputContainer.add_stream_from_template
ValueError: 'mp4' format does not support 'vp8' codec
```
