### PR TITLE
Warn when a prompt supplies node inputs that match no declared input

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -895,6 +895,10 @@ async def validate_inputs(prompt_id, prompt, item, validated, visiting=None):
 
     valid_inputs = set(class_inputs.get('required',{})).union(set(class_inputs.get('optional',{})))
 
+    unknown_inputs = set(inputs) - valid_inputs
+    if unknown_inputs:
+        logging.warning(f"Node {unique_id} ({class_type}): ignoring unknown input(s) {', '.join(sorted(unknown_inputs))}")
+
     for x in valid_inputs:
         input_type, input_category, extra_info = get_input_info(obj_class, x, class_inputs)
         assert extra_info is not None

--- a/tests-unit/execution_test/validate_inputs_unknown_test.py
+++ b/tests-unit/execution_test/validate_inputs_unknown_test.py
@@ -36,4 +36,8 @@ def test_unknown_input_is_warned_and_ignored(monkeypatch, caplog):
 
     assert valid
     assert errors == []
-    assert any("ref_audios" in record.message for record in caplog.records)
+    assert any(
+        "Node 1 (StubNodeForUnknownInputTest)" in record.message
+        and "ref_audios" in record.message
+        for record in caplog.records
+    )

--- a/tests-unit/execution_test/validate_inputs_unknown_test.py
+++ b/tests-unit/execution_test/validate_inputs_unknown_test.py
@@ -1,0 +1,39 @@
+import asyncio
+import logging
+
+from comfy.cli_args import args as cli_args
+
+cli_args.cpu = True
+
+import nodes  # noqa: E402
+import execution  # noqa: E402
+
+
+class StubNodeForUnknownInputTest:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {"a": ("INT", {})}}
+
+    RETURN_TYPES = ()
+    FUNCTION = "go"
+    CATEGORY = "test"
+
+    def go(self, a):
+        return ()
+
+
+def test_unknown_input_is_warned_and_ignored(monkeypatch, caplog):
+    monkeypatch.setitem(nodes.NODE_CLASS_MAPPINGS, "StubNodeForUnknownInputTest", StubNodeForUnknownInputTest)
+    prompt = {
+        "1": {
+            "class_type": "StubNodeForUnknownInputTest",
+            "inputs": {"a": 1, "ref_audios": {"ref_audio_0": ["2", 0]}},
+        }
+    }
+
+    with caplog.at_level(logging.WARNING):
+        valid, errors, node_id = asyncio.run(execution.validate_inputs("test-prompt", prompt, "1", {}))
+
+    assert valid
+    assert errors == []
+    assert any("ref_audios" in record.message for record in caplog.records)


### PR DESCRIPTION
Fixes #15669

### Problem

`validate_inputs()` in `execution.py` iterates only over a node's *declared*
inputs. Keys present in the prompt's `inputs` dict that match no declared
required or optional input (a typo, a stale key after a node's inputs were
renamed, or a nested key used where the flat/dotted form is expected) are
silently dropped: no server log line, no validation error, no history
record. The prompt validates, the job runs, and the result is simply the
unconditioned one.

### Fix

After `valid_inputs` is computed, diff the received input keys against it
and log a warning naming the node and the ignored key(s). This is a warning,
not an error, so prompts carrying harmless extra keys keep working exactly
as before — only the silence changes.

```
Node 6 (MiniMaxH3ReferenceToVideo): ignoring unknown input(s) ref_audios
```

### Test plan

Added `tests-unit/execution_test/validate_inputs_unknown_test.py`, which
registers a stub node with a single declared input, calls
`execution.validate_inputs()` with an extra unrecognized key, and asserts
validation still succeeds while a warning naming the unknown key is logged.

Confirmed the new test fails without the fix (via
`git checkout HEAD~1 -- execution.py`) and passes with it:

```
$ python -m pytest tests-unit/execution_test/validate_inputs_unknown_test.py -v
tests-unit/execution_test/validate_inputs_unknown_test.py::test_unknown_input_is_warned_and_ignored PASSED
1 passed in 5.09s
```

Ran the full `tests-unit` suite (with `tests-unit/requirements.txt`
installed): 1220 passed, 10 skipped. `tests-unit/execution_test/preview_method_override_test.py`
fails to collect in this sandbox both before and after this change — it
imports `comfy.model_management` at module scope, which probes
`torch.cuda.current_device()` without `--cpu` being set, and this sandbox
has no CUDA. Unrelated to this change.

`ruff check execution.py tests-unit/execution_test/validate_inputs_unknown_test.py` passes.

This change and its test were written with AI assistance (Claude Code).
