### PR TITLE
Fix crash when extra model paths config is empty

### DIFF
--- a/tests-unit/utils/extra_config_test.py
+++ b/tests-unit/utils/extra_config_test.py
@@ -2,6 +2,7 @@ import pytest
 import yaml
 import os
 import sys
+import logging
 from unittest.mock import Mock, patch, mock_open
 
 from utils.extra_config import load_extra_path_config
@@ -301,3 +302,26 @@ def test_load_extra_path_config_no_base_path(
     actual_diffusion = folder_paths.folder_names_and_paths["diffusion_models"][0]
     assert len(actual_diffusion) == 1, "Should have one path for 'diffusion_models'."
     assert actual_diffusion[0] == os.path.abspath(expected_unet)
+
+
+@pytest.mark.parametrize("yaml_content", [
+    "",
+    "   \n  \n  ",
+    "# only a comment\n# another comment\n",
+])
+def test_load_extra_path_config_empty_yaml(yaml_content, clear_folder_paths, tmp_path, caplog):
+    """
+    An empty, whitespace-only, or comments-only config file parses to None.
+    It should be skipped with a warning instead of crashing with a TypeError.
+    """
+    config_file = tmp_path / "extra_model_paths.yaml"
+    config_file.write_text(yaml_content)
+
+    with caplog.at_level(logging.WARNING):
+        load_extra_path_config(str(config_file))
+
+    # No model folder paths were registered from the empty config
+    assert folder_paths.folder_names_and_paths == {}
+    # A single warning explains why the config contributed nothing
+    assert len(caplog.records) == 1
+    assert "is empty; skipping" in caplog.text

--- a/utils/extra_config.py
+++ b/utils/extra_config.py
@@ -6,6 +6,9 @@ import logging
 def load_extra_path_config(yaml_path):
     with open(yaml_path, 'r', encoding='utf-8') as stream:
         config = yaml.safe_load(stream)
+    if config is None:
+        logging.warning("Extra model paths config {} is empty; skipping".format(yaml_path))
+        return
     yaml_dir = os.path.dirname(os.path.abspath(yaml_path))
     for c in config:
         conf = config[c]


### PR DESCRIPTION
## Problem

`load_extra_path_config()` iterates the result of `yaml.safe_load()` directly. A YAML file that is empty, whitespace-only, or made up entirely of comments parses to `None` rather than to an empty dict, so startup fails:

```
File "ComfyUI/main.py", line 132, in apply_custom_paths
    utils.extra_config.load_extra_path_config(extra_model_paths_config_path)
File "ComfyUI/utils/extra_config.py", line 10, in load_extra_path_config
    for c in config:
TypeError: 'NoneType' object is not iterable
```

This is reachable by commenting out every entry in `extra_model_paths.yaml`, which is a natural way to disable extra paths while keeping the file as a record. The `os.path.isfile()` guard in `main.py` passes, since the file does exist.

## Change

Skip a config with no entries and log a warning, instead of raising. The per-section `if conf is None: continue` immediately below already handled the analogous empty-*section* case; this covers the empty *document*.

The warning is deliberate rather than a silent return: `--extra-model-paths-config` takes an explicit path, and a file that contributes nothing is worth surfacing. Otherwise a user whose paths silently stop loading gets no signal.

## Tests

Added `test_load_extra_path_config_empty_yaml`, parametrized over empty, whitespace-only, and comments-only files. It writes real files to `tmp_path` rather than mocking `yaml.safe_load`, so PyYAML actually produces the `None`.

All three cases fail on master with the `TypeError` above and pass with this change:

```
$ pytest tests-unit/utils/extra_config_test.py
8 passed
```

Fixes #15670