### PR TITLE
fix(ci): authenticate the cloud tag dispatch with a GitHub App token

### DIFF
--- a/.github/workflows/tag-dispatch-cloud.yml
+++ b/.github/workflows/tag-dispatch-cloud.yml
@@ -9,9 +9,6 @@ jobs:
   dispatch-cloud:
     runs-on: ubuntu-latest
     steps:
-      # A GitHub App token is minted per run and cannot silently expire the way a
-      # static PAT does. Comfy-Org/cloud's own bump-comfyui-on-tag.yml already
-      # authenticates this way; this brings the sending half in line with it.
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@v3
@@ -56,9 +53,6 @@ jobs:
 
           echo "✅ Dispatched ComfyUI tag ${RELEASE_TAG} to Comfy-Org/cloud"
 
-      # This workflow failed silently on every run for two months. A failure here
-      # means the cloud bump PR is not opened and someone has to notice by hand, so
-      # make it visible rather than relying on anyone watching the Actions tab.
       - name: Open an issue if the dispatch failed
         if: failure()
         env:

--- a/.github/workflows/tag-dispatch-cloud.yml
+++ b/.github/workflows/tag-dispatch-cloud.yml
@@ -9,9 +9,21 @@ jobs:
   dispatch-cloud:
     runs-on: ubuntu-latest
     steps:
+      # A GitHub App token is minted per run and cannot silently expire the way a
+      # static PAT does. Comfy-Org/cloud's own bump-comfyui-on-tag.yml already
+      # authenticates this way; this brings the sending half in line with it.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.CLOUD_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.CLOUD_DISPATCH_APP_PRIVATE_KEY }}
+          owner: Comfy-Org
+          repositories: cloud
+
       - name: Send repository dispatch to cloud
         env:
-          DISPATCH_TOKEN: ${{ secrets.CLOUD_REPO_DISPATCH_TOKEN }}
+          DISPATCH_TOKEN: ${{ steps.app-token.outputs.token }}
           RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
@@ -43,3 +55,20 @@ jobs:
             -d "$PAYLOAD"
 
           echo "✅ Dispatched ComfyUI tag ${RELEASE_TAG} to Comfy-Org/cloud"
+
+      # This workflow failed silently on every run for two months. A failure here
+      # means the cloud bump PR is not opened and someone has to notice by hand, so
+      # make it visible rather than relying on anyone watching the Actions tab.
+      - name: Open an issue if the dispatch failed
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh issue create \
+            --title "Cloud tag dispatch failed for ${RELEASE_TAG}" \
+            --body "The dispatch to Comfy-Org/cloud failed for \`${RELEASE_TAG}\`, so the cloud ComfyUI bump PR was not opened automatically and must be triggered by hand (run the 'Bump ComfyUI on Upstream Tag' workflow in Comfy-Org/cloud).
+
+          Run: ${RUN_URL}" \
+            --label "bug" || echo "::warning::Could not open tracking issue" 


### PR DESCRIPTION
## Description

`tag-dispatch-cloud.yml` notifies `Comfy-Org/cloud` when a `v*` tag is pushed, which is what opens the cloud-side ComfyUI bump PR.

**It has failed on every run since 2026-06-16 — 19 consecutive failures**, all `curl` exit 22 (HTTP 401). `CLOUD_REPO_DISPATCH_TOKEN` is a static PAT and it expired. Nothing alerted on the failures, so this went unnoticed for two months.

The practical consequence: every ComfyUI version bump in cloud since mid-June — v0.29.0 through v0.31.0 — was opened because a person noticed a new tag, not because automation fired. It is a small part of the release chain (the dispatch itself is under a minute) but it is a step that is supposed to be automatic and silently is not.

Two changes:

1. **Mint a GitHub App token per run** instead of using a static PAT, scoped to `Comfy-Org/cloud`. This mirrors how cloud's own `bump-comfyui-on-tag.yml` already authenticates. App tokens are minted per run and cannot silently expire.
2. **Open a tracking issue on failure**, so the next breakage surfaces rather than sitting in the Actions tab unread.

## Requires before merge

This needs two secrets provisioned on this repo, which I cannot do:

- `vars.CLOUD_DISPATCH_APP_ID`
- `secrets.CLOUD_DISPATCH_APP_PRIVATE_KEY`

for a GitHub App installed on `Comfy-Org/cloud` with **contents: write** (enough for `repository_dispatch`). The cloud repo already uses an app for the receiving half, so the same app may be reusable — worth checking with whoever owns `vars.APP_ID` over there rather than registering a second one.

**If you want the immediate unblock instead**, just rotate `CLOUD_REPO_DISPATCH_TOKEN`; that restores the dispatch today without this PR. The app token is the durable fix so it does not rot again in six months.

## How has this been tested?

Not executed — the failure mode is authentication, which cannot be exercised until the secrets exist. The workflow logic is otherwise unchanged; only the token source and the failure-notification step are new. Verified the 19-failure history and the 401 via the Actions API before writing this.

## Documentation
- [x] No documentation changes needed