### PR TITLE
Add an alpha mask output to ImageUpscaleWithModel

### DIFF
--- a/comfy_extras/nodes_upscale_model.py
+++ b/comfy_extras/nodes_upscale_model.py
@@ -72,9 +72,9 @@ class ImageUpscaleWithModel(io.ComfyNode):
         device = upscale_model.patcher.load_device
 
         alpha = None
-        if image.shape[-1] > upscale_model.input_channels:
-            alpha = image[..., upscale_model.input_channels:upscale_model.input_channels + 1]
-            image = image[..., :upscale_model.input_channels]
+        if image.shape[-1] == 4:
+            alpha = image[..., 3:4]
+            image = image[..., :3]
 
         memory_required = (512 * 512 * 3) * image.element_size() * max(upscale_model.scale, 1.0) * 384.0 #The 384.0 is an estimate of how much some of these models take, TODO: make it more accurate
         memory_required += image.nelement() * image.element_size()

--- a/comfy_extras/nodes_upscale_model.py
+++ b/comfy_extras/nodes_upscale_model.py
@@ -63,12 +63,18 @@ class ImageUpscaleWithModel(io.ComfyNode):
             ],
             outputs=[
                 io.Image.Output(),
+                io.Mask.Output("alpha", tooltip="The input's alpha channel, upscaled to match (1 = transparent, LoadImage convention). Wire it to Join Image with Alpha to put the transparency back; add Invert Mask first for ImageCompositeMasked. All zeros when the input had no alpha."),
             ],
         )
 
     @classmethod
     def execute(cls, upscale_model, image) -> io.NodeOutput:
         device = upscale_model.patcher.load_device
+
+        alpha = None
+        if image.shape[-1] > upscale_model.input_channels:
+            alpha = image[..., upscale_model.input_channels:upscale_model.input_channels + 1]
+            image = image[..., :upscale_model.input_channels]
 
         memory_required = (512 * 512 * 3) * image.element_size() * max(upscale_model.scale, 1.0) * 384.0 #The 384.0 is an estimate of how much some of these models take, TODO: make it more accurate
         memory_required += image.nelement() * image.element_size()
@@ -95,7 +101,13 @@ class ImageUpscaleWithModel(io.ComfyNode):
                     raise e
 
         s = torch.clamp(s.movedim(-3,-1), min=0, max=1.0).to(comfy.model_management.intermediate_dtype())
-        return io.NodeOutput(s)
+
+        if alpha is None:
+            mask = torch.zeros(s.shape[:-1], device=s.device, dtype=s.dtype)
+        else:
+            alpha = comfy.utils.common_upscale(alpha.to(s).movedim(-1, -3), s.shape[2], s.shape[1], "bilinear", "disabled")
+            mask = 1.0 - alpha.movedim(-3, -1)[..., 0].clamp(min=0.0, max=1.0)
+        return io.NodeOutput(s, mask)
 
     upscale = execute  # TODO: remove
 

--- a/tests-unit/comfy_extras_test/upscale_model_alpha_test.py
+++ b/tests-unit/comfy_extras_test/upscale_model_alpha_test.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 from comfy.cli_args import args
@@ -19,9 +20,19 @@ class StubUpscaleModel:
     class patcher:
         load_device = torch.device("cpu")
 
+    def __init__(self):
+        self.seen_channels = None
+
     def __call__(self, image):
+        self.seen_channels = image.shape[1]
         assert image.shape[1] == self.input_channels, "model was handed a non-RGB tensor"
         return torch.nn.functional.interpolate(image, scale_factor=self.scale, mode="nearest")
+
+
+class GrayscaleUpscaleModel(StubUpscaleModel):
+    """A model that wants a single channel. It must not be fed a colour channel as alpha."""
+
+    input_channels = 1
 
 
 def rgba_image():
@@ -32,14 +43,17 @@ def rgba_image():
     return image
 
 
-def upscale(image, monkeypatch):
+def upscale(image, monkeypatch, model=None):
     monkeypatch.setattr(comfy.model_management, "load_models_gpu", lambda *args, **kwargs: None)
-    return ImageUpscaleWithModel.execute(StubUpscaleModel(), image).result
+    model = model or StubUpscaleModel()
+    return model, ImageUpscaleWithModel.execute(model, image)
 
 
 def test_rgba_input_does_not_reach_the_model_and_alpha_is_upscaled(monkeypatch):
-    image, mask = upscale(rgba_image(), monkeypatch)
+    model, out = upscale(rgba_image(), monkeypatch)
+    image, mask = out.result
 
+    assert model.seen_channels == 3
     assert image.shape == (1, 32, 32, 3)
     assert mask.shape == (1, 32, 32)
     # inverted convention: transparent -> 1, opaque -> 0
@@ -48,15 +62,31 @@ def test_rgba_input_does_not_reach_the_model_and_alpha_is_upscaled(monkeypatch):
 
 
 def test_rgb_input_reports_a_fully_opaque_mask(monkeypatch):
-    image, mask = upscale(torch.zeros(1, 16, 16, 3), monkeypatch)
+    model, out = upscale(torch.zeros(1, 16, 16, 3), monkeypatch)
+    image, mask = out.result
 
+    assert model.seen_channels == 3
     assert image.shape == (1, 32, 32, 3)
     assert mask.shape == (1, 32, 32)
     assert mask.max() == 0.0
 
 
+def test_rgb_input_is_untouched_by_a_model_that_wants_fewer_channels(monkeypatch):
+    """The alpha split keys off the image being RGBA, never off the model's channel count.
+
+    A single channel model must still receive all three colour channels and fail loudly,
+    rather than having the green channel silently reinterpreted as alpha.
+    """
+    image = torch.zeros(1, 16, 16, 3)
+    image[..., 1] = 0.7
+
+    with pytest.raises(AssertionError):
+        upscale(image, monkeypatch, model=GrayscaleUpscaleModel())
+
+
 def test_mask_round_trips_through_join_image_with_alpha(monkeypatch):
-    image, mask = upscale(rgba_image(), monkeypatch)
+    _, out = upscale(rgba_image(), monkeypatch)
+    image, mask = out.result
 
     rgba = JoinImageWithAlpha.execute(image, mask).result[0]
 

--- a/tests-unit/comfy_extras_test/upscale_model_alpha_test.py
+++ b/tests-unit/comfy_extras_test/upscale_model_alpha_test.py
@@ -1,0 +1,65 @@
+import torch
+
+from comfy.cli_args import args
+
+if not torch.cuda.is_available():
+    args.cpu = True
+
+import comfy.model_management  # noqa: E402
+from comfy_extras.nodes_compositing import JoinImageWithAlpha  # noqa: E402
+from comfy_extras.nodes_upscale_model import ImageUpscaleWithModel  # noqa: E402
+
+
+class StubUpscaleModel:
+    """Stands in for a spandrel ImageModelDescriptor that only accepts RGB."""
+
+    scale = 2
+    input_channels = 3
+
+    class patcher:
+        load_device = torch.device("cpu")
+
+    def __call__(self, image):
+        assert image.shape[1] == self.input_channels, "model was handed a non-RGB tensor"
+        return torch.nn.functional.interpolate(image, scale_factor=self.scale, mode="nearest")
+
+
+def rgba_image():
+    """16x16 RGBA where the top half is transparent and the bottom half opaque."""
+    image = torch.zeros(1, 16, 16, 4)
+    image[..., :3] = 0.5
+    image[0, 8:, :, 3] = 1.0
+    return image
+
+
+def upscale(image, monkeypatch):
+    monkeypatch.setattr(comfy.model_management, "load_models_gpu", lambda *args, **kwargs: None)
+    return ImageUpscaleWithModel.execute(StubUpscaleModel(), image).result
+
+
+def test_rgba_input_does_not_reach_the_model_and_alpha_is_upscaled(monkeypatch):
+    image, mask = upscale(rgba_image(), monkeypatch)
+
+    assert image.shape == (1, 32, 32, 3)
+    assert mask.shape == (1, 32, 32)
+    # inverted convention: transparent -> 1, opaque -> 0
+    assert mask[0, :14].min() > 0.9
+    assert mask[0, 18:].max() < 0.1
+
+
+def test_rgb_input_reports_a_fully_opaque_mask(monkeypatch):
+    image, mask = upscale(torch.zeros(1, 16, 16, 3), monkeypatch)
+
+    assert image.shape == (1, 32, 32, 3)
+    assert mask.shape == (1, 32, 32)
+    assert mask.max() == 0.0
+
+
+def test_mask_round_trips_through_join_image_with_alpha(monkeypatch):
+    image, mask = upscale(rgba_image(), monkeypatch)
+
+    rgba = JoinImageWithAlpha.execute(image, mask).result[0]
+
+    assert rgba.shape == (1, 32, 32, 4)
+    assert rgba[0, :14, :, 3].max() < 0.1
+    assert rgba[0, 18:, :, 3].min() > 0.9


### PR DESCRIPTION
`ImageUpscaleWithModel` passed the IMAGE straight to the model. Spandrel documents the input as `(1, input_channels, H, W)` and almost every upscale model is 3 channel, so upscaling a cut-out PNG failed in the model's first conv instead of upscaling it. There was also nowhere for the alpha to go even if it had survived.

Now the node splits off anything past `upscale_model.input_channels`, upscales the RGB as before, resizes the alpha to the result and returns it on a new `alpha` MASK output. Wiring `alpha` into Join Image with Alpha reassembles the transparent image.

**Polarity.** The mask is `1 - alpha`, matching `LoadImage` and `SplitImageWithAlpha`: 1 = transparent, 0 = opaque. That is what makes the obvious wiring — `alpha` into `JoinImageWithAlpha.alpha` — lossless without an `InvertMask` in between, since `JoinImageWithAlpha` inverts on the way back. The alternative polarity would need the same compensating `InvertMask` that `blueprints/Remove Background (BiRefNet).json` already has to carry. For `ImageCompositeMasked`-style use the tooltip says to add `InvertMask`, as `RemoveBackground` users already do.

When the input has no alpha the output is an all-zero mask, i.e. fully opaque — the same value `SplitImageWithAlpha` produces for a 3 channel input (`1.0 - torch.ones_like(...)`).

Appending an output is workflow compatible; existing links keep their slots.

This is the smallest instance of a wider pattern. `comfy/sd.py` trims extra channels inside `VAE.encode`, and `comfy_extras/nodes_seedvr.py` already documents its own strip and re-applies the alpha in a second node. https://github.com/Comfy-Org/ComfyUI/pull/11406 did the same kind of cleanup on `VAEEncode`, dropping `pixels[:,:,:,:3]` once the VAE handled channel width itself.

Tests: `tests-unit/comfy_extras_test/upscale_model_alpha_test.py` — a stub descriptor asserts the model only ever sees RGB; the mask is checked for the right polarity on both a transparent and an opaque region; and one test round-trips the mask through `JoinImageWithAlpha` and checks the alpha comes back where it started. `ruff check` clean.
