### PR TITLE
llama: fix non-local x path

### DIFF
--- a/comfy/text_encoders/llama.py
+++ b/comfy/text_encoders/llama.py
@@ -906,7 +906,8 @@ class Llama2_(nn.Module):
                 past_kv.prepare(seq_len)
 
             def core():
-                _, current_kv = layer(
+                nonlocal x
+                x, current_kv = layer(
                     x=x,
                     attention_mask=mask,
                     freqs_cis=freqs_cis,


### PR DESCRIPTION
The was causing non-graph llama to drop its activations between blocks.