### PR TITLE
ci: make unit and execution tests able to fail a PR

### DIFF
--- a/.github/workflows/test-execution.yml
+++ b/.github/workflows/test-execution.yml
@@ -9,10 +9,10 @@ on:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
-    continue-on-error: true
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python      

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -9,10 +9,10 @@ on:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-2022, macos-latest]
     runs-on: ${{ matrix.os }}
-    continue-on-error: true
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python      


### PR DESCRIPTION
`test-unit.yml` and `test-execution.yml` both set `continue-on-error: true` at the **job** level. They are the only two jobs in the whole workflow tree that do. A failing `pytest` run reports the job as `success`, so neither suite can fail a PR — "add a test" on this repo is advisory, not a gate.

Measured over the last 100 completed runs of each workflow (`gh api .../actions/workflows/<f>/runs?status=completed&per_page=100`):

| workflow | success | failure | action_required |
|---|---|---|---|
| `ruff.yml` (no `continue-on-error`) | 86 | **2** | 12 |
| `test-unit.yml` | 82 | **0** | 18 |
| `test-execution.yml` | 82 | **0** | 18 |

Ruff produces real `failure` conclusions. These two structurally cannot.

**Verified safe before removing the flag.** Both suites are genuinely green on `master` right now — this is not a case of removing a flag that is holding back a long-red build:

- Last **30 completed runs of each workflow on `master`**, inspected at the **step** level (`conclusion == "failure"` on any step, which `continue-on-error` does not hide): **0 failing steps** in either. That is 90 matrix legs per workflow across `ubuntu-latest`, `windows-2022`/`windows-latest` and `macos-latest`.
- Widened to the last **60 completed runs of each workflow across all branches** (not just `master`): still **0 failing steps**. So the flag is not currently masking anything — it is a hole waiting for the first real failure to fall through.

Also sets `fail-fast: false`. Without `continue-on-error`, the matrix default would cancel the other two OS legs as soon as one fails; keeping all three reporting preserves the signal that made this diff verifiable in the first place.

No change to what the suites run, only to whether their result counts.
