### PR TITLE
Fix PreviewAny escaping non-ASCII text in dict and list previews

### DIFF
--- a/comfy_extras/nodes_preview_any.py
+++ b/comfy_extras/nodes_preview_any.py
@@ -29,7 +29,7 @@ class PreviewAny():
             value = str(source)
         elif source is not None:
             try:
-                value = json.dumps(source, indent=4)
+                value = json.dumps(source, indent=4, ensure_ascii=False)
             except Exception:
                 try:
                     value = str(source)

--- a/tests-unit/comfy_extras_test/nodes_preview_any_test.py
+++ b/tests-unit/comfy_extras_test/nodes_preview_any_test.py
@@ -1,0 +1,30 @@
+from unittest.mock import patch, MagicMock
+
+mock_nodes = MagicMock()
+mock_nodes.MAX_RESOLUTION = 16384
+mock_server = MagicMock()
+
+with patch.dict("sys.modules", {"nodes": mock_nodes, "server": mock_server}):
+    from comfy_extras.nodes_preview_any import PreviewAny
+
+
+class TestPreviewAnyMain:
+    @staticmethod
+    def _exec(source) -> dict:
+        return PreviewAny().main(source)
+
+    def test_dict_keeps_non_ascii(self):
+        result = self._exec({"greeting": "你好"})
+        assert "你好" in result["ui"]["text"][0]
+        assert "\\u" not in result["ui"]["text"][0]
+        assert result["result"][0] == result["ui"]["text"][0]
+
+    def test_list_keeps_non_ascii(self):
+        result = self._exec(["你好", "こんにちは"])
+        assert "こんにちは" in result["result"][0]
+        assert "\\u" not in result["result"][0]
+
+    def test_string_passthrough(self):
+        result = self._exec("你好")
+        assert result["ui"]["text"][0] == "你好"
+        assert result["result"][0] == "你好"


### PR DESCRIPTION
## Problem

`PreviewAny` ("Preview as Text") escapes non-ASCII characters when the input is a dict or list, so a value like `你好` is displayed as `你好`. The node also returns that same string on its `STRING` output, so the escaped text propagates downstream into prompts and any other consumer, not just the preview panel.

## Cause

`comfy_extras/nodes_preview_any.py` called `json.dumps(source, indent=4)`, which defaults to `ensure_ascii=True`. That branch is only reached when `source` is not a `str`/`int`/`float`/`bool`, i.e. exactly the dict/list case.

## Change

Pass `ensure_ascii=False`, matching the existing choice already made in this repo for the sibling dict/array-to-string nodes: `_dump_json` at `comfy_extras/nodes_string.py:444-445`, used by `ConvertDictionaryToString` and `ConvertArrayToString`.

## Tests

Added `tests-unit/comfy_extras_test/nodes_preview_any_test.py` covering the dict and list branches (real characters, no `\u` escapes, in both the `ui` payload and the `result` tuple) and the plain-`str` passthrough.

```
python -m pytest tests-unit/comfy_extras_test/ --continue-on-collection-errors -q
170 passed, 1 error in 2.66s
```

The single collection error is pre-existing and unrelated: `compositor_node_test.py` imports `comfy.model_management` at module scope, which fails on a CPU-only torch build.

`ruff check comfy_extras/nodes_preview_any.py tests-unit/comfy_extras_test/nodes_preview_any_test.py` → `All checks passed!`

Linear: FE-1116
