### PR TITLE
Fix Flux 2 Dev tokenizer regression with Transformers 5.15

### DIFF
--- a/comfy/text_encoders/flux.py
+++ b/comfy/text_encoders/flux.py
@@ -4,6 +4,9 @@ import comfy.text_encoders.sd3_clip
 import comfy.text_encoders.llama
 import comfy.model_management
 from transformers import T5TokenizerFast, LlamaTokenizerFast, Qwen2Tokenizer
+from transformers.convert_slow_tokenizer import bytes_to_unicode
+from tokenizers import Regex, Tokenizer, decoders, pre_tokenizers, processors
+from tokenizers.models import BPE
 import torch
 import os
 import json
@@ -76,11 +79,6 @@ def load_mistral_tokenizer(data):
     if torch.is_tensor(data):
         data = data.numpy().tobytes()
 
-    try:
-        from transformers.integrations.mistral import MistralConverter
-    except ModuleNotFoundError:
-        from transformers.models.pixtral.convert_pixtral_weights_to_hf import MistralConverter
-
     mistral_vocab = json.loads(data)
 
     special_tokens = {}
@@ -109,6 +107,74 @@ def load_mistral_tokenizer(data):
     special_tokens.update(vocab)
     vocab = special_tokens
     return {"tokenizer_object": MistralConverter(vocab=vocab, additional_special_tokens=all_special).converted(), "legacy": False}
+
+
+class MistralConverter:
+    """
+    A general tiktoken converter.
+    """
+
+    def __init__(
+        self,
+        vocab=None,
+        pattern=r"""(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\r\n\p{L}\p{N}]?\p{L}+|\p{N}{1,3}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+(?!\S)|\s+""",
+        add_prefix_space=False,
+        additional_special_tokens=None
+    ):
+        self.vocab = vocab
+        self.pattern = pattern
+        self.add_prefix_space = add_prefix_space
+        self.additional_special_tokens = additional_special_tokens
+
+    def extract_vocab_merges_from_model(self, vocab: dict):
+        bpe_ranks = vocab
+        byte_encoder = bytes_to_unicode()
+
+        def token_bytes_to_string(b):
+            return "".join([byte_encoder[ord(char)] for char in b.decode("latin-1")])
+
+        merges = []
+        vocab = {}
+        for idx, (token, rank) in enumerate(bpe_ranks.items()):
+            if token not in self.additional_special_tokens:
+                vocab[token_bytes_to_string(token)] = idx
+                if len(token) == 1:
+                    continue
+                local = []
+                for index in range(1, len(token)):
+                    piece_l, piece_r = token[:index], token[index:]
+                    if piece_l in bpe_ranks and piece_r in bpe_ranks and (piece_l + piece_r) in bpe_ranks:
+                        local.append((piece_l, piece_r, rank))
+                local = sorted(local, key=lambda x: (bpe_ranks[x[0]], bpe_ranks[x[1]]), reverse=False)
+                merges.extend(local)
+            else:
+                vocab[token] = idx
+        merges = sorted(merges, key=lambda val: val[2], reverse=False)
+        merges = [(token_bytes_to_string(val[0]), token_bytes_to_string(val[1])) for val in merges]
+        return vocab, merges
+
+    def tokenizer(self):
+        vocab_scores, merges = self.extract_vocab_merges_from_model(self.vocab)
+        tokenizer = Tokenizer(BPE(vocab_scores, merges, fuse_unk=False))
+        if hasattr(tokenizer.model, "ignore_merges"):
+            tokenizer.model.ignore_merges = True
+        return tokenizer
+
+    def converted(self) -> Tokenizer:
+        tokenizer = self.tokenizer()
+        tokenizer.pre_tokenizer = pre_tokenizers.Sequence(
+            [
+                pre_tokenizers.Split(Regex(self.pattern), behavior="isolated", invert=False),
+                pre_tokenizers.ByteLevel(add_prefix_space=self.add_prefix_space, use_regex=False),
+            ]
+        )
+        tokenizer.decoder = decoders.ByteLevel()
+        tokenizer.add_special_tokens(self.additional_special_tokens)
+
+        tokenizer.post_processor = processors.ByteLevel(trim_offsets=False)
+
+        return tokenizer
+
 
 class MistralTokenizerClass:
     @staticmethod


### PR DESCRIPTION
# Summary

Transformers 5.15 changed the internal MistralConverter API to require a vocabulary file instead of accepting vocabulary data directly. This behavior was introduced by [huggingface/transformers#47507](https://github.com/huggingface/transformers/pull/47507).

ComfyUI stores the Mistral vocabulary data within the model rather than in a separate vocabulary file. As a result, Mistral tokenizer loading fails when using Transformers 5.15.

This PR adds a local MistralConverter implementation based on the behavior used by Transformers 4.50.3 through 5.14.1. The implementation uses the public tokenizers API instead of depending on Transformers’ internal MistralConverter, reducing the likelihood that future internal Transformers changes will break Mistral tokenizer loading in ComfyUI.

# Testing
Confirmed that Mistral tokenizer loading fails with Transformers 5.15 before this change.
Confirmed that the tokenizer loads successfully after this change.
Confirmed that tokenization produces the expected output.