### PR TITLE
Fix OFT/BOFT lora strength being applied twice

### DIFF
--- a/comfy/weight_adapter/boft.py
+++ b/comfy/weight_adapter/boft.py
@@ -126,7 +126,7 @@ class BOFTAdapter(WeightAdapterBase):
                     function,
                 )
             else:
-                weight += function((strength * lora_diff).type(weight.dtype))
+                weight += function(lora_diff.type(weight.dtype))
         except Exception as e:
             logging.error("ERROR {} {} {}".format(self.name, key, e))
         return weight

--- a/comfy/weight_adapter/oft.py
+++ b/comfy/weight_adapter/oft.py
@@ -232,7 +232,7 @@ class OFTAdapter(WeightAdapterBase):
             _, *shape = weight.shape
             lora_diff = torch.einsum(
                 "k n m, k n ... -> k m ...",
-                (r * strength) - strength * I_w,
+                r - I_w,
                 weight.view(block_num, block_size, *shape),
             ).view(-1, *shape)
             if dora_scale is not None:


### PR DESCRIPTION
## Problem

When an OFT or BOFT lora is applied through the weight patching path, the strength is applied twice, so the effect scales quadratically with the LoraLoader strength instead of linearly:

- `oft.py` builds `lora_diff` as `((r * strength) - strength * I) @ W`, i.e. `strength` is already baked in, and then adds `strength * lora_diff`, giving `strength^2 * (R - I) @ W`.
- `boft.py` interpolates every butterfly stage with `bi = bi * strength + (1 - strength) * I`, so `lora_diff` already contains the strength, and then multiplies the diff by `strength` again.

Concretely: strength 0.5 applies 25% of the trained rotation, 2.0 applies 4x, and for OFT a negative strength behaves exactly like the positive one (`(-s)^2 == s^2`). Only strength 1.0 behaves correctly, which is why this is easy to miss.

The cause is a convention mismatch: the einsum/loop were ported from LyCORIS `make_weight(scale)`, where the multiplier is baked into the returned weight and `get_merged_weight()` never scales it again, while ComfyUI adapters build an unscaled `lora_diff` and apply `strength` once at the end (like lora/loha/lokr).

## Fix

One line in each file so strength is applied exactly once:

- `oft.py`: build the unscaled diff `(r - I_w) @ W` and keep the final `strength * lora_diff`. For a single rotation `W + s*(R-I)@W == (s*R + (1-s)*I) @ W`, so this matches LyCORIS at every strength. It also passes `weight_decompose()` the unscaled diff it expects (it applies strength itself), fixing the same double-scaling in the DoRA branch.
- `boft.py`: keep the per-stage interpolation (the LyCORIS semantic for partial strength) and drop the extra `strength *` on the final diff.

Both merge paths now also agree with the bypass implementations (`g()`) in the same files, which apply the multiplier once. Behavior at strength 1.0 is bit-identical, so existing workflows at default strength are unaffected.

## Testing

- `python -m py_compile` and `ruff check` pass on both files.
- Verified the algebra with a small dependency-free numeric check of the three formulas (current, fixed, LyCORIS `make_weight`): the fixed path matches the reference at strengths 0, 0.25, 0.5, 1, -1 and 2, the current path only at 0 and 1, and current OFT produces identical weights for strength -1 and +1.
- I don't have a torch environment on this machine, so I could not run an end-to-end sampling test; the change is a pure algebra fix that only affects strength != 1.

Related: #15093 fixes an independent constraint-scaling issue in these files and does not touch strength handling.