### PR TITLE
Close PIL Image file handle in LoadImage node

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1761,27 +1761,32 @@ class LoadImage:
         output_masks = []
         w, h = None, None
 
-        for i in ImageSequence.Iterator(img):
-            i = node_helpers.pillow(ImageOps.exif_transpose, i)
+        try:
+            for i in ImageSequence.Iterator(img):
+                i = node_helpers.pillow(ImageOps.exif_transpose, i)
 
-            image = i.convert("RGB")
+                image = i.convert("RGB")
 
-            if len(output_images) == 0:
-                w = image.size[0]
-                h = image.size[1]
+                if len(output_images) == 0:
+                    w = image.size[0]
+                    h = image.size[1]
 
-            if image.size[0] != w or image.size[1] != h:
-                continue
+                if image.size[0] != w or image.size[1] != h:
+                    continue
 
-            image = np.array(image).astype(np.float32) / 255.0
-            image = torch.from_numpy(image)[None,]
-            if 'A' in i.getbands():
-                mask = np.array(i.getchannel('A')).astype(np.float32) / 255.0
-                mask = 1. - torch.from_numpy(mask)
-            else:
-                mask = torch.zeros((64, 64), dtype=torch.float32, device="cpu")
-            output_images.append(image.to(dtype=dtype))
-            output_masks.append(mask.unsqueeze(0).to(dtype=dtype))
+                image = np.array(image).astype(np.float32) / 255.0
+                image = torch.from_numpy(image)[None,]
+                if 'A' in i.getbands():
+                    mask = np.array(i.getchannel('A')).astype(np.float32) / 255.0
+                    mask = 1. - torch.from_numpy(mask)
+                else:
+                    mask = torch.zeros((64, 64), dtype=torch.float32, device="cpu")
+                output_images.append(image.to(dtype=dtype))
+                output_masks.append(mask.unsqueeze(0).to(dtype=dtype))
+        finally:
+            # Release the underlying file handle so the source file isn't
+            # left open (e.g. preventing deletion/rename on Windows).
+            img.close()
 
         output_image = torch.cat(output_images, dim=0)
         output_mask = torch.cat(output_masks, dim=0)


### PR DESCRIPTION
Fixes #3477

## Problem
`LoadImage.load_image()` opens an image with `node_helpers.pillow(Image.open, image_path)` and loops over frames via `ImageSequence.Iterator(img)`, but never closes `img`. PIL nulls the public `img.fp` after reading pixel data (making the image look closed), but the private `img._fp` — the real OS file handle — stays open until the object is garbage collected. This leaks a handle per load and can prevent deleting/renaming the source file immediately afterward on some platforms.

## On the existing discussion in the issue
A couple of earlier comments on this issue argued an explicit close isn't necessary, since CPython's refcounting will call `img.__del__()` (closing the file) as soon as the local variable goes out of scope at function return. That's true for CPython specifically, but it's relying on an implementation detail rather than a guarantee: it doesn't hold on non-refcounted Python implementations (e.g. PyPy) where GC timing is non-deterministic, and it silently breaks if `img` or a reference to it is ever captured/returned/cached elsewhere in a future change. An explicit `close()` once all frames have been read is more portable and doesn't depend on GC timing at all, so I think it's still worth doing even though the current CPython behavior happens to mask the leak in the common case.

## Fix
Wrapped the frame-iteration loop in `try/finally` and added `img.close()` in the `finally` block, so the handle is released only after all frames have been copied into independent tensors (this comes after `exif_transpose` etc. inside the loop, so it doesn't hit the earlier concern about closing too early).

## Testing
The `LoadImage` node itself requires a full ComfyUI runtime (torch, folder_paths, app init) that isn't practical to spin up here. I isolated the same PIL access pattern (open → iterate frames → exif_transpose → convert) in a standalone script to verify the handle-leak behavior directly: before the fix, `img._fp` stayed open after the function returned and the source file could not be deleted; after the fix, the handle was released and the file could be deleted immediately.