### PR TITLE
Restore friendly errors for corrupt safetensors files on safetensors 0.6+

### DIFF
--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -142,9 +142,12 @@ def load_torch_file(ckpt, safe_load=False, device=None, return_metadata=False):
         except Exception as e:
             if len(e.args) > 0:
                 message = e.args[0]
-                if "HeaderTooLarge" in message:
+                # safetensors < 0.6 rendered these as the Rust enum variant name
+                # ("HeaderTooLarge"), 0.6+ renders them as prose ("header too large").
+                # requirements.txt allows >=0.4.2, so match both spellings.
+                if "HeaderTooLarge" in message or "header too large" in message:
                     raise ValueError("{}\n\nFile path: {}\n\nThe safetensors file is corrupt or invalid. Make sure this is actually a safetensors file and not a ckpt or pt or other filetype.".format(message, ckpt))
-                if "MetadataIncompleteBuffer" in message:
+                if "MetadataIncompleteBuffer" in message or "file not fully covered" in message:
                     raise ValueError("{}\n\nFile path: {}\n\nThe safetensors file is corrupt/incomplete. Check the file size and make sure you have copied/downloaded it correctly.".format(message, ckpt))
             raise e
     else:

--- a/tests-unit/comfy_test/load_torch_file_errors_test.py
+++ b/tests-unit/comfy_test/load_torch_file_errors_test.py
@@ -1,0 +1,47 @@
+import struct
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+import comfy.memory_management
+import comfy.utils
+
+
+@pytest.fixture(autouse=True)
+def use_safetensors_reader(monkeypatch):
+    # Pin the plain safetensors reader so these tests exercise the safetensors
+    # error messages rather than the aimdo mmap parser.
+    monkeypatch.setattr(comfy.memory_management, "aimdo_enabled", False)
+
+
+def write_valid_file(path):
+    save_file({"weight": torch.zeros(4)}, str(path))
+    return path
+
+
+def test_bogus_header_reports_wrong_filetype(tmp_path):
+    # Declares a header far larger than the file: what you get when a ckpt/pt
+    # file (or an HTML error page) is renamed to .safetensors.
+    path = tmp_path / "bogus_header.safetensors"
+    path.write_bytes(struct.pack("<Q", 1 << 40) + b"{}")
+
+    with pytest.raises(ValueError, match="not a ckpt or pt or other filetype"):
+        comfy.utils.load_torch_file(str(path))
+
+
+def test_truncated_file_reports_incomplete_download(tmp_path):
+    good = write_valid_file(tmp_path / "good.safetensors")
+    truncated = tmp_path / "truncated.safetensors"
+    truncated.write_bytes(good.read_bytes()[:-4])
+
+    with pytest.raises(ValueError, match="corrupt/incomplete"):
+        comfy.utils.load_torch_file(str(truncated))
+
+
+def test_valid_file_still_loads(tmp_path):
+    path = write_valid_file(tmp_path / "good.safetensors")
+
+    sd = comfy.utils.load_torch_file(str(path))
+
+    assert list(sd.keys()) == ["weight"]


### PR DESCRIPTION
## Problem

`load_torch_file` translates two safetensors corruption signatures into friendly errors, but
safetensors changed how it renders them in 0.6 — from the Rust enum variant name to prose:

| safetensors | message |
|---|---|
| 0.5.3 | `Error while deserializing header: HeaderTooLarge` |
| 0.6.1+ / 0.8.0 | `Error while deserializing header: header too large` |

The checks still match only `"HeaderTooLarge"` / `"MetadataIncompleteBuffer"`, so on any modern
install **both friendly messages are dead code**. A user with a truncated download or a `.ckpt`
renamed to `.safetensors` gets the raw `SafetensorError` instead of the message telling them
what actually went wrong.

## Fix

Match the new prose spellings alongside the old enum names. The old ones are kept because
`requirements.txt` allows `safetensors>=0.4.2`; verified working on both 0.5.3 and 0.8.0.

## Test plan

Adds `tests-unit/comfy_test/load_torch_file_errors_test.py`, which writes genuinely corrupt
safetensors files (bogus header length; truncated valid file) rather than monkeypatching the
exception — so it keeps validating against the real installed safetensors, and fails if the
wording changes again. A third test asserts valid files still load.

Before this change: 2 failed, 1 passed. After: 3 passed.
Full `tests-unit`: 1251 passed, 17 skipped (1 unrelated pre-existing Windows path failure,
reproducible on unmodified master). `ruff check .` clean.

Fixes the second half of #15602.

Note: #15459 adds a *different* pattern (`is invalid for input of size`) to this same `except`
block for the aimdo mmap path. The two are complementary — that PR's description assumes these
two existing patterns still fire, which is what this PR restores. Happy to rebase if it lands first.
