### PR TITLE
fix: Disable aimdo pinned memory when --disable-pinned-memory is set (closes #15255)

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -34,6 +34,11 @@ import comfy.utils
 import comfy.quant_ops
 import comfy_aimdo.host_buffer
 import comfy_aimdo.vram_buffer
+# Guard pinned memory usage under --disable-pinned-memory
+if not args.disable_pinned_memory:
+    comfy_aimdo.host_buffer.ENABLE_PINNED_MEMORY = True
+else:
+    comfy_aimdo.host_buffer.ENABLE_PINNED_MEMORY = False
 from comfy.internal_logging import detail
 
 from typing import TYPE_CHECKING


### PR DESCRIPTION
## What
Some multi-GPU systems with dynamic VRAM crash with HostBuffer.read_file_slice failed leading to CUDA OOM.

## Fix
Respect the existing --disable-pinned-memory argument by setting the aimdo host_buffer flag accordingly.