### PR TITLE
fix(model_detection): guard state_dict key access and support quantized tensor shapes for MiniMax H3

### DIFF
--- a/comfy/model_detection.py
+++ b/comfy/model_detection.py
@@ -378,7 +378,10 @@ def detect_unet_config(state_dict, key_prefix, metadata=None):
         qkv = state_dict['{}blocks.0.attn.qkv_proj.weight'.format(key_prefix)]
         dit_config["num_attention_heads"] = qkv.shape[0] // (3 * dit_config["attention_head_dim"])
         dit_config["ffn_hidden_size"] = state_dict['{}blocks.0.mlp.fc1.weight'.format(key_prefix)].shape[0] // 2
-        dit_config["text_dim"] = state_dict['{}condition_proj.weight'.format(key_prefix)].shape[1]
+        cond_key = '{}condition_proj.weight'.format(key_prefix)
+        if cond_key in state_dict_keys:
+            w = state_dict[cond_key]
+            dit_config["text_dim"] = getattr(w, "tensor_shape", w.shape)[1] if len(getattr(w, "tensor_shape", w.shape)) > 1 else w.shape[0]
         table_key = '{}adaln_t_table'.format(key_prefix)
         if table_key in state_dict_keys:
             # adaln shipped over a precomputed curve basis: the adaln linears span a small shared basis of the time-embedding curve (no time embedder)
@@ -386,11 +389,15 @@ def detect_unet_config(state_dict, key_prefix, metadata=None):
             dit_config["adaln_curve_grid"] = table[0]
             dit_config["time_embed_dim"] = table[1]
         else:
-            te = state_dict['{}time_embedder.proj_in.weight'.format(key_prefix)]
-            dit_config["timestep_input_dim"] = te.shape[1]
-            dit_config["time_embed_hidden_size"] = te.shape[0]
-            dit_config["time_embed_dim"] = state_dict['{}time_embedder.proj_out.weight'.format(key_prefix)].shape[0]
-        dit_config["rope_inv_freq_len"] = state_dict['{}rope.inv_freq'.format(key_prefix)].shape[0]
+            te_key = '{}time_embedder.proj_in.weight'.format(key_prefix)
+            if te_key in state_dict_keys:
+                te = state_dict[te_key]
+                dit_config["timestep_input_dim"] = getattr(te, "tensor_shape", te.shape)[1] if len(getattr(te, "tensor_shape", te.shape)) > 1 else te.shape[0]
+                dit_config["time_embed_hidden_size"] = te.shape[0]
+            if '{}time_embedder.proj_out.weight'.format(key_prefix) in state_dict_keys:
+                dit_config["time_embed_dim"] = state_dict['{}time_embedder.proj_out.weight'.format(key_prefix)].shape[0]
+        if '{}rope.inv_freq'.format(key_prefix) in state_dict_keys:
+            dit_config["rope_inv_freq_len"] = state_dict['{}rope.inv_freq'.format(key_prefix)].shape[0]
         if metadata is not None and "config" in metadata:
             dit_config.update(json.loads(metadata["config"]).get("transformer", {}))
         return dit_config

--- a/tests/test_minimax_h3.py
+++ b/tests/test_minimax_h3.py
@@ -1,60 +1,16 @@
-import os
 import unittest
 from unittest.mock import MagicMock
 
 import torch
 
-import comfy.ldm.minimax.model as m
-import comfy.ldm.minimax.audio_vae as avae
 import comfy.model_detection as md
 
 
-class TestMiniMaxH3Optimizations(unittest.TestCase):
-    def test_patchify_unpatchify_roundtrip(self):
-        latent = torch.randn(1, 24, 5, 16, 16)
-        patched = m.patchify_video(latent)
-        unpatched = m.unpatchify_video(patched, 5, 8, 8, 24)
-        self.assertTrue(torch.allclose(latent, unpatched))
-
-    def test_snake_activation(self):
-        x = torch.randn(2, 32, 100)
-        alpha = torch.randn(1, 32, 1)
-        beta = torch.randn(1, 32, 1).abs() + 0.1
-        out = avae.snake(x, alpha, beta)
-        self.assertEqual(out.shape, x.shape)
-
-    def test_model_forward_and_caching(self):
-        model = m.MiniMaxH3Model(
-            hidden_size=256,
-            num_layers=2,
-            num_attention_heads=4,
-            attention_head_dim=128,
-            ffn_hidden_size=512,
-            time_embed_hidden_size=256,
-            time_embed_dim=256,
-            operations=m.comfy.ops.manual_cast,
-        )
-        for p in model.parameters():
-            torch.nn.init.normal_(p, std=0.02)
-            p.requires_grad = False
-
-        x_video = torch.randn(1, 24, 2, 8, 8)
-        x_audio = torch.randn(1, 32, 2, 10)
-        context = torch.randn(1, 16, 256)
-        timestep = torch.tensor([500.0])
-
-        payload = {}
-        out1 = model([x_video, x_audio], timestep, context, minimax_payload=payload)
-        out2 = model([x_video, x_audio], timestep, context, minimax_payload=payload)
-
-        self.assertTrue(torch.allclose(out1[0], out2[0], atol=1e-5))
-        self.assertTrue(torch.allclose(out1[1], out2[1], atol=1e-5))
-
+class TestMiniMaxH3ModelDetection(unittest.TestCase):
     def test_quantized_model_detection(self):
-        # Mock NVFP4 4-bit packed linear weight (shape[1] is 768, tensor_shape[1] is 1536)
-        quant_weight = MagicMock()
-        quant_weight.shape = torch.Size([4608, 768])
-        quant_weight.tensor_shape = torch.Size([4608, 1536])
+        packed_condition_weight = MagicMock()
+        packed_condition_weight.shape = torch.Size([1536, 2048])
+        packed_condition_weight.tensor_shape = torch.Size([1536, 4096])
 
         state_dict = {
             "video_patch_proj.weight": torch.empty(1536, 96),
@@ -62,9 +18,9 @@ class TestMiniMaxH3Optimizations(unittest.TestCase):
             "final_layer.video_out.weight": torch.empty(96, 1536),
             "final_layer.audio_out.weight": torch.empty(64, 1536),
             "blocks.0.attn.q_norm.weight": torch.empty(128),
-            "blocks.0.attn.qkv_proj.weight": quant_weight,
+            "blocks.0.attn.qkv_proj.weight": torch.empty(4608, 768),
             "blocks.0.mlp.fc1.weight": torch.empty(8192, 1536),
-            "condition_proj.weight": torch.empty(1536, 4096),
+            "condition_proj.weight": packed_condition_weight,
             "time_embedder.proj_in.weight": torch.empty(512, 256),
             "time_embedder.proj_out.weight": torch.empty(512, 512),
             "rope.inv_freq": torch.empty(16),
@@ -74,22 +30,32 @@ class TestMiniMaxH3Optimizations(unittest.TestCase):
         self.assertEqual(config.get("image_model"), "minimax_h3")
         self.assertEqual(config.get("hidden_size"), 1536)
         self.assertEqual(config.get("text_dim"), 4096)
+        self.assertNotEqual(packed_condition_weight.shape[1], config["text_dim"])
 
-        # Test key-guarding when optional keys (condition_proj, time_embedder, rope) are omitted
-        minimal_state_dict = {
-            "video_patch_proj.weight": torch.empty(1536, 96),
-            "audio_patch_proj.weight": torch.empty(1536, 64),
-            "final_layer.video_out.weight": torch.empty(96, 1536),
-            "final_layer.audio_out.weight": torch.empty(64, 1536),
-            "blocks.0.attn.q_norm.weight": torch.empty(128),
-            "blocks.0.attn.qkv_proj.weight": quant_weight,
-            "blocks.0.mlp.fc1.weight": torch.empty(8192, 1536),
+        omission_cases = {
+            "condition_proj": (
+                ("condition_proj.weight",),
+                ("text_dim",),
+            ),
+            "time_embedder": (
+                ("time_embedder.proj_in.weight", "time_embedder.proj_out.weight"),
+                ("timestep_input_dim", "time_embed_hidden_size", "time_embed_dim"),
+            ),
+            "rope": (
+                ("rope.inv_freq",),
+                ("rope_inv_freq_len",),
+            ),
         }
-        config_min = md.detect_unet_config(minimal_state_dict, "")
-        self.assertIsNotNone(config_min)
-        self.assertEqual(config_min.get("image_model"), "minimax_h3")
-        self.assertEqual(config_min.get("hidden_size"), 1536)
-        self.assertIsNone(config_min.get("text_dim"))
+        for name, (missing_keys, missing_config) in omission_cases.items():
+            with self.subTest(name=name):
+                incomplete_state_dict = dict(state_dict)
+                for key in missing_keys:
+                    incomplete_state_dict.pop(key)
+                incomplete_config = md.detect_unet_config(incomplete_state_dict, "")
+                self.assertEqual(incomplete_config.get("image_model"), "minimax_h3")
+                self.assertEqual(incomplete_config.get("hidden_size"), 1536)
+                for key in missing_config:
+                    self.assertNotIn(key, incomplete_config)
 
 
 if __name__ == "__main__":

--- a/tests/test_minimax_h3.py
+++ b/tests/test_minimax_h3.py
@@ -6,6 +6,7 @@ import torch
 
 import comfy.ldm.minimax.model as m
 import comfy.ldm.minimax.audio_vae as avae
+import comfy.model_detection as md
 
 
 class TestMiniMaxH3Optimizations(unittest.TestCase):
@@ -43,22 +44,25 @@ class TestMiniMaxH3Optimizations(unittest.TestCase):
         timestep = torch.tensor([500.0])
 
         payload = {}
-        with torch.inference_mode():
-            out1 = model([x_video, x_audio], timestep, context, minimax_payload=payload)
-            out2 = model([x_video, x_audio], timestep, context, minimax_payload=payload)
+        out1 = model([x_video, x_audio], timestep, context, minimax_payload=payload)
+        out2 = model([x_video, x_audio], timestep, context, minimax_payload=payload)
 
         self.assertTrue(torch.allclose(out1[0], out2[0], atol=1e-5))
         self.assertTrue(torch.allclose(out1[1], out2[1], atol=1e-5))
 
     def test_quantized_model_detection(self):
-        import comfy.model_detection as md
+        # Mock NVFP4 4-bit packed linear weight (shape[1] is 768, tensor_shape[1] is 1536)
+        quant_weight = MagicMock()
+        quant_weight.shape = torch.Size([4608, 768])
+        quant_weight.tensor_shape = torch.Size([4608, 1536])
+
         state_dict = {
             "video_patch_proj.weight": torch.empty(1536, 96),
             "audio_patch_proj.weight": torch.empty(1536, 64),
             "final_layer.video_out.weight": torch.empty(96, 1536),
             "final_layer.audio_out.weight": torch.empty(64, 1536),
             "blocks.0.attn.q_norm.weight": torch.empty(128),
-            "blocks.0.attn.qkv_proj.weight": torch.empty(4608, 1536),
+            "blocks.0.attn.qkv_proj.weight": quant_weight,
             "blocks.0.mlp.fc1.weight": torch.empty(8192, 1536),
             "condition_proj.weight": torch.empty(1536, 4096),
             "time_embedder.proj_in.weight": torch.empty(512, 256),
@@ -70,6 +74,22 @@ class TestMiniMaxH3Optimizations(unittest.TestCase):
         self.assertEqual(config.get("image_model"), "minimax_h3")
         self.assertEqual(config.get("hidden_size"), 1536)
         self.assertEqual(config.get("text_dim"), 4096)
+
+        # Test key-guarding when optional keys (condition_proj, time_embedder, rope) are omitted
+        minimal_state_dict = {
+            "video_patch_proj.weight": torch.empty(1536, 96),
+            "audio_patch_proj.weight": torch.empty(1536, 64),
+            "final_layer.video_out.weight": torch.empty(96, 1536),
+            "final_layer.audio_out.weight": torch.empty(64, 1536),
+            "blocks.0.attn.q_norm.weight": torch.empty(128),
+            "blocks.0.attn.qkv_proj.weight": quant_weight,
+            "blocks.0.mlp.fc1.weight": torch.empty(8192, 1536),
+        }
+        config_min = md.detect_unet_config(minimal_state_dict, "")
+        self.assertIsNotNone(config_min)
+        self.assertEqual(config_min.get("image_model"), "minimax_h3")
+        self.assertEqual(config_min.get("hidden_size"), 1536)
+        self.assertIsNone(config_min.get("text_dim"))
 
 
 if __name__ == "__main__":

--- a/tests/test_minimax_h3.py
+++ b/tests/test_minimax_h3.py
@@ -37,6 +37,14 @@ class TestMiniMaxH3ModelDetection(unittest.TestCase):
                 ("condition_proj.weight",),
                 ("text_dim",),
             ),
+            "time_embedder_proj_in": (
+                ("time_embedder.proj_in.weight",),
+                ("timestep_input_dim", "time_embed_hidden_size"),
+            ),
+            "time_embedder_proj_out": (
+                ("time_embedder.proj_out.weight",),
+                ("time_embed_dim",),
+            ),
             "time_embedder": (
                 ("time_embedder.proj_in.weight", "time_embedder.proj_out.weight"),
                 ("timestep_input_dim", "time_embed_hidden_size", "time_embed_dim"),

--- a/tests/test_minimax_h3.py
+++ b/tests/test_minimax_h3.py
@@ -1,0 +1,76 @@
+import os
+import unittest
+from unittest.mock import MagicMock
+
+import torch
+
+import comfy.ldm.minimax.model as m
+import comfy.ldm.minimax.audio_vae as avae
+
+
+class TestMiniMaxH3Optimizations(unittest.TestCase):
+    def test_patchify_unpatchify_roundtrip(self):
+        latent = torch.randn(1, 24, 5, 16, 16)
+        patched = m.patchify_video(latent)
+        unpatched = m.unpatchify_video(patched, 5, 8, 8, 24)
+        self.assertTrue(torch.allclose(latent, unpatched))
+
+    def test_snake_activation(self):
+        x = torch.randn(2, 32, 100)
+        alpha = torch.randn(1, 32, 1)
+        beta = torch.randn(1, 32, 1).abs() + 0.1
+        out = avae.snake(x, alpha, beta)
+        self.assertEqual(out.shape, x.shape)
+
+    def test_model_forward_and_caching(self):
+        model = m.MiniMaxH3Model(
+            hidden_size=256,
+            num_layers=2,
+            num_attention_heads=4,
+            attention_head_dim=128,
+            ffn_hidden_size=512,
+            time_embed_hidden_size=256,
+            time_embed_dim=256,
+            operations=m.comfy.ops.manual_cast,
+        )
+        for p in model.parameters():
+            torch.nn.init.normal_(p, std=0.02)
+            p.requires_grad = False
+
+        x_video = torch.randn(1, 24, 2, 8, 8)
+        x_audio = torch.randn(1, 32, 2, 10)
+        context = torch.randn(1, 16, 256)
+        timestep = torch.tensor([500.0])
+
+        payload = {}
+        with torch.inference_mode():
+            out1 = model([x_video, x_audio], timestep, context, minimax_payload=payload)
+            out2 = model([x_video, x_audio], timestep, context, minimax_payload=payload)
+
+        self.assertTrue(torch.allclose(out1[0], out2[0], atol=1e-5))
+        self.assertTrue(torch.allclose(out1[1], out2[1], atol=1e-5))
+
+    def test_quantized_model_detection(self):
+        import comfy.model_detection as md
+        state_dict = {
+            "video_patch_proj.weight": torch.empty(1536, 96),
+            "audio_patch_proj.weight": torch.empty(1536, 64),
+            "final_layer.video_out.weight": torch.empty(96, 1536),
+            "final_layer.audio_out.weight": torch.empty(64, 1536),
+            "blocks.0.attn.q_norm.weight": torch.empty(128),
+            "blocks.0.attn.qkv_proj.weight": torch.empty(4608, 1536),
+            "blocks.0.mlp.fc1.weight": torch.empty(8192, 1536),
+            "condition_proj.weight": torch.empty(1536, 4096),
+            "time_embedder.proj_in.weight": torch.empty(512, 256),
+            "time_embedder.proj_out.weight": torch.empty(512, 512),
+            "rope.inv_freq": torch.empty(16),
+        }
+        config = md.detect_unet_config(state_dict, "")
+        self.assertIsNotNone(config)
+        self.assertEqual(config.get("image_model"), "minimax_h3")
+        self.assertEqual(config.get("hidden_size"), 1536)
+        self.assertEqual(config.get("text_dim"), 4096)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

- Guard optional state_dict key dereferences (condition_proj, time_embedder, rope.inv_freq)
- Use tensor_shape property for QuantizedTensor objects to prevent 4-bit packed shape[1] miscalculations
- Add unit test test_quantized_model_detection