### PR TITLE
Handle offloaded dequantized embeddings

### DIFF
--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -1621,13 +1621,17 @@ def mixed_precision_ops(quant_config={}, compute_dtype=torch.bfloat16, full_prec
                 # Optimized path: lookup in fp8/int8, dequantize only the selected rows.
                 if isinstance(weight, QuantizedTensor) and len(self.weight_function) == 0:
                     with CastBiasWeightContext(self, device=input.device, dtype=weight.dtype, offloadable=True) as (qdata, _bias):
-                        if isinstance(qdata, QuantizedTensor):
-                            params = qdata._params
-                            scale = params.scale
-                            qdata = qdata._qdata
-                        else:
-                            params = weight._params
-                            scale = None
+                        if not isinstance(qdata, QuantizedTensor):
+                            # Dynamic VRAM can dequantize while moving the weight to the
+                            # execution device. The returned tensor already contains the scale.
+                            x = torch.nn.functional.embedding(
+                                input, qdata, self.padding_idx, self.max_norm,
+                                self.norm_type, self.scale_grad_by_freq, self.sparse)
+                            return x if out_dtype is None else x.to(dtype=out_dtype)
+
+                        params = qdata._params
+                        scale = params.scale
+                        qdata = qdata._qdata
 
                         # int8: per-row scale possible ConvRot, so let the layout do the gather
                         if self.quant_format == "int8_tensorwise":

--- a/tests-unit/comfy_quant/test_mixed_precision.py
+++ b/tests-unit/comfy_quant/test_mixed_precision.py
@@ -3,6 +3,7 @@ import torch
 import sys
 import os
 import json
+from unittest import mock
 
 # Add comfy to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
@@ -283,6 +284,80 @@ class TestMixedPrecisionOps(unittest.TestCase):
         saved = model.state_dict()
         saved_conf = json.loads(saved["layer.comfy_quant"].numpy().tobytes())
         self.assertTrue(saved_conf["convrot"])
+
+    def _int8_embedding_layer(self, weight):
+        layer = ops.mixed_precision_ops({}).Embedding(
+            weight.shape[0], weight.shape[1], device="cpu", dtype=torch.bfloat16
+        )
+        layer.weight = torch.nn.Parameter(weight, requires_grad=False)
+        layer.weight_function = []
+        layer.bias_function = []
+        layer.quant_format = "int8_tensorwise"
+        layer.layout_type = weight._layout_cls
+        return layer
+
+    def test_int8_embedding_uses_layout_while_weight_is_quantized(self):
+        weight = torch.arange(18, dtype=torch.float32).reshape(6, 3).to(torch.bfloat16)
+        quantized_weight = QuantizedTensor.from_float(weight, "TensorWiseINT8Layout")
+        layer = self._int8_embedding_layer(quantized_weight)
+        indices = torch.tensor([[0, 2], [3, 5]])
+        layout_output = torch.full((2, 2, 3), 7.0, dtype=torch.bfloat16)
+        calls = []
+
+        class Layout:
+            @staticmethod
+            def dequantize_embedding(qdata, params, input):
+                calls.append((qdata.dtype, params is quantized_weight._params, input is indices))
+                return layout_output
+
+        class QuantizedCastContext:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            def __enter__(self):
+                return quantized_weight, None
+
+            def __exit__(self, *_args):
+                return None
+
+        with mock.patch.object(ops, "CastBiasWeightContext", QuantizedCastContext):
+            with mock.patch.object(ops, "get_layout_class", lambda _layout_type: Layout):
+                output = layer.forward_comfy_cast_weights(indices)
+
+        self.assertTrue(torch.equal(output, layout_output))
+        self.assertEqual(calls, [(torch.int8, True, True)])
+
+    def test_int8_embedding_handles_weight_dequantized_by_offload(self):
+        weight = torch.arange(18, dtype=torch.float32).reshape(6, 3).to(torch.bfloat16)
+        quantized_weight = QuantizedTensor.from_float(weight, "TensorWiseINT8Layout")
+        dequantized_weight = quantized_weight.dequantize().to(torch.bfloat16)
+        layer = self._int8_embedding_layer(quantized_weight)
+        indices = torch.tensor([[0, 2], [3, 5]])
+        expected = torch.nn.functional.embedding(indices, dequantized_weight)
+        calls = []
+
+        class Layout:
+            @staticmethod
+            def dequantize_embedding(qdata, params, input):
+                calls.append((qdata.dtype, params is quantized_weight._params))
+                return torch.full_like(expected, 7.0)
+
+        class DequantizedCastContext:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            def __enter__(self):
+                return dequantized_weight, None
+
+            def __exit__(self, *_args):
+                return None
+
+        with mock.patch.object(ops, "CastBiasWeightContext", DequantizedCastContext):
+            with mock.patch.object(ops, "get_layout_class", lambda _layout_type: Layout):
+                output = layer.forward_comfy_cast_weights(indices)
+
+        self.assertEqual(calls, [])
+        self.assertTrue(torch.equal(output, expected))
 
     def test_convrot_w4a4_loads_into_params(self):
         """ConvRot W4A4 checkpoints must load as the dedicated kitchen layout."""


### PR DESCRIPTION
## Problem

`MixedPrecisionOps.Embedding` takes an optimized path when its stored weight is a `QuantizedTensor`. Dynamic VRAM can dequantize that weight while moving it to the execution device, in which case `CastBiasWeightContext` returns an ordinary bf16/fp16 tensor.

The old code still passed this already-dequantized tensor to the int8 layout's `dequantize_embedding()`. This reaches the failure reported in #15545:

```text
NoCapableBackendError: No backend can handle 'dequantize_int8_embedding':
eager: q: dtype torch.bfloat16 not in {torch.int8}
```

## Change

If the cast context returns a non-`QuantizedTensor`, use the normal `torch.nn.functional.embedding` lookup and apply `out_dtype` as requested. The returned weight already has quantization scale applied by the Dynamic VRAM cast.

If the context still returns a `QuantizedTensor`, the existing optimized fp8/int8 layout path is unchanged.

Fixes #15545.

## Tests

Added CPU-only coverage to `tests-unit/comfy_quant/test_mixed_precision.py`:

- the int8 layout path is still used while the cast weight remains quantized;
- when the cast context returns a dequantized plain tensor, the layer performs a normal embedding lookup and does not call the int8 layout dequantizer.

Validation boundary: the regression uses a mock cast context to exercise the Dynamic VRAM return shape on CPU. It does not require the reported 25 GB model or GPU hardware.