### PR TITLE
[Server.py] Update CSP to allow `blob:` and `data:`

### DIFF
--- a/server.py
+++ b/server.py
@@ -206,7 +206,7 @@ def create_block_external_middleware():
         else:
             response = await handler(request)
 
-        response.headers['Content-Security-Policy'] = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' data:; frame-src 'self'; object-src 'self';"
+        response.headers['Content-Security-Policy'] = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' data: blob:; font-src 'self'; connect-src 'self' data: blob:; frame-src 'self'; object-src 'self';"
         return response
 
     return block_external_middleware


### PR DESCRIPTION
### Summary

Fixes media playback and file upload failures in the frontend when running with `--disable-api-nodes`.
For example the `Record Audio` node.

### Problem

When `--disable-api-nodes` is enabled, `create_block_external_middleware` applies a restrictive Content Security Policy. The current policy omits `blob:` from `connect-src` and lacks an explicit `media-src` directive (which falls back to `default-src 'self'`).

As a result, frontend nodes handling audio and video uploads fail when trying to fetch or play back client-side `blob:` URLs, throwing browser CSP violation errors.

### Solution

Add `blob:` to `connect-src` and define `media-src 'self' data: blob:;` in the CSP header.

This allows the UI to process audio/video buffers created by the browser while still respecting the goal of the `--disable-api-nodes` flag.