### PR TITLE
fix(ci): dispatch releases to Comfy-Org/Comfy-Desktop, not the archived repo

### DIFF
--- a/.github/workflows/release-webhook.yml
+++ b/.github/workflows/release-webhook.yml
@@ -110,8 +110,13 @@ jobs:
           echo "✅ Release webhook sent successfully"
 
       - name: Send repository dispatch to desktop
+        # Runs even if the webhook step above failed: the two deliveries are
+        # independent, and a failing webhook endpoint must not silently skip
+        # the desktop release bump.
+        if: ${{ !cancelled() }}
         env:
           DISPATCH_TOKEN: ${{ env.DESKTOP_REPO_DISPATCH_TOKEN }}
+          DISPATCH_REPO: Comfy-Org/Comfy-Desktop
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           RELEASE_URL: ${{ github.event.release.html_url }}
         run: |
@@ -138,7 +143,7 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
-            https://api.github.com/repos/Comfy-Org/desktop/dispatches \
+            "https://api.github.com/repos/${DISPATCH_REPO}/dispatches" \
             -d "$PAYLOAD"
 
-          echo "✅ Dispatched ComfyUI release ${RELEASE_TAG} to Comfy-Org/desktop"
+          echo "✅ Dispatched ComfyUI release ${RELEASE_TAG} to ${DISPATCH_REPO}"


### PR DESCRIPTION
Two changes to `.github/workflows/release-webhook.yml`, plus a finding that may make a third change the better answer — see the end.

### 1. The dispatch target is an archived repo

`Send repository dispatch to desktop` POSTs to `Comfy-Org/desktop`, added by https://github.com/Comfy-Org/ComfyUI/pull/12398 (2026-02-11).

`gh repo view Comfy-Org/desktop` → `"isArchived": true`, last push `2026-06-26`, description `"[ARCHIVED] Superseded by https://github.com/Comfy-Org/Comfy-Desktop"`. Archived repos are read-only, so a `repository_dispatch` POST cannot succeed there.

Retargeted to `Comfy-Org/Comfy-Desktop`, via a `DISPATCH_REPO` env var so the repo name appears once rather than three times.

### 2. A failure in the webhook step silently skips the dispatch

The two deliveries are unrelated — one POSTs to `RELEASE_GITHUB_WEBHOOK_URL`, the other bumps Desktop — but they are sequential steps in one job with no `if:`, so a failure in the first skips the second.

Not hypothetical. **All 15 of the most recent `Release Webhook` runs failed**, back to `v0.20.1` on 2026-04-27, every one the same way:

```
Set up job                      success
Send release webhook            failure
Send repository dispatch ...    skipped
Complete job                    success
```

The first step dies on `curl: (22) The requested URL returned error: 500` from the webhook endpoint (run `30782727003`, `v0.30.0`, 2026-08-03). **So the desktop dispatch step has never executed on any release in at least three and a half months.**

`if: ${{ !cancelled() }}` decouples them. The 500 itself is server-side, outside this repo, and is not addressed here — but it should stop taking the Desktop bump down with it, and somebody should own that endpoint. A workflow that is red on every single release is not being watched.

### 3. The finding worth acting on before merging this

**There is no `repository_dispatch` listener for `comfyui_release_published` anywhere.** I grepped every workflow file in both repos:

- `Comfy-Org/Comfy-Desktop` — 9 workflows, zero hits for `repository_dispatch` or `comfyui_release_published`.
- `Comfy-Org/desktop` (archived, i.e. as it stood at archive time) — 9 workflows, zero hits.

https://github.com/Comfy-Org/ComfyUI/pull/12398's stated goal was *"let Desktop auto-create ComfyUI bump PRs when Core publishes a GitHub Release"*, but the receiving half was never added. And the architecture has since moved: `Comfy-Org/Comfy-Desktop` 1.0.x resolves the ComfyUI version at runtime from the R2 standalone catalog (`src/main/sources/standalone/r2Catalog.ts`, `comfyui_version`), and its `version-bump.yml` is `workflow_dispatch`-only and bumps the Desktop app's own version. There is no pinned ComfyUI version for a dispatch to bump.

So: this PR makes the step correct-if-anyone-wires-it-up, and stops it from being silently skipped. But **deleting the step outright may be the right answer**, and I am happy to change this PR to that if the Desktop side confirms the hook is not wanted. Deciding that is not mine to make — flagging it rather than quietly shipping plumbing to nowhere.

### Correction to a claim that may be circulating internally

We had this recorded as "every release since late June successfully dispatched into a dead repo and printed a green checkmark". **Both halves are wrong and are corrected here:** the workflow has been visibly *red* on every release, and the dispatch never ran at all.
