### PR TITLE
Save JSON files like workflows with 2 space indentation for compatibility with source control and readability

### DIFF
--- a/app/user_manager.py
+++ b/app/user_manager.py
@@ -400,17 +400,13 @@ class UserManager():
             try:
                 body = await request.read()
 
-                # Pretty print JSON files for better source control
                 if path.lower().endswith('.json'):
                     try:
-                        # Parse JSON and re-serialize with indentation
                         json_data = json.loads(body.decode('utf-8'))
                         formatted_body = json.dumps(json_data, indent=2).encode('utf-8')
                     except (json.JSONDecodeError, UnicodeDecodeError):
-                        # If JSON parsing fails, save as-is
                         formatted_body = body
                 else:
-                    # Non-JSON files are saved as-is
                     formatted_body = body
 
                 dir_name = os.path.dirname(path)

--- a/app/user_manager.py
+++ b/app/user_manager.py
@@ -400,11 +400,24 @@ class UserManager():
             try:
                 body = await request.read()
 
+                # Pretty print JSON files for better source control
+                if path.lower().endswith('.json'):
+                    try:
+                        # Parse JSON and re-serialize with indentation
+                        json_data = json.loads(body.decode('utf-8'))
+                        formatted_body = json.dumps(json_data, indent=2).encode('utf-8')
+                    except (json.JSONDecodeError, UnicodeDecodeError):
+                        # If JSON parsing fails, save as-is
+                        formatted_body = body
+                else:
+                    # Non-JSON files are saved as-is
+                    formatted_body = body
+
                 dir_name = os.path.dirname(path)
                 fd, tmp_path = tempfile.mkstemp(dir=dir_name)
                 try:
                     with os.fdopen(fd, "wb") as f:
-                        f.write(body)
+                        f.write(formatted_body)
                     os.replace(tmp_path, path)
                 except:
                     os.unlink(tmp_path)

--- a/tests-unit/prompt_server_test/user_manager_test.py
+++ b/tests-unit/prompt_server_test/user_manager_test.py
@@ -291,3 +291,72 @@ async def test_listuserdata_v2_url_encoded_path(aiohttp_client, app, tmp_path):
     assert entry["name"] == "file.txt"
     # Ensure the path is correctly decoded and uses forward slash
     assert entry["path"] == "my dir/file.txt"
+
+
+async def test_post_userdata_json_pretty_print(aiohttp_client, app, tmp_path):
+    """Test that JSON files are saved with pretty printing (indentation)"""
+    import json
+
+    client = await aiohttp_client(app)
+
+    # Create a compact JSON workflow
+    workflow_data = {
+        "nodes": [
+            {"id": "1", "type": "LoadImage", "inputs": {"image": "test.png"}},
+            {"id": "2", "type": "SaveImage", "inputs": {"images": ["1", 0]}}
+        ],
+        "metadata": {"version": "1.0", "author": "test"}
+    }
+    compact_json = json.dumps(workflow_data).encode('utf-8')
+
+    # Save as JSON file
+    resp = await client.post("/userdata/workflow.json", data=compact_json)
+    assert resp.status == 200
+
+    # Read the saved file and verify it's pretty-printed
+    with open(tmp_path / "workflow.json", "r", encoding='utf-8') as f:
+        saved_content = f.read()
+
+    # Verify the file contains indentation (pretty-printed)
+    assert "  " in saved_content  # Should have 2-space indentation
+    assert "\n" in saved_content  # Should have newlines
+
+    # Verify the content is still valid JSON and matches original data
+    saved_data = json.loads(saved_content)
+    assert saved_data == workflow_data
+
+    # Verify it's actually formatted (not compact)
+    # Compact JSON would be much shorter
+    assert len(saved_content) > len(compact_json)
+
+
+async def test_post_userdata_json_invalid_fallback(aiohttp_client, app, tmp_path):
+    """Test that invalid JSON is saved as-is without error"""
+    client = await aiohttp_client(app)
+
+    # Create invalid JSON content
+    invalid_json = b'{"invalid": json content}'
+
+    # Save as JSON file - should not fail
+    resp = await client.post("/userdata/invalid.json", data=invalid_json)
+    assert resp.status == 200
+
+    # Verify file was saved as-is
+    with open(tmp_path / "invalid.json", "rb") as f:
+        assert f.read() == invalid_json
+
+
+async def test_post_userdata_non_json_unchanged(aiohttp_client, app, tmp_path):
+    """Test that non-JSON files are saved unchanged"""
+    client = await aiohttp_client(app)
+
+    # Create binary content
+    binary_content = b'\x00\x01\x02\x03\x04\x05'
+
+    # Save as non-JSON file
+    resp = await client.post("/userdata/test.bin", data=binary_content)
+    assert resp.status == 200
+
+    # Verify file was saved exactly as-is
+    with open(tmp_path / "test.bin", "rb") as f:
+        assert f.read() == binary_content

--- a/tests-unit/prompt_server_test/user_manager_test.py
+++ b/tests-unit/prompt_server_test/user_manager_test.py
@@ -1,5 +1,7 @@
-import pytest
+import json
 import os
+
+import pytest
 from aiohttp import web
 from app.user_manager import UserManager
 from unittest.mock import patch
@@ -294,12 +296,7 @@ async def test_listuserdata_v2_url_encoded_path(aiohttp_client, app, tmp_path):
 
 
 async def test_post_userdata_json_pretty_print(aiohttp_client, app, tmp_path):
-    """Test that JSON files are saved with pretty printing (indentation)"""
-    import json
-
     client = await aiohttp_client(app)
-
-    # Create a compact JSON workflow
     workflow_data = {
         "nodes": [
             {"id": "1", "type": "LoadImage", "inputs": {"image": "test.png"}},
@@ -309,54 +306,43 @@ async def test_post_userdata_json_pretty_print(aiohttp_client, app, tmp_path):
     }
     compact_json = json.dumps(workflow_data).encode('utf-8')
 
-    # Save as JSON file
     resp = await client.post("/userdata/workflow.json", data=compact_json)
     assert resp.status == 200
 
-    # Read the saved file and verify it's pretty-printed
     with open(tmp_path / "workflow.json", "r", encoding='utf-8') as f:
         saved_content = f.read()
 
-    # Verify the file contains indentation (pretty-printed)
-    assert "  " in saved_content  # Should have 2-space indentation
-    assert "\n" in saved_content  # Should have newlines
-
-    # Verify the content is still valid JSON and matches original data
-    saved_data = json.loads(saved_content)
-    assert saved_data == workflow_data
-
-    # Verify it's actually formatted (not compact)
-    # Compact JSON would be much shorter
-    assert len(saved_content) > len(compact_json)
+    assert saved_content == json.dumps(workflow_data, indent=2)
 
 
 async def test_post_userdata_json_invalid_fallback(aiohttp_client, app, tmp_path):
-    """Test that invalid JSON is saved as-is without error"""
     client = await aiohttp_client(app)
-
-    # Create invalid JSON content
     invalid_json = b'{"invalid": json content}'
 
-    # Save as JSON file - should not fail
     resp = await client.post("/userdata/invalid.json", data=invalid_json)
     assert resp.status == 200
 
-    # Verify file was saved as-is
     with open(tmp_path / "invalid.json", "rb") as f:
         assert f.read() == invalid_json
 
 
-async def test_post_userdata_non_json_unchanged(aiohttp_client, app, tmp_path):
-    """Test that non-JSON files are saved unchanged"""
+async def test_post_userdata_json_invalid_utf8_fallback(aiohttp_client, app, tmp_path):
     client = await aiohttp_client(app)
+    invalid_utf8 = b'{"value":"\xff"}'
 
-    # Create binary content
+    resp = await client.post("/userdata/invalid-utf8.json", data=invalid_utf8)
+    assert resp.status == 200
+
+    with open(tmp_path / "invalid-utf8.json", "rb") as f:
+        assert f.read() == invalid_utf8
+
+
+async def test_post_userdata_non_json_unchanged(aiohttp_client, app, tmp_path):
+    client = await aiohttp_client(app)
     binary_content = b'\x00\x01\x02\x03\x04\x05'
 
-    # Save as non-JSON file
     resp = await client.post("/userdata/test.bin", data=binary_content)
     assert resp.status == 200
 
-    # Verify file was saved exactly as-is
     with open(tmp_path / "test.bin", "rb") as f:
         assert f.read() == binary_content


### PR DESCRIPTION
This doesn't actually change any important behavior and makes it very easy to use source control to manage workflows and see exactly what has changed between revisions as currently the JSON is stored as a single line so diffs are just that the single line changed. The increase in size due to additional whitespace is negligible in the realm of ComfyUI disk usage.