### PR TITLE
Document Windows ROCm install for RX 6800/XT

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,9 +216,13 @@ This is the command to install the nightly with ROCm 7.2 which might have some p
 ```pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.2```
 
 
-### AMD GPUs (Experimental: Windows and Linux), RDNA 3, 3.5 and 4 only.
+### AMD GPUs (Experimental: Windows and Linux), RDNA 2, 3, 3.5 and 4.
 
 These have less hardware support than the builds above but they work on windows. You also need to install the pytorch version specific to your hardware.
+
+RDNA 2 (RX 6800/6800 XT, gfx1030):
+
+```python -m pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ "torch[device-gfx1030]==2.12.0+rocm7.14.0" "torchvision[device-gfx1030]==0.27.0+rocm7.14.0" "torchaudio==2.11.0+rocm7.14.0"```
 
 RDNA 3 (RX 7000 series):
 


### PR DESCRIPTION
## Problem

The manual AMD section currently excludes RDNA 2 from the experimental Windows path even though current AMD ROCm/PyTorch packages support `gfx1030`, including RX 6800 and RX 6800 XT.

## Change

- include RDNA 2 in the Windows/Linux AMD hardware list
- add the AMD multi-arch PyTorch install command for `gfx1030`
- keep the existing RDNA 3/3.5/4 instructions unchanged

## Validation

Tested on Windows with an RX 6800 XT (`PCI DEV_73BF`):

```text
available=True
name=AMD Radeon RX 6800 XT
arch=gfx1030
hip=7.15.26290
```

AMD's current Windows support matrix also lists RX 6800 and RX 6800 XT as `gfx1030`. Related user report: #15354.