### PR TITLE
chore: fail the CodeRabbit status when the review did not run

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,6 +11,10 @@ reviews:
   review_status: false
   review_details: true
   commit_status: true
+  # Without this, a review that never happened (rate limit, internal error)
+  # still posts a green "CodeRabbit" commit status, so a throttled review is
+  # indistinguishable from a clean one.
+  fail_commit_status: true
   collapse_walkthrough: true
   changed_files_summary: false
   sequence_diagrams: false


### PR DESCRIPTION
`.coderabbit.yaml` sets `commit_status: true` but leaves `fail_commit_status` at its default of `false`. Per the CodeRabbit v2 schema, `fail_commit_status` is what makes review *errors* fail the outward status surface; without it, a review that never ran still posts green.

Measured, on https://github.com/Comfy-Org/workflow_templates/pull/1092:

```
$ gh api repos/.../commits/36659b8d/statuses
{"context":"CodeRabbit","state":"pending","description":"Review queued"}
{"context":"CodeRabbit","state":"pending","description":"Review in progress"}
{"context":"CodeRabbit","state":"success","description":"Review rate limited"}
```

`state: success`. A throttled review is indistinguishable from a clean one at a glance, and `gh pr checks` prints it as `pass`.

This is not theoretical on this repo. Five PRs in one recent batch ended with no automated review at all while showing green, and one PR needed four `@coderabbitai review` invocations before a review actually ran — the one that ran found a Critical.

**Caveat, stated plainly:** the schema documents `fail_commit_status` as applying to "review errors". Whether CodeRabbit classifies a *rate limit* as an error is not something I can prove from outside — the flag is the only relevant knob in the schema (`review_status`, `commit_status`, `fail_commit_status` are the complete set), and the failure mode is worth closing if it does apply. If it turns out not to cover rate limits, that is worth raising with CodeRabbit rather than living with a green check that means nothing.

Companion change for the frontend: https://github.com/Comfy-Org/ComfyUI_frontend/pull/14880
