### PR TITLE
Fix fp16 crash in BiRefNet shifted-window attention mask

### DIFF
--- a/comfy/background_removal/birefnet.py
+++ b/comfy/background_removal/birefnet.py
@@ -258,7 +258,7 @@ class BasicLayer(nn.Module):
     def forward(self, x, H, W):
         Hp = int(np.ceil(H / self.window_size)) * self.window_size
         Wp = int(np.ceil(W / self.window_size)) * self.window_size
-        img_mask = torch.zeros((1, Hp, Wp, 1), device=x.device)  # 1 Hp Wp 1
+        img_mask = torch.zeros((1, Hp, Wp, 1), device=x.device, dtype=x.dtype)  # 1 Hp Wp 1
         h_slices = (slice(0, -self.window_size),
                     slice(-self.window_size, -self.shift_size),
                     slice(-self.shift_size, None))


### PR DESCRIPTION
Fixes #15571

## Problem

`ImageRemBG` with a BiRefNet model crashes when the model runs in fp16 (the default `text_encoder_dtype` on most CUDA GPUs):

```
File "comfy/background_removal/birefnet.py", line 119, in forward
    x = (attn @ v).transpose(1, 2).reshape(B_, N, C)
RuntimeError: expected scalar type Float but found Half
```

`BasicLayer.forward` builds the shifted-window attention mask without a dtype, so `img_mask` and the derived `attn_mask` are always fp32. In `WindowAttention.forward`, `attn + mask` then promotes `attn` from fp16 to fp32, and the following `attn @ v` mixes fp32 and fp16 operands, which matmul rejects. Running with `--fp32-text-enc` avoids the crash, which matches the diagnosis in the issue.

## Fix

Create `img_mask` in `x.dtype` so the mask matches the attention compute dtype. The mask only contains small region ids (0-8), their differences, and -100.0/0.0 fill values, all exactly representable in fp16/bf16, so the fp32 path is unchanged and no numerical behavior changes. This mirrors how #14217 handled `relative_position_bias` with `cast_to_input` in the same forward, and matches the equivalent fix in the original BiRefNet repo, which casts the mask with `.to(x.dtype)` ([swin_v1.py](https://github.com/ZhengPeng7/BiRefNet/blob/main/models/backbones/swin_v1.py)).

## Verification

- Traced the dtype flow: `img_mask` -> `window_partition` -> `attn_mask` all inherit `x.dtype`, so `attn + mask` no longer promotes and `attn @ v` stays in one dtype.
- The issue reporter confirmed that casting the mask to `x.dtype` at this exact spot fixes the crash on their setup (ComfyUI 0.32.0, RTX 4070 Ti SUPER, PyTorch 2.9.1+cu130).
- `python -m py_compile` and `ruff check` pass on the changed file. I could not run GPU inference in my environment.