### PR TITLE
Fix VAEDecodeTiled crash on NestedTensor latents (MiniMax H3)

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -364,8 +364,12 @@ class VAEDecodeTiled:
             temporal_size = None
             temporal_overlap = None
 
+        latent = samples["samples"]
+        if latent.is_nested:
+            latent = latent.unbind()[0]
+
         compression = vae.spacial_compression_decode()
-        images = vae.decode_tiled(samples["samples"], tile_x=tile_size // compression, tile_y=tile_size // compression, overlap=overlap // compression, tile_t=temporal_size, overlap_t=temporal_overlap)
+        images = vae.decode_tiled(latent, tile_x=tile_size // compression, tile_y=tile_size // compression, overlap=overlap // compression, tile_t=temporal_size, overlap_t=temporal_overlap)
         if len(images.shape) == 5: #Combine batches
             images = images.reshape(-1, images.shape[-3], images.shape[-2], images.shape[-1])
         return (images, )

--- a/tests-unit/comfy_test/test_vae_decode_tiled_nested.py
+++ b/tests-unit/comfy_test/test_vae_decode_tiled_nested.py
@@ -1,0 +1,27 @@
+from unittest.mock import MagicMock
+
+import torch
+
+from comfy.cli_args import args as cli_args
+
+if not torch.cuda.is_available():
+    cli_args.cpu = True
+
+import comfy.nested_tensor  # noqa: E402
+import nodes  # noqa: E402
+
+
+def test_vae_decode_tiled_unwraps_nested_tensor():
+    video = torch.zeros(1, 4, 2, 8, 8)
+    audio = torch.zeros(1, 2, 2, 40)
+    samples = {"samples": comfy.nested_tensor.NestedTensor((video, audio))}
+
+    vae = MagicMock()
+    vae.temporal_compression_decode.return_value = None
+    vae.spacial_compression_decode.return_value = 8
+    vae.decode_tiled.return_value = torch.zeros(1, 3, 2, 8, 8)
+
+    nodes.VAEDecodeTiled().decode(vae, samples, tile_size=512)
+
+    decoded_arg = vae.decode_tiled.call_args[0][0]
+    assert decoded_arg is video


### PR DESCRIPTION
## Problem

Fixes #15468.

`VAEDecodeTiled` crashes on MiniMax H3 latents:

```
TypeError: to() received an invalid combination of arguments - got (NestedTensor), but expected one of:
 ...
  File "comfy\ldm\minimax\vae.py", line 684, in decode
    latents_mean = self.latents_mean.view(1, -1, 1, 1, 1).to(z)
```

MiniMax H3 latents are a `comfy.nested_tensor.NestedTensor` pair
`(video, audio)`. `VAEDecode.decode()` already unwraps this to the
video component before calling `vae.decode()`:

```python
latent = samples["samples"]
if latent.is_nested:
    latent = latent.unbind()[0]
```

`VAEDecodeTiled.decode()` never did this and passed the raw
`NestedTensor` straight into `vae.decode_tiled()`. It reaches the
MiniMax H3 video VAE's `decode()`, where a real tensor's `.to(z)` call
fails because `z` is not a plain `Tensor`.

## Fix

Apply the same unwrap in `VAEDecodeTiled.decode()` that `VAEDecode`
already does.

## Test

Added `tests-unit/comfy_test/test_vae_decode_tiled_nested.py`, which
builds a `NestedTensor(video, audio)` latent, calls
`VAEDecodeTiled.decode()` with a mocked VAE, and asserts
`vae.decode_tiled()` is called with the unwrapped video tensor.

- Confirmed the test fails against the unmodified `nodes.py`
  (`git checkout HEAD~1 -- nodes.py`), with the mock receiving the
  `NestedTensor` unchanged instead of the unwrapped video tensor.
- Confirmed the test passes after restoring the fix.
- Full suite: `python -m pytest tests-unit/` → `1225 passed, 10 skipped`
- `ruff check nodes.py tests-unit/comfy_test/test_vae_decode_tiled_nested.py` → `All checks passed!`

## AI disclosure

This change was written with the assistance of Claude Code (Anthropic).
