### PR TITLE
Fix: Verify aotriton kernels actually launch before enabling pytorch attention

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -495,19 +495,31 @@ try:
 
             can_use_flash_attention() evaluates runtime eligibility for the given
             parameters; on a ROCm build that includes checking the gpu arch against the
-            kernel images AOTriton was compiled for. Querying it avoids assuming where
-            those images live inside the torch install. The probe tensor is shaped and
+            arches AOTriton was built for. Querying it avoids assuming where the kernel
+            images live inside the torch install. The probe tensor is shaped and
             typed to pass the unrelated SDPA checks, so False means no hardware support
             rather than a rejected shape.
+
+            It answers True on a supported arch whose kernel image was never shipped,
+            and that only fails at launch, without raising. So run one attention
+            through the flash backend and force the pending error check.
             """
             try:
+                device = get_torch_device()
                 if not torch.backends.cuda.is_flash_attention_available():  # not built with flash attention
                     return False
-                q = torch.empty((1, 1, 8, 64), dtype=torch.float16, device=get_torch_device())
+                q = torch.zeros((1, 1, 8, 64), dtype=torch.float16, device=device)
                 params = torch.backends.cuda.SDPAParams(q, q, q, None, 0.0, False, False)
-                return torch.backends.cuda.can_use_flash_attention(params, False)
-            except (AttributeError, RuntimeError, TypeError) as e:
-                logging.warning("Could not query aotriton support: {}".format(e))
+                if not torch.backends.cuda.can_use_flash_attention(params, False):
+                    return False
+                from torch.nn.attention import SDPBackend, sdpa_kernel
+                with sdpa_kernel(SDPBackend.FLASH_ATTENTION):
+                    torch.nn.functional.scaled_dot_product_attention(q, q, q)
+                torch.cuda.synchronize()
+                torch.zeros(1, device=device).add_(1).item()  # raises if the launch above failed
+                return True
+            except Exception as e:
+                logging.warning("Could not run flash attention, disabling it: {}".format(e))
                 return False
 
         logging.info("AMD arch: {}".format(arch))


### PR DESCRIPTION
Fixes https://github.com/Comfy-Org/ComfyUI/issues/15647 and https://github.com/Comfy-Org/ComfyUI/issues/15653.

`can_use_flash_attention()` checks whether the flash backend accepts the given parameters, but not whether the build contains kernel images for the target architecture. After AOTriton's experimental gate, it can return `True` even when no compatible images are available. This causes `ENABLE_PYTORCH_ATTENTION` to be enabled on builds where flash attention cannot run, leading to `hipErrorInvalidValue` on the first attention call.

The error can remain pending until a later launch, causing the traceback to point to an unrelated operation such as `torch.cat`.

After the eligibility check passes, run a flash-attention operation and then force a throwaway launch to surface any pending error. Builds with working kernels are unaffected, while builds without compatible kernels fall back to the alternative attention path at startup.

This preserves 2220d111's approach of not assuming where kernel images are located. A directory listing is unnecessary because the probe also detects cases where the images directory exists but does not contain images for the target architecture.

Verified on gfx1200, ROCm 7.15, torch 2.14, including a build with `aotriton.images` removed. The probe correctly keeps `ENABLE_PYTORCH_ATTENTION` disabled when kernels are unavailable and enabled when they are present.

FP8 detection remains unaffected.