### PR TITLE
Query pytorch for aotriton support instead of listing its lib directory

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -490,28 +490,33 @@ try:
         except:
             rocm_version = (6, -1)
 
-        def aotriton_supported(gpu_arch):
-            path = torch.__path__[0]
-            path = os.path.join(os.path.join(path, "lib"), "aotriton.images")
-            gfx = set(map(lambda a: a[4:], filter(lambda a: a.startswith("amd-gfx"), os.listdir(path))))
-            if gpu_arch in gfx:
-                return True
-            if "{}x".format(gpu_arch[:-1]) in gfx:
-                return True
-            if "{}xx".format(gpu_arch[:-2]) in gfx:
-                return True
-            return False
+        def aotriton_supported():
+            # Ask pytorch whether it can actually run flash attention on this gpu instead of
+            # listing the aotriton.images dir: on ROCm can_use_flash_attention() ends up calling
+            # aotriton::v2::flash::check_gpu(), which fails when aotriton has no image for this arch.
+            try:
+                if not torch.backends.cuda.is_flash_attention_available():  # built without aotriton
+                    return False
+                q = torch.empty((1, 1, 8, 64), dtype=torch.float16, device=get_torch_device())
+                try:
+                    params = torch.backends.cuda.SDPAParams(q, q, q, None, 0.0, False, False)
+                except TypeError:  # enable_gqa arg was added in torch 2.5
+                    params = torch.backends.cuda.SDPAParams(q, q, q, None, 0.0, False)
+                return torch.backends.cuda.can_use_flash_attention(params, False)
+            except Exception as e:
+                logging.warning("Could not query aotriton support: {}".format(e))
+                return False
 
         logging.info("AMD arch: {}".format(arch))
         logging.info("ROCm version: {}".format(rocm_version))
         if args.use_split_cross_attention == False and args.use_quad_cross_attention == False:
-            if aotriton_supported(arch):  # AMD efficient attention implementation depends on aotriton.
+            if aotriton_supported():  # AMD efficient attention implementation depends on aotriton.
                 if torch_version_numeric >= (2, 7):  # works on 2.6 but doesn't actually seem to improve much
                     if any((a in arch) for a in ["gfx90a", "gfx942", "gfx950", "gfx1100", "gfx1101", "gfx1150", "gfx1151"]):  # TODO: more arches, TODO: gfx950
                         ENABLE_PYTORCH_ATTENTION = True
                 if rocm_version >= (7, 0):
-                   if any((a in arch) for a in ["gfx1200", "gfx1201"]):
-                       ENABLE_PYTORCH_ATTENTION = True
+                    if any((a in arch) for a in ["gfx1200", "gfx1201"]):
+                        ENABLE_PYTORCH_ATTENTION = True
         if torch_version_numeric >= (2, 7) and rocm_version >= (6, 4):
             if any((a in arch) for a in ["gfx1200", "gfx1201", "gfx950"]):  # TODO: more arches, "gfx942" gives error on pytorch nightly 2.10 1013 rocm7.0
                 SUPPORT_FP8_OPS = True

--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -491,19 +491,21 @@ try:
             rocm_version = (6, -1)
 
         def aotriton_supported():
-            # Ask pytorch whether it can actually run flash attention on this gpu instead of
-            # listing the aotriton.images dir: on ROCm can_use_flash_attention() ends up calling
-            # aotriton::v2::flash::check_gpu(), which fails when aotriton has no image for this arch.
+            """Whether pytorch can actually run flash attention on this gpu.
+
+            On ROCm can_use_flash_attention() calls aotriton::v2::flash::check_gpu(),
+            which fails when aotriton has no kernel image compiled for this arch. Asking
+            pytorch avoids assuming where those images live inside the torch install.
+            The probe tensor is shaped and typed to pass the unrelated SDPA checks, so a
+            False result means hardware support and not a rejected shape.
+            """
             try:
                 if not torch.backends.cuda.is_flash_attention_available():  # built without aotriton
                     return False
                 q = torch.empty((1, 1, 8, 64), dtype=torch.float16, device=get_torch_device())
-                try:
-                    params = torch.backends.cuda.SDPAParams(q, q, q, None, 0.0, False, False)
-                except TypeError:  # enable_gqa arg was added in torch 2.5
-                    params = torch.backends.cuda.SDPAParams(q, q, q, None, 0.0, False)
+                params = torch.backends.cuda.SDPAParams(q, q, q, None, 0.0, False, False)
                 return torch.backends.cuda.can_use_flash_attention(params, False)
-            except Exception as e:
+            except (AttributeError, RuntimeError, TypeError) as e:
                 logging.warning("Could not query aotriton support: {}".format(e))
                 return False
 

--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -491,16 +491,17 @@ try:
             rocm_version = (6, -1)
 
         def aotriton_supported():
-            """Whether pytorch can actually run flash attention on this gpu.
+            """Whether pytorch reports flash attention as usable on this gpu.
 
-            On ROCm can_use_flash_attention() calls aotriton::v2::flash::check_gpu(),
-            which fails when aotriton has no kernel image compiled for this arch. Asking
-            pytorch avoids assuming where those images live inside the torch install.
-            The probe tensor is shaped and typed to pass the unrelated SDPA checks, so a
-            False result means hardware support and not a rejected shape.
+            can_use_flash_attention() evaluates runtime eligibility for the given
+            parameters; on a ROCm build that includes checking the gpu arch against the
+            kernel images AOTriton was compiled for. Querying it avoids assuming where
+            those images live inside the torch install. The probe tensor is shaped and
+            typed to pass the unrelated SDPA checks, so False means no hardware support
+            rather than a rejected shape.
             """
             try:
-                if not torch.backends.cuda.is_flash_attention_available():  # built without aotriton
+                if not torch.backends.cuda.is_flash_attention_available():  # not built with flash attention
                     return False
                 q = torch.empty((1, 1, 8, 64), dtype=torch.float16, device=get_torch_device())
                 params = torch.backends.cuda.SDPAParams(q, q, q, None, 0.0, False, False)


### PR DESCRIPTION
Stops a build with no aotriton.images directory from raising FileNotFoundError out of the enclosing try block, which silently skipped the SUPPORT_FP8_OPS detection below it. This problem is exactly what i was hitting when trying to build through nix where the pytorch library is built a little different from normal.

Also cleans up needing to query specific architectures that must be added to over time.

Tested building in the same nix system on my system (which is a gfx1151) and ran a Wan2.2 example pipeline on it. It lets me skip having to specify --use-pytorch-cross-attention when running it.

excerpt from the startup of comfyui with the change and no extra flags
```
[INFO] pytorch version: 2.12.0
[INFO] Set: torch.backends.cudnn.enabled = False for better AMD performance.
[INFO] AMD arch: gfx1151
[INFO] ROCm version: (7, 2)
[INFO] Set vram state to: NORMAL_VRAM
[INFO] Device: cuda:0 AMD Radeon 8060S Graphics : native
[INFO] Using async weight offloading with 2 streams
[INFO] Enabled pinned memory 84611.0
[INFO] Using pytorch attention
[INFO] Python version: 3.14.6 (main, Jun 10 2026, 10:03:53) [GCC 15.3.0]
```
