### PR TITLE
Extend ER-SDE noise scaler by scaling h(t)

### DIFF
--- a/comfy_extras/nodes_custom_sampler.py
+++ b/comfy_extras/nodes_custom_sampler.py
@@ -591,7 +591,7 @@ class SamplerER_SDE(io.ComfyNode):
             inputs=[
                 io.Combo.Input("solver_type", options=["ER-SDE", "Reverse-time SDE", "ODE"]),
                 io.Int.Input("max_stage", default=3, min=1, max=3, advanced=True),
-                io.Float.Input("eta", default=1.0, min=0.0, max=100.0, step=0.01, round=False, tooltip="Stochastic strength of reverse-time SDE.\nWhen eta=0, it reduces to deterministic ODE. This setting doesn't apply to ER-SDE solver type.", advanced=True),
+                io.Float.Input("eta", default=1.0, min=0.0, max=10.0, step=0.01, round=False, tooltip="Stochastic strength of SDEs.\nWhen eta=0, they reduce to deterministic ODE.\nLarge eta may cause invalid outputs. If this occurs, try decreasing this value.", advanced=True),
                 io.Float.Input("s_noise", default=1.0, min=0.0, max=100.0, step=0.01, round=False, advanced=True),
             ],
             outputs=[io.Sampler.Output()]
@@ -599,21 +599,35 @@ class SamplerER_SDE(io.ComfyNode):
 
     @classmethod
     def execute(cls, solver_type, max_stage, eta, s_noise) -> io.NodeOutput:
-        if solver_type == "ODE" or (solver_type == "Reverse-time SDE" and eta == 0):
-            eta = 0
-            s_noise = 0
+        # Extend existing noise scalers phi(x) with eta-controlled noise scalers:
+        #   psi(x) = x**(1-eta) * phi(x)**eta
+        # where eta is constant and directly scales the h^2(t) contribution.
 
-        def reverse_time_sde_noise_scaler(x):
+        def er_sde_noise_scaler(x: torch.Tensor) -> torch.Tensor:
+            return x * ((x ** 0.3).exp() + 10.0) ** eta
+
+        def reverse_time_sde_noise_scaler(x: torch.Tensor) -> torch.Tensor:
             return x ** (eta + 1)
 
-        if solver_type == "ER-SDE":
-            # Use the default one in sample_er_sde()
-            noise_scaler = None
-        else:
-            noise_scaler = reverse_time_sde_noise_scaler
+        def ode_noise_scaler(x: torch.Tensor) -> torch.Tensor:
+            return x
+
+        solver_scalers = {
+            "ER-SDE": er_sde_noise_scaler,
+            "Reverse-time SDE": reverse_time_sde_noise_scaler,
+            "ODE": ode_noise_scaler,
+        }
+
+        if solver_type == "ODE" or eta == 0:
+            s_noise = 0.0
+            solver_type = "ODE"
+        noise_scaler = solver_scalers[solver_type]
 
         sampler_name = "er_sde"
-        sampler = comfy.samplers.ksampler(sampler_name, {"s_noise": s_noise, "noise_scaler": noise_scaler, "max_stage": max_stage})
+        sampler = comfy.samplers.ksampler(
+            sampler_name,
+            {"s_noise": s_noise, "noise_scaler": noise_scaler, "max_stage": max_stage},
+        )
         return io.NodeOutput(sampler)
 
     get_sampler = execute


### PR DESCRIPTION
This introduces an eta parameter to control the stochastic strength of the ER-SDE noise scaler.

I know there is another PR (#14313) for this, but it has been open for a while. It also introduces some new mechanisms into this solver. Since the noise scaler itself controls the stochasticity, I think modifying the noise scaler should be sufficient.

In the ER-SDE framework, any function phi(x) that satisfies the required constraints can be used as a noise scaler. In fact, there are multiple possible ways to introduce a stochastic strength parameter.

A straightforward approach is to adopt an extension that can naturally adapt the standard reverse-time SDE  (RT-SDE) noise scaler (`phi(x) = x^2`) to the adjustable form: `psi(x) = x^(eta + 1)`.

After derivation, if eta is constant, we can construct a new noise scaler psi(x) based on the existing noise scaler phi(x) by:
```
psi(x) = x^(1-eta) * phi(x)^eta
```
which can extend the RT-SDE noise scaler to that adjustable form.

## Derivation
This part might be inaccurate.
Let's review these reverse-time SDE families.
<img width="941" height="414" alt="SDEs" src="https://github.com/user-attachments/assets/bf96b01d-0d64-4ad3-bf82-9a56f7e9f0e1" />

Each one can be viewed as an extended version of the previous one.
When h(t) = g(t), the corresponding noise scaler phi(x) is x^2 in the ER-SDE framework (see A.8 in the paper). Inspired by the evolution from Eq. 1 to Eq. 2, we can apply an additional scaling factor kappa to h^2(t), resulting in this form of SDE:
<img width="1182" height="276" alt="er-sde-kappa" src="https://github.com/user-attachments/assets/52c4ef1d-9293-4151-8ef4-a47392a897e7" />

It's still under the ER-SDE framework, so there exists a corresponding noise scaler psi(x) for it. In addition, when h(t) = g(t), this SDE reduces to the SDE in Eq. 2.

Following the derivation and proofs in the paper, we can obtain this:
<img width="964" height="432" alt="er-sde_kappa-derivation" src="https://github.com/user-attachments/assets/04329bb2-9cc3-49cb-9eb9-ed9308cb7c8f" />

Now, we can construct two equations corresponding to phi(x) and psi(x), respectively.
<img width="1172" height="800" alt="psi" src="https://github.com/user-attachments/assets/9a1e78ac-d805-4968-bebc-bf1df80013ae" />

Finally, by applying the existing noise scalers to this extension, we can get the expected results for ODE and RT-SDE.
<img width="936" height="461" alt="noise_scaler" src="https://github.com/user-attachments/assets/d80837b1-185d-4b40-9581-409e06c9d3f9" />


## Other Changes
- Decrease the maximum value of eta in the node. Since the noise scaler is applied to individual values instead of their ratio, large eta can cause inf values for consecutive steps.
- ODE noise scaler: just to skip unnecessary computation.