### PR TITLE
fix: stop ModelPatcher.__del__ raising during interpreter shutdown

### DIFF
--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -22,6 +22,7 @@ import collections
 import inspect
 import logging
 import math
+import sys
 import time
 import uuid
 from typing import Callable, Optional
@@ -1742,7 +1743,14 @@ class ModelPatcher:
         unet_state_dict = self.model_state_dict_for_saving(self.model.diffusion_model, "diffusion_model.")
         return self.model.state_dict_for_saving(unet_state_dict, clip_state_dict=clip_state_dict, vae_state_dict=vae_state_dict, clip_vision_state_dict=clip_vision_state_dict)
 
-    def __del__(self):
+    def __del__(self, _is_finalizing=sys.is_finalizing):
+        # At interpreter exit the module globals are cleared before the last
+        # objects are collected, so `detach` reaches `CallbacksMP` after it is
+        # already None. `sys` is cleared the same way, so the check is bound as
+        # a default argument to capture it while the module is still alive.
+        # Nothing here matters once the process is going away.
+        if _is_finalizing():
+            return
         self.unpin_all_weights()
         self.detach(unpatch_all=False)
 


### PR DESCRIPTION
## Problem

`ModelPatcher.__del__` calls `detach`, which reads `CallbacksMP.ON_DETACH`. CPython clears a module's globals before collecting the last objects at interpreter exit, so `CallbacksMP` is already `None` when the patcher is finalized. Any run that still holds a `ModelPatcher` ends with:

```
Exception ignored in: <function ModelPatcher.__del__ at 0x...>
Traceback (most recent call last):
  File "comfy/model_patcher.py", line 1747, in __del__
  File "comfy/model_patcher.py", line 1300, in detach
AttributeError: 'NoneType' object has no attribute 'ON_DETACH'
```

It is noise rather than a functional failure, since Python swallows exceptions from `__del__` and the process still exits, but it prints on every exit and looks like a crash to anyone reading the terminal. This was reported once before in #6834 and closed as belonging to ComfyUI-to-Python-Extension. It is reproducible with no custom nodes and no extension, using only core modules.

## Fix

Detaching cannot accomplish anything once the process is going away, so skip it while the interpreter is finalizing.

The detail worth flagging: a plain `sys.is_finalizing()` call inside `__del__` does **not** work. `sys` is cleared by the same teardown, so it only moves the failure one line up:

```
AttributeError: 'NoneType' object has no attribute 'is_finalizing'
```

I hit that on the first attempt. Binding the check as a default argument captures the function while the module is still alive, which is the documented way to reach a global from `__del__`.

This also brings the method in line with its neighbours, which already guard themselves: `ModelPatcherDynamic.__del__` uses `getattr(..., None)` with early returns, and `LoadedModel.__del__` checks its finalizer against `None`.

## Verification

Windows, RTX 3050 Laptop 4 GB, torch 2.10.0+cu130, driving `ImageUpscaleWithModel` with `RealESRGAN_x4plus_anime_6B.pth`.

Before, on `b323a34`:

```
RESULT: upscale SUCCEEDED
Exception ignored in: <function ModelPatcher.__del__ ...>
AttributeError: 'NoneType' object has no attribute 'ON_DETACH'
```

After: same run, no traceback.

Both branches were checked directly rather than relying on when the collector happens to run, since a `del` plus `gc.collect()` test passed and failed identically on clean master and told me nothing:

```
PASS  normal run: __del__ detached (ON_DETACH fired)
PASS  finalizing: __del__ skipped detach and raised nothing
```

The first case is the one that matters for behaviour: an ordinary collection during a running process still detaches exactly as before. Only the shutdown path changes.

`tests-unit/comfy_test/folder_path_test.py` and `tests-unit/utils` give 29 passed both with and without this change.
