### PR TITLE
Forward node class attributes into schema for dataset nodes

### DIFF
--- a/comfy_extras/nodes_dataset.py
+++ b/comfy_extras/nodes_dataset.py
@@ -692,6 +692,7 @@ class ImageProcessingNode(io.ComfyNode):
             category=cls.category,
             description=cls.description,
             is_experimental=True,
+            is_deprecated=cls.is_deprecated,
             is_input_list=is_group,  # True for group, False for individual
             inputs=inputs,
             outputs=[
@@ -861,9 +862,12 @@ class TextProcessingNode(io.ComfyNode):
 
         return io.Schema(
             node_id=cls.node_id,
+            search_aliases=cls.search_aliases,
             display_name=cls.display_name or cls.node_id,
             category="text",
+            description=cls.description,
             is_experimental=True,
+            is_deprecated=cls.is_deprecated,
             is_input_list=is_group,  # True for group, False for individual
             inputs=inputs,
             outputs=[

--- a/tests-unit/comfy_extras_test/nodes_dataset_test.py
+++ b/tests-unit/comfy_extras_test/nodes_dataset_test.py
@@ -1,49 +1,53 @@
-"""Tests for the class-attribute contract of the dataset node base classes.
+"""Tests that dataset node config declared as class attributes reaches the schema.
 
 ``ImageProcessingNode`` and ``TextProcessingNode`` let subclasses configure
 themselves with plain class attributes, and their shared ``define_schema()`` is
-what forwards those attributes into ``io.Schema``. Anything ``define_schema()``
-forgets to forward is silently dropped from ``/object_info``, so these tests pin
-the forwarding itself rather than any single field.
+what forwards those attributes into ``io.Schema``. Anything it forgets to
+forward is silently dropped from /object_info, so this pins the forwarding
+itself rather than any single field.
 """
+
+import dataclasses
 
 import pytest
 
-from comfy_extras.nodes_dataset import ImageProcessingNode, TextProcessingNode
+from comfy_api.latest import io
+from comfy_extras import nodes_dataset
 
-BASE_CLASSES = (ImageProcessingNode, TextProcessingNode)
+# Structural schema members, not per-node config; a node class would never
+# declare these as class attributes.
+IGNORED_FIELDS = {"inputs", "outputs", "hidden", "node_id"}
 
-# Class attribute -> io.Schema field. The names match today, but keeping the
-# mapping explicit means a rename on either side has to be made deliberately.
-FORWARDED_ATTRS = {
-    "description": "description",
-    "search_aliases": "search_aliases",
-    "is_deprecated": "is_deprecated",
-}
+SCHEMA_FIELDS = [
+    f.name for f in dataclasses.fields(io.Schema) if f.name not in IGNORED_FIELDS
+]
 
 
 def _node_classes():
-    """Every concrete node built on the dataset base classes."""
+    """Every concrete node defined in nodes_dataset."""
     found = []
-    stack = list(BASE_CLASSES)
-    while stack:
-        cls = stack.pop()
-        stack.extend(cls.__subclasses__())
-        if cls in BASE_CLASSES or cls.node_id is None:
-            continue  # abstract base class, not a registered node
-        found.append(cls)
+    for obj in vars(nodes_dataset).values():
+        if not isinstance(obj, type) or not issubclass(obj, io.ComfyNode):
+            continue
+        if obj.__module__ != nodes_dataset.__name__:
+            continue
+        if getattr(obj, "node_id", "") is None:
+            continue  # abstract base class, define_schema() would raise
+        found.append(obj)
     return sorted(found, key=lambda c: c.__name__)
 
 
 @pytest.mark.parametrize("node_cls", _node_classes(), ids=lambda c: c.__name__)
 def test_class_attributes_are_forwarded_to_schema(node_cls):
     schema = node_cls.define_schema()
-    for attr, field in FORWARDED_ATTRS.items():
-        assert getattr(schema, field) == getattr(node_cls, attr), (
-            f"{node_cls.__name__}.{attr} is not forwarded into io.Schema by "
+    for name in SCHEMA_FIELDS:
+        declared = getattr(node_cls, name, None)
+        if not declared:
+            continue  # unset, or left at the base class default
+        assert getattr(schema, name) == declared, (
+            f"{node_cls.__name__}.{name} is not forwarded into io.Schema by "
             f"define_schema(), so /object_info reports "
-            f"{field}={getattr(schema, field)!r} instead of "
-            f"{getattr(node_cls, attr)!r}"
+            f"{name}={getattr(schema, name)!r} instead of {declared!r}"
         )
 
 

--- a/tests-unit/comfy_extras_test/nodes_dataset_test.py
+++ b/tests-unit/comfy_extras_test/nodes_dataset_test.py
@@ -1,0 +1,52 @@
+"""Tests for the class-attribute contract of the dataset node base classes.
+
+``ImageProcessingNode`` and ``TextProcessingNode`` let subclasses configure
+themselves with plain class attributes, and their shared ``define_schema()`` is
+what forwards those attributes into ``io.Schema``. Anything ``define_schema()``
+forgets to forward is silently dropped from ``/object_info``, so these tests pin
+the forwarding itself rather than any single field.
+"""
+
+import pytest
+
+from comfy_extras.nodes_dataset import ImageProcessingNode, TextProcessingNode
+
+BASE_CLASSES = (ImageProcessingNode, TextProcessingNode)
+
+# Class attribute -> io.Schema field. The names match today, but keeping the
+# mapping explicit means a rename on either side has to be made deliberately.
+FORWARDED_ATTRS = {
+    "description": "description",
+    "search_aliases": "search_aliases",
+    "is_deprecated": "is_deprecated",
+}
+
+
+def _node_classes():
+    """Every concrete node built on the dataset base classes."""
+    found = []
+    stack = list(BASE_CLASSES)
+    while stack:
+        cls = stack.pop()
+        stack.extend(cls.__subclasses__())
+        if cls in BASE_CLASSES or cls.node_id is None:
+            continue  # abstract base class, not a registered node
+        found.append(cls)
+    return sorted(found, key=lambda c: c.__name__)
+
+
+@pytest.mark.parametrize("node_cls", _node_classes(), ids=lambda c: c.__name__)
+def test_class_attributes_are_forwarded_to_schema(node_cls):
+    schema = node_cls.define_schema()
+    for attr, field in FORWARDED_ATTRS.items():
+        assert getattr(schema, field) == getattr(node_cls, attr), (
+            f"{node_cls.__name__}.{attr} is not forwarded into io.Schema by "
+            f"define_schema(), so /object_info reports "
+            f"{field}={getattr(schema, field)!r} instead of "
+            f"{getattr(node_cls, attr)!r}"
+        )
+
+
+def test_node_classes_are_discovered():
+    """Guard against the parametrization above collapsing to zero cases."""
+    assert len(_node_classes()) > 10

--- a/tests-unit/comfy_extras_test/nodes_dataset_test.py
+++ b/tests-unit/comfy_extras_test/nodes_dataset_test.py
@@ -49,4 +49,4 @@ def test_class_attributes_are_forwarded_to_schema(node_cls):
 
 def test_node_classes_are_discovered():
     """Guard against the parametrization above collapsing to zero cases."""
-    assert len(_node_classes()) > 10
+    assert _node_classes()


### PR DESCRIPTION
`ImageProcessingNode` and `TextProcessingNode` in `nodes_dataset.py` let subclasses configure themselves with class attributes (`description`, `search_aliases`, `is_deprecated`, etc.), and their shared `define_schema()` is what passes those into `io.Schema`. It was dropping some of them, and since `/object_info` is built from the schema, anything it drops never reaches the frontend. `is_deprecated` was dropped by both base classes, so the ten nodes marked deprecated in #14002 still showed up in node search with the hide deprecated nodes filter on. `description` and `search_aliases` were also dropped by `TextProcessingNode` (`ImageProcessingNode` already passed both), so all eight text nodes have an empty description in `/object_info` and no tooltip on hover, and the `lowercase`/`uppercase` aliases on `TextToLowercaseNode` and `TextToUppercaseNode` never matched anything. That second part affects nodes that aren't deprecated too, like `TruncateTextNode`. The fix is to pass the missing attributes through in both `define_schema()` implementations. I left `category` hardcoded to `"text"` in `TextProcessingNode`, since it isn't part of the documented attribute list there and forwarding `cls.category` would make the base class raise for any subclass that omits it, which is already a latent sharp edge in `ImageProcessingNode`. I also added a test that takes the field list from `io.Schema` and walks every node in the file, checking each class attribute against the corresponding schema field, so this gets caught for any field rather than just the three, and a base class added later is covered without touching the test. 11 of its 36 cases fail against the current code and all 36 pass with the fix.