### PR TITLE
Stop LTX prompt generation at final channel close

### DIFF
--- a/comfy/text_encoders/gemma4.py
+++ b/comfy/text_encoders/gemma4.py
@@ -1667,6 +1667,10 @@ class Gemma4UnifiedTokenizer(Gemma4Tokenizer):
 
 
 # Model wrappers
+FINAL_CHANNEL_PROMPT_TOKEN_IDS = (100, 10218, 107)  # <|channel>final\n
+CHANNEL_CLOSE_TOKEN_ID = 101  # <channel|>
+
+
 class Gemma4Model(sd1_clip.SDClipModel):
     model_class = None
     def __init__(self, device="cpu", layer="all", layer_idx=None, dtype=None, attention_mask=True, model_options={}):
@@ -1698,7 +1702,12 @@ class Gemma4Model(sd1_clip.SDClipModel):
                 expanded_idx += 1
         initial_token_ids = [ids]
         input_ids = torch.tensor(initial_token_ids, device=self.execution_device)
-        return self.transformer.generate(embeds, do_sample, max_length, temperature, top_k, top_p, min_p, repetition_penalty, seed, initial_tokens=initial_token_ids[0], presence_penalty=presence_penalty, initial_input_ids=input_ids, embeds_info=embeds_info)
+        stop_tokens = self.model.config.stop_tokens
+        # A prompt primed with a final channel is complete when that channel closes. Waiting
+        # for the turn close lets sampling start another final channel and repeat the output.
+        if tuple(initial_token_ids[0][-len(FINAL_CHANNEL_PROMPT_TOKEN_IDS):]) == FINAL_CHANNEL_PROMPT_TOKEN_IDS:
+            stop_tokens = [*stop_tokens, CHANNEL_CLOSE_TOKEN_ID]
+        return self.transformer.generate(embeds, do_sample, max_length, temperature, top_k, top_p, min_p, repetition_penalty, seed, stop_tokens=stop_tokens, initial_tokens=initial_token_ids[0], presence_penalty=presence_penalty, initial_input_ids=input_ids, embeds_info=embeds_info)
 
 
 def gemma4_clip_model(model_class):

--- a/tests-unit/comfy_test/gemma4_template_test.py
+++ b/tests-unit/comfy_test/gemma4_template_test.py
@@ -2,6 +2,7 @@
 
 import pytest
 import torch
+from types import SimpleNamespace
 
 from comfy.cli_args import args
 
@@ -59,3 +60,54 @@ def test_thinking_disabled_primes_a_thought_channel(variant):
 @pytest.mark.parametrize("thinking", [False, True])
 def test_skip_template_passes_text_through_unchanged(variant, thinking):
     assert build_template(variant, skip_template=True, thinking=thinking) == PROMPT
+
+
+def run_generate(initial_token_ids, monkeypatch):
+    captured = {}
+
+    def capture_generate(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return []
+
+    def capture_process_tokens(self, token_ids, device):
+        return torch.zeros((1, len(token_ids[0]), 1), device=device), None, None, []
+
+    monkeypatch.setattr(
+        gemma4.sd1_clip.SDClipModel,
+        "process_tokens",
+        capture_process_tokens,
+    )
+    model = SimpleNamespace(
+        transformer=SimpleNamespace(generate=capture_generate),
+        execution_device=torch.device("cpu"),
+        model=SimpleNamespace(config=SimpleNamespace(stop_tokens=[1, 50, 106])),
+    )
+    tokens = [[(token_id, 1.0, None) for token_id in initial_token_ids]]
+    gemma4.Gemma4Model.generate(
+        model,
+        tokens,
+        do_sample=False,
+        max_length=1,
+        temperature=1.0,
+        top_k=0,
+        top_p=1.0,
+        min_p=0.0,
+        repetition_penalty=1.0,
+        seed=0,
+    )
+    return captured["kwargs"].get("stop_tokens")
+
+
+def test_final_channel_prompt_stops_at_channel_close(monkeypatch):
+    # Generate LTX2 Prompt primes final output with these tokens when thinking is disabled.
+    prompt = [105, 106, *gemma4.FINAL_CHANNEL_PROMPT_TOKEN_IDS]
+    stop_tokens = run_generate(prompt, monkeypatch)
+    assert stop_tokens is not None
+    assert gemma4.CHANNEL_CLOSE_TOKEN_ID in stop_tokens
+
+
+def test_thinking_prompt_does_not_stop_at_channel_close(monkeypatch):
+    # In thinking mode, a channel close can end the reasoning channel before
+    # the final answer is generated, so it must not become a stop token.
+    assert gemma4.CHANNEL_CLOSE_TOKEN_ID not in run_generate([105, 106], monkeypatch)

--- a/tests-unit/comfy_test/gemma4_template_test.py
+++ b/tests-unit/comfy_test/gemma4_template_test.py
@@ -103,11 +103,10 @@ def test_final_channel_prompt_stops_at_channel_close(monkeypatch):
     # Generate LTX2 Prompt primes final output with these tokens when thinking is disabled.
     prompt = [105, 106, *gemma4.FINAL_CHANNEL_PROMPT_TOKEN_IDS]
     stop_tokens = run_generate(prompt, monkeypatch)
-    assert stop_tokens is not None
-    assert gemma4.CHANNEL_CLOSE_TOKEN_ID in stop_tokens
+    assert stop_tokens == [1, 50, 106, gemma4.CHANNEL_CLOSE_TOKEN_ID]
 
 
 def test_thinking_prompt_does_not_stop_at_channel_close(monkeypatch):
     # In thinking mode, a channel close can end the reasoning channel before
     # the final answer is generated, so it must not become a stop token.
-    assert gemma4.CHANNEL_CLOSE_TOKEN_ID not in run_generate([105, 106], monkeypatch)
+    assert run_generate([105, 106], monkeypatch) == [1, 50, 106]


### PR DESCRIPTION
## Description

`Generate LTX2 Prompt` primes Gemma 4 generation with an open final channel. Once that channel closes, the requested caption is complete. Continuing until the turn closes gives the sampler an opportunity to open another final channel and emit a near-duplicate of the caption.

This change adds the Gemma channel-close token to the stop-token set only when the prompt ends with the primed final-channel sequence. Other Gemma generation paths retain the model-configured stop tokens unchanged; in particular, thinking prompts can still close a reasoning channel before generating the final answer.

## Testing

- `python -m pytest tests-unit -q`
  - 1294 passed
  - 17 skipped
- `python -m ruff check .` — passes
- `git diff --check` — passes

New unit coverage captures the transformer generation arguments and verifies both the final-channel and non-final-channel prompt shapes.

Fixes #15649.
