### PR TITLE
Allow cross-site navigation to ComfyUI root

### DIFF
--- a/middleware/origin_middleware.py
+++ b/middleware/origin_middleware.py
@@ -35,9 +35,14 @@ def is_loopback(host):
 def create_origin_only_middleware():
     @web.middleware
     async def origin_only_middleware(request: web.Request, handler):
-        if 'Sec-Fetch-Site' in request.headers:
-            sec_fetch_site = request.headers['Sec-Fetch-Site']
-            if sec_fetch_site == 'cross-site':
+        if request.headers.get('Sec-Fetch-Site') == 'cross-site':
+            is_top_level_navigation = (
+                request.method == 'GET'
+                and request.path == '/'
+                and request.headers.get('Sec-Fetch-Mode') == 'navigate'
+                and request.headers.get('Sec-Fetch-Dest') == 'document'
+            )
+            if not is_top_level_navigation:
                 return web.Response(status=403)
         #this code is used to prevent the case where a random website can queue comfy workflows by making a POST to 127.0.0.1 which browsers don't prevent for some dumb reason.
         #in that case the Host and Origin hostnames won't match

--- a/middleware/origin_middleware.py
+++ b/middleware/origin_middleware.py
@@ -1,0 +1,73 @@
+import ipaddress
+import logging
+import socket
+import urllib
+
+from aiohttp import web
+
+
+def is_loopback(host):
+    if host is None:
+        return False
+    try:
+        if ipaddress.ip_address(host).is_loopback:
+            return True
+        else:
+            return False
+    except:
+        pass
+
+    loopback = False
+    for family in (socket.AF_INET, socket.AF_INET6):
+        try:
+            r = socket.getaddrinfo(host, None, family, socket.SOCK_STREAM)
+            for family, _, _, _, sockaddr in r:
+                if not ipaddress.ip_address(sockaddr[0]).is_loopback:
+                    return loopback
+                else:
+                    loopback = True
+        except socket.gaierror:
+            pass
+
+    return loopback
+
+
+def create_origin_only_middleware():
+    @web.middleware
+    async def origin_only_middleware(request: web.Request, handler):
+        if 'Sec-Fetch-Site' in request.headers:
+            sec_fetch_site = request.headers['Sec-Fetch-Site']
+            if sec_fetch_site == 'cross-site':
+                return web.Response(status=403)
+        #this code is used to prevent the case where a random website can queue comfy workflows by making a POST to 127.0.0.1 which browsers don't prevent for some dumb reason.
+        #in that case the Host and Origin hostnames won't match
+        #I know the proper fix would be to add a cookie but this should take care of the problem in the meantime
+        if 'Host' in request.headers and 'Origin' in request.headers:
+            host = request.headers['Host']
+            origin = request.headers['Origin']
+            host_domain = host.lower()
+            parsed = urllib.parse.urlparse(origin)
+            origin_domain = parsed.netloc.lower()
+            host_domain_parsed = urllib.parse.urlsplit('//' + host_domain)
+
+            #limit the check to when the host domain is localhost, this makes it slightly less safe but should still prevent the exploit
+            loopback = is_loopback(host_domain_parsed.hostname)
+
+            if parsed.port is None: #if origin doesn't have a port strip it from the host to handle weird browsers, same for host
+                host_domain = host_domain_parsed.hostname
+            if host_domain_parsed.port is None:
+                origin_domain = parsed.hostname
+
+            if loopback and host_domain is not None and origin_domain is not None and len(host_domain) > 0 and len(origin_domain) > 0:
+                if host_domain != origin_domain:
+                    logging.warning("WARNING: request with non matching host and origin {} != {}, returning 403".format(host_domain, origin_domain))
+                    return web.Response(status=403)
+
+        if request.method == "OPTIONS":
+            response = web.Response()
+        else:
+            response = await handler(request)
+
+        return response
+
+    return origin_only_middleware

--- a/server.py
+++ b/server.py
@@ -23,8 +23,6 @@ import json
 import glob
 import struct
 import ssl
-import socket
-import ipaddress
 from PIL import Image, ImageOps
 from PIL.PngImagePlugin import PngInfo
 from io import BytesIO
@@ -61,6 +59,7 @@ from protocol import BinaryEventTypes
 
 # Import cache control middleware
 from middleware.cache_middleware import cache_control
+from middleware.origin_middleware import create_origin_only_middleware
 
 if args.enable_manager:
     import comfyui_manager
@@ -128,73 +127,6 @@ def create_cors_middleware(allowed_origin: str):
         return response
 
     return cors_middleware
-
-
-def is_loopback(host):
-    if host is None:
-        return False
-    try:
-        if ipaddress.ip_address(host).is_loopback:
-            return True
-        else:
-            return False
-    except:
-        pass
-
-    loopback = False
-    for family in (socket.AF_INET, socket.AF_INET6):
-        try:
-            r = socket.getaddrinfo(host, None, family, socket.SOCK_STREAM)
-            for family, _, _, _, sockaddr in r:
-                if not ipaddress.ip_address(sockaddr[0]).is_loopback:
-                    return loopback
-                else:
-                    loopback = True
-        except socket.gaierror:
-            pass
-
-    return loopback
-
-
-def create_origin_only_middleware():
-    @web.middleware
-    async def origin_only_middleware(request: web.Request, handler):
-        if 'Sec-Fetch-Site' in request.headers:
-            sec_fetch_site = request.headers['Sec-Fetch-Site']
-            if sec_fetch_site == 'cross-site':
-                return web.Response(status=403)
-        #this code is used to prevent the case where a random website can queue comfy workflows by making a POST to 127.0.0.1 which browsers don't prevent for some dumb reason.
-        #in that case the Host and Origin hostnames won't match
-        #I know the proper fix would be to add a cookie but this should take care of the problem in the meantime
-        if 'Host' in request.headers and 'Origin' in request.headers:
-            host = request.headers['Host']
-            origin = request.headers['Origin']
-            host_domain = host.lower()
-            parsed = urllib.parse.urlparse(origin)
-            origin_domain = parsed.netloc.lower()
-            host_domain_parsed = urllib.parse.urlsplit('//' + host_domain)
-
-            #limit the check to when the host domain is localhost, this makes it slightly less safe but should still prevent the exploit
-            loopback = is_loopback(host_domain_parsed.hostname)
-
-            if parsed.port is None: #if origin doesn't have a port strip it from the host to handle weird browsers, same for host
-                host_domain = host_domain_parsed.hostname
-            if host_domain_parsed.port is None:
-                origin_domain = parsed.hostname
-
-            if loopback and host_domain is not None and origin_domain is not None and len(host_domain) > 0 and len(origin_domain) > 0:
-                if host_domain != origin_domain:
-                    logging.warning("WARNING: request with non matching host and origin {} != {}, returning 403".format(host_domain, origin_domain))
-                    return web.Response(status=403)
-
-        if request.method == "OPTIONS":
-            response = web.Response()
-        else:
-            response = await handler(request)
-
-        return response
-
-    return origin_only_middleware
 
 
 def create_block_external_middleware():

--- a/tests-unit/server_test/test_origin_middleware.py
+++ b/tests-unit/server_test/test_origin_middleware.py
@@ -1,0 +1,117 @@
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
+
+from middleware.origin_middleware import create_origin_only_middleware
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def ok_handler(request):
+    return web.Response(status=200)
+
+
+async def test_allows_cross_site_top_level_get_navigation():
+    request = make_mocked_request(
+        'GET',
+        '/',
+        headers={
+            'Sec-Fetch-Site': 'cross-site',
+            'Sec-Fetch-Mode': 'navigate',
+            'Sec-Fetch-Dest': 'document',
+            'Sec-Fetch-User': '?1',
+        },
+    )
+
+    response = await create_origin_only_middleware()(request, ok_handler)
+
+    assert response.status == 200
+
+
+async def test_blocks_cross_site_top_level_navigation_to_other_routes():
+    request = make_mocked_request(
+        'GET',
+        '/system_stats',
+        headers={
+            'Sec-Fetch-Site': 'cross-site',
+            'Sec-Fetch-Mode': 'navigate',
+            'Sec-Fetch-Dest': 'document',
+        },
+    )
+
+    response = await create_origin_only_middleware()(request, ok_handler)
+
+    assert response.status == 403
+
+
+@pytest.mark.parametrize(
+    ('method', 'headers'),
+    [
+        (
+            'POST',
+            {
+                'Sec-Fetch-Site': 'cross-site',
+                'Sec-Fetch-Mode': 'navigate',
+                'Sec-Fetch-Dest': 'document',
+            },
+        ),
+        (
+            'GET',
+            {
+                'Sec-Fetch-Site': 'cross-site',
+                'Sec-Fetch-Mode': 'cors',
+                'Sec-Fetch-Dest': 'empty',
+            },
+        ),
+        (
+            'GET',
+            {
+                'Sec-Fetch-Site': 'cross-site',
+                'Sec-Fetch-Mode': 'websocket',
+                'Sec-Fetch-Dest': 'empty',
+            },
+        ),
+        (
+            'GET',
+            {
+                'Sec-Fetch-Site': 'cross-site',
+                'Sec-Fetch-Mode': 'navigate',
+                'Sec-Fetch-Dest': 'iframe',
+            },
+        ),
+        ('GET', {'Sec-Fetch-Site': 'cross-site'}),
+    ],
+    ids=['form-post', 'fetch', 'websocket', 'iframe', 'missing-context'],
+)
+async def test_blocks_other_cross_site_requests(method, headers):
+    request = make_mocked_request(method, '/', headers=headers)
+
+    response = await create_origin_only_middleware()(request, ok_handler)
+
+    assert response.status == 403
+
+
+async def test_preserves_loopback_origin_check_without_fetch_metadata():
+    request = make_mocked_request(
+        'POST',
+        '/prompt',
+        headers={
+            'Host': '127.0.0.1:8188',
+            'Origin': 'https://evil.example',
+        },
+    )
+
+    response = await create_origin_only_middleware()(request, ok_handler)
+
+    assert response.status == 403
+
+
+@pytest.mark.parametrize('site', ['same-origin', 'same-site', 'none', None])
+async def test_preserves_allowed_request_sources(site):
+    headers = {'Sec-Fetch-Site': site} if site is not None else {}
+    request = make_mocked_request('GET', '/', headers=headers)
+
+    response = await create_origin_only_middleware()(request, ok_handler)
+
+    assert response.status == 200


### PR DESCRIPTION
## Summary

- allow cross-site top-level `GET /` navigation to open the ComfyUI interface
- continue blocking cross-site form submissions, API fetches, WebSockets, iframe navigation, and all other routes
- move the origin middleware into a directly testable module and add security regression coverage

[PR #13261](https://github.com/Comfy-Org/ComfyUI/pull/13261) introduced the Fetch Metadata guard to protect local ComfyUI instances from cross-site requests. This keeps that protection intact while exempting only navigation to the UI root, allowing links from GitHub and other sites to open public or proxied ComfyUI instances.

## Testing

- `pytest tests-unit/server_test -q` (52 passed)
- `ruff check middleware/origin_middleware.py server.py tests-unit/server_test/test_origin_middleware.py`