### PR TITLE
Make the lowvram LoRA patch path numerically match the eager one

### DIFF
--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -199,7 +199,11 @@ class LowVramPatch:
 
     def __call__(self, weight):
         patches = self.prepared_patches if self.prepared_patches is not None else self.patches[self.key]
-        return comfy.lora.calculate_weight(patches, weight, self.key, intermediate_dtype=weight.dtype)
+        temp_dtype = comfy.model_management.lora_compute_dtype(weight.device)
+        temp_weight = comfy.model_management.cast_to_device(weight, weight.device, temp_dtype, copy=True)
+        out_weight = comfy.lora.calculate_weight(patches, temp_weight, self.key)
+        return comfy.float.stochastic_rounding(out_weight, weight.dtype,
+                                               seed=comfy.utils.string_to_seed(self.key))
 
 LOWVRAM_PATCH_ESTIMATE_MATH_FACTOR = 2
 


### PR DESCRIPTION
`LowVramPatch.__call__` runs `calculate_weight` with `intermediate_dtype=weight.dtype`, so LoRA math for an offloaded module happens in the storage dtype (bf16) instead of `lora_compute_dtype`, and the result is truncated to storage dtype instead of going through `stochastic_rounding`. `patch_weight_to_device` does both. `convert_func`/`set_func` are also stored in `__init__` but never used in `__call__`. The same LoRA on the same model therefore produces different weights depending only on whether a module happened to be offloaded.

Measured on a 4096x4096 bf16 weight with a rank-32 LoRA (max |w| = 9.625, `lora_compute_dtype` resolves to fp16 here), max abs diff between the lowvram and eager results:

| LoRA strength | before | after |
|---|---|---|
| 0.0 | 0.000000 | 0.000000 |
| 0.4 | 0.007812 | 0.003906 |
| 1.2 | 0.031250 | 0.015625 |

The remaining difference is inherent: `stochastic_rounding` is stochastic, so the two paths round independently.

No new memory pressure - `low_vram_patch_estimate_vram` already budgets `numel * model_dtype.itemsize * LOWVRAM_PATCH_ESTIMATE_MATH_FACTOR` with the factor at 2, i.e. the offload accounting already assumes one intermediate copy of the weight.

Tested on 2x RTX PRO 6000 Blackwell, torch cu128, LTX-2 22B bf16.

Separately, and not addressed here: on a long-running instance, renders with a LoRA attached to an LTX-2 model degrade badly compared to the same job on a freshly started instance (identity metric 0.299 vs 0.793, everything else identical), and it reproduces at LoRA strength 0.0 where the patched weights are bit-identical to unpatched. Unloading models or restarting clears it. That points somewhere other than these two functions and I don't have a diagnosis yet.
