### PR TITLE
Update workflow templates to v0.11.40

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 comfyui-frontend-package==1.48.7
-comfyui-workflow-templates==0.11.39
+comfyui-workflow-templates==0.11.40
 comfyui-embedded-docs==0.5.9
 torch
 torchsde


### PR DESCRIPTION
## Update workflow templates to v0.11.40
Updated all 3 LTX-2.5 OSS templates' settings

From 

<img width="790" height="626" alt="image" src="https://github.com/user-attachments/assets/f4eaa796-7a13-48bd-a9ca-4979986025f3" />

to

<img width="824" height="674" alt="image" src="https://github.com/user-attachments/assets/d5f4ad6a-b22e-4e14-bc01-8662f1151cda" />


### 📦 Package Information
- **PyPI**: https://pypi.org/project/comfyui-workflow-templates/0.11.40/
- **Release**: https://github.com/Comfy-Org/workflow_templates/releases/tag/v0.11.40

### 📝 Changes
Updated dependency version in `requirements.txt`:
```diff
- comfyui-workflow-templates==0.11.39
+ comfyui-workflow-templates==0.11.40
```

---
*This is an automated draft PR created by the auto-pr-script*