### PR TITLE
fix: normalize output-axis DoRA with adapted weights

### DIFF
--- a/comfy/weight_adapter/base.py
+++ b/comfy/weight_adapter/base.py
@@ -284,9 +284,9 @@ def weight_decompose(
     wd_on_output_axis = dora_scale.shape[0] == weight_calc.shape[0]
     if wd_on_output_axis:
         weight_norm = (
-            weight.reshape(weight.shape[0], -1)
+            weight_calc.reshape(weight_calc.shape[0], -1)
             .norm(dim=1, keepdim=True)
-            .reshape(weight.shape[0], *[1] * (weight.dim() - 1))
+            .reshape(weight_calc.shape[0], *[1] * (weight_calc.dim() - 1))
         )
     else:
         weight_norm = (

--- a/tests-unit/comfy_test/test_weight_adapter.py
+++ b/tests-unit/comfy_test/test_weight_adapter.py
@@ -1,0 +1,57 @@
+"""Weight-adapter regression tests."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from comfy.cli_args import args
+
+if not torch.cuda.is_available():
+    args.cpu = True
+
+from comfy.weight_adapter.base import weight_decompose  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "weight_shape",
+    [
+        pytest.param((4, 6), id="linear"),
+        pytest.param((4, 3, 2, 2), id="conv2d"),
+    ],
+)
+def test_weight_decompose_output_axis_uses_adapted_weight_norm(weight_shape):
+    generator = torch.Generator(device="cpu").manual_seed(42)
+    weight = torch.randn(weight_shape, generator=generator, dtype=torch.float32)
+    lora_diff = torch.randn(weight_shape, generator=generator, dtype=torch.float32)
+
+    alpha = 0.625
+    strength = 1.0
+    adapted_weight = weight + alpha * lora_diff
+
+    output_axis_shape = (weight_shape[0], *[1] * (len(weight_shape) - 1))
+    adapted_norm = (
+        adapted_weight.reshape(weight_shape[0], -1)
+        .norm(dim=1, keepdim=True)
+        .reshape(output_axis_shape)
+    )
+    target_scale = torch.linspace(
+        0.75,
+        1.25,
+        steps=weight_shape[0],
+        dtype=weight.dtype,
+    ).reshape(output_axis_shape)
+    dora_scale = adapted_norm * target_scale
+
+    actual = weight_decompose(
+        dora_scale=dora_scale,
+        weight=weight.clone(),
+        lora_diff=lora_diff.clone(),
+        alpha=alpha,
+        strength=strength,
+        intermediate_dtype=torch.float32,
+        function=lambda tensor: tensor,
+    )
+
+    expected = adapted_weight * target_scale
+    torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-6)


### PR DESCRIPTION
## Summary

- normalize output-axis DoRA weights using the adapted weight `W + ΔW`
- keep the existing input-axis behavior unchanged
- add regression coverage for linear and Conv2d-shaped weights

## Problem

`weight_decompose()` currently builds the adapted weight first:

```python
weight_calc = weight + lora_diff
```

but the output-axis branch calculates its norm from the original base weight:

```python
weight_norm = norm(weight)
```

This applies:

```text
m * (W + ΔW) / ||W||
```

instead of the DoRA decomposition:

```text
m * (W + ΔW) / ||W + ΔW||
```

The input-axis branch already normalizes `weight_calc`, so this change also makes both branches consistent. The behavior now matches the current LyCORIS LoKr/DoRA implementation.

## Tests

A focused CPU regression harness matching the added assertions passed both cases:

```text
linear: passed
conv2d: passed
```

The added repository test can be run with:

```bash
pytest tests-unit/comfy_test/test_weight_adapter.py
```

The full ComfyUI test suite was not run in the connector environment; GitHub CI is expected to provide repository-level validation.

## Related work

This is a separate semantic-correctness fix from the `dora_scale` broadcasting issue tracked in #12938 and PR #13011. The broadcasting fix may touch the same function, but the adapted-weight normalization remains required after that change.