### PR TITLE
Fix lazy Linear placeholder weight shape

### DIFF
--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -555,7 +555,7 @@ class disable_weight_init:
                 local_metadata,
                 missing_keys,
                 unexpected_keys,
-                weight_shape=(self.in_features, self.out_features),
+                weight_shape=(self.out_features, self.in_features),
                 bias_shape=(self.out_features,),
             )
 

--- a/tests-unit/comfy_test/test_ops.py
+++ b/tests-unit/comfy_test/test_ops.py
@@ -1,0 +1,23 @@
+import sys
+from unittest import mock
+
+import torch
+
+
+with mock.patch.object(sys, "argv", ["ComfyUI", "--cpu"]):
+    from comfy.options import enable_args_parsing
+
+    enable_args_parsing()
+    import comfy.memory_management
+    import comfy.ops
+    enable_args_parsing(False)
+
+
+def test_lazy_linear_placeholder_has_torch_linear_weight_shape():
+    with mock.patch.object(comfy.memory_management, "aimdo_enabled", True):
+        linear = comfy.ops.disable_weight_init.Linear(3, 5, bias=False)
+        result = linear.load_state_dict({}, strict=False, assign=False)
+
+    assert result.missing_keys == ["weight"]
+    assert linear.weight.shape == (5, 3)
+    assert linear(torch.arange(6, dtype=torch.float32).reshape(2, 3)).shape == (2, 5)


### PR DESCRIPTION
## Summary
- Preserve `torch.nn.Linear`'s `[out_features, in_features]` weight layout when the dynamic-loading lazy path initializes a missing weight.
- Add a focused CPU unit test that drives the lazy state-dict fallback with no supplied weight.

Fixes #15435.

## Why this bug is visible
When a model has missing text-encoder keys (the CommonCanvas logs in the issue show the pre-existing `clip missing` warning), the lazy loader creates a placeholder for the missing Linear weight. The previous fallback passed `(in_features, out_features)`, producing a transposed weight. A CLIP MLP `fc1` layer configured as `1024 -> 4096` therefore received a `[1024, 4096]` placeholder and failed during text encoding with the shape error reported in the issue.

## Validation
- Before the code change, the new test failed with `torch.Size([3, 5]) != (5, 3)`.
- After the change: `python -m pytest tests-unit/comfy_test/test_ops.py -q` -> `1 passed`.
- Validation is CPU-only via the available Windows Python environment. I did not run an end-to-end CommonCanvas generation or any GPU/DynamicVRAM workflow.
- The other provided local test environment currently fails while importing its CPU Torch build (`c10.dll` initialization, WinError 1114/access violation), so the successful test above was run with the alternate provided environment.