### PR TITLE
Forward Gemma4 tokenization options

### DIFF
--- a/comfy/text_encoders/gemma4.py
+++ b/comfy/text_encoders/gemma4.py
@@ -1561,7 +1561,9 @@ class Gemma4_Tokenizer():
                 model_open = "<|channel>thought\n<channel|>" if self.prime_empty_thought and not thinking else ""
                 llama_text = f"{system}<|turn>user\n{text}{media}<turn|>\n<|turn>model\n{model_open}"
 
-        text_tokens = super().tokenize_with_weights(llama_text, return_word_ids)
+        text_tokens = super().tokenize_with_weights(
+            llama_text, return_word_ids=return_word_ids, **kwargs
+        )
 
         def _replace_placeholders(token_list, token_id, embeds):
             """Replace first placeholder with embed dict, remove remaining consecutive ones."""

--- a/tests-unit/comfy_test/gemma4_tokenization_test.py
+++ b/tests-unit/comfy_test/gemma4_tokenization_test.py
@@ -1,13 +1,50 @@
 """Gemma4 tokenization regression tests."""
 
+import importlib
+import importlib.util
+
 import torch
 
 from comfy.cli_args import args
 
-if not torch.cuda.is_available():
+
+def supported_accelerator_available():
+    if torch.cuda.is_available():
+        return True
+    try:
+        if torch.backends.mps.is_available():
+            return True
+    except (AttributeError, RuntimeError):
+        pass
+    try:
+        if torch.xpu.is_available():
+            return True
+    except (AttributeError, RuntimeError):
+        pass
+    if args.directml is not None:
+        return True
+    if hasattr(torch, "corex"):
+        return True
+    return any(
+        importlib.util.find_spec(package) is not None
+        for package in ("torch_npu", "torch_mlu")
+    )
+
+
+prior_cpu_mode = args.cpu
+if not supported_accelerator_available():
     args.cpu = True
 
-from comfy.text_encoders.gemma4 import Gemma4SDTokenizer  # noqa: E402
+try:
+    gemma4 = importlib.import_module("comfy.text_encoders.gemma4")
+finally:
+    args.cpu = prior_cpu_mode
+
+Gemma4SDTokenizer = gemma4.Gemma4SDTokenizer
+
+
+def test_cpu_mode_is_restored_after_import():
+    assert args.cpu == prior_cpu_mode
 
 
 class _SingleTokenTokenizer:

--- a/tests-unit/comfy_test/gemma4_tokenization_test.py
+++ b/tests-unit/comfy_test/gemma4_tokenization_test.py
@@ -1,0 +1,50 @@
+"""Gemma4 tokenization regression tests."""
+
+import torch
+
+from comfy.cli_args import args
+
+if not torch.cuda.is_available():
+    args.cpu = True
+
+from comfy.text_encoders.gemma4 import Gemma4SDTokenizer  # noqa: E402
+
+
+class _SingleTokenTokenizer:
+    def __call__(self, _text):
+        return {"input_ids": [7]}
+
+
+def _ltx_tokenizer():
+    tokenizer = Gemma4SDTokenizer.__new__(Gemma4SDTokenizer)
+    tokenizer.tokenizer = _SingleTokenTokenizer()
+    tokenizer.max_length = 100
+    tokenizer.min_length = 8
+    tokenizer.min_padding = None
+    tokenizer.pad_to_max_length = False
+    tokenizer.pad_left = True
+    tokenizer.pad_token = 0
+    tokenizer.tokens_start = 0
+    tokenizer.start_token = 2
+    tokenizer.end_token = None
+    tokenizer.tokenizer_adds_end_token = False
+    tokenizer.max_word_length = 8
+    tokenizer.embedding_identifier = "embedding:"
+    tokenizer.embedding_directory = None
+    tokenizer.embedding_key = "gemma4"
+    tokenizer.disable_weights = True
+    return tokenizer
+
+
+def _token_ids(tokens):
+    return [token for token, _weight in tokens[0]]
+
+
+def test_text_generation_min_length_overrides_the_ltx_default():
+    tokens = _ltx_tokenizer().tokenize_with_weights("<|turn>model\nanswer", min_length=1)
+    assert _token_ids(tokens) == [2, 7]
+
+
+def test_normal_tokenization_keeps_the_ltx_default_padding():
+    tokens = _ltx_tokenizer().tokenize_with_weights("<|turn>model\nanswer")
+    assert _token_ids(tokens) == [0, 0, 0, 0, 0, 0, 2, 7]

--- a/tests-unit/comfy_test/gemma4_tokenization_test.py
+++ b/tests-unit/comfy_test/gemma4_tokenization_test.py
@@ -1,11 +1,18 @@
 """Gemma4 tokenization regression tests."""
 
 import importlib
-import importlib.util
 
 import torch
 
 from comfy.cli_args import args
+
+
+def optional_torch_backend_available(module_name, backend_name):
+    try:
+        importlib.import_module(module_name)
+        return getattr(torch, backend_name).is_available()
+    except (AttributeError, ImportError, RuntimeError):
+        return False
 
 
 def supported_accelerator_available():
@@ -26,8 +33,8 @@ def supported_accelerator_available():
     if hasattr(torch, "corex"):
         return True
     return any(
-        importlib.util.find_spec(package) is not None
-        for package in ("torch_npu", "torch_mlu")
+        optional_torch_backend_available(module_name, backend_name)
+        for module_name, backend_name in (("torch_npu", "npu"), ("torch_mlu", "mlu"))
     )
 
 


### PR DESCRIPTION
## Description

The remaining text-only `Generate LTX2 Prompt` failure path comes from tokenization options being dropped. `TextGenerate` explicitly requests `min_length=1`, but `Gemma4_Tokenizer.tokenize_with_weights` called its base tokenizer without forwarding the remaining keyword options. The LTX2 tokenizer configuration therefore applied its larger default minimum length and left-padding to the prompt.

This change forwards the remaining keyword options to the base tokenizer. The existing default padding behavior is unchanged when no override is supplied.

## Testing

- `python -m pytest tests-unit -q`
  - 1294 passed
  - 17 skipped
- `python -m ruff check .` — passes
- `git diff --check` — passes

The new regression test drives the real Gemma4 tokenizer wrapper with a small stub tokenizer and verifies both the `min_length=1` override and unchanged default padding.

Fixes #15596.
