### PR TITLE
Fix H2D copy in SymmetricPatchifier blocking CUDA graph capture

### DIFF
--- a/comfy/ldm/lightricks/symmetric_patchifier.py
+++ b/comfy/ldm/lightricks/symmetric_patchifier.py
@@ -21,11 +21,9 @@ def latent_to_pixel_coords(
     Returns:
         Tensor: A tensor of pixel coordinates corresponding to the input latent coordinates.
     """
-    shape = [1] * latent_coords.ndim
-    shape[1] = -1
-    pixel_coords = (
-        latent_coords
-        * torch.tensor(scale_factors, device=latent_coords.device).view(*shape)
+    pixel_coords = torch.stack(
+        [latent_coords[:, i] * scale_factors[i] for i in range(latent_coords.shape[1])],
+        dim=1,
     )
     if causal_fix:
         # Fix temporal scale for first frame to 1 due to causality
@@ -75,14 +73,15 @@ class Patchifier(ABC):
             indexing="ij",
         )
         latent_sample_coords_start = torch.stack(latent_sample_coords, dim=0)
-        delta = torch.tensor(self._patch_size, device=latent_sample_coords_start.device, dtype=latent_sample_coords_start.dtype)[:, None, None, None]
-        latent_sample_coords_end = latent_sample_coords_start + delta
 
         latent_sample_coords_start = latent_sample_coords_start.unsqueeze(0).repeat(batch_size, 1, 1, 1, 1)
         latent_sample_coords_start = rearrange(
             latent_sample_coords_start, "b c f h w -> b c (f h w)", b=batch_size
         )
         if self.start_end:
+            latent_sample_coords_end = torch.stack(
+                [latent_sample_coords[i] + self._patch_size[i] for i in range(3)], dim=0
+            )
             latent_sample_coords_end = latent_sample_coords_end.unsqueeze(0).repeat(batch_size, 1, 1, 1, 1)
             latent_sample_coords_end = rearrange(
                 latent_sample_coords_end, "b c f h w -> b c (f h w)", b=batch_size

--- a/tests-unit/comfy_test/test_symmetric_patchifier.py
+++ b/tests-unit/comfy_test/test_symmetric_patchifier.py
@@ -1,0 +1,44 @@
+import torch
+
+from comfy.ldm.lightricks.symmetric_patchifier import (
+    SymmetricPatchifier,
+    latent_to_pixel_coords,
+)
+
+
+def _guard_no_tensor_from_python_data(monkeypatch):
+    real_tensor = torch.tensor
+
+    def guarded(data, *args, **kwargs):
+        raise AssertionError(
+            "must not build a tensor from python scalars on every call; this is an "
+            "H2D copy that breaks CUDA graph capture"
+        )
+
+    monkeypatch.setattr(torch, "tensor", guarded)
+    return real_tensor
+
+
+def test_get_latent_coords_end_matches_patch_size_without_host_tensor(monkeypatch):
+    patchifier = SymmetricPatchifier(patch_size=2, start_end=True)
+    _guard_no_tensor_from_python_data(monkeypatch)
+
+    coords = patchifier.get_latent_coords(
+        latent_num_frames=2, latent_height=4, latent_width=4, batch_size=1,
+        device=torch.device("cpu"),
+    )
+
+    start = coords[..., 0]
+    end = coords[..., 1]
+    for axis, patch in enumerate(patchifier.patch_size):
+        assert torch.equal(end[:, axis], start[:, axis] + patch)
+
+
+def test_latent_to_pixel_coords_scales_each_axis_without_host_tensor(monkeypatch):
+    latent_coords = torch.tensor([[[0, 1], [0, 2], [0, 3]]])
+    real_tensor = _guard_no_tensor_from_python_data(monkeypatch)
+
+    pixel_coords = latent_to_pixel_coords(latent_coords, scale_factors=(8, 32, 32))
+
+    expected = real_tensor([[[0, 8], [0, 64], [0, 96]]])
+    assert torch.equal(pixel_coords, expected)


### PR DESCRIPTION
Fixes #15550

## Problem

`SymmetricPatchifier.get_latent_coords()` and the module-level helper
`latent_to_pixel_coords()` in `comfy/ldm/lightricks/symmetric_patchifier.py`
each built a small tensor from a python tuple directly on the target device
(`torch.tensor(python_data, device=...)`) on every call. Both are called on
every sampler step for LTXV/LTXAV models.

`torch.tensor(python_data, device=cuda)` first materializes the data on host
memory and then does a host-to-device copy. That copy is illegal during
`torch.cuda.graph` stream capture (`cudaErrorStreamCaptureUnsupported`) and
adds avoidable per-step launch overhead even outside of capture.

## Fix

Replace both tensor-from-python-list constructions with per-axis
tensor-scalar arithmetic on tensors that already live on the target device
(`tensor + python_int`, `tensor * python_int`). PyTorch dispatches a
tensor-scalar op as a kernel argument rather than a host memory copy, so no
H2D transfer happens and the result is capture-safe. The computed values are
unchanged.

## Test plan

Added `tests-unit/comfy_test/test_symmetric_patchifier.py`:
- Guards `torch.tensor` during both calls to prove no host tensor is
  constructed from python data (this is what fails against the pre-fix
  code — see below).
- Asserts `get_latent_coords(..., start_end=True)` still produces
  `end == start + patch_size` per axis.
- Asserts `latent_to_pixel_coords` still scales each axis by the matching
  `scale_factors` entry.

Verified the tests fail without the fix:

```
$ git checkout HEAD~1 -- comfy/ldm/lightricks/symmetric_patchifier.py
$ python -m pytest tests-unit/comfy_test/test_symmetric_patchifier.py -v
...
FAILED test_get_latent_coords_end_matches_patch_size_without_host_tensor
FAILED test_latent_to_pixel_coords_scales_each_axis_without_host_tensor
2 failed, 1 warning in 0.92s
$ git checkout HEAD -- comfy/ldm/lightricks/symmetric_patchifier.py
```

And pass with the fix:

```
$ python -m pytest tests-unit/comfy_test/test_symmetric_patchifier.py -v
test_get_latent_coords_end_matches_patch_size_without_host_tensor PASSED
test_latent_to_pixel_coords_scales_each_axis_without_host_tensor PASSED
2 passed, 1 warning in 0.86s
```

`ruff check` passes on both changed files.

## AI assistance disclosure

This change was written with AI assistance (Claude Code).
