### PR TITLE
Fix asym_w4a8_int8 loading on MPS

### DIFF
--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -1203,6 +1203,11 @@ def _load_quantized_module(module, super_load, state_dict, prefix, local_metadat
                 raise ValueError(f"Missing W4A8 group scale (weight_s_rel) for layer {layer_name}")
             if scale.dtype == torch.uint8:
                 scale = scale.view(torch.float8_e4m3fn)
+            if comfy.model_management.get_torch_device().type == "mps":
+                # MPS has no fp8 casts at all, so the eager dequant path dies on
+                # s_rel.float(). fp32 is the only other dtype the eager backend
+                # declares for s_rel, so fp16 is not an option here.
+                scale = scale.float()
             params_conf = layer_conf.get("params", {})
             if not isinstance(params_conf, dict):
                 params_conf = {}

--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -1203,7 +1203,7 @@ def _load_quantized_module(module, super_load, state_dict, prefix, local_metadat
                 raise ValueError(f"Missing W4A8 group scale (weight_s_rel) for layer {layer_name}")
             if scale.dtype == torch.uint8:
                 scale = scale.view(torch.float8_e4m3fn)
-            if comfy.model_management.get_torch_device().type == "mps":
+            if device.type == "mps":
                 # MPS has no fp8 casts at all, so the eager dequant path dies on
                 # s_rel.float(). fp32 is the only other dtype the eager backend
                 # declares for s_rel, so fp16 is not an option here.


### PR DESCRIPTION
## Problem

No `asym_w4a8_int8` model loads on Apple Silicon. Loading one (e.g. `Kijai/MiniMax-H3-experimental/minimax_h3_fl2va_pruned_w4a8_mixed.safetensors`) fails as soon as a weight is dequantized:

```
File ".../comfy_kitchen/backends/eager/w4a8_int8.py", line 414, in _dequant_int4_grouped_to_int8
    values = values.view(n, groups, group_size) * s_rel.float().unsqueeze(-1)
RuntimeError: Undefined type Float8_e4m3fn
```

The cause is in torch, not here — the MPS backend implements no fp8 casts at all:

```python
>>> t = torch.tensor([1.0, 2.0]).to(torch.float8_e4m3fn)
>>> t.float()                     # cpu
tensor([1., 2.])
>>> t.to('mps').float()           # mps
RuntimeError: Undefined type Float8_e4m3fn
```

Since `weight_s_rel` is stored as `float8_e4m3fn`, the eager W4A8 kernels cannot touch it once it is on an MPS device.

## Change

Convert the group scale to fp32 at load time when the compute device is MPS. `float32` is one of the two dtypes the eager backend declares for `s_rel`:

```python
"s_rel": ParamConstraint(dtypes=frozenset({torch.float8_e4m3fn, torch.float32}), ...)
```

so the registry dispatches normally afterwards. This is a one-time conversion at load, not a per-forward cast.

## Verification

On an M-series Mac (torch 2.14.0.dev, MPS), with the patch applied, `minimax_h3_fl2va_pruned_w4a8_mixed.safetensors` loads and samples end to end and produces correct video output.

Isolated check through the registry-dispatched entry points, fp32 vs fp8 scales carrying the same values:

- `w4a8_int8_linear` on MPS with fp32 `s_rel` matches the CPU fp8 reference exactly (`maxdiff 0.0`)
- `dequantize_w4a8_int8_weight` on MPS with fp32 `s_rel` succeeds; with fp8 it raises the error above

## Why not fp16

fp16 represents every `float8_e4m3fn` value exactly, so it would halve the memory cost of this widening (the group scales are one value per 16 weights, so on a ~22B-param model fp32 costs roughly 4 GB more than the native fp8). I tried it and the numerics are bit-identical.

It does not work, though: the eager backend's `ParamConstraint` for `s_rel` admits only `{float8_e4m3fn, float32}`, so a fp16 scale fails dispatch with

```
NoCapableBackendError: No backend can handle 'dequantize_w4a8_int8_weight': eager: s_rel: dtype torch.float16 not in {torch.float8_e4m3fn, torch.float32}
```

Adding fp16 to that constraint in comfy-kitchen would be the cheaper fix if the extra memory matters; this PR stays within what the current backend accepts.