### PR TITLE
Silence spurious ConnectionResetError tracebacks on Windows

### DIFF
--- a/main.py
+++ b/main.py
@@ -424,6 +424,17 @@ def prompt_worker(q, server_instance):
                 asset_seeder.resume()
 
 
+def suppress_proactor_connection_reset(loop, context):
+    # On Windows the proactor event loop tears down transports with
+    # socket.shutdown(), which raises WinError 10054 if the client (usually the
+    # frontend websocket) already disconnected abruptly. The connection is gone
+    # either way, so drop the error traceback instead of logging it after every
+    # generation. See https://github.com/Comfy-Org/ComfyUI/issues/15163
+    if isinstance(context.get("exception"), ConnectionResetError) and "_Proactor" in context.get("message", ""):
+        return
+    loop.default_exception_handler(context)
+
+
 async def run(server_instance, address='', port=8188, verbose=True, call_on_start=None):
     addresses = []
     for addr in address.split(","):
@@ -512,6 +523,8 @@ def start_comfyui(asyncio_loop=None):
     if not asyncio_loop:
         asyncio_loop = asyncio.new_event_loop()
         asyncio.set_event_loop(asyncio_loop)
+        if os.name == "nt":
+            asyncio_loop.set_exception_handler(suppress_proactor_connection_reset)
     prompt_server = server.PromptServer(asyncio_loop)
 
     if args.enable_manager and not args.disable_manager_ui:


### PR DESCRIPTION
On Windows, the proactor event loop tears down socket transports by calling `socket.shutdown()` inside `_ProactorBasePipeTransport._call_connection_lost`. When a client disconnects abruptly - typically the frontend closing its websocket right as a generation finishes - that call can fail with `WinError 10054`, and asyncio's default exception handler prints an `[ERROR]` traceback to the console:

```
[ERROR] Exception in callback _ProactorBasePipeTransport._call_connection_lost(None)
...
  File "...\asyncio\proactor_events.py", line 165, in _call_connection_lost
    self._sock.shutdown(socket.SHUT_RDWR)
ConnectionResetError: [WinError 10054]
```

The connection is already gone at that point, so there is nothing actionable; the generation completes and saves fine. CPython still ships the unguarded `shutdown()` call as of 3.14, and the same noise is well known in other asyncio servers (e.g. [uvicorn](https://github.com/Kludex/uvicorn/discussions/2105), [discord.py](https://github.com/Rapptz/discord.py/issues/2347)). It regularly alarms users into thinking their run failed.

This installs an exception handler on the asyncio loop (Windows only, and only for the loop ComfyUI creates itself) that drops `ConnectionResetError` raised from proactor transport internals, identified by the `_Proactor` callback name in the context message. Everything else - other exception types, and `ConnectionResetError` from tasks or non-proactor callbacks - is still passed to `loop.default_exception_handler`, so real errors keep their tracebacks.

Fixes #15163

## Verification

The reset-on-shutdown winsock state needs a real network peer, so I couldn't trigger it on loopback. Instead I drove the real teardown path on a `ProactorEventLoop`: a server transport whose socket raises `ConnectionResetError(10054)` from `shutdown()`, then `transport.close()`. Unpatched, this reproduces the exact traceback from the issue through `_call_connection_lost`. With the handler installed (extracted from this branch's `main.py`):

- the teardown noise is suppressed,
- a callback raising `RuntimeError` is still logged,
- a non-proactor `ConnectionResetError` is still logged.

`python -m py_compile main.py` and `ruff check main.py` pass.