### PR TITLE
Don't let a custom node rename a builtin it cannot replace

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -2296,7 +2296,7 @@ async def load_custom_node(module_path: str, ignore=set(), module_parent="custom
                     NODE_CLASS_MAPPINGS[name] = node_cls
                     node_cls.RELATIVE_PYTHON_MODULE = "{}.{}".format(module_parent, get_module_name(module_path))
             if hasattr(module, "NODE_DISPLAY_NAME_MAPPINGS") and getattr(module, "NODE_DISPLAY_NAME_MAPPINGS") is not None:
-                NODE_DISPLAY_NAME_MAPPINGS.update(module.NODE_DISPLAY_NAME_MAPPINGS)
+                NODE_DISPLAY_NAME_MAPPINGS.update({name: display_name for name, display_name in module.NODE_DISPLAY_NAME_MAPPINGS.items() if name not in ignore})
             return True
         # V3 Extension Definition
         elif hasattr(module, "comfy_entrypoint"):
@@ -2323,8 +2323,8 @@ async def load_custom_node(module_path: str, ignore=set(), module_parent="custom
                     if schema.node_id not in ignore:
                         NODE_CLASS_MAPPINGS[schema.node_id] = node_cls
                         node_cls.RELATIVE_PYTHON_MODULE = "{}.{}".format(module_parent, get_module_name(module_path))
-                    if schema.display_name is not None:
-                        NODE_DISPLAY_NAME_MAPPINGS[schema.node_id] = schema.display_name
+                        if schema.display_name is not None:
+                            NODE_DISPLAY_NAME_MAPPINGS[schema.node_id] = schema.display_name
                 return True
             except Exception as e:
                 logging.warning(f"Error while calling comfy_entrypoint in {module_path}: {e}")


### PR DESCRIPTION
In the `comfy_entrypoint` registration path, the `ignore` guard (builtin node ids) gates `NODE_CLASS_MAPPINGS` but not `NODE_DISPLAY_NAME_MAPPINGS` (nodes.py: the class assignment is inside the guard, the display-name assignment two lines later is not). So a V3 node whose node_id collides with a builtin cannot replace the node -- but still renames it in the UI menu.

This moves the display-name assignment under the same guard. One-line change.

Note: the V1 path has the same gap -- `NODE_DISPLAY_NAME_MAPPINGS.update(module.NODE_DISPLAY_NAME_MAPPINGS)` is ungated too, so a V1 pack can also rename a builtin's display name. Happy to extend this PR to filter that update against `ignore` as well if you want both paths closed, or keep this V3-only.