### PR TITLE
Fix --disable-mmap not bypassing safetensors mmap read

### DIFF
--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -119,6 +119,10 @@ def load_safetensors(ckpt):
     return sd, header.get("__metadata__", {}),
 
 
+# Matches the header size limit enforced by the safetensors library itself.
+MAX_SAFETENSORS_HEADER_SIZE = 100_000_000
+
+
 def load_safetensors_no_mmap(ckpt, device):
     # safetensors.safe_open()/get_tensor() reads tensor data through an mmap of
     # the file. On Windows that mmap-backed read can crash with an access
@@ -127,6 +131,8 @@ def load_safetensors_no_mmap(ckpt, device):
     sd = {}
     with open(ckpt, "rb") as f:
         header_size = struct.unpack("<Q", f.read(8))[0]
+        if header_size > MAX_SAFETENSORS_HEADER_SIZE:
+            raise ValueError("Invalid safetensors header: header size exceeds the maximum allowed size")
         header = json.loads(f.read(header_size).decode("utf-8"))
         data_start = 8 + header_size
         for name, info in header.items():
@@ -135,12 +141,17 @@ def load_safetensors_no_mmap(ckpt, device):
             start, end = info["data_offsets"]
             dtype = _TYPES[info["dtype"]]
             shape = info["shape"]
-            if start == end:
+            expected_size = math.prod(shape) * dtype.itemsize
+            if end < start or end - start != expected_size:
+                raise ValueError("Invalid safetensors header: tensor '{}' data range does not match its declared shape/dtype".format(name))
+            if expected_size == 0:
                 sd[name] = torch.empty(shape, dtype=dtype, device=device)
                 continue
             f.seek(data_start + start)
-            raw = f.read(end - start)
-            sd[name] = torch.frombuffer(bytearray(raw), dtype=dtype).view(shape).to(device=device)
+            raw = bytearray(end - start)
+            if f.readinto(raw) != len(raw):
+                raise ValueError("Invalid safetensors file: tensor '{}' data is truncated".format(name))
+            sd[name] = torch.frombuffer(raw, dtype=dtype).view(shape).to(device=device)
     return sd, header.get("__metadata__", {})
 
 

--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -119,6 +119,31 @@ def load_safetensors(ckpt):
     return sd, header.get("__metadata__", {}),
 
 
+def load_safetensors_no_mmap(ckpt, device):
+    # safetensors.safe_open()/get_tensor() reads tensor data through an mmap of
+    # the file. On Windows that mmap-backed read can crash with an access
+    # violation for large files in a long-running process. Read the tensors
+    # with plain file I/O instead so no mmap of the file is ever created.
+    sd = {}
+    with open(ckpt, "rb") as f:
+        header_size = struct.unpack("<Q", f.read(8))[0]
+        header = json.loads(f.read(header_size).decode("utf-8"))
+        data_start = 8 + header_size
+        for name, info in header.items():
+            if name == "__metadata__":
+                continue
+            start, end = info["data_offsets"]
+            dtype = _TYPES[info["dtype"]]
+            shape = info["shape"]
+            if start == end:
+                sd[name] = torch.empty(shape, dtype=dtype, device=device)
+                continue
+            f.seek(data_start + start)
+            raw = f.read(end - start)
+            sd[name] = torch.frombuffer(bytearray(raw), dtype=dtype).view(shape).to(device=device)
+    return sd, header.get("__metadata__", {})
+
+
 def load_torch_file(ckpt, safe_load=False, device=None, return_metadata=False):
     if device is None:
         device = torch.device("cpu")
@@ -129,14 +154,15 @@ def load_torch_file(ckpt, safe_load=False, device=None, return_metadata=False):
                 sd, metadata = load_safetensors(ckpt)
                 if not return_metadata:
                     metadata = None
+            elif DISABLE_MMAP:
+                sd, metadata = load_safetensors_no_mmap(ckpt, device)
+                if not return_metadata:
+                    metadata = None
             else:
                 with safetensors.safe_open(ckpt, framework="pt", device=device.type) as f:
                     sd = {}
                     for k in f.keys():
-                        tensor = f.get_tensor(k)
-                        if DISABLE_MMAP:  # TODO: Not sure if this is the best way to bypass the mmap issues
-                            tensor = tensor.to(device=device, copy=True)
-                        sd[k] = tensor
+                        sd[k] = f.get_tensor(k)
                     if return_metadata:
                         metadata = f.metadata()
         except Exception as e:

--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -135,6 +135,9 @@ def load_safetensors_no_mmap(ckpt, device):
             raise ValueError("Invalid safetensors header: header size exceeds the maximum allowed size")
         header = json.loads(f.read(header_size).decode("utf-8"))
         data_start = 8 + header_size
+        data_size = os.fstat(f.fileno()).st_size - data_start
+
+        tensors = []
         for name, info in header.items():
             if name == "__metadata__":
                 continue
@@ -142,9 +145,23 @@ def load_safetensors_no_mmap(ckpt, device):
             dtype = _TYPES[info["dtype"]]
             shape = info["shape"]
             expected_size = math.prod(shape) * dtype.itemsize
-            if end < start or end - start != expected_size:
+            if start < 0 or end < start or end - start != expected_size:
                 raise ValueError("Invalid safetensors header: tensor '{}' data range does not match its declared shape/dtype".format(name))
-            if expected_size == 0:
+            tensors.append((start, end, name, dtype, shape))
+
+        # The data region must be fully and contiguously indexed by the header,
+        # with no gaps, overlaps, or trailing bytes, matching the validation
+        # the safetensors library itself performs on the mmap path.
+        next_start = 0
+        for start, end, name, _dtype, _shape in sorted(tensors, key=lambda t: t[0]):
+            if start != next_start:
+                raise ValueError("Invalid safetensors header: tensor data ranges are not contiguous")
+            next_start = end
+        if next_start != data_size:
+            raise ValueError("Invalid safetensors header: tensor data does not cover the full file")
+
+        for start, end, name, dtype, shape in tensors:
+            if start == end:
                 sd[name] = torch.empty(shape, dtype=dtype, device=device)
                 continue
             f.seek(data_start + start)

--- a/tests-unit/comfy_test/load_torch_file_test.py
+++ b/tests-unit/comfy_test/load_torch_file_test.py
@@ -48,3 +48,49 @@ def test_load_safetensors_no_mmap_rejects_corrupt_data_offsets(tmp_path):
 
     with pytest.raises(ValueError):
         comfy.utils.load_safetensors_no_mmap(str(path), torch.device("cpu"))
+
+
+def _write_safetensors_with_raw_offsets(path, header, data):
+    header_bytes = json.dumps(header).encode("utf-8")
+    with open(path, "wb") as f:
+        f.write(struct.pack("<Q", len(header_bytes)))
+        f.write(header_bytes)
+        f.write(data)
+
+
+def test_load_safetensors_no_mmap_rejects_gap_between_tensors(tmp_path):
+    # weight2 starts one byte after weight ends, leaving an unindexed gap.
+    header = {
+        "weight": {"dtype": "F32", "shape": [1], "data_offsets": [0, 4]},
+        "weight2": {"dtype": "F32", "shape": [1], "data_offsets": [5, 9]},
+    }
+    path = tmp_path / "gap.safetensors"
+    _write_safetensors_with_raw_offsets(path, header, b"\x00" * 9)
+
+    with pytest.raises(ValueError):
+        comfy.utils.load_safetensors_no_mmap(str(path), torch.device("cpu"))
+
+
+def test_load_safetensors_no_mmap_rejects_overlapping_tensors(tmp_path):
+    # weight2 starts before weight ends, so the ranges overlap.
+    header = {
+        "weight": {"dtype": "F32", "shape": [1], "data_offsets": [0, 4]},
+        "weight2": {"dtype": "F32", "shape": [1], "data_offsets": [2, 6]},
+    }
+    path = tmp_path / "overlap.safetensors"
+    _write_safetensors_with_raw_offsets(path, header, b"\x00" * 6)
+
+    with pytest.raises(ValueError):
+        comfy.utils.load_safetensors_no_mmap(str(path), torch.device("cpu"))
+
+
+def test_load_safetensors_no_mmap_rejects_trailing_bytes(tmp_path):
+    # The declared data region ends before the end of the file.
+    header = {
+        "weight": {"dtype": "F32", "shape": [1], "data_offsets": [0, 4]},
+    }
+    path = tmp_path / "trailing.safetensors"
+    _write_safetensors_with_raw_offsets(path, header, b"\x00" * 8)
+
+    with pytest.raises(ValueError):
+        comfy.utils.load_safetensors_no_mmap(str(path), torch.device("cpu"))

--- a/tests-unit/comfy_test/load_torch_file_test.py
+++ b/tests-unit/comfy_test/load_torch_file_test.py
@@ -1,4 +1,6 @@
+import json
 import os
+import struct
 import tempfile
 
 import pytest
@@ -30,3 +32,19 @@ def test_disable_mmap_does_not_use_safe_open(safetensors_file, monkeypatch):
 
     assert torch.equal(sd["weight"], tensors["weight"])
     assert metadata == {"format": "pt"}
+
+
+def test_load_safetensors_no_mmap_rejects_corrupt_data_offsets(tmp_path):
+    # A corrupt header claiming a non-empty shape with start == end must be
+    # rejected instead of silently producing an uninitialized tensor.
+    header = {
+        "weight": {"dtype": "F32", "shape": [3, 4], "data_offsets": [0, 0]},
+    }
+    header_bytes = json.dumps(header).encode("utf-8")
+    path = tmp_path / "corrupt.safetensors"
+    with open(path, "wb") as f:
+        f.write(struct.pack("<Q", len(header_bytes)))
+        f.write(header_bytes)
+
+    with pytest.raises(ValueError):
+        comfy.utils.load_safetensors_no_mmap(str(path), torch.device("cpu"))

--- a/tests-unit/comfy_test/load_torch_file_test.py
+++ b/tests-unit/comfy_test/load_torch_file_test.py
@@ -1,0 +1,32 @@
+import os
+import tempfile
+
+import pytest
+import safetensors.torch
+import torch
+
+import comfy.utils
+
+
+@pytest.fixture
+def safetensors_file():
+    tensors = {"weight": torch.arange(12, dtype=torch.float32).reshape(3, 4)}
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        path = os.path.join(tmpdirname, "model.safetensors")
+        safetensors.torch.save_file(tensors, path, metadata={"format": "pt"})
+        yield path, tensors
+
+
+def test_disable_mmap_does_not_use_safe_open(safetensors_file, monkeypatch):
+    path, tensors = safetensors_file
+    monkeypatch.setattr(comfy.utils, "DISABLE_MMAP", True)
+
+    def boom(*args, **kwargs):
+        raise AssertionError("safetensors.safe_open should not be used when DISABLE_MMAP is set")
+
+    monkeypatch.setattr(comfy.utils.safetensors, "safe_open", boom)
+
+    sd, metadata = comfy.utils.load_torch_file(path, device=torch.device("cpu"), return_metadata=True)
+
+    assert torch.equal(sd["weight"], tensors["weight"])
+    assert metadata == {"format": "pt"}


### PR DESCRIPTION
## Problem

Fixes #15424.

`--disable-mmap` is supposed to make ComfyUI avoid mmap-based file reads, but in `load_torch_file` (`comfy/utils.py`) the safetensors path only wrapped the tensor in a copy *after* `safetensors.safe_open()` / `f.get_tensor(k)` had already produced it:

```python
with safetensors.safe_open(ckpt, framework="pt", device=device.type) as f:
    for k in f.keys():
        tensor = f.get_tensor(k)
        if DISABLE_MMAP:
            tensor = tensor.to(device=device, copy=True)  # too late, the mmap read already happened
```

`get_tensor()` itself reads the tensor data through safetensors' internal mmap of the file, so `--disable-mmap` never actually avoided the mmap-backed read. On Windows, mmap-backed reads of large (>10GB) safetensors files can crash the long-running ComfyUI process with an access violation (see the issue for the full repro and stack trace — the same file loads fine with plain file I/O in a standalone script, but crashes inside the ComfyUI process).

## Fix

Added `load_safetensors_no_mmap()`, which parses the safetensors header and reads each tensor's bytes with plain `open()`/`seek()`/`read()` calls instead of a memory map. `load_torch_file` now calls this helper directly when `DISABLE_MMAP` is set, instead of going through `safetensors.safe_open()` at all.

No behavior change for the default (non-`--disable-mmap`) path.

## Test

Added `tests-unit/comfy_test/load_torch_file_test.py`, which saves a small safetensors file, monkeypatches `safetensors.safe_open` to raise if it's ever called, sets `DISABLE_MMAP = True`, and asserts `load_torch_file` still loads the correct tensor data and metadata. This fails against the pre-fix code (with the assertion error below, proving the old `--disable-mmap` path still called into `safe_open`/mmap) and passes with the fix.

Before fix:
```
$ python -m pytest tests-unit/comfy_test/load_torch_file_test.py -v
FAILED tests-unit/comfy_test/load_torch_file_test.py::test_disable_mmap_does_not_use_safe_open - AssertionError: safetensors.safe_open should not be used when DISABLE_MMAP is set
1 failed in 2.47s
```

After fix:
```
$ python -m pytest tests-unit/comfy_test/load_torch_file_test.py -v
tests-unit/comfy_test/load_torch_file_test.py::test_disable_mmap_does_not_use_safe_open PASSED
1 passed in 2.37s
```

Also ran the broader `tests-unit/comfy_test/` suite (excluding a handful of pre-existing, environment-specific failures unrelated to this change — missing CUDA and a torchvision/torch version mismatch in this sandbox, reproduced identically on unmodified `master`): 19 passed, 0 failed.

`ruff check comfy/utils.py tests-unit/comfy_test/load_torch_file_test.py`: all checks passed.

---
Note: this PR was prepared with AI assistance (Claude Code).
