### PR TITLE
Restore friendly errors for corrupt safetensors files on safetensors 0.6+

### DIFF
--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -142,9 +142,9 @@ def load_torch_file(ckpt, safe_load=False, device=None, return_metadata=False):
         except Exception as e:
             if len(e.args) > 0:
                 message = e.args[0]
-                if "HeaderTooLarge" in message:
+                if "HeaderTooLarge" in message or "header too large" in message:
                     raise ValueError("{}\n\nFile path: {}\n\nThe safetensors file is corrupt or invalid. Make sure this is actually a safetensors file and not a ckpt or pt or other filetype.".format(message, ckpt))
-                if "MetadataIncompleteBuffer" in message:
+                if "MetadataIncompleteBuffer" in message or "metadata buffer incomplete" in message or "incomplete metadata" in message:
                     raise ValueError("{}\n\nFile path: {}\n\nThe safetensors file is corrupt/incomplete. Check the file size and make sure you have copied/downloaded it correctly.".format(message, ckpt))
             raise e
     else:

--- a/tests-unit/comfy_test/load_torch_file_errors_test.py
+++ b/tests-unit/comfy_test/load_torch_file_errors_test.py
@@ -1,0 +1,38 @@
+import struct
+import json
+
+import pytest
+
+from comfy.utils import load_torch_file
+
+
+def _write_safetensors(path, payload: bytes) -> str:
+    path.write_bytes(payload)
+    return str(path)
+
+
+def test_load_torch_file_header_too_large(tmp_path):
+    """A header length prefix too large to be a real safetensors header
+    (e.g. a .ckpt or .pt renamed to .safetensors) raises the friendly
+    'corrupt or invalid' message instead of the raw SafetensorError."""
+    payload = struct.pack("<Q", 2**40) + b"x" * 64
+    path = _write_safetensors(tmp_path / "too_large.safetensors", payload)
+    with pytest.raises(ValueError, match="corrupt or invalid"):
+        load_torch_file(path)
+
+
+def test_load_torch_file_incomplete_download(tmp_path):
+    """A valid header whose tensor data is cut short (truncated download)
+    raises the friendly 'corrupt/incomplete' message."""
+    header = json.dumps({"a": {"dtype": "F32", "shape": [2], "data_offsets": [0, 8]}}).encode()
+    payload = struct.pack("<Q", len(header)) + header + b"\x00\x00"
+    path = _write_safetensors(tmp_path / "truncated.safetensors", payload)
+    with pytest.raises(ValueError, match="corrupt/incomplete"):
+        load_torch_file(path)
+
+
+def test_load_torch_file_valid_empty_file(tmp_path):
+    """A valid (empty) safetensors file still loads without error."""
+    payload = struct.pack("<Q", 2) + b"{}"
+    path = _write_safetensors(tmp_path / "valid.safetensors", payload)
+    assert load_torch_file(path) == {}


### PR DESCRIPTION
## Problem

`load_torch_file` translates two safetensors corruption signatures into friendly errors, but safetensors changed how it renders them in 0.6 — from the Rust enum variant name to prose:

| safetensors | message |
|---|---|
| 0.5.3 | `Error while deserializing header: HeaderTooLarge` |
| 0.6.1+ / 0.8.0 | `Error while deserializing header: header too large` |

The checks still match only `"HeaderTooLarge"` / `"MetadataIncompleteBuffer"`, so on any modern install **both friendly messages are dead code**. A user with a truncated download or a `.ckpt` renamed to `.safetensors` gets the raw `SafetensorError` instead of the message telling them what actually went wrong.

## Fix

Match the new prose spellings alongside the old enum names. The old ones are kept because `requirements.txt` allows `safetensors>=0.4.2`. On safetensors 0.8.0 the incomplete-download signature renders as `incomplete metadata, file not fully covered`, so that prose is matched too.

## Test plan

Adds `tests-unit/comfy_test/load_torch_file_errors_test.py`, which writes genuinely corrupt safetensors files (bogus header length; valid header with truncated tensor data) rather than monkeypatching the exception — so it keeps validating against the real installed safetensors, and fails if the wording changes again. A third test asserts valid files still load.

Verified locally (safetensors 0.8.0): before this change the two error tests fail with the raw `SafetensorError`; after, 3/3 pass. Related suites `tests-unit/comfy_test` + `tests-unit/utils`: 106 passed.

Fixes #15672