### PR TITLE
model_patcher: synchronize and release offloaded Hook weights

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -885,6 +885,11 @@ def free_memory(memory_required, device, keep_loaded=[], for_dynamic=False, pins
     for i in sorted(unloaded_model, reverse=True):
         unloaded_models.append(current_loaded_models.pop(i))
 
+    for unloaded in unloaded_models:
+        model = unloaded.model
+        if model is not None:
+            model.finalize_model_unload()
+
     if not for_dynamic and pins_required > 0:
         ensure_pin_budget(pins_required)
         ensure_pin_registerable(pins_required)

--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -213,6 +213,19 @@ def low_vram_patch_estimate_vram(model, key):
 
     return weight.numel() * model_dtype.itemsize * LOWVRAM_PATCH_ESTIMATE_MATH_FACTOR
 
+def _collect_quantized_weight_state_dict_keys(model):
+    """Return state-dict keys owned by each module's QuantizedTensor weight."""
+    keys = set()
+    for module_name, module in model.named_modules(remove_duplicate=False):
+        weight = getattr(module, "weight", None)
+        if not isinstance(weight, QuantizedTensor):
+            continue
+        prefix = f"{module_name}." if module_name else ""
+        weight_key = f"{prefix}weight"
+        keys.update(k for k in weight.state_dict(weight_key) if k != weight_key)
+        keys.add(f"{prefix}comfy_quant")
+    return keys
+
 def get_key_weight(model, key):
     set_func = None
     convert_func = None
@@ -865,11 +878,14 @@ class ModelPatcher:
 
     def get_key_patches(self, filter_prefix=None):
         model_sd = self.model_state_dict()
+        quantized_weight_state_dict_keys = _collect_quantized_weight_state_dict_keys(self.model)
         p = {}
         for k in model_sd:
             if filter_prefix is not None:
                 if not k.startswith(filter_prefix):
                     continue
+            if k in quantized_weight_state_dict_keys:
+                continue
             bk = self.backup.get(k, None)
             hbk = self.hook_backup.get(k, None)
             weight, set_func, convert_func = get_key_weight(self.model, k)

--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -1318,6 +1318,9 @@ class ModelPatcher:
             callback(self, unpatch_all)
         return self.model
 
+    def finalize_model_unload(self):
+        pass
+
     def current_loaded_device(self):
         return self.model.device
 
@@ -2145,6 +2148,10 @@ class ModelPatcherDynamic(ModelPatcher):
             self.partially_unload(None, 1e32)
             for m in self.model.modules():
                 move_weight_functions(m, device_to)
+
+    def finalize_model_unload(self):
+        # A loaded Dynamic model owns the ordinary model kept for Hook reuse.
+        self.non_dynamic_delegate_model = None
 
     def partially_load(self, device_to, extra_memory=0, force_patch_weights=False):
         assert not force_patch_weights #See above

--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -392,6 +392,7 @@ class ModelPatcher:
         self.forced_hooks: Optional[comfy.hooks.HookGroup] = None  # NOTE: only used for CLIP at this time
         self.is_clip = False
         self.hook_mode = comfy.hooks.EnumHookMode.MaxSpeed
+        self._hook_async_offload_disabled = False
 
         self.cached_patcher_init: tuple[Callable, tuple] | tuple[Callable, tuple, int] | None = None
         self.is_multigpu_base_clone = False
@@ -1642,6 +1643,9 @@ class ModelPatcher:
             self.current_hooks = hooks
 
     def patch_cached_hook_weights(self, cached_weights: dict, key: str, memory_counter: MemoryCounter):
+        _, set_func, _ = get_key_weight(self.model, key)
+        if set_func is None:
+            self._disable_async_offload_for_hooks()
         if key not in self.hook_backup:
             weight: torch.Tensor = comfy.utils.get_attr(self.model, key)
             target_device = self.offload_device
@@ -1656,12 +1660,28 @@ class ModelPatcher:
         self.cached_hook_patches.clear()
         self.patch_hooks(None)
 
+    def _disable_async_offload_for_hooks(self):
+        if self._hook_async_offload_disabled:
+            return
+        # Hook writeback changes prepared weight storage after model loading.
+        # Keep this delegate's transfers synchronous and honor its model dtypes.
+        for module in self.model.modules():
+            if hasattr(module, "comfy_cast_weights"):
+                module.comfy_disable_async_offload = True
+                for param_name, param in module.named_parameters(recurse=False):
+                    model_dtype = getattr(module, param_name + "_comfy_model_dtype", None)
+                    if model_dtype is not None and param.dtype != model_dtype:
+                        module.comfy_cast_weights = True
+        self._hook_async_offload_disabled = True
+
     def patch_hook_weight_to_device(self, hooks: comfy.hooks.HookGroup, combined_patches: dict, key: str, original_weights: dict, memory_counter: MemoryCounter):
         if key not in combined_patches:
             return
 
         weight, set_func, convert_func = get_key_weight(self.model, key)
         weight: torch.Tensor
+        if set_func is None:
+            self._disable_async_offload_for_hooks()
         if key not in self.hook_backup:
             target_device = self.offload_device
             if self.hook_mode == comfy.hooks.EnumHookMode.MaxSpeed:

--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -384,8 +384,9 @@ def cast_bias_weight(s, input=None, dtype=None, device=None, bias_dtype=None, of
         return format_return((weight, bias, (offload_stream, offload_device, None)), offloadable)
 
 
-    if offloadable and (device != s.weight.device or
-                        (s.bias is not None and device != s.bias.device)):
+    if (offloadable and not getattr(s, "comfy_disable_async_offload", False) and
+        (device != s.weight.device or
+         (s.bias is not None and device != s.bias.device))):
         offload_stream = comfy.model_management.get_offload_stream(device)
     else:
         offload_stream = None
@@ -475,6 +476,7 @@ class CastBiasWeightContext:
 
 class CastWeightBiasOp:
     comfy_cast_weights = False
+    comfy_disable_async_offload = False
     weight_function = []
     bias_function = []
 

--- a/tests-unit/comfy_quant/test_mixed_precision.py
+++ b/tests-unit/comfy_quant/test_mixed_precision.py
@@ -14,8 +14,9 @@ from comfy.cli_args import args
 if not has_gpu():
     args.cpu = True
 
-from comfy import ops
-from comfy.quant_ops import QUANT_ALGOS, QuantizedTensor
+from comfy import hooks, ops
+from comfy.model_patcher import ModelPatcher
+from comfy.quant_ops import QUANT_ALGOS, QuantizedTensor, TensorCoreFP8E4M3Layout
 import comfy.utils
 
 
@@ -336,6 +337,61 @@ class TestMixedPrecisionOps(unittest.TestCase):
         self.assertEqual(saved_conf["convrot_groupsize"], 256)
         self.assertEqual(saved_conf["linear_dtype"], "int8")
         self.assertNotIn("quant_group_size", saved_conf)
+
+    def test_hook_patches_skip_only_quantized_weight_pieces(self):
+        operations = ops.mixed_precision_ops(compute_dtype=torch.float32)
+        model = torch.nn.Module()
+        model.linear = operations.Linear(4, 4, bias=False, device="cpu")
+        qdata, params = TensorCoreFP8E4M3Layout.quantize(
+            torch.ones(4, 4), scale="recalculate"
+        )
+        model.linear.quant_format = "float8_e4m3fn"
+        model.linear.layout_type = "TensorCoreFP8E4M3Layout"
+        model.linear.weight = torch.nn.Parameter(
+            QuantizedTensor(qdata, model.linear.layout_type, params),
+            requires_grad=False,
+        )
+        model.linear.input_scale = torch.nn.Parameter(
+            torch.tensor(0.125), requires_grad=False
+        )
+        model.linear_alias = model.linear
+        model.patch_target = torch.nn.Linear(4, 4, bias=False)
+        torch.nn.init.zeros_(model.patch_target.weight)
+
+        patcher = ModelPatcher(model, torch.device("cpu"), torch.device("cpu"))
+        weight = model.linear.weight
+        input_scale = model.linear.input_scale
+        hook = hooks.WeightHook()
+        hook.need_weight_init = False
+        hook.weights = {
+            "patch_target.weight": (torch.ones_like(model.patch_target.weight),)
+        }
+        hook_group = hooks.HookGroup()
+        hook_group.add(hook)
+        patcher.register_all_hook_patches(
+            hook_group, hooks.create_target_dict(hooks.EnumWeightTarget.Model)
+        )
+        patcher.patch_hooks(hook_group)
+
+        self.assertIs(model.linear.weight, weight)
+        self.assertIs(model.linear.input_scale, input_scale)
+        self.assertTrue(
+            torch.equal(
+                model.patch_target.weight,
+                torch.ones_like(model.patch_target.weight),
+            )
+        )
+
+        self.assertEqual(
+            set(patcher.get_key_patches()),
+            {
+                "linear.weight",
+                "linear.input_scale",
+                "linear_alias.weight",
+                "linear_alias.input_scale",
+                "patch_target.weight",
+            },
+        )
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests-unit/comfy_quant/test_mixed_precision.py
+++ b/tests-unit/comfy_quant/test_mixed_precision.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest import mock
 import torch
 import sys
 import os
@@ -392,6 +393,87 @@ class TestMixedPrecisionOps(unittest.TestCase):
                 "patch_target.weight",
             },
         )
+
+    def test_hook_targets_disable_async_offload(self):
+        model = torch.nn.Module()
+        model.linear = ops.disable_weight_init.Linear(
+            4, 4, bias=False, device="cpu", dtype=torch.bfloat16
+        )
+        model.other = ops.disable_weight_init.Linear(
+            4, 4, bias=False, device="cpu", dtype=torch.bfloat16
+        )
+        model.linear.weight = torch.nn.Parameter(
+            model.linear.weight.float(), requires_grad=False
+        )
+        model.other.weight = torch.nn.Parameter(
+            model.other.weight.float(), requires_grad=False
+        )
+        model.linear.weight_comfy_model_dtype = torch.bfloat16
+        model.other.weight_comfy_model_dtype = torch.bfloat16
+        model.control = torch.nn.Parameter(torch.zeros(1))
+        torch.nn.init.zeros_(model.linear.weight)
+        patcher = ModelPatcher(model, torch.device("cpu"), torch.device("cpu"))
+
+        hook = hooks.WeightHook()
+        hook.need_weight_init = False
+        hook.weights = {
+            "linear.weight": (
+                torch.zeros_like(model.linear.weight),
+            )
+        }
+        group = hooks.HookGroup()
+        group.add(hook)
+        patcher.register_all_hook_patches(
+            group, hooks.create_target_dict(hooks.EnumWeightTarget.Model)
+        )
+
+        patcher.patch_hooks(group)
+        self.assertTrue(model.linear.comfy_disable_async_offload)
+        self.assertTrue(model.other.comfy_disable_async_offload)
+        self.assertTrue(model.linear.comfy_cast_weights)
+        self.assertTrue(model.other.comfy_cast_weights)
+        output = model.linear(torch.zeros(1, 4, dtype=torch.bfloat16))
+        self.assertEqual(output.dtype, torch.bfloat16)
+        self.assertTrue(torch.isfinite(output).all())
+        patcher.patch_hooks(None)
+
+        model.linear.comfy_disable_async_offload = False
+        model.other.comfy_disable_async_offload = False
+        patcher._hook_async_offload_disabled = False
+        patcher.patch_hooks(group)
+        self.assertTrue(model.linear.comfy_disable_async_offload)
+        self.assertTrue(model.other.comfy_disable_async_offload)
+        patcher.patch_hooks(None)
+
+    def test_cast_weight_honors_async_offload_disable(self):
+        linear = ops.disable_weight_init.Linear(
+            4, 4, bias=False, device="cpu", dtype=torch.float32
+        )
+        target = torch.device("cpu", 1)
+
+        linear.comfy_disable_async_offload = True
+        with mock.patch(
+            "comfy.model_management.get_offload_stream", return_value=None
+        ) as get_offload_stream:
+            ops.cast_bias_weight(
+                linear,
+                dtype=torch.float32,
+                device=target,
+                offloadable=True,
+            )
+        get_offload_stream.assert_not_called()
+
+        linear.comfy_disable_async_offload = False
+        with mock.patch(
+            "comfy.model_management.get_offload_stream", return_value=None
+        ) as get_offload_stream:
+            ops.cast_bias_weight(
+                linear,
+                dtype=torch.float32,
+                device=target,
+                offloadable=True,
+            )
+        get_offload_stream.assert_called_once_with(target)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests-unit/comfy_quant/test_mixed_precision.py
+++ b/tests-unit/comfy_quant/test_mixed_precision.py
@@ -15,8 +15,9 @@ from comfy.cli_args import args
 if not has_gpu():
     args.cpu = True
 
+import comfy.model_management as model_management
 from comfy import hooks, ops
-from comfy.model_patcher import ModelPatcher
+from comfy.model_patcher import ModelPatcher, ModelPatcherDynamic
 from comfy.quant_ops import QUANT_ALGOS, QuantizedTensor, TensorCoreFP8E4M3Layout
 import comfy.utils
 
@@ -474,6 +475,117 @@ class TestMixedPrecisionOps(unittest.TestCase):
                 offloadable=True,
             )
         get_offload_stream.assert_called_once_with(target)
+
+    def test_dynamic_delegate_is_released_only_after_model_unload(self):
+        patcher = object.__new__(ModelPatcherDynamic)
+        patcher.model = torch.nn.Module()
+        delegate = object()
+        patcher.non_dynamic_delegate_model = delegate
+        patcher.partially_unload_ram = mock.Mock()
+        patcher.partially_unload = mock.Mock()
+
+        with mock.patch.object(ModelPatcher, "unpatch_model") as base_unpatch:
+            patcher.unpatch_model(unpatch_weights=False)
+            base_unpatch.assert_called_once_with(
+                device_to=None, unpatch_weights=False
+            )
+        self.assertIs(patcher.non_dynamic_delegate_model, delegate)
+        patcher.partially_unload_ram.assert_not_called()
+        patcher.partially_unload.assert_not_called()
+
+        patcher.partially_unload_ram.reset_mock()
+        patcher.partially_unload.reset_mock()
+        with mock.patch.object(ModelPatcher, "unpatch_model") as base_unpatch:
+            patcher.unpatch_model(
+                device_to=torch.device("cpu"), unpatch_weights=True
+            )
+            base_unpatch.assert_called_once_with(
+                device_to=None, unpatch_weights=False
+            )
+        self.assertIs(patcher.non_dynamic_delegate_model, delegate)
+        patcher.partially_unload_ram.assert_called_once_with(1e32)
+        patcher.partially_unload.assert_called_once_with(None, 1e32)
+
+        patcher.finalize_model_unload()
+        self.assertIsNone(patcher.non_dynamic_delegate_model)
+
+    def test_dynamic_delegate_is_recreated_after_model_unload(self):
+        patcher = object.__new__(ModelPatcherDynamic)
+        initial_override = object()
+        first_override = object()
+        second_override = object()
+        first_delegate = mock.Mock()
+        second_delegate = mock.Mock()
+        first_delegate.get_clone_model_override.return_value = first_override
+        second_delegate.get_clone_model_override.return_value = second_override
+        patcher.non_dynamic_delegate_model = initial_override
+        patcher.clone = mock.Mock(
+            side_effect=[first_delegate, second_delegate]
+        )
+
+        self.assertIs(patcher.get_non_dynamic_delegate(), first_delegate)
+        patcher.clone.assert_called_with(
+            disable_dynamic=True, model_override=initial_override
+        )
+        self.assertIs(patcher.non_dynamic_delegate_model, first_override)
+
+        patcher.finalize_model_unload()
+        self.assertIsNone(patcher.non_dynamic_delegate_model)
+
+        self.assertIs(patcher.get_non_dynamic_delegate(), second_delegate)
+        patcher.clone.assert_called_with(
+            disable_dynamic=True, model_override=None
+        )
+        self.assertIs(patcher.non_dynamic_delegate_model, second_override)
+
+    def test_free_memory_finalizes_only_removed_models(self):
+        device = torch.device("cpu")
+        kept_patcher = mock.Mock()
+        kept_patcher.model = torch.nn.Module()
+        kept = mock.Mock()
+        kept.device = device
+        kept.model = kept_patcher
+        kept.is_dead.return_value = False
+
+        unloaded_patcher = mock.Mock()
+        unloaded_patcher.model = torch.nn.Module()
+        unload = mock.Mock()
+        unload.device = device
+        unload.model = unloaded_patcher
+        unload.is_dead.return_value = False
+        unload.model_offloaded_memory.return_value = 0
+        unload.model_memory.return_value = 1
+        unload.model_unload.return_value = True
+
+        def assert_only_kept_before_finalize():
+            self.assertEqual(
+                model_management.current_loaded_models, [kept]
+            )
+
+        unloaded_patcher.finalize_model_unload.side_effect = (
+            assert_only_kept_before_finalize
+        )
+        with (
+            mock.patch.object(
+                model_management, "current_loaded_models", [kept, unload]
+            ),
+            mock.patch.object(model_management, "cleanup_models_gc"),
+            mock.patch.object(
+                model_management, "get_free_memory", return_value=0
+            ),
+            mock.patch.object(model_management, "soft_empty_cache"),
+        ):
+            unloaded = model_management.free_memory(
+                1, device, keep_loaded=[kept]
+            )
+            self.assertEqual(unloaded, [unload])
+            self.assertEqual(
+                model_management.current_loaded_models, [kept]
+            )
+
+        kept.model_unload.assert_not_called()
+        kept_patcher.finalize_model_unload.assert_not_called()
+        unloaded_patcher.finalize_model_unload.assert_called_once_with()
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Keep plain-weight Hook delegates on synchronous transfers after Hook writeback
changes prepared model storage, while preserving each module's declared model
dtype. Release the retained ordinary Hook model when DynamicVRAM actually
unloads its owning model.

This was discovered while following up #14382 and is independent of #14413's
quantized state-key fix.

## Problem

BF16 model LoRAs work through `LoraLoaderModelOnly`, but the equivalent mapped
`WeightHook` can complete with an all-black/non-finite image after the model has
been prepared for DynamicVRAM offload.

The Hook path uses a plain delegate. After mapped weight writeback changes
prepared storage, that delegate still uses model-level pinned asynchronous
transfers. A mapped zero-valued Hook also fails, while an unmatched zero-patch
Hook is normal.

After the transfer fix, the reporter confirmed full BF16 Hook sampling works,
but the retained delegate survived model unload: VAE load reported
`0 models unloaded`, left about 20.96 GiB allocated on a 24 GiB card, and both
regular and tiled decode OOMed. Restarting and decoding the saved latent worked.

## Change

- Keep a plain-weight Hook delegate on synchronous weight transfers after its
  first mapped write.
- Restore declared model dtype casting where storage dtype differs.
- Leave quantized setter-backed weights on their separate replacement path.
- Keep the ordinary delegate for normal Hook reuse, but finalize it after
  `free_memory()` removes the real LoadedModel.
- Finalize only models that were actually removed; `keep_loaded` models are
  unchanged.

## Tests

The PR branch passes 13/13 focused tests covering transfer selection, model
dtype restoration, delegate retention/recreation, post-removal finalization,
and multi-model `keep_loaded`. Its full CPU suite is baseline-equivalent:
`1232 passed, 10 skipped, 2 failed`, with both failures in container MIME
registration tests.

The combined test branch (#14413, #15532, #15533, and #15456) passes 32/32
focused/VAE tests and a baseline-equivalent full suite
(`1241 passed, 10 skipped, 2 failed`).

On one physical gfx1100 GPU with PyTorch 2.9.1 / ROCm 7.2.1 and
`comfy-kitchen==0.2.30`:

- before the unload change, `unload_all_models()` left the delegate `1 -> 1`
  and following ordinary prompts took about 29 seconds;
- after the change, the delegate reaches zero and following prompts return to
  15-16 seconds;
- Hook/no-LoRA/ordinary outputs for seeds 12345-12348 remain pixel-identical,
  every final dynamic pin count is zero, and logs contain no Hook, LoRA, OOM,
  HIP, traceback, or index error;
- the mapped BF16 subset remains pixel-identical to the prior fix and finite,
  nonblack.

The earlier PyTorch 2.12 / ROCm 7.13 validation also confirms that no-LoRA
and ordinary BF16 controls remain finite, a mapped zero-valued Hook matches
the no-LoRA control pixel-for-pixel, and two repeated mapped-Hook prompts
complete without the previous black-image false success.

A later Hook recreates its delegate in unit coverage. A full
Hook -> unload -> Hook GPU run reaches the second delegate creation without a
code error but exceeds the available 30 GiB host-memory envelope.

The [#14382 reporter](https://github.com/Comfy-Org/ComfyUI/issues/14382#issuecomment-5277914590)
then completed two consecutive full BF16 sampling and VAE runs on the original
RX 7900 XTX workflow using combined branch `dad437146b`. This closes the
reporter boundary for VAE decode and a second generation after the real unload.
The branch also contains #15456, so this is end-to-end integration evidence,
not an isolated claim for #15456's generic VAE retry.

This draft branch is stacked on #14413 so the combined follow-up remains
testable before that PR merges. The combined test branch additionally includes
#15532 and existing VAE retry PR #15456; #15456's `comfy/sd.py` changes are not
part of this PR.

Addresses #15531.

---

*This is an experimental, AI-generated code change, reviewed by AMD engineers before submission.*

Made with [Cursor](https://cursor.com)
