### PR TITLE
docs(samplers): fix typo in cast_to_load_options docstring

### DIFF
--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -1138,7 +1138,7 @@ def get_total_hook_groups_in_conds(conds: dict[str, list[dict[str]]]):
 
 def cast_to_load_options(model_options: dict[str], device=None, dtype=None):
     '''
-    If any patches from hooks, wrappers, or callbacks have .to to be called, call it.
+    If any patches from hooks, wrappers, or callbacks have .to() to be called, call it.
     '''
     if model_options is None:
         return


### PR DESCRIPTION
### WHY

The docstring of `cast_to_load_options` reads:

```python
If any patches from hooks, wrappers, or callbacks have .to to be called, call it.
```

`.to to be called` is a typo — the referenced method is the PyTorch tensor `.to()` method, so it should read `.to()`.

### WHAT

```diff
-    If any patches from hooks, wrappers, or callbacks have .to to be called, call it.
+    If any patches from hooks, wrappers, or callbacks have .to() to be called, call it.
```

Doc only; no code change.