### PR TITLE
Support saving nested latents

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -591,8 +591,11 @@ class LoadLatent:
         )
         if shape_keys:
             latent_shapes = [tuple(int(size) for size in latent[key]) for key in shape_keys]
+            unpacked_latents = comfy.utils.unpack_latents(latent_tensor, latent_shapes)
+            if len(latent_shapes) == 1:
+                unpacked_latents[0] = unpacked_latents[0].reshape(latent_shapes[0])
             latent_tensor = comfy.nested_tensor.NestedTensor(
-                comfy.utils.unpack_latents(latent_tensor, latent_shapes)
+                unpacked_latents
             )
 
         samples = {"samples": latent_tensor}

--- a/nodes.py
+++ b/nodes.py
@@ -24,6 +24,7 @@ import comfy.diffusers_load
 import comfy.samplers
 import comfy.sample
 import comfy.sd
+import comfy.nested_tensor
 import comfy.utils
 import comfy.controlnet
 from comfy.comfy_types import IO, ComfyNodeABC, InputTypeDict, FileLocator
@@ -549,8 +550,14 @@ class SaveLatent:
 
         file = os.path.join(full_output_folder, file)
 
+        latent_tensor = samples["samples"]
         output = {}
-        output["latent_tensor"] = samples["samples"].contiguous()
+        if getattr(latent_tensor, "is_nested", False):
+            latent_tensor, latent_shapes = comfy.utils.pack_latents(latent_tensor.unbind())
+            for i, shape in enumerate(latent_shapes):
+                output[f"latent_shape_{i}"] = torch.tensor(shape, dtype=torch.int64)
+
+        output["latent_tensor"] = latent_tensor.contiguous()
         output["latent_format_version_0"] = torch.tensor([])
 
         comfy.utils.save_torch_file(output, file, metadata=metadata)
@@ -577,7 +584,18 @@ class LoadLatent:
         multiplier = 1.0
         if "latent_format_version_0" not in latent:
             multiplier = 1.0 / 0.18215
-        samples = {"samples": latent["latent_tensor"].float() * multiplier}
+        latent_tensor = latent["latent_tensor"].float() * multiplier
+        shape_keys = sorted(
+            (key for key in latent if key.startswith("latent_shape_")),
+            key=lambda key: int(key.rsplit("_", 1)[1]),
+        )
+        if shape_keys:
+            latent_shapes = [tuple(int(size) for size in latent[key]) for key in shape_keys]
+            latent_tensor = comfy.nested_tensor.NestedTensor(
+                comfy.utils.unpack_latents(latent_tensor, latent_shapes)
+            )
+
+        samples = {"samples": latent_tensor}
         return (samples, )
 
     @classmethod

--- a/tests-unit/comfy_test/test_latent_file.py
+++ b/tests-unit/comfy_test/test_latent_file.py
@@ -1,0 +1,39 @@
+import torch
+import safetensors.torch
+
+from comfy.cli_args import args as cli_args
+
+if not torch.cuda.is_available():
+    cli_args.cpu = True
+
+import comfy.nested_tensor
+import comfy.utils
+import folder_paths
+import nodes
+
+
+def test_save_and_load_nested_latent_roundtrip(tmp_path, monkeypatch):
+    output_path = tmp_path / "latent_00001_.latent"
+    monkeypatch.setattr(folder_paths, "get_output_directory", lambda: str(tmp_path))
+    monkeypatch.setattr(
+        folder_paths,
+        "get_save_image_path",
+        lambda filename_prefix, output_dir: (tmp_path, "latent", 1, "", filename_prefix),
+    )
+
+    video = torch.arange(4, dtype=torch.float32).reshape(1, 2, 1, 2, 1)
+    audio = torch.arange(4, dtype=torch.float32).reshape(1, 2, 1, 2)
+    samples = {"samples": comfy.nested_tensor.NestedTensor((video, audio))}
+
+    nodes.SaveLatent().save(samples, prompt=None, extra_pnginfo=None)
+
+    saved = safetensors.torch.load_file(str(output_path))
+    expected, _ = comfy.utils.pack_latents((video, audio))
+    assert torch.equal(saved["latent_tensor"], expected)
+    assert torch.equal(saved["latent_shape_0"], torch.tensor(video.shape, dtype=torch.int64))
+    assert torch.equal(saved["latent_shape_1"], torch.tensor(audio.shape, dtype=torch.int64))
+
+    monkeypatch.setattr(folder_paths, "get_annotated_filepath", lambda filename: str(output_path))
+    loaded = nodes.LoadLatent().load(str(output_path))[0]["samples"]
+    assert torch.equal(loaded.tensors[0], video)
+    assert torch.equal(loaded.tensors[1], audio)

--- a/tests-unit/comfy_test/test_latent_file.py
+++ b/tests-unit/comfy_test/test_latent_file.py
@@ -12,7 +12,7 @@ import folder_paths
 import nodes
 
 
-def test_save_and_load_nested_latent_roundtrip(tmp_path, monkeypatch):
+def configure_latent_output_directory(tmp_path, monkeypatch):
     output_path = tmp_path / "latent_00001_.latent"
     monkeypatch.setattr(folder_paths, "get_output_directory", lambda: str(tmp_path))
     monkeypatch.setattr(
@@ -20,6 +20,11 @@ def test_save_and_load_nested_latent_roundtrip(tmp_path, monkeypatch):
         "get_save_image_path",
         lambda filename_prefix, output_dir: (tmp_path, "latent", 1, "", filename_prefix),
     )
+    return output_path
+
+
+def test_save_and_load_nested_latent_roundtrip(tmp_path, monkeypatch):
+    output_path = configure_latent_output_directory(tmp_path, monkeypatch)
 
     video = torch.arange(4, dtype=torch.float32).reshape(1, 2, 1, 2, 1)
     audio = torch.arange(4, dtype=torch.float32).reshape(1, 2, 1, 2)
@@ -37,3 +42,17 @@ def test_save_and_load_nested_latent_roundtrip(tmp_path, monkeypatch):
     loaded = nodes.LoadLatent().load(str(output_path))[0]["samples"]
     assert torch.equal(loaded.tensors[0], video)
     assert torch.equal(loaded.tensors[1], audio)
+
+
+def test_save_and_load_one_stream_nested_latent_roundtrip(tmp_path, monkeypatch):
+    output_path = configure_latent_output_directory(tmp_path, monkeypatch)
+    video = torch.arange(4, dtype=torch.float32).reshape(1, 2, 1, 2)
+    samples = {"samples": comfy.nested_tensor.NestedTensor((video,))}
+
+    nodes.SaveLatent().save(samples, prompt=None, extra_pnginfo=None)
+
+    monkeypatch.setattr(folder_paths, "get_annotated_filepath", lambda filename: str(output_path))
+    loaded = nodes.LoadLatent().load(str(output_path))[0]["samples"]
+    assert len(loaded.tensors) == 1
+    assert loaded.tensors[0].shape == video.shape
+    assert torch.equal(loaded.tensors[0], video)


### PR DESCRIPTION
## Summary
- Pack nested LATENT streams into the existing single safetensors tensor.
- Store each stream’s original shape alongside the packed tensor.
- Reconstruct the nested LATENT when loading the file.

## Fixes
Fixes #15254

## Testing
- Added a CPU-only save/load regression test for a two-stream nested latent.
- `python -m pytest tests-unit/comfy_test/test_latent_file.py tests-unit/comfy_test/test_vae_decode_tiled_nested.py -q`
- `python -m pytest tests/execution/test_jobs.py -q`
- `ruff check nodes.py tests-unit/comfy_test/test_latent_file.py`
- `python -m compileall -q nodes.py tests-unit/comfy_test/test_latent_file.py`

No GPU or model downloads were used. The regression test was confirmed to fail on `master` with `AttributeError: 'NestedTensor' object has no attribute 'contiguous'` before the change.