### PR TITLE
Fix loading multi-picture images

### DIFF
--- a/comfy_api/latest/_input_impl/video_types.py
+++ b/comfy_api/latest/_input_impl/video_types.py
@@ -305,6 +305,20 @@ class VideoFromFile(VideoInput):
         with av.open(self.__file, mode='r') as container:
             return container.format.name
 
+    @staticmethod
+    def _is_multi_picture_still(
+        frames: list[torch.Tensor],
+        codec_name: str,
+        has_audio_stream: bool,
+    ) -> bool:
+        """Return whether decoded frames represent an embedded multi-picture still."""
+        return (
+            len(frames) > 1
+            and not has_audio_stream
+            and codec_name == "mjpeg"
+            and any(frame.shape != frames[0].shape for frame in frames[1:])
+        )
+
     def get_components_internal(self, container: InputContainer) -> VideoComponents:
         video_stream = self._get_first_video_stream(container)
         start_time, duration = self.get_active_trim_window()
@@ -430,7 +444,11 @@ class VideoFromFile(VideoInput):
                         audio_frames.append(frame.to_ndarray())
 
         # Multi-picture still images can expose embedded thumbnails as ragged frames.
-        if len(frames) > 1 and not audio_frames and any(frame.shape != frames[0].shape for frame in frames[1:]):
+        if self._is_multi_picture_still(
+            frames,
+            video_stream.codec_context.name,
+            audio_stream is not None,
+        ):
             main_frame = max(range(len(frames)), key=lambda i: frames[i].shape[0] * frames[i].shape[1])
             frames = [frames[main_frame]]
             if alphas is not None:

--- a/comfy_api/latest/_input_impl/video_types.py
+++ b/comfy_api/latest/_input_impl/video_types.py
@@ -429,6 +429,13 @@ class VideoFromFile(VideoInput):
                     else:
                         audio_frames.append(frame.to_ndarray())
 
+        # Multi-picture still images can expose embedded thumbnails as ragged frames.
+        if len(frames) > 1 and not audio_frames and any(frame.shape != frames[0].shape for frame in frames[1:]):
+            main_frame = max(range(len(frames)), key=lambda i: frames[i].shape[0] * frames[i].shape[1])
+            frames = [frames[main_frame]]
+            if alphas is not None:
+                alphas = [alphas[main_frame]]
+
         images = process_image_format(torch.stack(frames)) if len(frames) > 0 else torch.zeros(0, 0, 0, 3)
         if alphas is not None:
             alphas = process_image_format(torch.stack(alphas)) if len(alphas) > 0 else torch.zeros(0, 0, 0, 1)

--- a/tests-unit/comfy_api_test/video_types_test.py
+++ b/tests-unit/comfy_api_test/video_types_test.py
@@ -6,6 +6,7 @@ import sys
 import av
 import io
 from fractions import Fraction
+from PIL import Image
 from comfy_api.input_impl.video_types import VideoFromFile, VideoFromComponents
 from comfy_api.util.video_types import VideoComponents, VideoContainer, VideoCodec
 from comfy_api.input.basic_types import AudioInput
@@ -122,6 +123,18 @@ def test_video_from_file_get_duration(simple_video_file):
     video = VideoFromFile(simple_video_file)
     duration = video.get_duration()
     assert duration == pytest.approx(0.1, abs=0.01)
+
+
+def test_mpo_without_extension_loads_main_image(tmp_path):
+    """An extensionless MPO keeps its main image even when its thumbnail decodes."""
+    path = tmp_path / "multi_picture_image"
+    main_image = Image.new("RGB", (1360, 768), (200, 30, 30))
+    thumbnail = Image.new("RGB", (512, 289), (30, 30, 200))
+    main_image.save(path, format="MPO", append_images=[thumbnail], save_all=True)
+
+    components = VideoFromFile(str(path)).get_components()
+
+    assert components.images.shape == (1, 768, 1360, 3)
 
 
 def test_video_from_file_get_dimensions(simple_video_file):

--- a/tests-unit/comfy_api_test/video_types_test.py
+++ b/tests-unit/comfy_api_test/video_types_test.py
@@ -137,6 +137,18 @@ def test_mpo_without_extension_loads_main_image(tmp_path):
     assert components.images.shape == (1, 768, 1360, 3)
 
 
+def test_multi_picture_guard_rejects_ragged_video():
+    frames = [torch.zeros((8, 16, 3)), torch.zeros((4, 8, 3))]
+
+    assert not VideoFromFile._is_multi_picture_still(frames, "h264", False)
+
+
+def test_multi_picture_guard_rejects_audio_streams():
+    frames = [torch.zeros((8, 16, 3)), torch.zeros((4, 8, 3))]
+
+    assert not VideoFromFile._is_multi_picture_still(frames, "mjpeg", True)
+
+
 def test_video_from_file_get_dimensions(simple_video_file):
     """Dimensions read from stream without decoding frames"""
     video = VideoFromFile(simple_video_file)


### PR DESCRIPTION
## Description

Since the PyAV migration, an MPO/multi-picture JPEG uploaded through `LoadImage` can be decoded through the extensionless `jpeg_pipe` path. PyAV then returns both the main image and an embedded thumbnail with a different size, and `torch.stack` fails:

```text
stack expects each tensor to be equal size
```

For a still image with no audio and ragged frame dimensions, keep the largest frame as the main picture and select the matching alpha frame. Equal-sized video frames are unchanged, and inputs containing audio keep the existing behavior rather than silently dropping video frames.

Fixes #14127.

## Testing

- New regression generates an MPO with a `1360x768` main image and `512x289` thumbnail, writes it to an extensionless path, and verifies the loaded result is the single main image.
- The new test failed on clean `master` with the reported `torch.stack` size error and passes with the fix.
- `python -m pytest tests-unit/comfy_api_test/video_types_test.py tests-unit/comfy_api_test/video_bit_depth_test.py -q` — 35 passed, 1 skipped
- `python -m ruff check .` — passes
- `git diff --check` — passes
