### PR TITLE
Gate CUDA-only Comfy Kitchen attention on ROCm

### DIFF
--- a/comfy/ldm/modules/attention.py
+++ b/comfy/ldm/modules/attention.py
@@ -51,7 +51,9 @@ except ImportError:
         logging.error(f"\n\nTo use the `--use-flash-attention` feature, the `flash-attn` package must be installed first.\ncommand:\n\t{sys.executable} -m pip install flash-attn")
         exit(-1)
 
-COMFY_KITCHEN_INT8_ATTENTION_IS_AVAILABLE = comfy_kitchen.int8_attention_is_available()
+COMFY_KITCHEN_INT8_ATTENTION_IS_AVAILABLE = (
+    torch.version.hip is None and comfy_kitchen.int8_attention_is_available()
+)
 
 REGISTERED_ATTENTION_FUNCTIONS = {}
 def register_attention_function(name: str, func: Callable):


### PR DESCRIPTION
## Summary
- only advertise the CUDA-only Comfy Kitchen INT8 attention backend when PyTorch is not a ROCm build
- prevent gfx1151 (11, 5) capability reporting from selecting an NVIDIA CUDA SageAttention kernel
- let ROCm continue through PyTorch SDPA/AOTriton

## Validation
- Python compile check passed
- live gfx1151 ComfyUI restarted successfully
- ModelAttentionBackend now exposes only pytorch attention and the server reports Using pytorch attention
- queue is empty and /system_stats reports the native AMD Radeon 8060S device
