### PR TITLE
Fix comfy_kitchen int8 attention alignment error for MiniMax H3

### DIFF
--- a/comfy/ldm/modules/attention.py
+++ b/comfy/ldm/modules/attention.py
@@ -592,6 +592,10 @@ def _comfy_kitchen_int8_inputs(q, k, v, heads, mask, skip_reshape, enable_gqa):
         q, k, v = _reshape_qkv_to_heads(q, k, v, b, heads, dim_head, enable_gqa, expand_kv=False)
         q, k, v = map(lambda t: t.transpose(1, 2), (q, k, v))
 
+    # the int8 quantization kernel requires contiguous B/H/N strides; skip_reshape
+    # callers (e.g. MiniMax H3) pass transposed views that don't satisfy this
+    q, k, v = (t.contiguous() for t in (q, k, v))
+
     if mask is not None:
         if mask.ndim == 2:
             mask = mask.unsqueeze(0)

--- a/tests-unit/comfy_test/test_attention_int8_inputs.py
+++ b/tests-unit/comfy_test/test_attention_int8_inputs.py
@@ -1,0 +1,39 @@
+import os
+import sys
+
+import torch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from comfy.cli_args import args
+
+if not torch.cuda.is_available():
+    args.cpu = True
+
+from comfy.ldm.modules.attention import _comfy_kitchen_int8_inputs
+
+
+def test_skip_reshape_inputs_are_made_contiguous():
+    # mirrors comfy/ldm/minimax/model.py's Attention.forward, which hands the
+    # int8 kernel transposed views (q/k/v shape (s, heads, head_dim) -> (1, heads, s, head_dim))
+    s, heads, head_dim = 8, 4, 16
+    q = torch.randn(s, heads, head_dim).transpose(0, 1).unsqueeze(0)
+    k = torch.randn(s, heads, head_dim).transpose(0, 1).unsqueeze(0)
+    v = torch.randn(s, heads, head_dim).transpose(0, 1).unsqueeze(0)
+    assert not q.is_contiguous()
+    assert not k.is_contiguous()
+    assert not v.is_contiguous()
+
+    q_out, k_out, v_out, mask_out, b, dim_head = _comfy_kitchen_int8_inputs(
+        q, k, v, heads, None, skip_reshape=True, enable_gqa=False
+    )
+
+    assert q_out.is_contiguous()
+    assert k_out.is_contiguous()
+    assert v_out.is_contiguous()
+    assert torch.equal(q_out, q)
+    assert torch.equal(k_out, k)
+    assert torch.equal(v_out, v)
+    assert mask_out is None
+    assert b == 1
+    assert dim_head == head_dim


### PR DESCRIPTION
Fixes #15494.

## Problem

Running a MiniMax H3 int8 checkpoint with comfy-kitchen's int8 attention
backend raises:

```
RuntimeError: quant_qk_per_thread_int8: Q/K base pointers and B/H/N strides must preserve 4-element alignment
```

`comfy.ldm.minimax.model.Attention.forward` calls `optimized_attention(...,
skip_reshape=True)` with q/k/v tensors built as
`tensor.transpose(0, 1).unsqueeze(0)`. That's a non-contiguous view (the
sequence and head dimensions are swapped without copying), and
`_comfy_kitchen_int8_inputs` only reshaped/transposed (and never made
contiguous) the non-`skip_reshape` path, so the `skip_reshape=True` inputs
used by MiniMax H3 reached the int8 kernel with strides it doesn't support.

## Fix

Make `_comfy_kitchen_int8_inputs` call `.contiguous()` on q/k/v before
handing them to the int8 kernel, regardless of which reshape path was
taken. `.contiguous()` is a no-op when the tensor is already contiguous, so
this doesn't add overhead on paths that were already fine.

## Testing

Added `tests-unit/comfy_test/test_attention_int8_inputs.py`, which builds
q/k/v the same way `comfy/ldm/minimax/model.py` does (transposed,
non-contiguous views) and asserts `_comfy_kitchen_int8_inputs` returns
contiguous tensors with unchanged values. Confirmed the test fails against
the pre-fix code (`assert False` on `q_out.is_contiguous()`) and passes
with the fix.

```
$ python -m pytest tests-unit/comfy_test/test_attention_int8_inputs.py -v
tests-unit/comfy_test/test_attention_int8_inputs.py::test_skip_reshape_inputs_are_made_contiguous PASSED
1 passed in 2.39s
```

Also ran the broader `tests-unit/comfy_test/` suite (excluding tests that
fail to collect in this sandbox for unrelated torch/torchvision version
mismatches — no CUDA-enabled torch build available here) and `ruff check`
on the changed files; both clean.

```
$ python -m pytest tests-unit/comfy_test/ -q --ignore=... (unrelated pre-existing collection failures)
23 passed in 2.56s

$ ruff check comfy/ldm/modules/attention.py tests-unit/comfy_test/test_attention_int8_inputs.py
All checks passed!
```

I don't have access to comfy-kitchen-capable CUDA hardware, so I could not
run the actual MiniMax H3 int8 kernel end-to-end; the fix and test target
the exact tensor-layout mismatch described in the issue and by the
`_comfy_kitchen_int8_inputs`/MiniMax `Attention.forward` code paths.

*This PR was written with AI assistance (Claude Code).*
