### PR TITLE
test: cover Gemma4 channel-aware close marker decoding

### DIFF
--- a/tests-unit/comfy_test/gemma4_decode_test.py
+++ b/tests-unit/comfy_test/gemma4_decode_test.py
@@ -1,0 +1,52 @@
+"""Gemma4 channel-marker decode regression tests."""
+
+import torch
+
+from comfy.cli_args import args
+
+if not torch.cuda.is_available():
+    args.cpu = True
+
+from comfy.text_encoders.gemma4 import Gemma4SDTokenizer  # noqa: E402
+
+
+class _CannedTokenizer:
+    """Stands in for the wrapped tokenizer so decode is checked without model files."""
+    def __init__(self, text):
+        self.text = text
+
+    def decode(self, token_ids, skip_special_tokens=False):
+        return self.text
+
+
+def decode(text):
+    tokenizer = Gemma4SDTokenizer.__new__(Gemma4SDTokenizer)
+    tokenizer.tokenizer = _CannedTokenizer(text)
+    return tokenizer.decode([])
+
+
+def test_thought_channel_becomes_think_tags():
+    assert decode("<|channel>thought\nreasoning<channel|>the answer") == "<think>\nreasoning</think>the answer"
+
+
+def test_primed_empty_thought_channel_closes_immediately():
+    assert decode("<|channel>thought\n<channel|>the answer") == "<think>\n</think>the answer"
+
+
+def test_thought_channel_left_unclosed_still_opens():
+    assert decode("<|channel>thought\nreasoning") == "<think>\nreasoning"
+
+
+def test_close_of_a_non_thought_channel_is_not_reasoning():
+    # Non-thinking LTX2 prompt enhancement primes a "final" channel in the prompt, so only its
+    # close is generated. Reading that close as </think> made the whole answer look like
+    # reasoning and the node returned an empty string.
+    assert decode("the answer<channel|>") == "the answer"
+
+
+def test_thought_close_does_not_consume_a_later_channel():
+    assert decode("<|channel>thought\nreasoning<channel|><|channel>final\nthe answer<channel|>") == "<think>\nreasoning</think>the answer"
+
+
+def test_turn_and_eos_markers_are_stripped():
+    assert decode("<|turn>model\nthe answer<turn|><eos>") == "the answer"


### PR DESCRIPTION
Adds decode-side coverage for the channel-marker handling fixed in #15611, which merged without tests.

`Gemma4SDTokenizer.decode` translates channel markers into `<think>`/`</think>`. Before #15611 the close was translated unconditionally, so a `<channel|>` that closed a *primed* channel became a `</think>` with no opener. `TextGenerateLTX2Prompt` primes `<|channel>final\n` in non-thinking mode, and since only new tokens are decoded the opener is never present — the node's parse then read the entire answer as reasoning and returned an empty string, which fed empty conditioning to `CLIPTextEncode`.

`gemma4_template_test.py` already covers the tokenize side; this is the matching decode side. The load-bearing case is `test_close_of_a_non_thought_channel_is_not_reasoning`.

Tests only — no source changes.

Verified against `master`: 22 passed with `gemma4_template_test.py`. Reverting `decode` to its pre-#15611 form fails 3 of the 6, so they hold the fix in place rather than restating it.
