### PR TITLE
Fix crash when Llama-based text encoder KV cache init runs on CPU

### DIFF
--- a/comfy/text_encoders/llama.py
+++ b/comfy/text_encoders/llama.py
@@ -791,7 +791,7 @@ class Llama2_(nn.Module):
 
     def init_kv_cache(self, batch, capacity, device, dtype):
         caches = []
-        fixed_kv = self.fixed_kv and comfy_kitchen.flash_attention_decode_is_available(device)
+        fixed_kv = self.fixed_kv and comfy.model_management.is_device_cuda(device) and comfy_kitchen.flash_attention_decode_is_available(device)
         for _ in range(self.config.num_hidden_layers):
             if fixed_kv:
                 key = torch.empty((batch, capacity, self.config.num_key_value_heads, self.config.head_dim), device=device, dtype=dtype)

--- a/tests-unit/comfy_test/test_llama_init_kv_cache.py
+++ b/tests-unit/comfy_test/test_llama_init_kv_cache.py
@@ -1,0 +1,39 @@
+"""Regression test for init_kv_cache crashing when the text encoder runs on CPU."""
+
+from __future__ import annotations
+
+import torch
+
+from comfy.cli_args import args
+
+if not torch.cuda.is_available():
+    args.cpu = True
+
+import comfy.ops as ops  # noqa: E402
+import comfy.text_encoders.llama as llama  # noqa: E402
+
+
+def _make_model():
+    config = llama.Llama2Config(
+        vocab_size=16, hidden_size=8, intermediate_size=8,
+        num_hidden_layers=1, num_attention_heads=2, num_key_value_heads=2,
+    )
+    config.head_dim = 4
+    config.fixed_kv = True
+    return llama.Llama2_(config, device="cpu", dtype=torch.float32, ops=ops.manual_cast)
+
+
+def test_init_kv_cache_on_cpu_does_not_probe_cuda_capability(monkeypatch):
+    def _raise_if_not_cuda(device):
+        if torch.device(device).type != "cuda":
+            raise ValueError(f"Expected a cuda device, but got: {device}")
+        return True
+
+    monkeypatch.setattr(
+        llama.comfy_kitchen, "flash_attention_decode_is_available", _raise_if_not_cuda
+    )
+
+    model = _make_model()
+    past = model.init_kv_cache(1, 4, torch.device("cpu"), torch.float32)
+
+    assert not isinstance(past[0], llama.FixedKV)


### PR DESCRIPTION
Fixes #15607

## Problem

`MiniMaxMusic3TextEncode` crashes with `ValueError: Expected a cuda device, but got: cpu` on GPUs where the MiniMax Music3 text encoder is offloaded to CPU (e.g. a 6GB GTX 1660 SUPER, per the issue report).

`Llama2_.init_kv_cache` (comfy/text_encoders/llama.py) unconditionally calls `comfy_kitchen.flash_attention_decode_is_available(device)`, which internally calls `torch.cuda.get_device_capability(device)`. When `torch.cuda.is_available()` is `True` (a CUDA-capable machine) but the *execution device* for this particular model is CPU (because ComfyUI offloaded the text encoder there), that call raises, since `get_device_capability` requires an actual CUDA device.

## Fix

Guard the flash-attention-decode capability probe with `comfy.model_management.is_device_cuda(device)` before calling into `comfy_kitchen`, so it's only checked when the execution device is actually CUDA. This mirrors the existing `cuda_device = torch.device(device).type == "cuda"` guard already used a few lines away in `comfy/ldm/minimax_music/ar.py` for the same device.

## Test plan

Added `tests-unit/comfy_test/test_llama_init_kv_cache.py`, which builds a minimal `Llama2_` model and calls `init_kv_cache` with a CPU device while `comfy_kitchen.flash_attention_decode_is_available` is monkeypatched to raise `ValueError("Expected a cuda device, but got: cpu")` for non-CUDA devices (mirroring the real reported crash).

- Confirmed the test **fails** against the unmodified code (`git checkout HEAD~1 -- comfy/text_encoders/llama.py`) with the exact `ValueError` from the issue's traceback.
- Confirmed the test **passes** with the fix applied.

```
tests-unit/comfy_test/test_llama_init_kv_cache.py::test_init_kv_cache_on_cpu_does_not_probe_cuda_capability PASSED
```

Also ran:
- `ruff check comfy/text_encoders/llama.py tests-unit/comfy_test/test_llama_init_kv_cache.py` → all checks passed.
- `pytest tests-unit/comfy_test tests-unit/comfy_quant` → 93 passed.
- Full `pytest tests-unit` → 1187 passed, 10 skipped; the remaining 58 errors are pre-existing missing-plugin issues in this environment (e.g. `aiohttp_client` fixture not registered) unrelated to this change, reproducible identically on unmodified `master`.

## AI assistance disclosure

This change was authored with AI assistance (an autonomous Claude-based coding agent), including the diagnosis, fix, and test. It was verified locally per the test plan above before submission.
