### PR TITLE
Report corrupt safetensors files with a clear error message

### DIFF
--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -146,6 +146,8 @@ def load_torch_file(ckpt, safe_load=False, device=None, return_metadata=False):
                     raise ValueError("{}\n\nFile path: {}\n\nThe safetensors file is corrupt or invalid. Make sure this is actually a safetensors file and not a ckpt or pt or other filetype.".format(message, ckpt))
                 if "MetadataIncompleteBuffer" in message:
                     raise ValueError("{}\n\nFile path: {}\n\nThe safetensors file is corrupt/incomplete. Check the file size and make sure you have copied/downloaded it correctly.".format(message, ckpt))
+                if "is invalid for input of size" in message:
+                    raise ValueError("{}\n\nFile path: {}\n\nThe safetensors file is corrupt/incomplete. Check the file size and make sure you have copied/downloaded it correctly.".format(message, ckpt))
             raise e
     else:
         torch_args = {}

--- a/tests-unit/comfy_test/load_torch_file_test.py
+++ b/tests-unit/comfy_test/load_torch_file_test.py
@@ -1,0 +1,16 @@
+import pytest
+
+import comfy.memory_management
+import comfy.utils
+
+
+def test_shape_mismatch_reports_corrupt_file(monkeypatch):
+    monkeypatch.setattr(comfy.memory_management, "aimdo_enabled", True)
+
+    def fake_load_safetensors(ckpt):
+        raise RuntimeError("shape '[25600, 2560]' is invalid for input of size 3930620")
+
+    monkeypatch.setattr(comfy.utils, "load_safetensors", fake_load_safetensors)
+
+    with pytest.raises(ValueError, match="corrupt/incomplete"):
+        comfy.utils.load_torch_file("fake_path.safetensors", safe_load=True)


### PR DESCRIPTION
## Problem

Fixes #15455.

When a safetensors file is truncated or corrupted, the `comfy_aimdo` mmap-based
loader (`comfy.utils.load_safetensors`, used when dynamic-VRAM/`aimdo` is
enabled) raises a raw `torch.frombuffer(...).view(shape)` error such as:

```
RuntimeError: shape '[25600, 2560]' is invalid for input of size 3930620
```

This bubbles straight up to the user as an unexplained shape-mismatch crash in
whichever node loaded the file (`CLIPLoader` in the report), instead of a clear
message pointing at the actual cause. `load_torch_file` already turns two other
safetensors-corruption signatures (`HeaderTooLarge`, `MetadataIncompleteBuffer`)
into a friendly "file is corrupt/incomplete" `ValueError` — this shape-mismatch
signature from the same failure class was missing from that same `except` block.

## Fix

Add the `"is invalid for input of size"` message pattern to the existing error
translation in `load_torch_file` (`comfy/utils.py`), reusing the same
corrupt/incomplete-file message already used for the other two cases.

## Test plan

Added `tests-unit/comfy_test/load_torch_file_test.py`, which monkeypatches
`load_safetensors` to raise the exact `RuntimeError` from the issue and asserts
`load_torch_file` turns it into a `ValueError` mentioning the file is
corrupt/incomplete.

Confirmed the test fails on the pre-fix code and passes after the fix:

```
$ python -m pytest tests-unit/comfy_test/load_torch_file_test.py -v
# before fix:
tests-unit/comfy_test/load_torch_file_test.py::test_shape_mismatch_reports_corrupt_file FAILED
E       RuntimeError: shape '[25600, 2560]' is invalid for input of size 3930620

# after fix:
tests-unit/comfy_test/load_torch_file_test.py::test_shape_mismatch_reports_corrupt_file PASSED
1 passed in 2.54s
```

Also ran the broader unit suite (`tests-unit/comfy_test`, `tests-unit/utils`)
that can run in this environment (a few unrelated model-detection/seedvr tests
error out here on collection due to missing CUDA / a torch-torchvision version
mismatch in this sandbox, unrelated to this change and reproducible on
unmodified `master`); all other tests, including the new one, pass. Ran
`ruff check` on the changed files with no issues.

---
Note: this PR was prepared with AI assistance (Claude Code).
