### PR TITLE
fix(sam3): use standard noqa directive and organize imports in detector

### DIFF
--- a/comfy/ldm/sam3/detector.py
+++ b/comfy/ldm/sam3/detector.py
@@ -9,11 +9,11 @@ from torchvision.ops import roi_align
 
 from comfy.ldm.modules.attention import optimized_attention
 from comfy.ldm.sam3.tracker import SAM3Tracker, SAM31Tracker
-from comfy.ldm.sam3.sam import SAM3VisionBackbone  # noqa: used in __init__
+from comfy.ldm.sam3.sam import SAM3VisionBackbone  # noqa: F401
 from comfy.ldm.sam3.sam import MLP, PositionEmbeddingSine
+from comfy.ops import cast_to_input
 
 TRACKER_CLASSES = {"SAM3": SAM3Tracker, "SAM31": SAM31Tracker}
-from comfy.ops import cast_to_input
 
 
 def box_cxcywh_to_xyxy(x):


### PR DESCRIPTION
### Summary
- Fixes invalid `# noqa: used in __init__` directive in `comfy/ldm/sam3/detector.py` to standard `# noqa: F401`.
- Places `from comfy.ops import cast_to_input` at top-level import block.

### Validation
- `ruff check comfy/ comfy_extras/` -> All checks passed without warnings.