### PR TITLE
Fix BiRefNet background removal crash in fp16 and bf16

### DIFF
--- a/comfy/background_removal/birefnet.py
+++ b/comfy/background_removal/birefnet.py
@@ -258,7 +258,7 @@ class BasicLayer(nn.Module):
     def forward(self, x, H, W):
         Hp = int(np.ceil(H / self.window_size)) * self.window_size
         Wp = int(np.ceil(W / self.window_size)) * self.window_size
-        img_mask = torch.zeros((1, Hp, Wp, 1), device=x.device)  # 1 Hp Wp 1
+        img_mask = torch.zeros((1, Hp, Wp, 1), device=x.device, dtype=x.dtype)  # 1 Hp Wp 1
         h_slices = (slice(0, -self.window_size),
                     slice(-self.window_size, -self.shift_size),
                     slice(-self.shift_size, None))

--- a/tests-unit/comfy_test/test_birefnet_dtype.py
+++ b/tests-unit/comfy_test/test_birefnet_dtype.py
@@ -1,0 +1,41 @@
+from functools import partial
+
+import pytest
+import torch
+
+from comfy.cli_args import args as cli_args
+
+if not torch.cuda.is_available():
+    cli_args.cpu = True
+
+import comfy.ops
+from comfy.background_removal.birefnet import BasicLayer
+
+
+def _basic_layer(dtype, window_size=4):
+    # Mirrors how SwinTransformer builds its stages: a depth of 2 gives one
+    # regular block and one shifted block, and the shifted one is the only
+    # consumer of the attention mask built in BasicLayer.forward.
+    return BasicLayer(
+        dim=32,
+        depth=2,
+        num_heads=4,
+        window_size=window_size,
+        norm_layer=partial(comfy.ops.manual_cast.LayerNorm, device="cpu", dtype=dtype),
+        device="cpu",
+        dtype=dtype,
+        operations=comfy.ops.manual_cast,
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_birefnet_shifted_window_attention_keeps_compute_dtype(dtype):
+    # A resolution that is not a multiple of the window size forces the padded,
+    # shifted-window path where the attention mask is applied.
+    layer = _basic_layer(dtype)
+    height = width = 6
+    x = torch.randn(1, height * width, 32, dtype=dtype)
+
+    out = layer(x, height, width)[0]
+
+    assert out.dtype == dtype


### PR DESCRIPTION
Fixes #15571

## Problem

`RemoveBackground` with a BiRefNet model crashes whenever the backbone runs in a
half-precision compute dtype:

```
File "comfy/background_removal/birefnet.py", line 119, in forward
    x = (attn @ v).transpose(1, 2).reshape(B_, N, C)
RuntimeError: expected scalar type Float but found Half
```

`BasicLayer.forward` builds the shifted-window attention mask with
`torch.zeros((1, Hp, Wp, 1), device=x.device)` and no dtype, so `img_mask` and the
derived `attn_mask` are always fp32. In `WindowAttention.forward`, `attn + mask`
then promotes `attn` from the compute dtype to fp32 while `v` stays in the compute
dtype, and the following matmul rejects the mixed operands.

## Fix

Build the mask in `x.dtype` so it matches the attention compute dtype.

This mirrors how #14217 fixed `relative_position_bias` with `cast_to_input` three
lines above in the same forward — that commit covered the parameter but not the
mask — and matches the equivalent cast in the upstream BiRefNet
[`swin_v1.py`](https://github.com/ZhengPeng7/BiRefNet/blob/main/models/backbones/swin_v1.py).

The mask only holds small region ids (0-8), their differences, and the `-100.0`/`0.0`
fill values, all exactly representable in fp16 and bf16, so the fp32 path is
numerically unchanged.

## Testing

`tests-unit/comfy_test/test_birefnet_dtype.py` runs a `BasicLayer` through the
padded, shifted-window path at fp32, fp16 and bf16. On master the fp16 and bf16
cases fail at `birefnet.py:119` with the reported error; with this change all three
pass. The test is CPU-only and runs in a few seconds.

Full `tests-unit` passes and `ruff check .` is clean.

## Note on #15582

PR #15582 proposed the same one-line change on 13 Aug and was closed by its author
the next day, without any maintainer review comment explaining why — so I could not
tell whether there was an objection to the approach. I verified independently that
the defect is still present on current `master` and that no other open PR touches
this file. Credit to @alooshxl for spotting it first; this PR adds the regression
test that one did not have. Happy to close in favour of a reopened #15582 if that is
preferred.
