### PR TITLE
Create weight backup namedtuple once at module level

### DIFF
--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -287,6 +287,9 @@ class MemoryCounter:
 
 CustomTorchDevice = collections.namedtuple("FakeDevice", ["type", "index"])("comfy-lazy-caster", 0)
 
+# Created once at module level: a new namedtuple class per backed-up weight adds GC pressure on large models.
+ModelPatcherBackup = collections.namedtuple("ModelPatcherBackup", ["weight", "inplace_update"])
+
 class LazyCastingParam(torch.nn.Parameter):
     def __new__(cls, model, key, tensor):
         return super().__new__(cls, tensor)
@@ -904,7 +907,7 @@ class ModelPatcher:
         inplace_update = self.weight_inplace_update or inplace_update
 
         if key not in self.backup and not return_weight:
-            self.backup[key] = collections.namedtuple('Dimension', ['weight', 'inplace_update'])(weight.to(device=self.offload_device, copy=inplace_update), inplace_update)
+            self.backup[key] = ModelPatcherBackup(weight.to(device=self.offload_device, copy=inplace_update), inplace_update)
 
         temp_dtype = comfy.model_management.lora_compute_dtype(device_to) if key in self.patches else None
         if device_to is not None:
@@ -1973,7 +1976,7 @@ class ModelPatcherDynamic(ModelPatcher):
                         key = key_param_name_to_key(n, param)
                         weight, _, _ = get_key_weight(self.model, key)
                         if key not in self.backup:
-                            self.backup[key] = collections.namedtuple('Dimension', ['weight', 'inplace_update'])(weight, False)
+                            self.backup[key] = ModelPatcherBackup(weight, False)
                         model_dtype = getattr(m, param + "_comfy_model_dtype", None)
                         casted_weight = weight.to(dtype=model_dtype, device=device_to)
                         comfy.utils.set_attr_param(self.model, key, casted_weight)

--- a/tests-unit/comfy_test/test_model_patcher_backup.py
+++ b/tests-unit/comfy_test/test_model_patcher_backup.py
@@ -1,0 +1,33 @@
+import torch
+
+from comfy.cli_args import args as cli_args
+
+if not torch.cuda.is_available():
+    cli_args.cpu = True
+
+from comfy.model_patcher import ModelPatcher, ModelPatcherBackup
+
+
+def test_backup_entries_share_one_type():
+    model = torch.nn.Module()
+    keys = []
+    for index in range(2):
+        key = "weight_{}".format(index)
+        keys.append(key)
+        model.register_parameter(key, torch.nn.Parameter(torch.ones(1)))
+
+    patcher = ModelPatcher(
+        model,
+        load_device=torch.device("cpu"),
+        offload_device=torch.device("cpu"),
+    )
+
+    for key in keys:
+        patcher.patch_weight_to_device(key, force_cast=True)
+
+    assert len(patcher.backup) == len(keys)
+    for entry in patcher.backup.values():
+        assert isinstance(entry, ModelPatcherBackup)
+        assert entry.weight is not None
+        assert entry.inplace_update is False
+    assert len({type(entry) for entry in patcher.backup.values()}) == 1

--- a/tests-unit/comfy_test/test_model_patcher_backup.py
+++ b/tests-unit/comfy_test/test_model_patcher_backup.py
@@ -23,7 +23,7 @@ def test_backup_entries_share_one_type():
     )
 
     for key in keys:
-        patcher.patch_weight_to_device(key, force_cast=True)
+        patcher.patch_weight_to_device(key, device_to=torch.device("cpu"), force_cast=True)
 
     assert len(patcher.backup) == len(keys)
     for entry in patcher.backup.values():


### PR DESCRIPTION
Fixes #15517

Each call to `patch_weight_to_device` constructed a new `collections.namedtuple` class inline for the backup entry. For large models with thousands of weights this creates thousands of GC-tracked class objects, adding unnecessary GC pressure and memory usage.

This hoists the namedtuple to a single module-level `ModelPatcherBackup` type shared by both backup sites (the old inline type name `Dimension` was internal-only and is not referenced anywhere else).

Added a unit test verifying backup entries share one type.