### PR TITLE
Validate deep prompt graphs iteratively

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -843,6 +843,22 @@ class PromptExecutor:
             self._notify_prompt_lifecycle("end", prompt_id)
 
 
+def _mark_validation_cycle(unique_id, prompt, visiting, validated):
+    cycle_path_nodes = visiting[visiting.index(unique_id):] + [unique_id]
+    cycle_nodes = list(dict.fromkeys(cycle_path_nodes))
+    cycle_path = " -> ".join(f"{node_id} ({prompt[node_id]['class_type']})" for node_id in cycle_path_nodes)
+    for node_id in cycle_nodes:
+        validated[node_id] = (False, [{
+            "type": "dependency_cycle",
+            "message": "Dependency cycle detected",
+            "details": cycle_path,
+            "extra_info": {
+                "node_id": node_id,
+                "cycle_nodes": cycle_nodes,
+            }
+        }], node_id)
+
+
 async def validate_inputs(prompt_id, prompt, item, validated, visiting=None):
     if visiting is None:
         visiting = []
@@ -852,21 +868,59 @@ async def validate_inputs(prompt_id, prompt, item, validated, visiting=None):
         return validated[unique_id]
 
     if unique_id in visiting:
-        cycle_path_nodes = visiting[visiting.index(unique_id):] + [unique_id]
-        cycle_nodes = list(dict.fromkeys(cycle_path_nodes))
-        cycle_path = " -> ".join(f"{node_id} ({prompt[node_id]['class_type']})" for node_id in cycle_path_nodes)
-        for node_id in cycle_nodes:
-            validated[node_id] = (False, [{
-                "type": "dependency_cycle",
-                "message": "Dependency cycle detected",
-                "details": cycle_path,
-                "extra_info": {
-                    "node_id": node_id,
-                    "cycle_nodes": cycle_nodes,
-                }
-            }], node_id)
+        _mark_validation_cycle(unique_id, prompt, visiting, validated)
         return validated[unique_id]
 
+    stack = [_validate_node(prompt_id, prompt, unique_id, validated, visiting)]
+    stack_nodes = {stack[0]: unique_id}
+    send_value = None
+    throw_value = None
+
+    # _validate_node yields the ID of each dependency that needs validation.  The
+    # driver injects that dependency's result back into the generator, keeping the
+    # Python call stack flat for arbitrarily deep acyclic prompts.
+    while stack:
+        generator = stack[-1]
+        try:
+            if throw_value is None:
+                dependency = await generator.asend(send_value)
+            else:
+                dependency = await generator.athrow(*throw_value)
+            throw_value = None
+        except StopAsyncIteration:
+            finished = stack.pop()
+            finished_node = stack_nodes.pop(finished)
+            result = validated[finished_node]
+            if not stack:
+                return result
+            send_value = result
+            continue
+        except BaseException as ex:
+            stack.pop()
+            stack_nodes.pop(generator)
+            if not stack:
+                raise
+            throw_value = (type(ex), ex, ex.__traceback__)
+            send_value = None
+            continue
+
+        if dependency in validated:
+            send_value = validated[dependency]
+        elif dependency in visiting:
+            _mark_validation_cycle(dependency, prompt, visiting, validated)
+            send_value = validated[dependency]
+        else:
+            child = _validate_node(prompt_id, prompt, dependency, validated, visiting)
+            stack.append(child)
+            stack_nodes[child] = dependency
+            send_value = None
+
+    return validated[unique_id]
+
+
+# Async generators cannot return a value. The driver reads the result from
+# validated[unique_id] after StopAsyncIteration.
+async def _validate_node(prompt_id, prompt, unique_id, validated, visiting):
     inputs = prompt[unique_id]['inputs']
     class_type = prompt[unique_id]['class_type']
     obj_class = nodes.NODE_CLASS_MAPPINGS[class_type]
@@ -952,7 +1006,7 @@ async def validate_inputs(prompt_id, prompt, item, validated, visiting=None):
             try:
                 visiting.append(unique_id)
                 try:
-                    r = await validate_inputs(prompt_id, prompt, o_id, validated, visiting)
+                    r = yield o_id
                 finally:
                     visiting.pop()
                 if r[0] is False:
@@ -1117,7 +1171,7 @@ async def validate_inputs(prompt_id, prompt, item, validated, visiting=None):
     )
 
     validated[unique_id] = ret
-    return ret
+    return
 
 def full_type_name(klass):
     module = klass.__module__

--- a/tests/execution/test_validation.py
+++ b/tests/execution/test_validation.py
@@ -1,0 +1,136 @@
+import asyncio
+
+import torch
+
+from comfy.cli_args import args as cli_args
+
+if not torch.cuda.is_available():
+    cli_args.cpu = True
+
+import execution  # noqa: E402
+
+
+def test_validate_inputs_deep_acyclic_chain(monkeypatch):
+    class Source:
+        RETURN_TYPES = ("INT",)
+
+        @classmethod
+        def INPUT_TYPES(cls):
+            return {"required": {}}
+
+    class Link:
+        RETURN_TYPES = ("INT",)
+
+        @classmethod
+        def INPUT_TYPES(cls):
+            return {"required": {"value": ("INT", {})}}
+
+    monkeypatch.setitem(execution.nodes.NODE_CLASS_MAPPINGS, "DeepValidationSource", Source)
+    monkeypatch.setitem(execution.nodes.NODE_CLASS_MAPPINGS, "DeepValidationLink", Link)
+
+    size = 2_000
+    prompt = {"0": {"class_type": "DeepValidationSource", "inputs": {}}}
+    for index in range(1, size):
+        prompt[str(index)] = {
+            "class_type": "DeepValidationLink",
+            "inputs": {"value": [str(index - 1), 0]},
+        }
+
+    validated = {}
+    result = execution.validate_inputs("test", prompt, str(size - 1), validated)
+    result = asyncio.run(result)
+
+    assert result == (True, [], str(size - 1))
+    assert len(validated) == size
+
+
+def test_validate_inputs_reports_dependency_cycles(monkeypatch):
+    class Link:
+        RETURN_TYPES = ("INT",)
+
+        @classmethod
+        def INPUT_TYPES(cls):
+            return {"required": {"value": ("INT", {})}}
+
+    monkeypatch.setitem(execution.nodes.NODE_CLASS_MAPPINGS, "CycleValidationLink", Link)
+    prompt = {
+        "0": {"class_type": "CycleValidationLink", "inputs": {"value": ["1", 0]}},
+        "1": {"class_type": "CycleValidationLink", "inputs": {"value": ["0", 0]}},
+    }
+
+    validated = {}
+    result = asyncio.run(execution.validate_inputs("test", prompt, "0", validated))
+
+    assert result[0] is False
+    assert result[2] == "0"
+    assert result[1][0]["type"] == "dependency_cycle"
+    assert result[1][0]["details"] == "0 (CycleValidationLink) -> 1 (CycleValidationLink) -> 0 (CycleValidationLink)"
+    assert [validated[node_id][0] for node_id in prompt] == [False, False]
+
+
+def test_validate_inputs_awaits_custom_validator(monkeypatch):
+    class Validated:
+        RETURN_TYPES = ("INT",)
+
+        @classmethod
+        def INPUT_TYPES(cls):
+            return {"required": {"value": ("INT", {"default": 7})}}
+
+        @classmethod
+        async def VALIDATE_INPUTS(cls, value):
+            await asyncio.sleep(0)
+            return value == 7
+
+    monkeypatch.setitem(execution.nodes.NODE_CLASS_MAPPINGS, "AsyncValidationValue", Validated)
+    prompt = {"0": {"class_type": "AsyncValidationValue", "inputs": {"value": 7}}}
+
+    result = asyncio.run(execution.validate_inputs("test", prompt, "0", {}))
+
+    assert result == (True, [], "0")
+
+
+def test_validate_inputs_reports_dependency_validation_exception(monkeypatch):
+    class Source:
+        RETURN_TYPES = ("INT",)
+
+        @classmethod
+        def INPUT_TYPES(cls):
+            return {"required": {}}
+
+    class Broken:
+        RETURN_TYPES = ("INT",)
+
+        @classmethod
+        def INPUT_TYPES(cls):
+            return {"required": {"value": ("INT", {})}}
+
+        @classmethod
+        async def VALIDATE_INPUTS(cls, value):
+            await asyncio.sleep(0)
+            raise RuntimeError("validation failed")
+
+    class Consumer:
+        RETURN_TYPES = ("INT",)
+
+        @classmethod
+        def INPUT_TYPES(cls):
+            return {"required": {"value": ("INT", {})}}
+
+    monkeypatch.setitem(execution.nodes.NODE_CLASS_MAPPINGS, "ExceptionValidationSource", Source)
+    monkeypatch.setitem(execution.nodes.NODE_CLASS_MAPPINGS, "ExceptionValidationLink", Broken)
+    monkeypatch.setitem(execution.nodes.NODE_CLASS_MAPPINGS, "ExceptionValidationConsumer", Consumer)
+    prompt = {
+        "0": {"class_type": "ExceptionValidationSource", "inputs": {}},
+        "1": {"class_type": "ExceptionValidationLink", "inputs": {"value": ["0", 0]}},
+        "2": {"class_type": "ExceptionValidationConsumer", "inputs": {"value": ["1", 0]}},
+    }
+
+    validated = {}
+    result = asyncio.run(execution.validate_inputs("test", prompt, "2", validated))
+
+    assert result[0] is False
+    assert result[2] == "2"
+    error = validated["1"][1][0]
+    assert error["type"] == "exception_during_inner_validation"
+    assert error["extra_info"]["exception_message"] == "validation failed"
+    assert validated["0"][0] is True


### PR DESCRIPTION
## Summary
- Moved dependency traversal for prompt validation to an explicit generator stack.
- Preserved recursive validation results, cycle reporting, dependency exception handling, and async custom validators.
- Validation now handles deep acyclic graphs without consuming one Python stack frame per node.

## Fixes
Fixes #14911

## Testing
- Added regression coverage for a 2,000-node acyclic chain.
- Added direct coverage for dependency cycles, awaited custom validators, and exceptions raised by a dependency validator.
- `python -m pytest tests/execution/test_validation.py -q`
- `ruff check execution.py tests/execution/test_validation.py`
- `python -m compileall -q execution.py tests/execution/test_validation.py`

The deep-chain regression test returns `(False, [], "1999")` on `master` and passes after this change. The end-to-end execution suite was not run because the available CPU test environment lacks its server dependencies; testing was limited to direct validation and static checks.