### PR TITLE
Prefer discrete AMD GPU when ROCm defaults to an APU

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -29,6 +29,27 @@ import weakref
 import gc
 import os
 from contextlib import contextmanager, nullcontext
+
+
+def _select_default_rocm_device():
+    if torch.version.hip is None or not torch.cuda.is_available():
+        return
+    if args.cuda_device is not None or args.default_device is not None:
+        return
+
+    current_device = torch.cuda.current_device()
+    if not torch.cuda.get_device_properties(current_device).is_integrated:
+        return
+
+    for device_index in range(torch.cuda.device_count()):
+        if not torch.cuda.get_device_properties(device_index).is_integrated:
+            torch.cuda.set_device(device_index)
+            logging.info("Using discrete AMD GPU: {}".format(torch.cuda.get_device_name(device_index)))
+            return
+
+
+_select_default_rocm_device()
+
 import comfy.memory_management
 import comfy.utils
 import comfy.quant_ops


### PR DESCRIPTION
## Problem

On ROCm systems with both an integrated AMD GPU and a discrete AMD GPU, PyTorch can default to the integrated device. On Windows this is especially misleading because the APU can report shared system RAM as a very large device-memory pool, so ComfyUI may pick the APU instead of the discrete GPU.

## Change

When no GPU is explicitly selected, prefer the first non-integrated ROCm device if the current device is integrated. Explicit --cuda-device and --default-device selections remain unchanged.

## Validation

Tested on Windows with:
- AMD Radeon(TM) Graphics: gfx1036, is_integrated=1
- AMD Radeon RX 6800 XT: gfx1030, is_integrated=0

Before: ComfyUI selected cuda:0 / gfx1036 and reported ~58.9 GB shared memory as VRAM.
After: ComfyUI selects cuda:1 / RX 6800 XT / gfx1030 and reports 16.3 GB VRAM.

Explicit integrated and discrete GPU selections were both verified to remain respected.

Related: #14274