### PR TITLE
perf(wan): make self-attention QKV contiguous on ROCm

### DIFF
--- a/comfy/ldm/wan/model.py
+++ b/comfy/ldm/wan/model.py
@@ -15,23 +15,23 @@ import comfy.ops
 import comfy.patcher_extension
 
 
-_amd_arch_cache = {}
+_AMD_ARCH_CACHE = {}
 
 
 def _amd_arch(device):
-    if device.type != "cuda" or not comfy.model_management.is_amd():
+    if device.type != "cuda":
         return None
     key = (device.type, device.index)
-    if key not in _amd_arch_cache:
-        try:
-            _amd_arch_cache[key] = torch.cuda.get_device_properties(device).gcnArchName.split(":", 1)[0]
-        except Exception:
-            _amd_arch_cache[key] = None
-    return _amd_arch_cache[key]
+    if key in _AMD_ARCH_CACHE:
+        return _AMD_ARCH_CACHE[key]
+    arch_name = torch.cuda.get_device_properties(device).gcnArchName
+    arch = arch_name.split(":", 1)[0]
+    _AMD_ARCH_CACHE[key] = arch
+    return arch
 
 
 def _should_make_qkv_contiguous(q, k, v):
-    if q.shape[-2] < 5000 or q.shape[-1] != 128:
+    if not comfy.model_management.is_amd() or q.shape[-2] < 5000 or q.shape[-1] != 128:
         return False
     if all(x.is_contiguous() for x in (q, k, v)):
         return False

--- a/comfy/ldm/wan/model.py
+++ b/comfy/ldm/wan/model.py
@@ -81,13 +81,25 @@ class WanSelfAttention(nn.Module):
         q = qkv_fn_q(x)
         k = qkv_fn_k(x)
 
-        x = optimized_attention(
-            q.view(b, s, n * d),
-            k.view(b, s, n * d),
-            self.v(x).view(b, s, n * d),
-            heads=self.num_heads,
-            transformer_options=transformer_options,
-        )
+        v = self.v(x)
+        if comfy.model_management.is_amd():
+            q_attn = q.transpose(1, 2).contiguous()
+            k_attn = k.transpose(1, 2).contiguous()
+            v_attn = v.view(b, s, n, d).transpose(1, 2).contiguous()
+            x = optimized_attention(
+                q_attn, k_attn, v_attn,
+                heads=self.num_heads,
+                skip_reshape=True,
+                transformer_options=transformer_options,
+            )
+        else:
+            x = optimized_attention(
+                q.view(b, s, n * d),
+                k.view(b, s, n * d),
+                v.view(b, s, n * d),
+                heads=self.num_heads,
+                transformer_options=transformer_options,
+            )
 
         if "attn1_patch" in patches:
             for p in patches["attn1_patch"]:

--- a/comfy/ldm/wan/model.py
+++ b/comfy/ldm/wan/model.py
@@ -15,6 +15,31 @@ import comfy.ops
 import comfy.patcher_extension
 
 
+_amd_arch_cache = {}
+
+
+def _amd_arch(device):
+    if device.type != "cuda" or not comfy.model_management.is_amd():
+        return None
+    key = (device.type, device.index)
+    if key not in _amd_arch_cache:
+        try:
+            _amd_arch_cache[key] = torch.cuda.get_device_properties(device).gcnArchName.split(":", 1)[0]
+        except Exception:
+            _amd_arch_cache[key] = None
+    return _amd_arch_cache[key]
+
+
+def _should_make_qkv_contiguous(q, k, v):
+    if q.shape[-2] < 5000 or q.shape[-1] != 128:
+        return False
+    if all(x.is_contiguous() for x in (q, k, v)):
+        return False
+    if _amd_arch(q.device) != "gfx1151":
+        return False
+    return True
+
+
 def sinusoidal_embedding_1d(dim, position):
     # preprocess
     assert dim % 2 == 0
@@ -82,10 +107,11 @@ class WanSelfAttention(nn.Module):
         k = qkv_fn_k(x)
 
         v = self.v(x)
-        if comfy.model_management.is_amd():
-            q_attn = q.transpose(1, 2).contiguous()
-            k_attn = k.transpose(1, 2).contiguous()
-            v_attn = v.view(b, s, n, d).transpose(1, 2).contiguous()
+        q_attn = q.transpose(1, 2)
+        k_attn = k.transpose(1, 2)
+        v_attn = v.view(b, s, n, d).transpose(1, 2)
+        if _should_make_qkv_contiguous(q_attn, k_attn, v_attn):
+            q_attn, k_attn, v_attn = (x.contiguous() for x in (q_attn, k_attn, v_attn))
             x = optimized_attention(
                 q_attn, k_attn, v_attn,
                 heads=self.num_heads,

--- a/tests-unit/comfy_test/test_wan_attention.py
+++ b/tests-unit/comfy_test/test_wan_attention.py
@@ -4,7 +4,7 @@ import comfy.ldm.wan.model as wan_model
 import comfy.ops
 
 
-def test_wan_self_attention_makes_qkv_contiguous_only_on_amd(monkeypatch):
+def test_wan_self_attention_preserves_outputs_across_layout_paths(monkeypatch):
     attention = wan_model.WanSelfAttention(
         dim=16,
         num_heads=4,
@@ -17,7 +17,6 @@ def test_wan_self_attention_makes_qkv_contiguous_only_on_amd(monkeypatch):
     )
     for parameter in attention.parameters():
         torch.nn.init.normal_(parameter, std=0.02)
-
     layouts = []
 
     def capture_attention(q, k, v, heads, skip_reshape=False, **kwargs):
@@ -34,13 +33,71 @@ def test_wan_self_attention_makes_qkv_contiguous_only_on_amd(monkeypatch):
 
     monkeypatch.setattr(wan_model, "optimized_attention", capture_attention)
     monkeypatch.setattr(wan_model, "apply_rope1", lambda tensor, freqs: tensor)
-
+    monkeypatch.setattr(wan_model, "_should_make_qkv_contiguous", lambda q, k, v: False)
     x = torch.randn(1, 23, 16)
-    monkeypatch.setattr(wan_model.comfy.model_management, "is_amd", lambda: False)
-    non_amd_output = attention(x, None)
+    original_output = attention(x, None)
 
-    monkeypatch.setattr(wan_model.comfy.model_management, "is_amd", lambda: True)
-    amd_output = attention(x, None)
+    monkeypatch.setattr(
+        wan_model,
+        "_should_make_qkv_contiguous",
+        lambda q, k, v: True,
+    )
+    optimized_output = attention(x, None)
 
     assert layouts == [(3, (True, True, True)), (4, (True, True, True))]
-    torch.testing.assert_close(amd_output, non_amd_output, rtol=0, atol=0)
+    torch.testing.assert_close(optimized_output, original_output, rtol=0, atol=0)
+
+
+def make_qkv(seq=5000, dim=128, contiguous=False, device="cpu"):
+    if contiguous:
+        return tuple(torch.randn(1, 2, seq, dim, device=device) for _ in range(3))
+    fused = torch.randn(1, seq, 6 * dim, device=device)
+    return tuple(x.view(1, seq, 2, dim).transpose(1, 2) for x in fused.split(2 * dim, dim=-1))
+
+
+def test_wan_qkv_gate_rejects_unvalidated_inputs(monkeypatch):
+    probe_calls = []
+    monkeypatch.setattr(wan_model, "_amd_arch", lambda device: probe_calls.append(device))
+    cases = [make_qkv(seq=4096), make_qkv(dim=64), make_qkv(contiguous=True)]
+
+    for inputs in cases:
+        assert not wan_model._should_make_qkv_contiguous(*inputs)
+    assert probe_calls == []
+
+
+def test_wan_qkv_gate_rejects_other_architectures(monkeypatch):
+    inputs = make_qkv()
+    monkeypatch.setattr(wan_model, "_amd_arch", lambda device: "gfx1100")
+    assert not wan_model._should_make_qkv_contiguous(*inputs)
+
+
+def test_wan_qkv_gate_accepts_validated_shape_on_gfx1151(monkeypatch):
+    inputs = make_qkv()
+    monkeypatch.setattr(wan_model, "_amd_arch", lambda device: "gfx1151")
+    assert wan_model._should_make_qkv_contiguous(*inputs)
+
+
+def test_wan_amd_arch_probe_is_device_guarded_cached_and_fail_closed(monkeypatch):
+    wan_model._amd_arch_cache.clear()
+    calls = []
+    monkeypatch.setattr(wan_model.comfy.model_management, "is_amd", lambda: True)
+    monkeypatch.setattr(
+        wan_model.torch.cuda,
+        "get_device_properties",
+        lambda device: calls.append(device) or type("Props", (), {"gcnArchName": "gfx1151:sramecc+"})(),
+    )
+    cuda = torch.device("cuda", 0)
+
+    assert wan_model._amd_arch(torch.device("cpu")) is None
+    assert wan_model._amd_arch(cuda) == "gfx1151"
+    assert wan_model._amd_arch(cuda) == "gfx1151"
+    assert calls == [cuda]
+
+    wan_model._amd_arch_cache.clear()
+    monkeypatch.setattr(
+        wan_model.torch.cuda,
+        "get_device_properties",
+        lambda device: (_ for _ in ()).throw(RuntimeError("probe failed")),
+    )
+    assert wan_model._amd_arch(cuda) is None
+    assert wan_model._amd_arch(cuda) is None

--- a/tests-unit/comfy_test/test_wan_attention.py
+++ b/tests-unit/comfy_test/test_wan_attention.py
@@ -1,0 +1,46 @@
+import torch
+
+import comfy.ldm.wan.model as wan_model
+import comfy.ops
+
+
+def test_wan_self_attention_makes_qkv_contiguous_only_on_amd(monkeypatch):
+    attention = wan_model.WanSelfAttention(
+        dim=16,
+        num_heads=4,
+        qk_norm=False,
+        operation_settings={
+            "operations": comfy.ops.disable_weight_init,
+            "device": "cpu",
+            "dtype": torch.float32,
+        },
+    )
+    for parameter in attention.parameters():
+        torch.nn.init.normal_(parameter, std=0.02)
+
+    layouts = []
+
+    def capture_attention(q, k, v, heads, skip_reshape=False, **kwargs):
+        layouts.append((q.ndim, tuple(t.is_contiguous() for t in (q, k, v))))
+        if not skip_reshape:
+            batch, sequence, channels = q.shape
+            head_dim = channels // heads
+            q, k, v = (
+                tensor.view(batch, sequence, heads, head_dim).transpose(1, 2)
+                for tensor in (q, k, v)
+            )
+        out = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+        return out.transpose(1, 2).reshape(out.shape[0], out.shape[2], -1)
+
+    monkeypatch.setattr(wan_model, "optimized_attention", capture_attention)
+    monkeypatch.setattr(wan_model, "apply_rope1", lambda tensor, freqs: tensor)
+
+    x = torch.randn(1, 23, 16)
+    monkeypatch.setattr(wan_model.comfy.model_management, "is_amd", lambda: False)
+    non_amd_output = attention(x, None)
+
+    monkeypatch.setattr(wan_model.comfy.model_management, "is_amd", lambda: True)
+    amd_output = attention(x, None)
+
+    assert layouts == [(3, (True, True, True)), (4, (True, True, True))]
+    torch.testing.assert_close(amd_output, non_amd_output, rtol=0, atol=0)

--- a/tests-unit/comfy_test/test_wan_attention.py
+++ b/tests-unit/comfy_test/test_wan_attention.py
@@ -33,6 +33,7 @@ def test_wan_self_attention_preserves_outputs_across_layout_paths(monkeypatch):
 
     monkeypatch.setattr(wan_model, "optimized_attention", capture_attention)
     monkeypatch.setattr(wan_model, "apply_rope1", lambda tensor, freqs: tensor)
+    monkeypatch.setattr(wan_model.comfy.model_management, "is_amd", lambda: True)
     monkeypatch.setattr(wan_model, "_should_make_qkv_contiguous", lambda q, k, v: False)
     x = torch.randn(1, 23, 16)
     original_output = attention(x, None)
@@ -56,48 +57,72 @@ def make_qkv(seq=5000, dim=128, contiguous=False, device="cpu"):
 
 
 def test_wan_qkv_gate_rejects_unvalidated_inputs(monkeypatch):
-    probe_calls = []
-    monkeypatch.setattr(wan_model, "_amd_arch", lambda device: probe_calls.append(device))
-    cases = [make_qkv(seq=4096), make_qkv(dim=64), make_qkv(contiguous=True)]
+    cases = [
+        (False, make_qkv()),
+        (True, make_qkv(seq=4999)),
+        (True, make_qkv(dim=64)),
+        (True, make_qkv(contiguous=True)),
+    ]
 
-    for inputs in cases:
+    for is_amd, inputs in cases:
+        probe_calls = []
+        monkeypatch.setattr(wan_model.comfy.model_management, "is_amd", lambda: is_amd)
+        monkeypatch.setattr(wan_model, "_amd_arch", lambda device: probe_calls.append(device))
         assert not wan_model._should_make_qkv_contiguous(*inputs)
-    assert probe_calls == []
+        assert probe_calls == []
 
 
 def test_wan_qkv_gate_rejects_other_architectures(monkeypatch):
     inputs = make_qkv()
+    monkeypatch.setattr(wan_model.comfy.model_management, "is_amd", lambda: True)
     monkeypatch.setattr(wan_model, "_amd_arch", lambda device: "gfx1100")
     assert not wan_model._should_make_qkv_contiguous(*inputs)
 
 
-def test_wan_qkv_gate_accepts_validated_shape_on_gfx1151(monkeypatch):
-    inputs = make_qkv()
-    monkeypatch.setattr(wan_model, "_amd_arch", lambda device: "gfx1151")
-    assert wan_model._should_make_qkv_contiguous(*inputs)
-
-
-def test_wan_amd_arch_probe_is_device_guarded_cached_and_fail_closed(monkeypatch):
-    wan_model._amd_arch_cache.clear()
-    calls = []
+def test_wan_qkv_gate_accepts_5000_boundary(monkeypatch):
+    inputs = make_qkv(seq=5000)
+    arch_calls = []
     monkeypatch.setattr(wan_model.comfy.model_management, "is_amd", lambda: True)
-    monkeypatch.setattr(
-        wan_model.torch.cuda,
-        "get_device_properties",
-        lambda device: calls.append(device) or type("Props", (), {"gcnArchName": "gfx1151:sramecc+"})(),
-    )
-    cuda = torch.device("cuda", 0)
+    monkeypatch.setattr(wan_model, "_amd_arch", lambda device: arch_calls.append(device) or "gfx1151")
+
+    assert wan_model._should_make_qkv_contiguous(*inputs)
+    assert arch_calls == [inputs[0].device]
+
+
+def test_wan_amd_arch_is_device_aware_cached(monkeypatch):
+    wan_model._AMD_ARCH_CACHE.clear()
+    calls = []
+
+    def get_properties(device):
+        calls.append(device)
+        return type("Props", (), {"gcnArchName": f"gfx115{device.index + 1}:sramecc+:xnack-"})()
+
+    monkeypatch.setattr(wan_model.torch.cuda, "get_device_properties", get_properties)
 
     assert wan_model._amd_arch(torch.device("cpu")) is None
-    assert wan_model._amd_arch(cuda) == "gfx1151"
-    assert wan_model._amd_arch(cuda) == "gfx1151"
-    assert calls == [cuda]
+    assert calls == []
+    assert wan_model._amd_arch(torch.device("cuda:0")) == "gfx1151"
+    assert wan_model._amd_arch(torch.device("cuda:0")) == "gfx1151"
+    assert wan_model._amd_arch(torch.device("cuda:1")) == "gfx1152"
+    assert wan_model._amd_arch(torch.device("cuda:1")) == "gfx1152"
+    assert calls == [torch.device("cuda:0"), torch.device("cuda:1")]
 
-    wan_model._amd_arch_cache.clear()
+    wan_model._AMD_ARCH_CACHE.clear()
+
+
+def test_wan_amd_arch_propagates_cuda_probe_errors(monkeypatch):
+    wan_model._AMD_ARCH_CACHE.clear()
     monkeypatch.setattr(
         wan_model.torch.cuda,
         "get_device_properties",
         lambda device: (_ for _ in ()).throw(RuntimeError("probe failed")),
     )
-    assert wan_model._amd_arch(cuda) is None
-    assert wan_model._amd_arch(cuda) is None
+
+    try:
+        wan_model._amd_arch(torch.device("cuda:0"))
+    except RuntimeError as error:
+        assert str(error) == "probe failed"
+    else:
+        raise AssertionError("CUDA probe error was silently ignored")
+
+    assert wan_model._AMD_ARCH_CACHE == {}


### PR DESCRIPTION
## Summary

- materialize contiguous Q/K/V head tensors only for validated large Wan self-attention workloads on AMD gfx1151
- preserve existing views on gfx1100, short sequences, other head dimensions, already-contiguous inputs, CUDA, and other backends
- add unit coverage for every architecture, workload, device, and cache guard

## Why

Wan computes separate Q/K/V projections, then passes flat `[B, S, H*D]` tensors to the generic attention helper. On Windows ROCm gfx1151, large Wan self-attention calls reach AOTriton as non-contiguous head views.

Copy-inclusive BF16 SDPA measurements on gfx1151 with Wan-shaped inputs:

| Shape | Existing layout | Contiguous HND | Speedup |
| --- | ---: | ---: | ---: |
| `S=18600`, `H=40`, `D=128` | 1.3444 s | 0.4368 s | 3.08x |
| `S=28500`, `H=40`, `D=128` | 4.9799 s | 1.0359 s | 4.81x |

A matched Wan 2.2 I2V workflow at 496x384 and 97 sampled frames decreased from 198.7 s end-to-end to 100.3 / 98.9 / 88.4 s across three hot runs (98.9 s median, 2.01x faster). The three optimized outputs had identical decoded-frame hashes. Baseline versus optimized encoded output SSIM was 0.999004.

[Related H3 testing and review in ComfyUI PR #15421](https://github.com/Comfy-Org/ComfyUI/pull/15421) found a small regression when the same kind of copy was enabled broadly on Linux gfx1100. The Wan workaround is therefore restricted to the empirically validated intersection:

- AMD gfx1151
- sequence length at least 5000
- head dimension 128
- at least one non-contiguous Q/K/V input

Architecture detection runs only for CUDA tensors and is cached by `(device.type, device.index)`. CUDA property lookup failures propagate and are not cached as a silent slower fallback; only successful architecture strings are normalized.

## Validation

- `pytest tests-unit/comfy_test/test_wan_attention.py -q` — 6 passed
- `ruff check comfy/ldm/wan/model.py tests-unit/comfy_test/test_wan_attention.py` — passed
- tests cover gfx1100, gfx1151, non-AMD, `S=4999`, `S=5000`, non-128 head dimensions, already-contiguous inputs, CPU bypass, successful per-device caching, architecture suffix normalization, and CUDA probe errors
- seven independent mutations of the workload, architecture, device, cache, and probe-error guards all fail the focused test file
- CPU reference test confirms exact output equivalence across the two layout paths
- three matched hot end-to-end runs completed successfully
