### PR TITLE
Fail loudly when quantization scale tensors go unrecognized instead of silently dropping them

### DIFF
--- a/comfy/model_base.py
+++ b/comfy/model_base.py
@@ -367,6 +367,13 @@ class BaseModel(torch.nn.Module):
 
         if len(u) > 0:
             logging.warning("unet unexpected: {}".format(u))
+            quant_scale_keys = [k for k in u if k.endswith((".weight_scale", ".weight_scale_2", ".input_scale"))]
+            if len(quant_scale_keys) > 0:
+                raise RuntimeError(
+                    "This checkpoint contains {} unrecognized quantization scale tensors (e.g. {}) "
+                    "but no usable quantization metadata, so it can't be loaded as a quantized model. "
+                    "Loading it as unquantized would silently produce garbage output.".format(
+                        len(quant_scale_keys), quant_scale_keys[0]))
         del to_load
         return self
 

--- a/tests-unit/comfy_quant/test_unrecognized_quant_metadata.py
+++ b/tests-unit/comfy_quant/test_unrecognized_quant_metadata.py
@@ -1,0 +1,61 @@
+import unittest
+import torch
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from comfy.cli_args import args
+if not torch.cuda.is_available():
+    args.cpu = True
+
+from comfy import ops
+import comfy.memory_management
+from comfy.model_base import BaseModel
+
+
+class SimpleModel(torch.nn.Module):
+    def __init__(self, operations=ops.disable_weight_init):
+        super().__init__()
+        self.layer1 = operations.Linear(10, 20, device="cpu", dtype=torch.bfloat16)
+
+    def forward(self, x):
+        return self.layer1(x)
+
+
+class FakeModelConfig:
+    def process_unet_state_dict(self, sd):
+        return sd
+
+
+class TestUnrecognizedQuantMetadata(unittest.TestCase):
+    def test_stray_quant_scale_tensors_raise(self):
+        """A checkpoint whose per-layer quantization scales are present but not
+        recognized (no _quantization_metadata / comfy_quant marker) must fail
+        loudly instead of silently loading the packed weight as unquantized.
+
+        The lazy-load path (used with dynamic VRAM loading, aimdo_enabled) assigns
+        the incoming tensor directly without a shape check, which is how the packed
+        NVFP4 weight ends up wired into a mismatched matmul at forward time."""
+        comfy.memory_management.aimdo_enabled = True
+        try:
+            model = BaseModel.__new__(BaseModel)
+            torch.nn.Module.__init__(model)
+            model.model_config = FakeModelConfig()
+            model.diffusion_model = SimpleModel()
+
+            state_dict = {
+                "layer1.weight": torch.zeros(20, 5, dtype=torch.uint8),
+                "layer1.weight_scale": torch.zeros(20, dtype=torch.float8_e4m3fn),
+                "layer1.weight_scale_2": torch.tensor(1.0),
+                "layer1.input_scale": torch.tensor(1.0),
+            }
+
+            with self.assertRaises(RuntimeError):
+                model.load_model_weights(state_dict, assign=True)
+        finally:
+            comfy.memory_management.aimdo_enabled = False
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests-unit/comfy_quant/test_unrecognized_quant_metadata.py
+++ b/tests-unit/comfy_quant/test_unrecognized_quant_metadata.py
@@ -37,6 +37,7 @@ class TestUnrecognizedQuantMetadata(unittest.TestCase):
         The lazy-load path (used with dynamic VRAM loading, aimdo_enabled) assigns
         the incoming tensor directly without a shape check, which is how the packed
         NVFP4 weight ends up wired into a mismatched matmul at forward time."""
+        old_aimdo_enabled = comfy.memory_management.aimdo_enabled
         comfy.memory_management.aimdo_enabled = True
         try:
             model = BaseModel.__new__(BaseModel)
@@ -51,10 +52,13 @@ class TestUnrecognizedQuantMetadata(unittest.TestCase):
                 "layer1.input_scale": torch.tensor(1.0),
             }
 
-            with self.assertRaises(RuntimeError):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                r"unrecognized quantization scale tensors.*layer1\.weight_scale",
+            ):
                 model.load_model_weights(state_dict, assign=True)
         finally:
-            comfy.memory_management.aimdo_enabled = False
+            comfy.memory_management.aimdo_enabled = old_aimdo_enabled
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #15511.

Some quantized checkpoints (e.g. the official NVFP4 LTX-2.5 diffusion
model) ship per-layer `weight_scale` / `weight_scale_2` / `input_scale`
tensors but no `_quantization_metadata` in the file header and no
`.comfy_quant` marker keys. `comfy.utils.detect_layer_quantization` only
recognizes `.comfy_quant` markers, so these checkpoints load through the
plain (unquantized) path.

That path assigns the packed weight tensor (half-width for NVFP4, since
two 4-bit values are packed per byte) straight into a regular `Linear`
layer, and the scale tensors are silently discarded as "unexpected keys"
during `load_state_dict(strict=False)` — logged as a single ~200KB
`[WARNING] unet unexpected: [...]` line that's easy to miss. Nothing
fails until the first forward pass, where it produces a `mat1 and mat2
shapes cannot be multiplied` error far removed from the real cause.

## Fix

`BaseModel.load_model_weights` (`comfy/model_base.py`) now checks the
unexpected keys it's about to drop: if any of them are quantization
scale tensors (`.weight_scale`, `.weight_scale_2`, `.input_scale`),
it raises a `RuntimeError` naming the dropped tensors instead of
silently continuing. This matches option 2 from the issue's "Expected
Behavior" section (fail loudly with a message that names the actual
problem), and matches this repo's own guidance in `AGENTS.md`: "Let
unsupported model formats, invalid quantization metadata, and bad
states fail with clear errors instead of silently producing lower
quality output."

Full detection + dequantization support for metadata-less NVFP4
checkpoints (option 1 in the issue) is a larger change spanning model
detection and the quantization loader; this PR only closes the silent
data-corruption path.

## Test plan

Added `tests-unit/comfy_quant/test_unrecognized_quant_metadata.py`,
which builds a minimal model with a stray packed weight plus
`weight_scale`/`weight_scale_2`/`input_scale` tensors and no
recognized quantization marker (mirroring the dynamic-VRAM lazy-load
path used in the issue's repro, where the mismatched weight shape is
assigned directly instead of shape-checked), and asserts
`load_model_weights` now raises.

Confirmed it fails without the fix (`git checkout HEAD~1 --
comfy/model_base.py`):

```
$ python -m unittest tests-unit.comfy_quant.test_unrecognized_quant_metadata -v
...
WARNING:root:unet unexpected: ['layer1.weight_scale', 'layer1.weight_scale_2', 'layer1.input_scale']
FAIL
AssertionError: RuntimeError not raised
```

And passes with it:

```
$ python -m unittest tests-unit.comfy_quant.test_unrecognized_quant_metadata -v
...
WARNING:root:unet unexpected: ['layer1.weight_scale', 'layer1.weight_scale_2', 'layer1.input_scale']
ok
```

Also ran the existing quantization suite to confirm no regressions:

```
$ python -m unittest discover -s tests-unit/comfy_quant -v
Ran 8 tests in 0.017s
OK
```

And the broader unit test suite:

```
$ python -m pytest tests-unit -q
1226 passed, 10 skipped, 12 warnings in 33.14s
```

`ruff check comfy/model_base.py tests-unit/comfy_quant/test_unrecognized_quant_metadata.py` passes.

---
This change was written with AI assistance (Claude).
