### PR TITLE
Disable MIOpen on RDNA1/RDNA2 to fix fp16 conv segfaults

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -475,13 +475,16 @@ except:
 SUPPORT_FP8_OPS = args.supports_fp8_compute
 
 AMD_RDNA2_AND_OLDER_ARCH = ["gfx1030", "gfx1031", "gfx1035", "gfx1010", "gfx1011", "gfx1012", "gfx906", "gfx900", "gfx803"]
+# MIOpen fp16 conv kernels segfault on RDNA1/RDNA2 (e.g. gfx1030 with ROCm 6.x), so
+# keep MIOpen only on the oldest GCN/Vega archs where it was the previous default.
+AMD_MIOPEN_KEEP_ENABLED_ARCH = ("gfx906", "gfx900", "gfx803")
 AMD_ENABLE_MIOPEN_ENV = 'COMFYUI_ENABLE_MIOPEN'
 
 try:
     if is_amd():
         arch = torch.cuda.get_device_properties(get_torch_device()).gcnArchName.split(':')[0]
-        if not (any((a in arch) for a in AMD_RDNA2_AND_OLDER_ARCH)):
-            if os.getenv(AMD_ENABLE_MIOPEN_ENV) != '1':
+        if os.getenv(AMD_ENABLE_MIOPEN_ENV) != '1':
+            if not any(a in arch for a in AMD_MIOPEN_KEEP_ENABLED_ARCH):
                 torch.backends.cudnn.enabled = False  # Seems to improve things a lot on AMD
                 logging.info("Set: torch.backends.cudnn.enabled = False for better AMD performance.")
 


### PR DESCRIPTION
## Problem

On AMD RDNA1/RDNA2 GPUs (reproduced on RX 6900 XT / gfx1030) with torch 2.6.0+rocm6.1, MIOpen fp16 conv kernels segfault the process. Reproduced with the MiniMax Music 3 workflow: the flow-diffusion model crashed on the first sampling step inside a `Conv1d` forward (`Fatal Python error: Segmentation fault`). Minimal repro: a single fp16 `F.conv1d` on the GPU segfaults; the same convs pass with MIOpen disabled.

## Change

`torch.backends.cudnn.enabled = False` (which disables MIOpen on ROCm builds) is currently only applied when the arch is NOT in `AMD_RDNA2_AND_OLDER_ARCH`, i.e. RDNA1/RDNA2/older kept MIOpen enabled. This keeps MIOpen enabled only on the oldest GCN/Vega archs (`gfx906`, `gfx900`, `gfx803`), so RDNA1/RDNA2 (`gfx101x`/`gfx103x`) get the same stable native-conv path as newer cards. The existing `COMFYUI_ENABLE_MIOPEN=1` env var still opts back in.

## Tests

- Minimal repro on gfx1030: fp16 `conv1d` (k=1 and k=7/dilation=3) and `conv_transpose1d` all segfault with MIOpen; all pass with `torch.backends.cudnn.enabled = False`.
- Full MiniMax Music 3 job (126 AR tokens + 30 flow-diffusion steps) completed and saved a valid MP3 with this change; previously it segfaulted at step 0/30.