### PR TITLE
Warn when VAE.encode drops input channels

### DIFF
--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -497,6 +497,7 @@ class VAE:
         self.latent_dim = 2
         self.output_channels = 3
         self.pad_channel_value = None
+        self.channel_trim_warned = False
         self.process_input = lambda image: image * 2.0 - 1.0
         self.process_output = lambda image: image.add_(1.0).div_(2.0).clamp_(0.0, 1.0)
         self.working_dtypes = [torch.bfloat16, torch.float32]
@@ -1053,6 +1054,9 @@ class VAE:
                     pixels = pixels.narrow(d + 1, x_offset, x)
 
         if pixels.shape[-1] > self.output_channels:
+            if not self.channel_trim_warned:
+                self.channel_trim_warned = True
+                logging.warning("VAE encode: input has {} channels, this VAE encodes {}. The extra channels are dropped; use SplitImageWithAlpha to keep an image's alpha as a MASK.".format(pixels.shape[-1], self.output_channels))
             pixels = pixels[..., :self.output_channels]
         elif pixels.shape[-1] < self.output_channels:
             if self.pad_channel_value is not None:

--- a/tests-unit/comfy_test/vae_channel_trim_test.py
+++ b/tests-unit/comfy_test/vae_channel_trim_test.py
@@ -1,0 +1,42 @@
+import logging
+
+import torch
+
+from comfy.cli_args import args
+
+if not torch.cuda.is_available():
+    args.cpu = True
+
+from comfy.sd import VAE  # noqa: E402
+
+
+def make_vae():
+    vae = VAE(sd={})
+    vae.crop_input = False
+    return vae
+
+
+def test_extra_channels_are_trimmed_and_warned_once(caplog):
+    vae = make_vae()
+    pixels = torch.zeros(1, 16, 16, 4)
+
+    with caplog.at_level(logging.WARNING):
+        first = vae.vae_encode_crop_pixels(pixels)
+        second = vae.vae_encode_crop_pixels(pixels)
+
+    assert first.shape == (1, 16, 16, 3)
+    assert second.shape == (1, 16, 16, 3)
+
+    trim_warnings = [r for r in caplog.records if "VAE encode" in r.getMessage()]
+    assert len(trim_warnings) == 1
+    assert "SplitImageWithAlpha" in trim_warnings[0].getMessage()
+
+
+def test_matching_channels_do_not_warn(caplog):
+    vae = make_vae()
+
+    with caplog.at_level(logging.WARNING):
+        out = vae.vae_encode_crop_pixels(torch.zeros(1, 16, 16, 3))
+
+    assert out.shape == (1, 16, 16, 3)
+    assert not [r for r in caplog.records if "VAE encode" in r.getMessage()]


### PR DESCRIPTION
`VAE.encode` trims anything past `self.output_channels` in `vae_encode_crop_pixels` and says nothing about it. For every ordinary 3-channel VAE that means a 4-channel IMAGE silently loses its alpha, which is the reason "my transparency disappeared somewhere in the graph" is hard to diagnose — the drop happens inside core, not at the node the user is looking at.

This warns once per `VAE` instance and names the node that keeps the alpha. Behavior is unchanged: the same trim still happens.

Related: this is also why the `vae.encode(image[:, :, :, :3])` idiom spread through `comfy_extras/` — those slices are redundant with this line. https://github.com/Comfy-Org/ComfyUI/pull/11406 already removed the slice from `VAEEncode` for that reason.

Tests: `tests-unit/comfy_test/vae_channel_trim_test.py` — trims 4->3 and warns exactly once across two calls; no warning when channels already match. `python -m pytest tests-unit/comfy_test/` passes, `ruff check` clean.
