### PR TITLE
Fix LTX VAE decoder RoPE crash on MPS with float64

### DIFF
--- a/comfy/ldm/lightricks/vae/na_diffusion_decoder.py
+++ b/comfy/ldm/lightricks/vae/na_diffusion_decoder.py
@@ -74,9 +74,11 @@ def default_rope_dim_split(head_dim):
 
 
 def rope_inv_freqs(dim, base=10000.0, device=None):
-    # float64 is computed on CPU because MPS does not support it, then cast/moved.
-    exponents = torch.arange(0, dim, 2, dtype=torch.float64) / dim
-    return (1.0 / torch.pow(torch.tensor(float(base), dtype=torch.float64), exponents)).to(torch.float32).to(device)
+    # float64 is computed on an explicit CPU device (never the implicit default,
+    # which could be changed elsewhere) because MPS does not support it, then cast/moved.
+    cpu = torch.device("cpu")
+    exponents = torch.arange(0, dim, 2, dtype=torch.float64, device=cpu) / dim
+    return (1.0 / torch.pow(torch.tensor(float(base), dtype=torch.float64, device=cpu), exponents)).to(torch.float32).to(device)
 
 
 def _rope_tables(lengths, inv_freqs, device):

--- a/comfy/ldm/lightricks/vae/na_diffusion_decoder.py
+++ b/comfy/ldm/lightricks/vae/na_diffusion_decoder.py
@@ -74,8 +74,9 @@ def default_rope_dim_split(head_dim):
 
 
 def rope_inv_freqs(dim, base=10000.0, device=None):
-    exponents = torch.arange(0, dim, 2, dtype=torch.float64, device=device) / dim
-    return (1.0 / torch.pow(torch.tensor(float(base), dtype=torch.float64, device=device), exponents)).to(torch.float32)
+    # float64 is computed on CPU because MPS does not support it, then cast/moved.
+    exponents = torch.arange(0, dim, 2, dtype=torch.float64) / dim
+    return (1.0 / torch.pow(torch.tensor(float(base), dtype=torch.float64), exponents)).to(torch.float32).to(device)
 
 
 def _rope_tables(lengths, inv_freqs, device):

--- a/tests-unit/comfy_test/test_ltx_na_diffusion_decoder_rope.py
+++ b/tests-unit/comfy_test/test_ltx_na_diffusion_decoder_rope.py
@@ -1,0 +1,33 @@
+import torch
+
+from comfy.cli_args import args as cli_args
+
+if not torch.cuda.is_available():
+    cli_args.cpu = True
+
+import comfy.ldm.lightricks.vae.na_diffusion_decoder as na_diffusion_decoder
+
+
+def test_rope_inv_freqs_never_allocates_float64_on_target_device(monkeypatch):
+    # Stands in for a device (like MPS) that cannot materialize float64 tensors.
+    device = torch.device("cpu")
+    real_arange = torch.arange
+    real_tensor = torch.tensor
+
+    def guarded_arange(*args, **kwargs):
+        if kwargs.get("dtype") == torch.float64 and kwargs.get("device") is device:
+            raise TypeError("Cannot convert a MPS Tensor to float64 dtype")
+        return real_arange(*args, **kwargs)
+
+    def guarded_tensor(*args, **kwargs):
+        if kwargs.get("dtype") == torch.float64 and kwargs.get("device") is device:
+            raise TypeError("Cannot convert a MPS Tensor to float64 dtype")
+        return real_tensor(*args, **kwargs)
+
+    monkeypatch.setattr(torch, "arange", guarded_arange)
+    monkeypatch.setattr(torch, "tensor", guarded_tensor)
+
+    result = na_diffusion_decoder.rope_inv_freqs(16, device=device)
+
+    assert result.dtype == torch.float32
+    assert result.device == device


### PR DESCRIPTION
## Problem

Fixes #15512. Decoding LTX 2.5 video latents with `VAEDecodeTiled` on
Apple Silicon (MPS) crashes with:

```
TypeError: Cannot convert a MPS Tensor to float64 dtype as the MPS
framework doesn't support float64. Please use float32 instead.
```

`rope_inv_freqs` in `comfy/ldm/lightricks/vae/na_diffusion_decoder.py`
allocated its float64 intermediate tensors directly on the caller's
device (`torch.arange(..., dtype=torch.float64, device=device)` and
`torch.tensor(..., dtype=torch.float64, device=device)`). MPS has no
float64 support, so this raises as soon as the decoder runs on an
Apple Silicon GPU.

## Fix

Compute the float64 intermediates on the default device (CPU, which
supports float64), cast the result to float32, and only then move it
to the caller's device with `.to(device)`. This preserves the
existing float64-precision RoPE numerics (matching `ltx-core`) while
never materializing a float64 tensor on MPS.

## Tests

Added `tests-unit/comfy_test/test_ltx_na_diffusion_decoder_rope.py`,
which monkeypatches `torch.arange`/`torch.tensor` to raise like MPS
does whenever a float64 tensor is requested directly on the target
device, then calls `rope_inv_freqs(16, device=device)`.

- With the bug present (verified via `git checkout HEAD~1 -- comfy/ldm/lightricks/vae/na_diffusion_decoder.py`), the test fails:
  ```
  TypeError: Cannot convert a MPS Tensor to float64 dtype
  comfy/ldm/lightricks/vae/na_diffusion_decoder.py:77: in rope_inv_freqs
      exponents = torch.arange(0, dim, 2, dtype=torch.float64, device=device) / dim
  ```
- With the fix, it passes.

Full suite (CPU-only torch, matching CI's `test-unit.yml` setup):
```
python -m pytest tests-unit
1226 passed, 10 skipped, 12 warnings in 37.32s
```

`ruff check .` passes with no new warnings.

## AI assistance disclosure

This change was written with the assistance of an AI coding agent
(Claude), with the diff reviewed and verified locally, including
reproducing the failure before the fix and confirming the fix and full
test suite pass.
