### PR TITLE
Catch ValueError when importing comfy_kitchen in quant_ops

### DIFF
--- a/comfy/quant_ops.py
+++ b/comfy/quant_ops.py
@@ -65,7 +65,10 @@ try:
         ck.registry.disable("triton")
     for k, v in ck.list_backends().items():
         logging.info(f"Found comfy_kitchen backend {k}: {v}")
-except ImportError as e:
+except (ImportError, ValueError) as e:
+    # comfy_kitchen can also fail with ValueError instead of ImportError: its custom ops are
+    # annotated with PEP 585 generics (e.g. list[int]) that torch.library.infer_schema only
+    # accepts from torch>=2.7, so importing it on an older torch raises ValueError there.
     logging.error(f"Failed to import comfy_kitchen, Error: {e}, fp8 and fp4 support will not be available.")
     _CK_AVAILABLE = False
 

--- a/comfy/quant_ops.py
+++ b/comfy/quant_ops.py
@@ -69,6 +69,10 @@ except (ImportError, ValueError) as e:
     # comfy_kitchen can also fail with ValueError instead of ImportError: its custom ops are
     # annotated with PEP 585 generics (e.g. list[int]) that torch.library.infer_schema only
     # accepts from torch>=2.7, so importing it on an older torch raises ValueError there.
+    # Only that specific schema-inference failure should degrade gracefully; any other
+    # ValueError (e.g. from backend configuration or ck.list_backends()) is a real bug.
+    if isinstance(e, ValueError) and "infer_schema" not in str(e):
+        raise
     logging.error(f"Failed to import comfy_kitchen, Error: {e}, fp8 and fp4 support will not be available.")
     _CK_AVAILABLE = False
 

--- a/tests-unit/comfy_quant/test_quant_ops_import_guard.py
+++ b/tests-unit/comfy_quant/test_quant_ops_import_guard.py
@@ -32,7 +32,31 @@ class TestQuantOpsImportGuard(unittest.TestCase):
         with mock.patch("builtins.__import__", side_effect=fake_import):
             spec.loader.exec_module(module)
 
+        self.assertTrue(triggered, "comfy_kitchen import was not intercepted")
         self.assertFalse(module._CK_AVAILABLE)
+
+    def test_reraises_unrelated_value_error(self):
+        """A ValueError from comfy_kitchen that isn't the known infer_schema schema-inference
+        failure (e.g. a bad backend state) is a real bug and must propagate, not be swallowed
+        into the degrade-gracefully fallback."""
+        real_import = builtins.__import__
+        triggered = []
+
+        def fake_import(name, *args, **kwargs):
+            if name == "comfy_kitchen" and not triggered:
+                triggered.append(True)
+                raise ValueError("some unrelated backend configuration error")
+            return real_import(name, *args, **kwargs)
+
+        spec = importlib.util.spec_from_file_location(
+            "quant_ops_unrelated_value_error_test", QUANT_OPS_PATH
+        )
+        module = importlib.util.module_from_spec(spec)
+        with mock.patch("builtins.__import__", side_effect=fake_import):
+            with self.assertRaises(ValueError):
+                spec.loader.exec_module(module)
+
+        self.assertTrue(triggered, "comfy_kitchen import was not intercepted")
 
 
 if __name__ == "__main__":

--- a/tests-unit/comfy_quant/test_quant_ops_import_guard.py
+++ b/tests-unit/comfy_quant/test_quant_ops_import_guard.py
@@ -1,0 +1,39 @@
+import builtins
+import importlib.util
+import os
+import unittest
+from unittest import mock
+
+QUANT_OPS_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "..", "comfy", "quant_ops.py"
+)
+
+
+class TestQuantOpsImportGuard(unittest.TestCase):
+    def test_survives_comfy_kitchen_schema_value_error(self):
+        """comfy_kitchen can raise ValueError (not ImportError) at import time when its
+        custom ops use PEP 585 generics (e.g. list[int]) that torch.library.infer_schema
+        only accepts from torch>=2.7. quant_ops must degrade instead of crashing startup."""
+        real_import = builtins.__import__
+        triggered = []
+
+        def fake_import(name, *args, **kwargs):
+            if name == "comfy_kitchen" and not triggered:
+                triggered.append(True)
+                raise ValueError(
+                    "infer_schema(func): Parameter kernel_size has unsupported type list[int]"
+                )
+            return real_import(name, *args, **kwargs)
+
+        spec = importlib.util.spec_from_file_location(
+            "quant_ops_value_error_test", QUANT_OPS_PATH
+        )
+        module = importlib.util.module_from_spec(spec)
+        with mock.patch("builtins.__import__", side_effect=fake_import):
+            spec.loader.exec_module(module)
+
+        self.assertFalse(module._CK_AVAILABLE)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #15441

## Problem

On PyTorch < 2.7, importing `comfy_kitchen` >= 0.2.28 can crash ComfyUI at
startup instead of degrading gracefully. `comfy_kitchen`'s custom ops (e.g.
`na3d` in `backends/eager/na.py`) annotate arguments with PEP 585 generics
such as `list[int]`, and `torch.library.infer_schema` only accepts that
syntax starting with `torch>=2.7`. On older torch versions the import raises:

```
ValueError: infer_schema(func): Parameter kernel_size has unsupported type list[int].
```

`comfy/quant_ops.py` already guards the `comfy_kitchen` import to let
ComfyUI keep running (without fp8/fp4 support) when `comfy_kitchen` is
missing or incompatible, but the guard only caught `ImportError`, not this
`ValueError`, so it propagated and crashed startup instead.

This is not ROCm-specific — any environment on torch <= 2.6 (CUDA included)
hits it. See the issue discussion, where this root cause was identified by
@0xDELUXA.

## Fix

Widen the `except` clause in `comfy/quant_ops.py` to also catch `ValueError`,
matching the existing pattern already used in `comfy/float.py` for the same
kind of optional-dependency probing (`except (AttributeError, ImportError)`).

## Test plan

Added `tests-unit/comfy_quant/test_quant_ops_import_guard.py`, which loads
`comfy/quant_ops.py` as a standalone module with `comfy_kitchen`'s import
mocked to raise the exact `ValueError` from the issue, and asserts the module
still imports successfully with `_CK_AVAILABLE = False`.

Confirmed the test fails without the fix and passes with it:

```
$ git stash push -- comfy/quant_ops.py   # revert to original except ImportError
$ python -m pytest tests-unit/comfy_quant/test_quant_ops_import_guard.py -v
...
E           ValueError: infer_schema(func): Parameter kernel_size has unsupported type list[int]
=========================== 1 failed in 1.18s ===========================

$ git stash pop   # restore the fix
$ python -m pytest tests-unit/comfy_quant/test_quant_ops_import_guard.py -v
tests-unit/comfy_quant/test_quant_ops_import_guard.py::TestQuantOpsImportGuard::test_survives_comfy_kitchen_schema_value_error PASSED
=========================== 1 passed in 1.53s ===========================
```

Also ran the existing quant test suite and the broader `tests-unit` suite
(with `comfy_kitchen==0.2.28` actually installed) to confirm no regressions:

```
$ python -m pytest tests-unit/comfy_quant -v
...8 passed in 2.26s

$ python -m pytest tests-unit -q
...56 failed, 834 passed, 10 skipped, 213 errors   # identical to the
    unmodified baseline (833 passed) aside from the one new passing test;
    the pre-existing failures/errors are environment-only (missing
    pytest-asyncio plugin, torchvision/torch ABI mismatch in this sandbox)
    and reproduce identically without this change.
```

Ran `ruff check` on the changed files: all checks passed.

## AI disclosure

This PR was prepared with AI assistance (Claude Code).
