### PR TITLE
Log a warning when the torch build has no aotriton.images

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -493,7 +493,12 @@ try:
         def aotriton_supported(gpu_arch):
             path = torch.__path__[0]
             path = os.path.join(os.path.join(path, "lib"), "aotriton.images")
-            gfx = set(map(lambda a: a[4:], filter(lambda a: a.startswith("amd-gfx"), os.listdir(path))))
+            try:
+                aotriton_files = os.listdir(path)
+            except FileNotFoundError:
+                logging.warning("No aotriton.images in this torch build, pytorch attention will not be auto enabled: {}".format(path))
+                return False
+            gfx = set(map(lambda a: a[4:], filter(lambda a: a.startswith("amd-gfx"), aotriton_files)))
             if gpu_arch in gfx:
                 return True
             if "{}x".format(gpu_arch[:-1]) in gfx:


### PR DESCRIPTION
Related to #15585 and #15586 (independent of both; either merges alone).

`aotriton_supported()` lists `torch/lib/aotriton.images` to decide whether to auto enable pytorch attention on AMD. Some torch builds ship without that directory. The 2.12.0+rocm7.14.0 wheel from repo.amd.com has `libaotriton_v2.so.0.11.2` in `torch/lib/` but no kernel images. On such a build `os.listdir` raises `FileNotFoundError`, the broad `try:` around the AMD setup block swallows it, and `ENABLE_PYTORCH_ATTENTION` plus the fp8 ops detection below it are skipped with nothing in the log.

The user visible result is that pytorch attention quietly stops being an auto backend and the memory estimator switches to its conservative formula, which on a 16 GB card can mean a forced partial load and heavy PCIe streaming (measured in #15585). Nothing points at the wheel as the cause.

This catches the missing directory, logs one warning naming the path it looked in, and returns False explicitly. There is no behavior change beyond the log line.

Tested on gfx1101 with the affected wheel: startup now prints the warning and continues exactly as before. `ruff check` passes.