### PR TITLE
Add --pinned-memory override for the pinned host memory cap

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -199,6 +199,7 @@ parser.add_argument("--fast", nargs="*", type=PerformanceFeature, help="Enable s
 parser.add_argument("--debug-hang", action="store_true", help="Enable stack trace dumps on Ctrl-C for debugging hangs.")
 
 parser.add_argument("--disable-pinned-memory", action="store_true", help="Disable pinned memory use.")
+parser.add_argument("--pinned-memory", type=float, default=None, metavar="GB", help="Set the maximum amount of RAM in GB usable for pinned (page-locked) host memory, instead of the value ComfyUI computes from total system RAM. Lower this on systems that become unstable with large amounts of pinned memory.")
 
 parser.add_argument("--mmap-torch-files", action="store_true", help="Use mmap when loading ckpt/pt files.")
 parser.add_argument("--disable-mmap", action="store_true", help="Don't use mmap when loading safetensors.")

--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -1,5 +1,6 @@
 import argparse
 import enum
+import math
 import os
 import comfy.options
 
@@ -198,8 +199,14 @@ parser.add_argument("--fast", nargs="*", type=PerformanceFeature, help="Enable s
 
 parser.add_argument("--debug-hang", action="store_true", help="Enable stack trace dumps on Ctrl-C for debugging hangs.")
 
+def non_negative_finite_float(value):
+    value = float(value)
+    if not math.isfinite(value) or value < 0:
+        raise argparse.ArgumentTypeError(f"{value} is not a non-negative, finite number")
+    return value
+
 parser.add_argument("--disable-pinned-memory", action="store_true", help="Disable pinned memory use.")
-parser.add_argument("--pinned-memory", type=float, default=None, metavar="GB", help="Set the maximum amount of RAM in GB usable for pinned (page-locked) host memory, instead of the value ComfyUI computes from total system RAM. Lower this on systems that become unstable with large amounts of pinned memory.")
+parser.add_argument("--pinned-memory", type=non_negative_finite_float, default=None, metavar="GB", help="Set the maximum amount of RAM in GB usable for pinned (page-locked) host memory, instead of the value ComfyUI computes from total system RAM. Lower this on systems that become unstable with large amounts of pinned memory.")
 
 parser.add_argument("--mmap-torch-files", action="store_true", help="Use mmap when loading ckpt/pt files.")
 parser.add_argument("--disable-mmap", action="store_true", help="Don't use mmap when loading safetensors.")

--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -201,7 +201,7 @@ parser.add_argument("--debug-hang", action="store_true", help="Enable stack trac
 
 def non_negative_finite_float(value):
     value = float(value)
-    if not math.isfinite(value) or value < 0:
+    if not math.isfinite(value) or value < 0 or not math.isfinite(value * 1024 ** 3):
         raise argparse.ArgumentTypeError(f"{value} is not a non-negative, finite number")
     return value
 

--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -1561,13 +1561,16 @@ def get_disk_swap_total():
         logging.warning("Could not get amount of swap memory on system.")
     return total
 
+def calculate_max_pinned_memory(ram_override, ram):
+    if ram_override is not None:
+        return ram_override * 1024 ** 3
+    if WINDOWS:
+        return ram * 0.40  # Windows limit is apparently 50%
+    return max(ram * 0.40, min(ram * 0.90, ram - 4 * 1024 ** 3, ram + get_disk_swap_total() - 16 * 1024 ** 3))
+
 if not args.disable_pinned_memory:
     if is_nvidia() or is_amd():
-        ram = get_total_memory(torch.device("cpu"))
-        if WINDOWS:
-            MAX_PINNED_MEMORY = ram * 0.40  # Windows limit is apparently 50%
-        else:
-            MAX_PINNED_MEMORY = max(ram * 0.40, min(ram * 0.90, ram - 4 * 1024 ** 3, ram + get_disk_swap_total() - 16 * 1024 ** 3))
+        MAX_PINNED_MEMORY = calculate_max_pinned_memory(args.pinned_memory, get_total_memory(torch.device("cpu")))
         logging.info("Enabled pinned memory {}".format(MAX_PINNED_MEMORY // (1024 * 1024)))
 
 PINNING_ALLOWED_TYPES = set(["Tensor", "Parameter", "QuantizedTensor"])

--- a/tests-unit/comfy_test/test_pinned_memory_override.py
+++ b/tests-unit/comfy_test/test_pinned_memory_override.py
@@ -26,7 +26,7 @@ def test_pinned_memory_default_uses_ram_based_calculation(monkeypatch):
     assert model_management.calculate_max_pinned_memory(None, ram) == expected
 
 
-@pytest.mark.parametrize("value", ["-1", "nan", "inf", "-inf"])
+@pytest.mark.parametrize("value", ["-1", "nan", "inf", "-inf", "1e308"])
 def test_pinned_memory_rejects_negative_and_non_finite_values(value):
     with pytest.raises(SystemExit):
         cli_parser.parse_args(["--pinned-memory", value])

--- a/tests-unit/comfy_test/test_pinned_memory_override.py
+++ b/tests-unit/comfy_test/test_pinned_memory_override.py
@@ -1,0 +1,24 @@
+import torch
+
+from comfy.cli_args import args as cli_args
+
+if not torch.cuda.is_available():
+    cli_args.cpu = True
+
+import comfy.model_management as model_management  # noqa: E402
+
+
+def test_pinned_memory_override_bypasses_ram_calculation():
+    ram = 64 * 1024 ** 3
+
+    assert model_management.calculate_max_pinned_memory(None, ram) != 8 * 1024 ** 3
+    assert model_management.calculate_max_pinned_memory(8, ram) == 8 * 1024 ** 3
+
+
+def test_pinned_memory_default_uses_ram_based_calculation():
+    ram = 64 * 1024 ** 3
+
+    default = model_management.calculate_max_pinned_memory(None, ram)
+
+    assert default > 0
+    assert default <= ram

--- a/tests-unit/comfy_test/test_pinned_memory_override.py
+++ b/tests-unit/comfy_test/test_pinned_memory_override.py
@@ -1,6 +1,7 @@
+import pytest
 import torch
 
-from comfy.cli_args import args as cli_args
+from comfy.cli_args import args as cli_args, parser as cli_parser
 
 if not torch.cuda.is_available():
     cli_args.cpu = True
@@ -15,10 +16,17 @@ def test_pinned_memory_override_bypasses_ram_calculation():
     assert model_management.calculate_max_pinned_memory(8, ram) == 8 * 1024 ** 3
 
 
-def test_pinned_memory_default_uses_ram_based_calculation():
+def test_pinned_memory_default_uses_ram_based_calculation(monkeypatch):
     ram = 64 * 1024 ** 3
 
-    default = model_management.calculate_max_pinned_memory(None, ram)
+    monkeypatch.setattr(model_management, "WINDOWS", False)
+    monkeypatch.setattr(model_management, "get_disk_swap_total", lambda: 0)
 
-    assert default > 0
-    assert default <= ram
+    expected = max(ram * 0.40, min(ram * 0.90, ram - 4 * 1024 ** 3, ram - 16 * 1024 ** 3))
+    assert model_management.calculate_max_pinned_memory(None, ram) == expected
+
+
+@pytest.mark.parametrize("value", ["-1", "nan", "inf", "-inf"])
+def test_pinned_memory_rejects_negative_and_non_finite_values(value):
+    with pytest.raises(SystemExit):
+        cli_parser.parse_args(["--pinned-memory", value])


### PR DESCRIPTION
Addresses part of #15488

## Problem

`MAX_PINNED_MEMORY` (the ceiling for page-locked host memory used to speed up
CPU<->GPU transfers) is always derived from `psutil`-reported total system RAM.
There is no way to lower it without physically hiding RAM from the OS.

#15488 reports that a Windows/Blackwell system reliably crashes the GPU
(`GPU is lost`, TDR) when comfy_kitchen quantized streaming runs with 64 GB of
RAM visible to the OS, but is stable with the same workload when Windows is
capped to 32 GB (`bcdedit /set removememory 32768`). The reporter asks:

> Is there a supported way to make ComfyUI behave as if the machine had less
> RAM (i.e. pin `cache_ram` / `MAX_PINNED_MEMORY` to the smaller values)
> without physically hiding memory from the OS?

`--cache-ram` already lets a user override the `cache_ram` / `cache_ram_inactive`
values directly. `MAX_PINNED_MEMORY` had no equivalent override.

## Change

Add `--pinned-memory GB`, which sets `MAX_PINNED_MEMORY` directly instead of
computing it from `psutil`'s total RAM (mirrors the existing `--cache-ram`
pattern). The RAM-based calculation is unchanged when the flag isn't passed.

## Testing

Added `tests-unit/comfy_test/test_pinned_memory_override.py`, which asserts
the override value is used verbatim and that the default calculation is
unaffected.

Verified the new test fails without the fix (`git checkout HEAD~1 --
comfy/model_management.py comfy/cli_args.py`, keeping the new test):
```
AttributeError: module 'comfy.model_management' has no attribute 'calculate_max_pinned_memory'
```

With the fix:
```
tests-unit/comfy_test/test_pinned_memory_override.py::test_pinned_memory_override_bypasses_ram_calculation PASSED
tests-unit/comfy_test/test_pinned_memory_override.py::test_pinned_memory_default_uses_ram_based_calculation PASSED
2 passed in 2.63s
```

Also ran the full `tests-unit` suite (1212 passed, 10 skipped) and `ruff check`
on the touched files (clean). `tests-unit/comfy_test/model_detection_test.py`
fails to collect in this CPU-only sandbox because it asserts CUDA availability;
this reproduces identically on unmodified `upstream/master` and is unrelated
to this change.

---
Drafted with AI assistance (Claude Code); verified by running the repo's test
suite and manually tracing the pinned-memory sizing code path.
