### PR TITLE
Warn when a custom node overrides another custom node's node id

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -2289,6 +2289,11 @@ async def load_custom_node(module_path: str, ignore=set(), module_parent="custom
         if hasattr(module, "NODE_CLASS_MAPPINGS") and getattr(module, "NODE_CLASS_MAPPINGS") is not None:
             for name, node_cls in module.NODE_CLASS_MAPPINGS.items():
                 if name not in ignore:
+                    if name in NODE_CLASS_MAPPINGS:
+                        logging.warning(
+                            "Node id '{}' from {} overrides the one already registered by {}".format(
+                                name, module_path,
+                                getattr(NODE_CLASS_MAPPINGS[name], "RELATIVE_PYTHON_MODULE", "unknown")))
                     NODE_CLASS_MAPPINGS[name] = node_cls
                     node_cls.RELATIVE_PYTHON_MODULE = "{}.{}".format(module_parent, get_module_name(module_path))
             if hasattr(module, "NODE_DISPLAY_NAME_MAPPINGS") and getattr(module, "NODE_DISPLAY_NAME_MAPPINGS") is not None:
@@ -2317,6 +2322,11 @@ async def load_custom_node(module_path: str, ignore=set(), module_parent="custom
                     node_cls: io.ComfyNode
                     schema = node_cls.GET_SCHEMA()
                     if schema.node_id not in ignore:
+                        if schema.node_id in NODE_CLASS_MAPPINGS:
+                            logging.warning(
+                                "Node id '{}' from {} overrides the one already registered by {}".format(
+                                    schema.node_id, module_path,
+                                    getattr(NODE_CLASS_MAPPINGS[schema.node_id], "RELATIVE_PYTHON_MODULE", "unknown")))
                         NODE_CLASS_MAPPINGS[schema.node_id] = node_cls
                         node_cls.RELATIVE_PYTHON_MODULE = "{}.{}".format(module_parent, get_module_name(module_path))
                     if schema.display_name is not None:


### PR DESCRIPTION
Pack-vs-pack node id collisions currently overwrite silently, and the winner depends on `os.listdir` order, which is filesystem-dependent -- the classic source of "works on my machine" reports where two users with the same packs end up with different nodes.

Builtin ids are already protected by the `ignore` set. This adds a warning -- no behavior change -- naming both modules when one custom pack replaces another's node, in both the V1 and `comfy_entrypoint` registration paths. The previous owner is identified via the `RELATIVE_PYTHON_MODULE` the loader already stamps on registered classes.