### PR TITLE
feat(minimax): support prompt embeddings

### DIFF
--- a/comfy/text_encoders/minimax.py
+++ b/comfy/text_encoders/minimax.py
@@ -127,10 +127,6 @@ class MiniMaxH3Tokenizer(comfy.sd1_clip.SD1Tokenizer):
         tokenizer = lambda *a, **kw: Qwen3VLSDTokenizer(*a, **kw, embedding_size=5120, embedding_key="qwen3vl_32b")
         super().__init__(embedding_directory=embedding_directory, tokenizer_data=tokenizer_data, name="qwen3vl_32b", tokenizer=tokenizer)
 
-    def _text_ids(self, text):
-        tok = self.qwen3vl_32b.tokenizer
-        return tok(text, add_special_tokens=False)["input_ids"]
-
     @staticmethod
     def _vision_entry(data, video_block=False):
         emb = {"type": "image", "data": data, "original_type": "image"}
@@ -143,7 +139,16 @@ class MiniMaxH3Tokenizer(comfy.sd1_clip.SD1Tokenizer):
         entries = []
 
         def add_text(s):
-            entries.extend((tid, 1.0) for tid in self._text_ids(s))
+            if not s:
+                return
+            token_batches = self.qwen3vl_32b.tokenize_with_weights(
+                s,
+                return_word_ids=False,
+                disable_weights=True,
+            )
+            if len(token_batches) != 1:
+                raise ValueError("MiniMax H3 text segment exceeds the supported prompt length.")
+            entries.extend(token_batches[0])
 
         def add_vision(data, video_block=False):
             entries.append((VISION_START, 1.0))


### PR DESCRIPTION
Adds support for `embedding:` syntax in prompt to load Minimax H3 embedding loading.
Manual test for loading was performed locally and omitted as to not bloat core repo with minor tests.

Test embedding:
[embeddings/art_is_explosion.safetensors](https://huggingface.co/silveroxides/repro-temp/blob/main/embeddings/art_is_explosion.safetensors)

Test workflow:
[video_minimax_h3_t2v_embedding.json](https://github.com/user-attachments/files/31163605/video_minimax_h3_t2v_embedding.json)

Turbo LoRA used in workflow:
[minimax_h3_fl2v_lightx2v_v0.1_dareties_v4_step600_comfy_fro.safetensors](https://huggingface.co/silveroxides/MiniMax-H3_tests/blob/main/minimax_h3_fl2v_lightx2v_v0.1_dareties_v4_step600_comfy_fro.safetensors)

Demo Video:

https://github.com/user-attachments/assets/aa4bef9b-3193-4444-a52a-ab1b93a95787

