### PR TITLE
ci: only dispatch ComfyUI tag to cloud from the public repo

### DIFF
--- a/.github/workflows/tag-dispatch-cloud.yml
+++ b/.github/workflows/tag-dispatch-cloud.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   dispatch-cloud:
     runs-on: ubuntu-latest
+    if: github.repository == 'Comfy-Org/ComfyUI'
     steps:
       - name: Send repository dispatch to cloud
         env:


### PR DESCRIPTION
## Summary

Guard the `dispatch-cloud` job in `.github/workflows/tag-dispatch-cloud.yml` so it only runs in the public `Comfy-Org/ComfyUI` repository.

## Why

`Comfy-Org/ComfyUI-private` is a locked mirror of this repo. Its tag-sync force-mirrors all upstream tags (`+refs/tags/*:refs/tags/*`), and because this workflow file is upstream content it is mirrored into private as well. On every mirrored `v*` tag push it fires there too — a latent double-fire of the cloud ComfyUI version bump (it currently only fails because private lacks the dispatch secret).

Adding `if: github.repository == 'Comfy-Org/ComfyUI'` makes the mirrored copy a no-op: the job is skipped (not failed) in private, so the public repo owns the tag -> cloud-bump exactly once.

## Change

One line added to the `dispatch-cloud` job:

```yaml
jobs:
  dispatch-cloud:
    runs-on: ubuntu-latest
    if: github.repository == 'Comfy-Org/ComfyUI'
    steps:
      ...
```

No other changes.