### PR TITLE
fix: respect --cuda-device argument to prevent multi-GPU crash (closes #15255)

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -143,7 +143,23 @@ except:
     npu_available = False
 
 try:
-    import torch_mlu  # noqa: F401
+    import torch_mlu  # noqa: F
+    _ = torch.mlu.device_count()
+    mlu_available = torch.mlu.is_available()
+except:
+    mlu_available = False
+
+# Set the default CUDA device based on the --cuda-device argument
+if torch.cuda.is_available():
+    cuda_device = getattr(args, 'cuda_device', None)
+    if cuda_device is not None and isinstance(cuda_device, int):
+        if 0 <= cuda_device < torch.cuda.device_count():
+            torch.cuda.set_device(cuda_device)
+        else:
+            logging.warning(f"CUDA device {cuda_device} is out of range, using default device 0")
+    else:
+        # Default to device 0 if not specified
+        torch.cuda.set_device(0)401
     _ = torch.mlu.device_count()
     mlu_available = torch.mlu.is_available()
 except:


### PR DESCRIPTION
## What
In multi-GPU systems, the dynamic VRAM streaming can crash with a CUDA OOM error due to improper GPU selection. The mod note indicates that using `--cuda-device 0` (or a higher number) resolves the issue, but the code does not automatically honor this argument when setting the default CUDA device.

## Fix
Added code to read the `args.cuda_device` configuration and call `torch.cuda.set_device()` accordingly. This ensures that pinned memory operations and model staging target the correct GPU, preventing the HostBuffer.read_file_slice failure that leads to the crash.

Closes #15255