### PR TITLE
Rebuild stale asset records when the assets system is enabled

### DIFF
--- a/alembic_db/versions/0007_add_asset_semantics_version.py
+++ b/alembic_db/versions/0007_add_asset_semantics_version.py
@@ -1,0 +1,34 @@
+"""
+Add asset_semantics_version table.
+
+Alembic records the *shape* of the assets tables. This table records the
+*meaning* of their contents: which generation of the derivation logic produced
+the values currently stored in them. The two move independently, so they are
+tracked independently.
+
+Revision ID: 0007_add_asset_semantics_version
+Revises: 0006_add_loader_path
+Create Date: 2026-08-18
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0007_add_asset_semantics_version"
+down_revision = "0006_add_loader_path"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "asset_semantics_version",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=False), nullable=False),
+        sa.PrimaryKeyConstraint("id", name="pk_asset_semantics_version"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("asset_semantics_version")

--- a/alembic_db/versions/0007_add_asset_semantics_version.py
+++ b/alembic_db/versions/0007_add_asset_semantics_version.py
@@ -1,11 +1,6 @@
 """
 Add asset_semantics_version table.
 
-Alembic records the *shape* of the assets tables. This table records the
-*meaning* of their contents: which generation of the derivation logic produced
-the values currently stored in them. The two move independently, so they are
-tracked independently.
-
 Revision ID: 0007_add_asset_semantics_version
 Revises: 0006_add_loader_path
 Create Date: 2026-08-18

--- a/app/assets/database/models.py
+++ b/app/assets/database/models.py
@@ -23,6 +23,28 @@ from app.assets.helpers import get_utc_now
 from app.database.models import Base
 
 
+class AssetSemanticsVersion(Base):
+    """Which generation of the derivation logic produced this database's rows.
+
+    Alembic tracks the *shape* of the assets tables; this tracks the *meaning*
+    of what is stored in them. A row can be structurally current and still hold
+    values a superseded rule computed, so the two versions move independently.
+    Reset steps in ``app.assets.semantics`` bring such rows forward and then
+    advance this stamp. Always a single row, keyed on id 1.
+    """
+
+    __tablename__ = "asset_semantics_version"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, default=1)
+    version: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=False), nullable=False, default=get_utc_now
+    )
+
+    def __repr__(self) -> str:
+        return f"<AssetSemanticsVersion version={self.version}>"
+
+
 class Asset(Base):
     __tablename__ = "assets"
 

--- a/app/assets/database/models.py
+++ b/app/assets/database/models.py
@@ -24,14 +24,7 @@ from app.database.models import Base
 
 
 class AssetSemanticsVersion(Base):
-    """Which generation of the derivation logic produced this database's rows.
-
-    Alembic tracks the *shape* of the assets tables; this tracks the *meaning*
-    of what is stored in them. A row can be structurally current and still hold
-    values a superseded rule computed, so the two versions move independently.
-    Reset steps in ``app.assets.semantics`` bring such rows forward and then
-    advance this stamp. Always a single row, keyed on id 1.
-    """
+    """Which generation of the derivation logic wrote these rows -- deliberately not the Alembic version, which tracks shape rather than meaning."""
 
     __tablename__ = "asset_semantics_version"
 

--- a/app/assets/database/queries/__init__.py
+++ b/app/assets/database/queries/__init__.py
@@ -52,6 +52,17 @@ from app.assets.database.queries.asset_reference import (
     update_reference_updated_at,
     upsert_reference,
 )
+from app.assets.database.queries.semantics import (
+    AUTOMATIC_TAG_ORIGIN,
+    DerivedStateRow,
+    bulk_add_automatic_tags,
+    bulk_remove_automatic_tags,
+    bulk_set_loader_paths,
+    get_file_backed_references_page,
+    get_semantics_version,
+    get_tags_by_reference,
+    set_semantics_version,
+)
 from app.assets.database.queries.tags import (
     AddTagsResult,
     RemoveTagsResult,
@@ -71,7 +82,9 @@ from app.assets.database.queries.tags import (
 
 __all__ = [
     "AddTagsResult",
+    "AUTOMATIC_TAG_ORIGIN",
     "CacheStateRow",
+    "DerivedStateRow",
     "RemoveTagsResult",
     "SetTagsResult",
     "UnenrichedReferenceRow",
@@ -81,6 +94,9 @@ __all__ = [
     "bulk_insert_assets",
     "bulk_insert_references_ignore_conflicts",
     "bulk_insert_tags_and_meta",
+    "bulk_add_automatic_tags",
+    "bulk_remove_automatic_tags",
+    "bulk_set_loader_paths",
     "bulk_update_enrichment_level",
     "count_active_siblings",
     "create_stub_asset",
@@ -96,6 +112,7 @@ __all__ = [
     "fetch_reference_asset_and_tags",
     "get_asset_by_hash",
     "get_existing_asset_ids",
+    "get_file_backed_references_page",
     "get_or_create_reference",
     "get_reference_by_file_path",
     "get_reference_by_id",
@@ -104,6 +121,8 @@ __all__ = [
     "get_reference_tags",
     "get_references_by_paths_and_asset_ids",
     "get_references_for_prefixes",
+    "get_semantics_version",
+    "get_tags_by_reference",
     "get_unenriched_references",
     "get_unreferenced_unhashed_asset_ids",
     "insert_reference",
@@ -123,6 +142,7 @@ __all__ = [
     "set_reference_metadata",
     "set_reference_preview",
     "set_reference_system_metadata",
+    "set_semantics_version",
     "soft_delete_reference_by_id",
     "set_reference_tags",
     "update_asset_hash_and_mime",

--- a/app/assets/database/queries/__init__.py
+++ b/app/assets/database/queries/__init__.py
@@ -60,7 +60,7 @@ from app.assets.database.queries.semantics import (
     bulk_set_loader_paths,
     get_file_backed_references_page,
     get_semantics_version,
-    get_tags_by_reference,
+    get_tag_origins_by_reference,
     set_semantics_version,
 )
 from app.assets.database.queries.tags import (
@@ -122,7 +122,7 @@ __all__ = [
     "get_references_by_paths_and_asset_ids",
     "get_references_for_prefixes",
     "get_semantics_version",
-    "get_tags_by_reference",
+    "get_tag_origins_by_reference",
     "get_unenriched_references",
     "get_unreferenced_unhashed_asset_ids",
     "insert_reference",

--- a/app/assets/database/queries/semantics.py
+++ b/app/assets/database/queries/semantics.py
@@ -1,0 +1,195 @@
+"""Queries backing the asset semantics reset (see ``app.assets.semantics``)."""
+
+from dataclasses import dataclass
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import sqlite
+from sqlalchemy.orm import Session
+
+from app.assets.database.models import (
+    Asset,
+    AssetReference,
+    AssetReferenceTag,
+    AssetSemanticsVersion,
+)
+from app.assets.database.queries.common import (
+    MAX_BIND_PARAMS,
+    iter_chunks,
+    iter_row_chunks,
+)
+from app.assets.database.queries.tags import ensure_tags_exist
+from app.assets.helpers import get_utc_now
+
+# The version table holds exactly one row; the id is a constant, not a sequence.
+_VERSION_ROW_ID = 1
+
+# Tags this subsystem derives from the filesystem rather than being told.
+AUTOMATIC_TAG_ORIGIN = "automatic"
+
+
+def get_semantics_version(session: Session) -> int:
+    """Return the stored semantics version, or 0 if none has been stamped."""
+    row = session.get(AssetSemanticsVersion, _VERSION_ROW_ID)
+    return int(row.version) if row is not None else 0
+
+
+def set_semantics_version(session: Session, version: int) -> None:
+    """Stamp the semantics version. Caller commits."""
+    row = session.get(AssetSemanticsVersion, _VERSION_ROW_ID)
+    if row is None:
+        session.add(
+            AssetSemanticsVersion(
+                id=_VERSION_ROW_ID, version=int(version), updated_at=get_utc_now()
+            )
+        )
+    else:
+        row.version = int(version)
+        row.updated_at = get_utc_now()
+    session.flush()
+
+
+@dataclass(frozen=True)
+class DerivedStateRow:
+    """A file-backed reference and the state a reprojection may rewrite."""
+
+    reference_id: str
+    file_path: str
+    loader_path: str | None
+    mtime_ns: int | None
+    is_missing: bool
+    needs_verify: bool
+    size_bytes: int | None
+
+
+def get_file_backed_references_page(
+    session: Session,
+    after_id: str | None,
+    limit: int,
+) -> list[DerivedStateRow]:
+    """Return up to ``limit`` file-backed references ordered by id, after ``after_id``.
+
+    Keyset pagination on the primary key so a reprojection can walk the whole
+    table in bounded transactions without holding one open across the walk.
+    Soft-deleted references are included: their derived columns are as stale as
+    anyone else's, and an undelete would serve them.
+    """
+    query = (
+        sa.select(
+            AssetReference.id,
+            AssetReference.file_path,
+            AssetReference.loader_path,
+            AssetReference.mtime_ns,
+            AssetReference.is_missing,
+            AssetReference.needs_verify,
+            Asset.size_bytes,
+        )
+        .join(Asset, Asset.id == AssetReference.asset_id)
+        .where(AssetReference.file_path.isnot(None))
+        .order_by(AssetReference.id.asc())
+        .limit(limit)
+    )
+    if after_id is not None:
+        query = query.where(AssetReference.id > after_id)
+
+    return [
+        DerivedStateRow(
+            reference_id=row[0],
+            file_path=row[1],
+            loader_path=row[2],
+            mtime_ns=row[3],
+            is_missing=bool(row[4]),
+            needs_verify=bool(row[5]),
+            size_bytes=int(row[6]) if row[6] is not None else None,
+        )
+        for row in session.execute(query).all()
+    ]
+
+
+def get_tags_by_reference(
+    session: Session, reference_ids: list[str]
+) -> dict[str, dict[str, str]]:
+    """Return {reference_id: {tag_name: origin}} for the given references."""
+    if not reference_ids:
+        return {}
+
+    by_reference: dict[str, dict[str, str]] = {}
+    for chunk in iter_chunks(reference_ids, MAX_BIND_PARAMS):
+        rows = session.execute(
+            sa.select(
+                AssetReferenceTag.asset_reference_id,
+                AssetReferenceTag.tag_name,
+                AssetReferenceTag.origin,
+            ).where(AssetReferenceTag.asset_reference_id.in_(chunk))
+        ).all()
+        for reference_id, tag_name, origin in rows:
+            by_reference.setdefault(reference_id, {})[tag_name] = origin
+    return by_reference
+
+
+def bulk_set_loader_paths(
+    session: Session, loader_paths: dict[str, str | None]
+) -> None:
+    """Set loader_path on the given references. Caller commits."""
+    if not loader_paths:
+        return
+    session.execute(
+        sa.update(AssetReference),
+        [
+            {"id": reference_id, "loader_path": loader_path}
+            for reference_id, loader_path in loader_paths.items()
+        ],
+    )
+
+
+def bulk_add_automatic_tags(session: Session, links: list[tuple[str, str]]) -> None:
+    """Attach (reference_id, tag_name) links with automatic origin. Caller commits."""
+    if not links:
+        return
+
+    now = get_utc_now()
+    ensure_tags_exist(session, {tag_name for _, tag_name in links})
+    rows = [
+        {
+            "asset_reference_id": reference_id,
+            "tag_name": tag_name,
+            "origin": AUTOMATIC_TAG_ORIGIN,
+            "added_at": now,
+        }
+        for reference_id, tag_name in links
+    ]
+    for chunk in iter_row_chunks(rows, cols_per_row=4):
+        session.execute(
+            sqlite.insert(AssetReferenceTag)
+            .values(chunk)
+            .on_conflict_do_nothing(
+                index_elements=[
+                    AssetReferenceTag.asset_reference_id,
+                    AssetReferenceTag.tag_name,
+                ]
+            )
+        )
+
+
+def bulk_remove_automatic_tags(session: Session, links: list[tuple[str, str]]) -> None:
+    """Detach (reference_id, tag_name) links, but only automatic ones.
+
+    The origin is re-asserted in the statement rather than trusted from the
+    caller's snapshot, so a manual tag can never be removed by this path.
+    Caller commits.
+    """
+    if not links:
+        return
+
+    by_reference: dict[str, list[str]] = {}
+    for reference_id, tag_name in links:
+        by_reference.setdefault(reference_id, []).append(tag_name)
+
+    for reference_id, tag_names in by_reference.items():
+        for chunk in iter_chunks(tag_names, MAX_BIND_PARAMS):
+            session.execute(
+                sa.delete(AssetReferenceTag).where(
+                    AssetReferenceTag.asset_reference_id == reference_id,
+                    AssetReferenceTag.tag_name.in_(chunk),
+                    AssetReferenceTag.origin == AUTOMATIC_TAG_ORIGIN,
+                )
+            )

--- a/app/assets/database/queries/semantics.py
+++ b/app/assets/database/queries/semantics.py
@@ -19,22 +19,22 @@ from app.assets.database.queries.common import (
 from app.assets.database.queries.tags import ensure_tags_exist
 from app.assets.helpers import get_utc_now
 
-_VERSION_ROW_ID = 1
+_SINGLETON_ROW_ID = 1
 
 AUTOMATIC_TAG_ORIGIN = "automatic"
 
 
 def get_semantics_version(session: Session) -> int:
-    row = session.get(AssetSemanticsVersion, _VERSION_ROW_ID)
+    row = session.get(AssetSemanticsVersion, _SINGLETON_ROW_ID)
     return int(row.version) if row is not None else 0
 
 
 def set_semantics_version(session: Session, version: int) -> None:
-    row = session.get(AssetSemanticsVersion, _VERSION_ROW_ID)
+    row = session.get(AssetSemanticsVersion, _SINGLETON_ROW_ID)
     if row is None:
         session.add(
             AssetSemanticsVersion(
-                id=_VERSION_ROW_ID, version=int(version), updated_at=get_utc_now()
+                id=_SINGLETON_ROW_ID, version=int(version), updated_at=get_utc_now()
             )
         )
     else:
@@ -93,7 +93,7 @@ def get_file_backed_references_page(
     ]
 
 
-def get_tags_by_reference(
+def get_tag_origins_by_reference(
     session: Session, reference_ids: list[str]
 ) -> dict[str, dict[str, str]]:
     if not reference_ids:

--- a/app/assets/database/queries/semantics.py
+++ b/app/assets/database/queries/semantics.py
@@ -1,4 +1,3 @@
-"""Queries backing the asset semantics reset (see ``app.assets.semantics``)."""
 
 from dataclasses import dataclass
 
@@ -20,21 +19,17 @@ from app.assets.database.queries.common import (
 from app.assets.database.queries.tags import ensure_tags_exist
 from app.assets.helpers import get_utc_now
 
-# The version table holds exactly one row; the id is a constant, not a sequence.
 _VERSION_ROW_ID = 1
 
-# Tags this subsystem derives from the filesystem rather than being told.
 AUTOMATIC_TAG_ORIGIN = "automatic"
 
 
 def get_semantics_version(session: Session) -> int:
-    """Return the stored semantics version, or 0 if none has been stamped."""
     row = session.get(AssetSemanticsVersion, _VERSION_ROW_ID)
     return int(row.version) if row is not None else 0
 
 
 def set_semantics_version(session: Session, version: int) -> None:
-    """Stamp the semantics version. Caller commits."""
     row = session.get(AssetSemanticsVersion, _VERSION_ROW_ID)
     if row is None:
         session.add(
@@ -50,7 +45,6 @@ def set_semantics_version(session: Session, version: int) -> None:
 
 @dataclass(frozen=True)
 class DerivedStateRow:
-    """A file-backed reference and the state a reprojection may rewrite."""
 
     reference_id: str
     file_path: str
@@ -66,13 +60,7 @@ def get_file_backed_references_page(
     after_id: str | None,
     limit: int,
 ) -> list[DerivedStateRow]:
-    """Return up to ``limit`` file-backed references ordered by id, after ``after_id``.
-
-    Keyset pagination on the primary key so a reprojection can walk the whole
-    table in bounded transactions without holding one open across the walk.
-    Soft-deleted references are included: their derived columns are as stale as
-    anyone else's, and an undelete would serve them.
-    """
+    """Soft-deleted references are deliberately included: their derived columns are as stale as anyone else's."""
     query = (
         sa.select(
             AssetReference.id,
@@ -108,7 +96,6 @@ def get_file_backed_references_page(
 def get_tags_by_reference(
     session: Session, reference_ids: list[str]
 ) -> dict[str, dict[str, str]]:
-    """Return {reference_id: {tag_name: origin}} for the given references."""
     if not reference_ids:
         return {}
 
@@ -129,7 +116,6 @@ def get_tags_by_reference(
 def bulk_set_loader_paths(
     session: Session, loader_paths: dict[str, str | None]
 ) -> None:
-    """Set loader_path on the given references. Caller commits."""
     if not loader_paths:
         return
     session.execute(
@@ -142,7 +128,6 @@ def bulk_set_loader_paths(
 
 
 def bulk_add_automatic_tags(session: Session, links: list[tuple[str, str]]) -> None:
-    """Attach (reference_id, tag_name) links with automatic origin. Caller commits."""
     if not links:
         return
 
@@ -171,12 +156,7 @@ def bulk_add_automatic_tags(session: Session, links: list[tuple[str, str]]) -> N
 
 
 def bulk_remove_automatic_tags(session: Session, links: list[tuple[str, str]]) -> None:
-    """Detach (reference_id, tag_name) links, but only automatic ones.
-
-    The origin is re-asserted in the statement rather than trusted from the
-    caller's snapshot, so a manual tag can never be removed by this path.
-    Caller commits.
-    """
+    """The origin is re-asserted below rather than trusted from the caller's snapshot."""
     if not links:
         return
 

--- a/app/assets/seeder.py
+++ b/app/assets/seeder.py
@@ -550,7 +550,15 @@ class _AssetSeeder:
                 return
 
             # Must precede the prune and the scan: both read and extend these rows.
-            run_pending_semantics_steps(interrupt_check=self._is_cancelled)
+            # _check_pause_and_cancel, not _is_cancelled: a pause has to suspend
+            # the walk between batches, or it keeps statting the whole table
+            # while the seeder reports PAUSED and a prompt runs.
+            run_pending_semantics_steps(interrupt_check=self._check_pause_and_cancel)
+
+            if self._is_cancelled():
+                logging.info("Asset scan cancelled during semantics reset")
+                cancelled = True
+                return
 
             if self._prune_first:
                 all_prefixes = get_owned_prefixes()

--- a/app/assets/seeder.py
+++ b/app/assets/seeder.py
@@ -23,6 +23,7 @@ from app.assets.scanner import (
     sync_root_safely,
     sync_temp_references_safely,
 )
+from app.assets.semantics import run_pending_semantics_steps
 from app.database.db import dependencies_available
 
 
@@ -547,6 +548,11 @@ class _AssetSeeder:
                     {"message": "Database dependencies not available"},
                 )
                 return
+
+            # Stale rows are brought forward before anything reads or extends
+            # them. A database already at the current semantics version costs a
+            # single row read here.
+            run_pending_semantics_steps(interrupt_check=self._is_cancelled)
 
             if self._prune_first:
                 all_prefixes = get_owned_prefixes()

--- a/app/assets/seeder.py
+++ b/app/assets/seeder.py
@@ -549,9 +549,7 @@ class _AssetSeeder:
                 )
                 return
 
-            # Stale rows are brought forward before anything reads or extends
-            # them. A database already at the current semantics version costs a
-            # single row read here.
+            # Must precede the prune and the scan: both read and extend these rows.
             run_pending_semantics_steps(interrupt_check=self._is_cancelled)
 
             if self._prune_first:

--- a/app/assets/semantics/__init__.py
+++ b/app/assets/semantics/__init__.py
@@ -1,0 +1,119 @@
+"""Reset steps that bring stale asset rows forward to the current semantics.
+
+Alembic migrates the *shape* of the assets tables. Nothing migrates their
+*meaning*: a row whose columns are structurally current can still hold values
+that a superseded rule computed, and the steady-state scan will not repair one,
+because it only ever looks at paths it has not seen before.
+
+A reset step closes that gap. Each step is numbered, applied in order from the
+version stamped in the database up to ``CURRENT_SEMANTICS_VERSION``, and stamped
+only once it finishes, so an interrupted run resumes rather than half-applying.
+Steps must be idempotent: re-running one on rows it has already fixed changes
+nothing.
+
+The registry, not any individual step, is the durable part. A step is free to be
+as broad or as surgical as its particular drift calls for.
+"""
+
+import logging
+import time
+
+from app.assets.database.queries.semantics import (
+    get_semantics_version,
+    set_semantics_version,
+)
+from app.assets.semantics.reproject_derived import reproject_derived_state
+from app.assets.semantics.step import (
+    InterruptCheck,
+    SemanticsStep,
+    SemanticsStepInterrupted,
+)
+from app.database.db import can_create_session, create_session
+
+__all__ = [
+    "CURRENT_SEMANTICS_VERSION",
+    "SEMANTICS_STEPS",
+    "InterruptCheck",
+    "SemanticsStep",
+    "SemanticsStepInterrupted",
+    "run_pending_semantics_steps",
+]
+
+SEMANTICS_STEPS: tuple[SemanticsStep, ...] = (
+    SemanticsStep(
+        version=1,
+        description="reproject path-derived reference state",
+        apply=reproject_derived_state,
+    ),
+)
+
+CURRENT_SEMANTICS_VERSION = SEMANTICS_STEPS[-1].version
+
+
+def run_pending_semantics_steps(interrupt_check: InterruptCheck | None = None) -> int:
+    """Apply every reset step this database has not been stamped for.
+
+    A database already at ``CURRENT_SEMANTICS_VERSION`` costs one indexed row
+    read and nothing else -- no filesystem is touched to discover there is
+    nothing to do, which is the overwhelmingly common case.
+
+    Returns the number of steps applied.
+    """
+    if not can_create_session():
+        return 0
+
+    try:
+        with create_session() as session:
+            stored_version = get_semantics_version(session)
+    except Exception:
+        logging.exception(
+            "Could not read the asset semantics version; skipping semantics reset"
+        )
+        return 0
+
+    pending = [step for step in SEMANTICS_STEPS if step.version > stored_version]
+    if not pending:
+        return 0
+
+    logging.info(
+        "Asset semantics at version %d, current is %d: applying %d step(s)",
+        stored_version,
+        CURRENT_SEMANTICS_VERSION,
+        len(pending),
+    )
+
+    applied = 0
+    for step in pending:
+        started = time.perf_counter()
+        try:
+            summary = step.apply(interrupt_check)
+        except SemanticsStepInterrupted:
+            logging.info(
+                "Asset semantics step %d (%s) interrupted; resuming on next start",
+                step.version,
+                step.description,
+            )
+            return applied
+        except Exception:
+            logging.exception(
+                "Asset semantics step %d (%s) failed; database stays at version %d",
+                step.version,
+                step.description,
+                stored_version + applied,
+            )
+            return applied
+
+        with create_session() as session:
+            set_semantics_version(session, step.version)
+            session.commit()
+
+        applied += 1
+        logging.info(
+            "Asset semantics step %d (%s) applied in %.3fs: %s",
+            step.version,
+            step.description,
+            time.perf_counter() - started,
+            summary,
+        )
+
+    return applied

--- a/app/assets/semantics/__init__.py
+++ b/app/assets/semantics/__init__.py
@@ -1,18 +1,10 @@
 """Reset steps that bring stale asset rows forward to the current semantics.
 
-Alembic migrates the *shape* of the assets tables. Nothing migrates their
-*meaning*: a row whose columns are structurally current can still hold values
-that a superseded rule computed, and the steady-state scan will not repair one,
-because it only ever looks at paths it has not seen before.
-
-A reset step closes that gap. Each step is numbered, applied in order from the
-version stamped in the database up to ``CURRENT_SEMANTICS_VERSION``, and stamped
-only once it finishes, so an interrupted run resumes rather than half-applying.
-Steps must be idempotent: re-running one on rows it has already fixed changes
-nothing.
-
-The registry, not any individual step, is the durable part. A step is free to be
-as broad or as surgical as its particular drift calls for.
+Alembic migrates the shape of the assets tables; these steps migrate the meaning
+of what is in them. A step must be idempotent, is applied in order from the
+version stamped in the database, and is stamped only once it finishes, so an
+interrupted run resumes rather than half-applying. How broad or surgical a step
+is depends on the drift it repairs; the registry is what stays.
 """
 
 import logging
@@ -51,14 +43,7 @@ CURRENT_SEMANTICS_VERSION = SEMANTICS_STEPS[-1].version
 
 
 def run_pending_semantics_steps(interrupt_check: InterruptCheck | None = None) -> int:
-    """Apply every reset step this database has not been stamped for.
-
-    A database already at ``CURRENT_SEMANTICS_VERSION`` costs one indexed row
-    read and nothing else -- no filesystem is touched to discover there is
-    nothing to do, which is the overwhelmingly common case.
-
-    Returns the number of steps applied.
-    """
+    """Returns steps applied. A database already at the current version costs one indexed row read."""
     if not can_create_session():
         return 0
 

--- a/app/assets/semantics/__init__.py
+++ b/app/assets/semantics/__init__.py
@@ -19,6 +19,7 @@ from app.assets.semantics.step import (
     InterruptCheck,
     SemanticsStep,
     SemanticsStepInterrupted,
+    StepResult,
 )
 from app.database.db import can_create_session, create_session
 
@@ -28,6 +29,7 @@ __all__ = [
     "InterruptCheck",
     "SemanticsStep",
     "SemanticsStepInterrupted",
+    "StepResult",
     "run_pending_semantics_steps",
 ]
 
@@ -85,6 +87,17 @@ def run_pending_semantics_steps(interrupt_check: InterruptCheck | None = None) -
                 step.version,
                 step.description,
                 stored_version + applied,
+            )
+            return applied
+
+        if not summary.complete:
+            logging.info(
+                "Asset semantics step %d (%s) left work unfinished, staying at "
+                "version %d so it runs again: %s",
+                step.version,
+                step.description,
+                stored_version + applied,
+                summary,
             )
             return applied
 

--- a/app/assets/semantics/__init__.py
+++ b/app/assets/semantics/__init__.py
@@ -101,9 +101,18 @@ def run_pending_semantics_steps(interrupt_check: InterruptCheck | None = None) -
             )
             return applied
 
-        with create_session() as session:
-            set_semantics_version(session, step.version)
-            session.commit()
+        try:
+            with create_session() as session:
+                set_semantics_version(session, step.version)
+                session.commit()
+        except Exception:
+            logging.exception(
+                "Asset semantics step %d (%s) finished but could not be stamped, "
+                "so it runs again; its own writes are already committed",
+                step.version,
+                step.description,
+            )
+            return applied
 
         applied += 1
         logging.info(

--- a/app/assets/semantics/reproject_derived.py
+++ b/app/assets/semantics/reproject_derived.py
@@ -1,0 +1,215 @@
+"""Semantics step 1: re-derive the reference state that comes from the path.
+
+Three columns are pure functions of a file's location and whether it is there:
+``loader_path``, the backend tags a path implies, and ``is_missing``. Every one
+of them was computed once, when the reference was first written, by whatever
+rules were current that day. ``loader_path`` in particular was added to existing
+databases as a NULL column and no path has ever filled it in, so references
+older than that column serve a null loader path forever.
+
+This step recomputes those three from the filesystem as it stands now. It reads
+no file contents: ``verify_file_unchanged`` answers whether a file still matches
+what the database recorded, and the only thing that answer is used for is
+deciding *not* to touch content-derived state. Nothing here re-hashes, so a
+library of untouched 500GB models costs one ``stat`` each.
+
+What the step will not touch:
+
+- ``hash`` and ``size_bytes`` -- content facts, unrecoverable without reading
+  the file. A file that has changed underneath its row is handed to the existing
+  ``needs_verify`` path instead, exactly as the scanner would flag it.
+- Anything a person chose: manual and upload-origin tags, ``user_metadata``,
+  ``preview_id``, ``deleted_at``, ``job_id``, ``name``.
+- References whose file is gone, or whose path is not under any root this
+  install currently knows about. Retiring the former is the scanner's job under
+  its own rules; the latter cannot be classified at all, and a misconfigured
+  ``extra_model_paths.yaml`` must not be able to strip tags off assets that are
+  merely out of view.
+"""
+
+import logging
+import os
+from dataclasses import dataclass
+
+from app.assets.database.queries import (
+    bulk_update_is_missing,
+    bulk_update_needs_verify,
+)
+from app.assets.database.queries.semantics import (
+    AUTOMATIC_TAG_ORIGIN,
+    DerivedStateRow,
+    bulk_add_automatic_tags,
+    bulk_remove_automatic_tags,
+    bulk_set_loader_paths,
+    get_file_backed_references_page,
+    get_tags_by_reference,
+)
+from app.assets.helpers import normalize_tags
+from app.assets.semantics.step import InterruptCheck, SemanticsStepInterrupted
+from app.assets.services.file_utils import verify_file_unchanged
+from app.assets.services.path_utils import (
+    compute_loader_path,
+    get_path_derived_tag_vocabulary,
+    get_path_derived_tags_from_path,
+)
+from app.database.db import create_session
+
+# Bounds each transaction. Small enough that an interrupt loses little work,
+# large enough that the walk is not dominated by session setup.
+_BATCH_SIZE = 500
+
+
+@dataclass
+class ReprojectionSummary:
+    """What a reprojection pass did, for the log line."""
+
+    scanned: int = 0
+    unchanged_files: int = 0
+    changed_files: int = 0
+    absent_files: int = 0
+    unclassified_paths: int = 0
+    loader_paths_rewritten: int = 0
+    tags_added: int = 0
+    tags_removed: int = 0
+    missing_flags_cleared: int = 0
+    verify_flags_set: int = 0
+
+    def __str__(self) -> str:
+        return (
+            f"scanned={self.scanned} unchanged={self.unchanged_files} "
+            f"changed={self.changed_files} absent={self.absent_files} "
+            f"unclassified={self.unclassified_paths} "
+            f"loader_paths={self.loader_paths_rewritten} "
+            f"tags+{self.tags_added}/-{self.tags_removed} "
+            f"unflagged_missing={self.missing_flags_cleared} "
+            f"flagged_verify={self.verify_flags_set}"
+        )
+
+
+def reproject_derived_state(
+    interrupt_check: InterruptCheck | None = None,
+) -> ReprojectionSummary:
+    """Re-derive path-derived state for every file-backed reference.
+
+    Walks the reference table in keyset-paginated batches, committing each one,
+    so a kill mid-walk leaves committed batches reprojected and the rest
+    untouched -- both states the step handles on its next run.
+    """
+    summary = ReprojectionSummary()
+    vocabulary = get_path_derived_tag_vocabulary()
+    after_id: str | None = None
+
+    while True:
+        if interrupt_check is not None and interrupt_check():
+            raise SemanticsStepInterrupted(
+                f"interrupted after {summary.scanned} references"
+            )
+
+        with create_session() as session:
+            rows = get_file_backed_references_page(
+                session, after_id=after_id, limit=_BATCH_SIZE
+            )
+            if not rows:
+                return summary
+            after_id = rows[-1].reference_id
+            _reproject_batch(session, rows, vocabulary, summary)
+            session.commit()
+
+
+def _reproject_batch(
+    session,
+    rows: list[DerivedStateRow],
+    vocabulary: set[str],
+    summary: ReprojectionSummary,
+) -> None:
+    stored_tags = get_tags_by_reference(session, [row.reference_id for row in rows])
+
+    loader_paths: dict[str, str | None] = {}
+    tags_to_add: list[tuple[str, str]] = []
+    tags_to_remove: list[tuple[str, str]] = []
+    clear_missing: list[str] = []
+    set_needs_verify: list[str] = []
+
+    for row in rows:
+        summary.scanned += 1
+        present, unchanged = _classify_file(row)
+
+        if not present:
+            # The scanner owns retiring these, under its own missing semantics.
+            summary.absent_files += 1
+            continue
+
+        if unchanged:
+            summary.unchanged_files += 1
+        else:
+            # The file moved on from what the row records, so its hash, size and
+            # mime no longer describe it. Re-deriving those means reading the
+            # file, which this step does not do; flag it for the path that does.
+            summary.changed_files += 1
+            if not row.needs_verify:
+                set_needs_verify.append(row.reference_id)
+
+        try:
+            derived_tags = set(
+                normalize_tags(get_path_derived_tags_from_path(row.file_path))
+            )
+        except ValueError:
+            summary.unclassified_paths += 1
+            continue
+
+        loader_path = compute_loader_path(row.file_path)
+        if loader_path != row.loader_path:
+            loader_paths[row.reference_id] = loader_path
+            summary.loader_paths_rewritten += 1
+
+        current_tags = stored_tags.get(row.reference_id, {})
+        for tag_name in sorted(derived_tags - set(current_tags)):
+            tags_to_add.append((row.reference_id, tag_name))
+        for tag_name, origin in sorted(current_tags.items()):
+            if (
+                origin == AUTOMATIC_TAG_ORIGIN
+                and tag_name in vocabulary
+                and tag_name not in derived_tags
+            ):
+                tags_to_remove.append((row.reference_id, tag_name))
+
+        if row.is_missing:
+            # The file is right there. Nothing else un-flags this: the scanner
+            # excludes already-missing references from its temp reconciliation.
+            clear_missing.append(row.reference_id)
+
+    bulk_set_loader_paths(session, loader_paths)
+    bulk_add_automatic_tags(session, tags_to_add)
+    bulk_remove_automatic_tags(session, tags_to_remove)
+    bulk_update_is_missing(session, clear_missing, value=False)
+    bulk_update_needs_verify(session, set_needs_verify, value=True)
+
+    summary.tags_added += len(tags_to_add)
+    summary.tags_removed += len(tags_to_remove)
+    summary.missing_flags_cleared += len(clear_missing)
+    summary.verify_flags_set += len(set_needs_verify)
+
+
+def _classify_file(row: DerivedStateRow) -> tuple[bool, bool]:
+    """Return (file is present, file still matches what the row recorded).
+
+    Mirrors the scanner's stat handling so the two agree about what counts as a
+    present file: a permission error means the file is there but unreadable, any
+    other OS error means treat it as gone.
+    """
+    try:
+        stat_result = os.stat(row.file_path, follow_symlinks=True)
+    except FileNotFoundError:
+        return False, False
+    except PermissionError:
+        logging.debug("Permission denied accessing %s", row.file_path)
+        return True, False
+    except OSError as error:
+        logging.debug("OSError checking %s: %s", row.file_path, error)
+        return False, False
+
+    return True, verify_file_unchanged(
+        mtime_db=row.mtime_ns,
+        size_db=row.size_bytes,
+        stat_result=stat_result,
+    )

--- a/app/assets/semantics/reproject_derived.py
+++ b/app/assets/semantics/reproject_derived.py
@@ -32,7 +32,11 @@ from app.assets.database.queries.semantics import (
     get_tag_origins_by_reference,
 )
 from app.assets.helpers import normalize_tags
-from app.assets.semantics.step import InterruptCheck, SemanticsStepInterrupted
+from app.assets.semantics.step import (
+    InterruptCheck,
+    SemanticsStepInterrupted,
+    StepResult,
+)
 from app.assets.services.file_utils import verify_file_unchanged
 from app.assets.services.path_utils import (
     compute_loader_path,
@@ -45,7 +49,7 @@ _ROWS_PER_TRANSACTION = 500
 
 
 @dataclass
-class ReprojectionSummary:
+class ReprojectionSummary(StepResult):
 
     scanned: int = 0
     unchanged_files: int = 0
@@ -57,6 +61,17 @@ class ReprojectionSummary:
     tags_removed: int = 0
     missing_flags_cleared: int = 0
     verify_flags_set: int = 0
+
+    @property
+    def complete(self) -> bool:
+        """A path under no known root today may be under one tomorrow.
+
+        Its file is on disk -- an absent file is counted separately -- so the
+        root was configured away rather than deleted, and nothing else will ever
+        re-derive the row: the scan only builds specs for paths it has not seen.
+        Staying unstamped is what lets restoring the root repair them.
+        """
+        return self.unclassified_paths == 0
 
     def __str__(self) -> str:
         return (

--- a/app/assets/semantics/reproject_derived.py
+++ b/app/assets/semantics/reproject_derived.py
@@ -129,14 +129,6 @@ def _reproject_batch(
             summary.absent_files += 1
             continue
 
-        if unchanged:
-            summary.unchanged_files += 1
-        else:
-            # Hand it to the verify path rather than re-read the file for hash and size.
-            summary.changed_files += 1
-            if not row.needs_verify:
-                set_needs_verify.append(row.reference_id)
-
         try:
             derived_tags = set(
                 normalize_tags(get_path_derived_tags_from_path(row.file_path))
@@ -144,6 +136,14 @@ def _reproject_batch(
         except ValueError:
             summary.unclassified_paths += 1
             continue
+
+        if unchanged:
+            summary.unchanged_files += 1
+        else:
+            # Hand it to the verify path rather than re-read the file for hash and size.
+            summary.changed_files += 1
+            if not row.needs_verify:
+                set_needs_verify.append(row.reference_id)
 
         loader_path = compute_loader_path(row.file_path)
         if loader_path != row.loader_path:

--- a/app/assets/semantics/reproject_derived.py
+++ b/app/assets/semantics/reproject_derived.py
@@ -1,30 +1,17 @@
 """Semantics step 1: re-derive the reference state that comes from the path.
 
-Three columns are pure functions of a file's location and whether it is there:
-``loader_path``, the backend tags a path implies, and ``is_missing``. Every one
-of them was computed once, when the reference was first written, by whatever
-rules were current that day. ``loader_path`` in particular was added to existing
-databases as a NULL column and no path has ever filled it in, so references
-older than that column serve a null loader path forever.
+Recomputes ``loader_path``, the backend tags a path implies, and ``is_missing``.
 
-This step recomputes those three from the filesystem as it stands now. It reads
-no file contents: ``verify_file_unchanged`` answers whether a file still matches
-what the database recorded, and the only thing that answer is used for is
-deciding *not* to touch content-derived state. Nothing here re-hashes, so a
-library of untouched 500GB models costs one ``stat`` each.
+It must keep reading no file contents, so an untouched model library costs one
+``stat`` per file. That rules out repairing anything derived from content --
+``hash``, ``size_bytes``, mime -- so a file that has changed underneath its row
+goes to the existing ``needs_verify`` path instead.
 
-What the step will not touch:
-
-- ``hash`` and ``size_bytes`` -- content facts, unrecoverable without reading
-  the file. A file that has changed underneath its row is handed to the existing
-  ``needs_verify`` path instead, exactly as the scanner would flag it.
-- Anything a person chose: manual and upload-origin tags, ``user_metadata``,
-  ``preview_id``, ``deleted_at``, ``job_id``, ``name``.
-- References whose file is gone, or whose path is not under any root this
-  install currently knows about. Retiring the former is the scanner's job under
-  its own rules; the latter cannot be classified at all, and a misconfigured
-  ``extra_model_paths.yaml`` must not be able to strip tags off assets that are
-  merely out of view.
+It must also leave alone anything a person chose (manual and upload-origin tags,
+``user_metadata``, ``preview_id``, ``deleted_at``, ``job_id``, ``name``),
+references whose file is gone, and references whose path is under no root this
+install currently knows about -- a misconfigured ``extra_model_paths.yaml`` must
+not be able to strip tags off assets that are merely out of view.
 """
 
 import logging
@@ -54,14 +41,11 @@ from app.assets.services.path_utils import (
 )
 from app.database.db import create_session
 
-# Bounds each transaction. Small enough that an interrupt loses little work,
-# large enough that the walk is not dominated by session setup.
 _BATCH_SIZE = 500
 
 
 @dataclass
 class ReprojectionSummary:
-    """What a reprojection pass did, for the log line."""
 
     scanned: int = 0
     unchanged_files: int = 0
@@ -89,12 +73,7 @@ class ReprojectionSummary:
 def reproject_derived_state(
     interrupt_check: InterruptCheck | None = None,
 ) -> ReprojectionSummary:
-    """Re-derive path-derived state for every file-backed reference.
-
-    Walks the reference table in keyset-paginated batches, committing each one,
-    so a kill mid-walk leaves committed batches reprojected and the rest
-    untouched -- both states the step handles on its next run.
-    """
+    """Each batch commits on its own, so a kill mid-walk is safe to resume."""
     summary = ReprojectionSummary()
     vocabulary = get_path_derived_tag_vocabulary()
     after_id: str | None = None
@@ -142,9 +121,7 @@ def _reproject_batch(
         if unchanged:
             summary.unchanged_files += 1
         else:
-            # The file moved on from what the row records, so its hash, size and
-            # mime no longer describe it. Re-deriving those means reading the
-            # file, which this step does not do; flag it for the path that does.
+            # Hand it to the verify path rather than re-read the file for hash and size.
             summary.changed_files += 1
             if not row.needs_verify:
                 set_needs_verify.append(row.reference_id)
@@ -174,8 +151,8 @@ def _reproject_batch(
                 tags_to_remove.append((row.reference_id, tag_name))
 
         if row.is_missing:
-            # The file is right there. Nothing else un-flags this: the scanner
-            # excludes already-missing references from its temp reconciliation.
+            # Nothing else un-flags this: the scanner excludes already-missing
+            # references from its temp reconciliation.
             clear_missing.append(row.reference_id)
 
     bulk_set_loader_paths(session, loader_paths)
@@ -191,12 +168,7 @@ def _reproject_batch(
 
 
 def _classify_file(row: DerivedStateRow) -> tuple[bool, bool]:
-    """Return (file is present, file still matches what the row recorded).
-
-    Mirrors the scanner's stat handling so the two agree about what counts as a
-    present file: a permission error means the file is there but unreadable, any
-    other OS error means treat it as gone.
-    """
+    """Mirrors the scanner's stat handling: permission denied means present-but-unreadable, any other OS error means gone."""
     try:
         stat_result = os.stat(row.file_path, follow_symlinks=True)
     except FileNotFoundError:

--- a/app/assets/semantics/reproject_derived.py
+++ b/app/assets/semantics/reproject_derived.py
@@ -64,13 +64,7 @@ class ReprojectionSummary(StepResult):
 
     @property
     def complete(self) -> bool:
-        """A path under no known root today may be under one tomorrow.
-
-        Its file is on disk -- an absent file is counted separately -- so the
-        root was configured away rather than deleted, and nothing else will ever
-        re-derive the row: the scan only builds specs for paths it has not seen.
-        Staying unstamped is what lets restoring the root repair them.
-        """
+        """Nothing else re-derives these rows -- the scan only builds specs for paths it has not seen -- so staying unstamped is what lets a restored root repair them."""
         return self.unclassified_paths == 0
 
     def __str__(self) -> str:

--- a/app/assets/semantics/reproject_derived.py
+++ b/app/assets/semantics/reproject_derived.py
@@ -29,7 +29,7 @@ from app.assets.database.queries.semantics import (
     bulk_remove_automatic_tags,
     bulk_set_loader_paths,
     get_file_backed_references_page,
-    get_tags_by_reference,
+    get_tag_origins_by_reference,
 )
 from app.assets.helpers import normalize_tags
 from app.assets.semantics.step import InterruptCheck, SemanticsStepInterrupted
@@ -41,7 +41,7 @@ from app.assets.services.path_utils import (
 )
 from app.database.db import create_session
 
-_BATCH_SIZE = 500
+_ROWS_PER_TRANSACTION = 500
 
 
 @dataclass
@@ -86,7 +86,7 @@ def reproject_derived_state(
 
         with create_session() as session:
             rows = get_file_backed_references_page(
-                session, after_id=after_id, limit=_BATCH_SIZE
+                session, after_id=after_id, limit=_ROWS_PER_TRANSACTION
             )
             if not rows:
                 return summary
@@ -101,7 +101,9 @@ def _reproject_batch(
     vocabulary: set[str],
     summary: ReprojectionSummary,
 ) -> None:
-    stored_tags = get_tags_by_reference(session, [row.reference_id for row in rows])
+    stored_tags = get_tag_origins_by_reference(
+        session, [row.reference_id for row in rows]
+    )
 
     loader_paths: dict[str, str | None] = {}
     tags_to_add: list[tuple[str, str]] = []

--- a/app/assets/semantics/step.py
+++ b/app/assets/semantics/step.py
@@ -1,0 +1,28 @@
+"""What a semantics reset step is. See ``app.assets.semantics`` for the why."""
+
+from dataclasses import dataclass
+from typing import Callable
+
+InterruptCheck = Callable[[], bool]
+
+
+class SemanticsStepInterrupted(Exception):
+    """A step stopped early on request.
+
+    Its partial work stands -- steps are idempotent, so a resumed run repeats it
+    harmlessly -- but the version is not stamped, so the step runs again.
+    """
+
+
+@dataclass(frozen=True)
+class SemanticsStep:
+    """One numbered reset step.
+
+    ``apply`` takes an optional interrupt check and returns a summary of what it
+    did, which is logged. It must be idempotent and must raise
+    ``SemanticsStepInterrupted`` rather than return if it stops early.
+    """
+
+    version: int
+    description: str
+    apply: Callable[[InterruptCheck | None], object]

--- a/app/assets/semantics/step.py
+++ b/app/assets/semantics/step.py
@@ -1,4 +1,3 @@
-"""What a semantics reset step is. See ``app.assets.semantics`` for the why."""
 
 from dataclasses import dataclass
 from typing import Callable
@@ -16,12 +15,7 @@ class SemanticsStepInterrupted(Exception):
 
 @dataclass(frozen=True)
 class SemanticsStep:
-    """One numbered reset step.
-
-    ``apply`` takes an optional interrupt check and returns a summary of what it
-    did, which is logged. It must be idempotent and must raise
-    ``SemanticsStepInterrupted`` rather than return if it stops early.
-    """
+    """``apply`` must be idempotent, and must raise SemanticsStepInterrupted rather than return early."""
 
     version: int
     description: str

--- a/app/assets/semantics/step.py
+++ b/app/assets/semantics/step.py
@@ -5,6 +5,15 @@ from typing import Callable
 InterruptCheck = Callable[[], bool]
 
 
+@dataclass
+class StepResult:
+    """What a step did. A falsy ``complete`` withholds the stamp, so the step runs again."""
+
+    @property
+    def complete(self) -> bool:
+        return True
+
+
 class SemanticsStepInterrupted(Exception):
     """A step stopped early on request.
 
@@ -19,4 +28,4 @@ class SemanticsStep:
 
     version: int
     description: str
-    apply: Callable[[InterruptCheck | None], object]
+    apply: Callable[[InterruptCheck | None], StepResult]

--- a/app/assets/services/path_utils.py
+++ b/app/assets/services/path_utils.py
@@ -330,9 +330,7 @@ def get_path_derived_tag_vocabulary() -> set[str]:
     vocabulary = {"input", "output", "temp", "models"}
     vocabulary.update(_KNOWN_SUBFOLDER_TAGS)
     for folder_name, _bases, _extensions in get_comfy_models_folders():
-        # Strip the name, not the finished tag: whitespace landing after
-        # "model_type:" survives the strip that stored names are put through,
-        # so the entry would never match the tag it authorises removing.
+        # Strip the name, not the finished tag: whitespace after "model_type:" survives an end-strip.
         vocabulary.add(f"model_type:{folder_name.strip()}")
     return vocabulary
 

--- a/app/assets/services/path_utils.py
+++ b/app/assets/services/path_utils.py
@@ -325,6 +325,21 @@ def get_path_derived_tags_from_path(path: str) -> list[str]:
     return tags
 
 
+def get_path_derived_tag_vocabulary() -> set[str]:
+    """Every tag get_path_derived_tags_from_path can emit under the current config.
+
+    Bounds which tags a re-derivation may take away: a stored automatic tag
+    inside this vocabulary that the current rules no longer emit was produced
+    by a superseded rule, while one outside it came from somewhere else and is
+    none of the derivation's business.
+    """
+    vocabulary = {"input", "output", "temp", "models"}
+    vocabulary.update(_KNOWN_SUBFOLDER_TAGS)
+    for folder_name, _bases, _extensions in get_comfy_models_folders():
+        vocabulary.add(f"model_type:{folder_name}")
+    return vocabulary
+
+
 def get_name_and_tags_from_asset_path(file_path: str) -> tuple[str, list[str]]:
     """Return (name, tags) derived from a filesystem path.
 

--- a/app/assets/services/path_utils.py
+++ b/app/assets/services/path_utils.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Literal
 
 import folder_paths
+from app.assets.helpers import normalize_tags
 
 
 _NON_MODEL_FOLDER_NAMES = frozenset({"configs", "custom_nodes"})
@@ -331,7 +332,10 @@ def get_path_derived_tag_vocabulary() -> set[str]:
     vocabulary.update(_KNOWN_SUBFOLDER_TAGS)
     for folder_name, _bases, _extensions in get_comfy_models_folders():
         vocabulary.add(f"model_type:{folder_name}")
-    return vocabulary
+    # Stored tag names reach the database through normalize_tags, so an
+    # un-normalized vocabulary entry would never match one and the stale tag
+    # it is meant to authorise removing would survive.
+    return set(normalize_tags(list(vocabulary)))
 
 
 def get_name_and_tags_from_asset_path(file_path: str) -> tuple[str, list[str]]:

--- a/app/assets/services/path_utils.py
+++ b/app/assets/services/path_utils.py
@@ -326,13 +326,7 @@ def get_path_derived_tags_from_path(path: str) -> list[str]:
 
 
 def get_path_derived_tag_vocabulary() -> set[str]:
-    """Every tag get_path_derived_tags_from_path can emit under the current config.
-
-    Bounds which tags a re-derivation may take away: a stored automatic tag
-    inside this vocabulary that the current rules no longer emit was produced
-    by a superseded rule, while one outside it came from somewhere else and is
-    none of the derivation's business.
-    """
+    """Bounds which stored tags a re-derivation may take away; one outside this set came from elsewhere."""
     vocabulary = {"input", "output", "temp", "models"}
     vocabulary.update(_KNOWN_SUBFOLDER_TAGS)
     for folder_name, _bases, _extensions in get_comfy_models_folders():

--- a/app/assets/services/path_utils.py
+++ b/app/assets/services/path_utils.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import Literal
 
 import folder_paths
-from app.assets.helpers import normalize_tags
 
 
 _NON_MODEL_FOLDER_NAMES = frozenset({"configs", "custom_nodes"})
@@ -331,10 +330,11 @@ def get_path_derived_tag_vocabulary() -> set[str]:
     vocabulary = {"input", "output", "temp", "models"}
     vocabulary.update(_KNOWN_SUBFOLDER_TAGS)
     for folder_name, _bases, _extensions in get_comfy_models_folders():
-        vocabulary.add(f"model_type:{folder_name}")
-    # Stored names reach the database through normalize_tags, so an un-normalized
-    # entry would never match the tag it exists to authorise removing.
-    return set(normalize_tags(list(vocabulary)))
+        # Strip the name, not the finished tag: whitespace landing after
+        # "model_type:" survives the strip that stored names are put through,
+        # so the entry would never match the tag it authorises removing.
+        vocabulary.add(f"model_type:{folder_name.strip()}")
+    return vocabulary
 
 
 def get_name_and_tags_from_asset_path(file_path: str) -> tuple[str, list[str]]:

--- a/app/assets/services/path_utils.py
+++ b/app/assets/services/path_utils.py
@@ -332,9 +332,8 @@ def get_path_derived_tag_vocabulary() -> set[str]:
     vocabulary.update(_KNOWN_SUBFOLDER_TAGS)
     for folder_name, _bases, _extensions in get_comfy_models_folders():
         vocabulary.add(f"model_type:{folder_name}")
-    # Stored tag names reach the database through normalize_tags, so an
-    # un-normalized vocabulary entry would never match one and the stale tag
-    # it is meant to authorise removing would survive.
+    # Stored names reach the database through normalize_tags, so an un-normalized
+    # entry would never match the tag it exists to authorise removing.
     return set(normalize_tags(list(vocabulary)))
 
 

--- a/tests-unit/assets_test/test_semantics_reset.py
+++ b/tests-unit/assets_test/test_semantics_reset.py
@@ -384,7 +384,6 @@ class TestTagReprojection:
     def test_vocabulary_matches_tags_as_the_database_stores_them(
         self, session, comfy_dirs
     ):
-        """Stored names arrive normalized, so a raw vocabulary entry never matches."""
         path = _write(comfy_dirs["checkpoints"], "model.safetensors")
         _register(
             session,

--- a/tests-unit/assets_test/test_semantics_reset.py
+++ b/tests-unit/assets_test/test_semantics_reset.py
@@ -1,9 +1,4 @@
-"""Tests for the asset semantics reset (app/assets/semantics).
-
-Runs standalone against in-memory SQLite:
-
-    pytest tests-unit/assets_test/test_semantics_reset.py --noconftest
-"""
+"""Tests for the asset semantics reset (app/assets/semantics)."""
 
 import os
 import tempfile
@@ -34,17 +29,12 @@ from app.assets.services.file_utils import get_mtime_ns
 
 @pytest.fixture(autouse=True)
 def autoclean_unit_test_assets():
-    """Override the package autouse fixture; these tests need no server."""
+    """Override parent autouse fixture - these tests don't need server cleanup."""
     yield
 
 
 @pytest.fixture
 def session_factory():
-    """A session factory over one shared in-memory database.
-
-    StaticPool keeps every session on the same connection, so the batching walk
-    sees its own committed writes across sessions.
-    """
     engine = create_engine(
         "sqlite:///:memory:",
         poolclass=StaticPool,
@@ -62,14 +52,12 @@ def session_factory():
 
 @pytest.fixture
 def session(session_factory) -> Session:
-    """A session for the test's own reads and writes."""
     with session_factory() as sess:
         yield sess
 
 
 @pytest.fixture
 def comfy_dirs():
-    """Point every asset root at a throwaway tree with one model category."""
     with tempfile.TemporaryDirectory() as base:
         dirs = {
             name: Path(base) / name
@@ -118,10 +106,6 @@ def _register(
     job_id: str | None = None,
     tags: dict[str, str] | None = None,
 ) -> AssetReference:
-    """Insert an Asset + AssetReference (+ tags as {name: origin}) and commit.
-
-    ``asset_hash=""`` means "any unique hash"; assets.hash is unique-indexed.
-    """
     if asset_hash == "":
         asset_hash = f"blake3:{ref_id}"
     if mtime_ns is None:
@@ -168,7 +152,6 @@ def _tags(session: Session, ref_id: str) -> dict[str, str]:
 
 
 def _snapshot(session: Session) -> list[tuple]:
-    """Every field the reset could plausibly touch, for equality across runs."""
     session.expire_all()
     refs = session.execute(select(AssetReference).order_by(AssetReference.id)).scalars()
     rows = [
@@ -195,7 +178,6 @@ def _snapshot(session: Session) -> list[tuple]:
 
 class TestLoaderPathReprojection:
     def test_null_loader_path_is_backfilled(self, session, comfy_dirs):
-        """The drift 0006 left behind: a column added with no backfill."""
         path = _write(comfy_dirs["checkpoints"], "flux/model.safetensors")
         _register(session, path, "ref-1", loader_path=None)
 
@@ -224,7 +206,6 @@ class TestLoaderPathReprojection:
         assert summary.loader_paths_rewritten == 0
 
     def test_unloadable_extension_loses_its_loader_path(self, session, comfy_dirs):
-        """The current rule gives no loader path to a file its category cannot load."""
         path = _write(comfy_dirs["checkpoints"], "notes.txt")
         _register(session, path, "ref-1", loader_path="notes.txt")
 
@@ -269,7 +250,6 @@ class TestHashPreservation:
     def test_changed_file_keeps_its_hash_and_is_flagged_for_verify(
         self, session, comfy_dirs
     ):
-        """A file that moved on is handed to the existing verify path, not re-read."""
         path = _write(comfy_dirs["checkpoints"], "big.safetensors")
         _register(
             session,
@@ -335,13 +315,11 @@ class TestIntentIsPreserved:
         tags = _tags(session, "ref-1")
         assert tags["favourite"] == "manual"
         assert tags["uploaded"] == "upload"
-        # ...while the derived state around them was still brought forward.
         assert ref.loader_path == "curated.safetensors"
 
     def test_manual_tag_inside_the_derived_vocabulary_is_not_removed(
         self, session, comfy_dirs
     ):
-        """A person may tag an input file 'models'; that is their business."""
         path = _write(comfy_dirs["input"], "photo.png")
         _register(session, path, "ref-1", tags={"models": "manual"})
 
@@ -363,7 +341,6 @@ class TestTagReprojection:
         }
 
     def test_superseded_automatic_tag_is_removed(self, session, comfy_dirs):
-        """An older rule tagged by directory alone; extensions now gate the tag."""
         path = _write(comfy_dirs["checkpoints"], "model.safetensors")
         _register(
             session,
@@ -384,7 +361,6 @@ class TestTagReprojection:
     def test_automatic_tag_outside_the_vocabulary_is_left_alone(
         self, session, comfy_dirs
     ):
-        """'missing' is automatic but not path-derived; the scanner owns it."""
         path = _write(comfy_dirs["checkpoints"], "model.safetensors")
         _register(session, path, "ref-1", tags={"missing": "automatic"})
 
@@ -424,7 +400,6 @@ class TestFileState:
         assert summary.absent_files == 1
 
     def test_path_outside_every_known_root_is_left_alone(self, session, comfy_dirs):
-        """A root missing from the config must not strip tags off its assets."""
         path = _write(comfy_dirs["elsewhere"], "model.safetensors")
         _register(
             session,
@@ -488,7 +463,6 @@ class TestIdempotence:
     def test_statements_chunked_by_bind_param_limit_stay_correct(
         self, session, comfy_dirs
     ):
-        """The bind-param chunking must not drop or duplicate a tag."""
         for index in range(4):
             _register(
                 session,

--- a/tests-unit/assets_test/test_semantics_reset.py
+++ b/tests-unit/assets_test/test_semantics_reset.py
@@ -1,0 +1,672 @@
+"""Tests for the asset semantics reset (app/assets/semantics).
+
+Runs standalone against in-memory SQLite:
+
+    pytest tests-unit/assets_test/test_semantics_reset.py --noconftest
+"""
+
+import os
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import app.assets.semantics as semantics
+from app.assets.database.models import (
+    Asset,
+    AssetReference,
+    AssetReferenceTag,
+    AssetSemanticsVersion,
+    Base,
+    Tag,
+)
+from app.assets.database.queries.semantics import get_semantics_version
+from app.assets.semantics import run_pending_semantics_steps
+from app.assets.semantics.reproject_derived import reproject_derived_state
+from app.assets.semantics.step import SemanticsStep, SemanticsStepInterrupted
+from app.assets.services.file_utils import get_mtime_ns
+
+
+@pytest.fixture(autouse=True)
+def autoclean_unit_test_assets():
+    """Override the package autouse fixture; these tests need no server."""
+    yield
+
+
+@pytest.fixture
+def session_factory():
+    """A session factory over one shared in-memory database.
+
+    StaticPool keeps every session on the same connection, so the batching walk
+    sees its own committed writes across sessions.
+    """
+    engine = create_engine(
+        "sqlite:///:memory:",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine)
+    with (
+        patch("app.assets.semantics.reproject_derived.create_session", factory),
+        patch("app.assets.semantics.create_session", factory),
+        patch("app.assets.semantics.can_create_session", return_value=True),
+    ):
+        yield factory
+
+
+@pytest.fixture
+def session(session_factory) -> Session:
+    """A session for the test's own reads and writes."""
+    with session_factory() as sess:
+        yield sess
+
+
+@pytest.fixture
+def comfy_dirs():
+    """Point every asset root at a throwaway tree with one model category."""
+    with tempfile.TemporaryDirectory() as base:
+        dirs = {
+            name: Path(base) / name
+            for name in ("checkpoints", "loras", "input", "output", "temp", "elsewhere")
+        }
+        for directory in dirs.values():
+            directory.mkdir()
+        with (
+            patch("folder_paths.get_input_directory", return_value=str(dirs["input"])),
+            patch(
+                "folder_paths.get_output_directory", return_value=str(dirs["output"])
+            ),
+            patch("folder_paths.get_temp_directory", return_value=str(dirs["temp"])),
+            patch(
+                "app.assets.services.path_utils.get_comfy_models_folders",
+                return_value=[
+                    ("checkpoints", [str(dirs["checkpoints"])], {".safetensors"}),
+                    ("loras", [str(dirs["loras"])], {".safetensors"}),
+                ],
+            ),
+        ):
+            yield dirs
+
+
+def _write(directory: Path, name: str, content: bytes = b"\x00" * 100) -> str:
+    path = directory / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return os.path.abspath(str(path))
+
+
+def _register(
+    session: Session,
+    file_path: str,
+    ref_id: str,
+    *,
+    loader_path: str | None = None,
+    asset_hash: str | None = "",
+    size_bytes: int = 100,
+    mtime_ns: int | None = None,
+    is_missing: bool = False,
+    needs_verify: bool = False,
+    user_metadata: dict | None = None,
+    preview_id: str | None = None,
+    deleted_at: datetime | None = None,
+    job_id: str | None = None,
+    tags: dict[str, str] | None = None,
+) -> AssetReference:
+    """Insert an Asset + AssetReference (+ tags as {name: origin}) and commit.
+
+    ``asset_hash=""`` means "any unique hash"; assets.hash is unique-indexed.
+    """
+    if asset_hash == "":
+        asset_hash = f"blake3:{ref_id}"
+    if mtime_ns is None:
+        mtime_ns = get_mtime_ns(os.stat(file_path, follow_symlinks=True))
+
+    session.add(Asset(id=f"asset-{ref_id}", hash=asset_hash, size_bytes=size_bytes))
+    session.flush()
+    ref = AssetReference(
+        id=ref_id,
+        asset_id=f"asset-{ref_id}",
+        name=os.path.basename(file_path),
+        owner_id="",
+        file_path=file_path,
+        loader_path=loader_path,
+        mtime_ns=mtime_ns,
+        is_missing=is_missing,
+        needs_verify=needs_verify,
+        user_metadata=user_metadata,
+        preview_id=preview_id,
+        deleted_at=deleted_at,
+        job_id=job_id,
+    )
+    session.add(ref)
+    session.flush()
+
+    for tag_name, origin in (tags or {}).items():
+        session.merge(Tag(name=tag_name))
+        session.add(
+            AssetReferenceTag(
+                asset_reference_id=ref_id, tag_name=tag_name, origin=origin
+            )
+        )
+    session.commit()
+    return ref
+
+
+def _tags(session: Session, ref_id: str) -> dict[str, str]:
+    rows = session.execute(
+        select(AssetReferenceTag.tag_name, AssetReferenceTag.origin).where(
+            AssetReferenceTag.asset_reference_id == ref_id
+        )
+    ).all()
+    return {name: origin for name, origin in rows}
+
+
+def _snapshot(session: Session) -> list[tuple]:
+    """Every field the reset could plausibly touch, for equality across runs."""
+    session.expire_all()
+    refs = session.execute(select(AssetReference).order_by(AssetReference.id)).scalars()
+    rows = [
+        (
+            ref.id,
+            ref.file_path,
+            ref.loader_path,
+            ref.is_missing,
+            ref.needs_verify,
+            ref.mtime_ns,
+            ref.name,
+            ref.preview_id,
+            str(ref.user_metadata),
+            ref.deleted_at,
+            ref.job_id,
+            tuple(sorted(_tags(session, ref.id).items())),
+        )
+        for ref in refs
+    ]
+    assets = session.execute(select(Asset).order_by(Asset.id)).scalars()
+    rows.extend((asset.id, asset.hash, asset.size_bytes) for asset in assets)
+    return rows
+
+
+class TestLoaderPathReprojection:
+    def test_null_loader_path_is_backfilled(self, session, comfy_dirs):
+        """The drift 0006 left behind: a column added with no backfill."""
+        path = _write(comfy_dirs["checkpoints"], "flux/model.safetensors")
+        _register(session, path, "ref-1", loader_path=None)
+
+        reproject_derived_state()
+
+        session.expire_all()
+        ref = session.get(AssetReference, "ref-1")
+        assert ref.loader_path == "flux/model.safetensors"
+
+    def test_stale_loader_path_is_rewritten(self, session, comfy_dirs):
+        path = _write(comfy_dirs["input"], "sub/photo.png")
+        _register(session, path, "ref-1", loader_path="checkpoints/sub/photo.png")
+
+        summary = reproject_derived_state()
+
+        session.expire_all()
+        assert session.get(AssetReference, "ref-1").loader_path == "sub/photo.png"
+        assert summary.loader_paths_rewritten == 1
+
+    def test_correct_loader_path_is_left_alone(self, session, comfy_dirs):
+        path = _write(comfy_dirs["loras"], "style.safetensors")
+        _register(session, path, "ref-1", loader_path="style.safetensors")
+
+        summary = reproject_derived_state()
+
+        assert summary.loader_paths_rewritten == 0
+
+    def test_unloadable_extension_loses_its_loader_path(self, session, comfy_dirs):
+        """The current rule gives no loader path to a file its category cannot load."""
+        path = _write(comfy_dirs["checkpoints"], "notes.txt")
+        _register(session, path, "ref-1", loader_path="notes.txt")
+
+        reproject_derived_state()
+
+        session.expire_all()
+        assert session.get(AssetReference, "ref-1").loader_path is None
+
+    def test_reference_without_file_path_is_skipped(self, session, comfy_dirs):
+        session.add(Asset(id="asset-api", hash="blake3:abc", size_bytes=10))
+        session.flush()
+        session.add(
+            AssetReference(
+                id="ref-api", asset_id="asset-api", name="api.png", owner_id=""
+            )
+        )
+        session.commit()
+
+        summary = reproject_derived_state()
+
+        assert summary.scanned == 0
+        session.expire_all()
+        assert session.get(AssetReference, "ref-api").loader_path is None
+
+
+class TestHashPreservation:
+    def test_unchanged_file_keeps_its_hash_and_is_not_read(self, session, comfy_dirs):
+        path = _write(comfy_dirs["checkpoints"], "big.safetensors")
+        _register(session, path, "ref-1", asset_hash="blake3:original", size_bytes=100)
+
+        with patch(
+            "app.assets.services.hashing.compute_blake3_hash",
+            side_effect=AssertionError("the reset must never re-hash"),
+        ):
+            summary = reproject_derived_state()
+
+        session.expire_all()
+        assert session.get(Asset, "asset-ref-1").hash == "blake3:original"
+        assert summary.unchanged_files == 1
+        assert summary.changed_files == 0
+
+    def test_changed_file_keeps_its_hash_and_is_flagged_for_verify(
+        self, session, comfy_dirs
+    ):
+        """A file that moved on is handed to the existing verify path, not re-read."""
+        path = _write(comfy_dirs["checkpoints"], "big.safetensors")
+        _register(
+            session,
+            path,
+            "ref-1",
+            asset_hash="blake3:original",
+            mtime_ns=1,
+            size_bytes=100,
+        )
+
+        summary = reproject_derived_state()
+
+        session.expire_all()
+        assert session.get(Asset, "asset-ref-1").hash == "blake3:original"
+        assert session.get(Asset, "asset-ref-1").size_bytes == 100
+        assert session.get(AssetReference, "ref-1").needs_verify is True
+        assert summary.changed_files == 1
+
+    def test_changed_file_still_gets_its_path_state_reprojected(
+        self, session, comfy_dirs
+    ):
+        path = _write(comfy_dirs["loras"], "style.safetensors")
+        _register(session, path, "ref-1", loader_path=None, mtime_ns=1)
+
+        reproject_derived_state()
+
+        session.expire_all()
+        assert session.get(AssetReference, "ref-1").loader_path == "style.safetensors"
+
+
+class TestIntentIsPreserved:
+    def test_manual_tags_metadata_preview_and_deletion_survive(
+        self, session, comfy_dirs
+    ):
+        path = _write(comfy_dirs["checkpoints"], "curated.safetensors")
+        other = _write(comfy_dirs["input"], "thumb.png")
+        _register(session, other, "ref-preview")
+        deleted = datetime(2026, 1, 2, 3, 4, 5)
+        _register(
+            session,
+            path,
+            "ref-1",
+            loader_path=None,
+            user_metadata={"note": "hand written", "filename": "kept.safetensors"},
+            preview_id="ref-preview",
+            deleted_at=deleted,
+            job_id="job-42",
+            tags={"favourite": "manual", "uploaded": "upload"},
+        )
+
+        reproject_derived_state()
+
+        session.expire_all()
+        ref = session.get(AssetReference, "ref-1")
+        assert ref.user_metadata == {
+            "note": "hand written",
+            "filename": "kept.safetensors",
+        }
+        assert ref.preview_id == "ref-preview"
+        assert ref.deleted_at == deleted
+        assert ref.job_id == "job-42"
+        assert ref.name == "curated.safetensors"
+        tags = _tags(session, "ref-1")
+        assert tags["favourite"] == "manual"
+        assert tags["uploaded"] == "upload"
+        # ...while the derived state around them was still brought forward.
+        assert ref.loader_path == "curated.safetensors"
+
+    def test_manual_tag_inside_the_derived_vocabulary_is_not_removed(
+        self, session, comfy_dirs
+    ):
+        """A person may tag an input file 'models'; that is their business."""
+        path = _write(comfy_dirs["input"], "photo.png")
+        _register(session, path, "ref-1", tags={"models": "manual"})
+
+        reproject_derived_state()
+
+        assert _tags(session, "ref-1")["models"] == "manual"
+
+
+class TestTagReprojection:
+    def test_missing_derived_tags_are_added(self, session, comfy_dirs):
+        path = _write(comfy_dirs["checkpoints"], "model.safetensors")
+        _register(session, path, "ref-1", tags={})
+
+        reproject_derived_state()
+
+        assert _tags(session, "ref-1") == {
+            "models": "automatic",
+            "model_type:checkpoints": "automatic",
+        }
+
+    def test_superseded_automatic_tag_is_removed(self, session, comfy_dirs):
+        """An older rule tagged by directory alone; extensions now gate the tag."""
+        path = _write(comfy_dirs["checkpoints"], "model.safetensors")
+        _register(
+            session,
+            path,
+            "ref-1",
+            tags={
+                "models": "automatic",
+                "model_type:checkpoints": "automatic",
+                "model_type:loras": "automatic",
+            },
+        )
+
+        reproject_derived_state()
+
+        assert "model_type:loras" not in _tags(session, "ref-1")
+        assert "model_type:checkpoints" in _tags(session, "ref-1")
+
+    def test_automatic_tag_outside_the_vocabulary_is_left_alone(
+        self, session, comfy_dirs
+    ):
+        """'missing' is automatic but not path-derived; the scanner owns it."""
+        path = _write(comfy_dirs["checkpoints"], "model.safetensors")
+        _register(session, path, "ref-1", tags={"missing": "automatic"})
+
+        reproject_derived_state()
+
+        assert "missing" in _tags(session, "ref-1")
+
+
+class TestFileState:
+    def test_present_file_is_unflagged_as_missing(self, session, comfy_dirs):
+        path = _write(comfy_dirs["temp"], "preview.png")
+        _register(session, path, "ref-1", is_missing=True)
+
+        summary = reproject_derived_state()
+
+        session.expire_all()
+        assert session.get(AssetReference, "ref-1").is_missing is False
+        assert summary.missing_flags_cleared == 1
+
+    def test_absent_file_is_left_to_the_scanner(self, session, comfy_dirs):
+        path = os.path.join(str(comfy_dirs["checkpoints"]), "gone.safetensors")
+        _register(
+            session,
+            path,
+            "ref-1",
+            mtime_ns=1,
+            loader_path="stale/gone.safetensors",
+            is_missing=True,
+        )
+
+        summary = reproject_derived_state()
+
+        session.expire_all()
+        ref = session.get(AssetReference, "ref-1")
+        assert ref.is_missing is True
+        assert ref.loader_path == "stale/gone.safetensors"
+        assert summary.absent_files == 1
+
+    def test_path_outside_every_known_root_is_left_alone(self, session, comfy_dirs):
+        """A root missing from the config must not strip tags off its assets."""
+        path = _write(comfy_dirs["elsewhere"], "model.safetensors")
+        _register(
+            session,
+            path,
+            "ref-1",
+            loader_path="model.safetensors",
+            tags={"models": "automatic", "model_type:checkpoints": "automatic"},
+        )
+
+        summary = reproject_derived_state()
+
+        session.expire_all()
+        assert session.get(AssetReference, "ref-1").loader_path == "model.safetensors"
+        assert _tags(session, "ref-1") == {
+            "models": "automatic",
+            "model_type:checkpoints": "automatic",
+        }
+        assert summary.unclassified_paths == 1
+
+
+class TestIdempotence:
+    def test_empty_database_is_a_no_op(self, session, comfy_dirs):
+        summary = reproject_derived_state()
+
+        assert summary.scanned == 0
+        assert summary.loader_paths_rewritten == 0
+        assert summary.tags_added == 0
+
+    def test_second_run_changes_nothing(self, session, comfy_dirs):
+        _register(
+            session,
+            _write(comfy_dirs["checkpoints"], "a/model.safetensors"),
+            "ref-1",
+            loader_path=None,
+            tags={"model_type:loras": "automatic", "favourite": "manual"},
+        )
+        _register(
+            session,
+            _write(comfy_dirs["input"], "pasted/clip.png"),
+            "ref-2",
+            loader_path="wrong.png",
+            is_missing=True,
+        )
+        _register(
+            session,
+            os.path.join(str(comfy_dirs["output"]), "gone.png"),
+            "ref-3",
+            mtime_ns=1,
+        )
+
+        reproject_derived_state()
+        after_first = _snapshot(session)
+
+        second = reproject_derived_state()
+        assert _snapshot(session) == after_first
+        assert second.loader_paths_rewritten == 0
+        assert second.tags_added == 0
+        assert second.tags_removed == 0
+        assert second.missing_flags_cleared == 0
+
+    def test_statements_chunked_by_bind_param_limit_stay_correct(
+        self, session, comfy_dirs
+    ):
+        """The bind-param chunking must not drop or duplicate a tag."""
+        for index in range(4):
+            _register(
+                session,
+                _write(comfy_dirs["checkpoints"], f"m{index}.safetensors"),
+                f"ref-{index}",
+                tags={"model_type:loras": "automatic"},
+            )
+
+        with (
+            patch("app.assets.database.queries.semantics.MAX_BIND_PARAMS", 2),
+            patch("app.assets.database.queries.common.MAX_BIND_PARAMS", 2),
+        ):
+            reproject_derived_state()
+
+        for index in range(4):
+            assert _tags(session, f"ref-{index}") == {
+                "models": "automatic",
+                "model_type:checkpoints": "automatic",
+            }
+
+    def test_walk_crosses_batch_boundaries(self, session, comfy_dirs):
+        for index in range(7):
+            _register(
+                session,
+                _write(comfy_dirs["checkpoints"], f"m{index:02d}.safetensors"),
+                f"ref-{index:02d}",
+                loader_path=None,
+            )
+
+        with patch("app.assets.semantics.reproject_derived._BATCH_SIZE", 2):
+            summary = reproject_derived_state()
+
+        assert summary.scanned == 7
+        session.expire_all()
+        assert all(
+            session.get(AssetReference, f"ref-{index:02d}").loader_path
+            == f"m{index:02d}.safetensors"
+            for index in range(7)
+        )
+
+
+class TestRunner:
+    def test_pending_step_runs_and_stamps(self, session, comfy_dirs):
+        _register(
+            session,
+            _write(comfy_dirs["checkpoints"], "model.safetensors"),
+            "ref-1",
+            loader_path=None,
+        )
+
+        assert run_pending_semantics_steps() == 1
+
+        session.expire_all()
+        assert get_semantics_version(session) == semantics.CURRENT_SEMANTICS_VERSION
+        assert session.get(AssetReference, "ref-1").loader_path == "model.safetensors"
+
+    def test_stamped_database_does_not_walk_again(self, session, comfy_dirs):
+        run_pending_semantics_steps()
+
+        with patch(
+            "app.assets.semantics.reproject_derived.get_file_backed_references_page",
+            side_effect=AssertionError("a stamped database must not be walked"),
+        ):
+            assert run_pending_semantics_steps() == 0
+
+    def test_stamp_is_not_advanced_when_a_step_raises(self, session, comfy_dirs):
+        def _explode(_interrupt_check):
+            raise RuntimeError("step failed")
+
+        with patch.object(
+            semantics,
+            "SEMANTICS_STEPS",
+            (SemanticsStep(version=1, description="explodes", apply=_explode),),
+        ):
+            assert run_pending_semantics_steps() == 0
+
+        session.expire_all()
+        assert get_semantics_version(session) == 0
+        assert session.get(AssetSemanticsVersion, 1) is None
+
+    def test_stamp_is_not_advanced_when_a_step_is_interrupted(
+        self, session, comfy_dirs
+    ):
+        def _interrupted(_interrupt_check):
+            raise SemanticsStepInterrupted("stopped")
+
+        with patch.object(
+            semantics,
+            "SEMANTICS_STEPS",
+            (SemanticsStep(version=1, description="interrupts", apply=_interrupted),),
+        ):
+            assert run_pending_semantics_steps() == 0
+
+        session.expire_all()
+        assert get_semantics_version(session) == 0
+
+    def test_earlier_steps_stay_stamped_when_a_later_one_fails(
+        self, session, comfy_dirs
+    ):
+        def _ok(_interrupt_check):
+            return "fine"
+
+        def _explode(_interrupt_check):
+            raise RuntimeError("step failed")
+
+        with patch.object(
+            semantics,
+            "SEMANTICS_STEPS",
+            (
+                SemanticsStep(version=1, description="ok", apply=_ok),
+                SemanticsStep(version=2, description="explodes", apply=_explode),
+            ),
+        ):
+            assert run_pending_semantics_steps() == 1
+
+        session.expire_all()
+        assert get_semantics_version(session) == 1
+
+    def test_steps_below_the_stored_version_are_skipped(self, session, comfy_dirs):
+        applied: list[int] = []
+
+        def _record(version):
+            def _apply(_interrupt_check):
+                applied.append(version)
+                return version
+
+            return _apply
+
+        steps = (
+            SemanticsStep(version=1, description="one", apply=_record(1)),
+            SemanticsStep(version=2, description="two", apply=_record(2)),
+        )
+        with patch.object(semantics, "SEMANTICS_STEPS", steps[:1]):
+            run_pending_semantics_steps()
+        with patch.object(semantics, "SEMANTICS_STEPS", steps):
+            run_pending_semantics_steps()
+
+        assert applied == [1, 2]
+
+    def test_interrupted_walk_leaves_committed_work_and_resumes(
+        self, session, comfy_dirs
+    ):
+        for index in range(4):
+            _register(
+                session,
+                _write(comfy_dirs["checkpoints"], f"m{index}.safetensors"),
+                f"ref-{index}",
+                loader_path=None,
+            )
+
+        calls = {"n": 0}
+
+        def _stop_after_first_batch() -> bool:
+            calls["n"] += 1
+            return calls["n"] > 1
+
+        with (
+            patch("app.assets.semantics.reproject_derived._BATCH_SIZE", 2),
+            patch.object(
+                semantics,
+                "SEMANTICS_STEPS",
+                (
+                    SemanticsStep(
+                        version=1,
+                        description="reproject",
+                        apply=reproject_derived_state,
+                    ),
+                ),
+            ),
+        ):
+            assert run_pending_semantics_steps(_stop_after_first_batch) == 0
+            session.expire_all()
+            assert get_semantics_version(session) == 0
+            assert session.get(AssetReference, "ref-0").loader_path is not None
+            assert session.get(AssetReference, "ref-3").loader_path is None
+
+            assert run_pending_semantics_steps() == 1
+
+        session.expire_all()
+        assert get_semantics_version(session) == 1
+        assert session.get(AssetReference, "ref-3").loader_path == "m3.safetensors"

--- a/tests-unit/assets_test/test_semantics_reset.py
+++ b/tests-unit/assets_test/test_semantics_reset.py
@@ -23,7 +23,11 @@ from app.assets.database.models import (
 from app.assets.database.queries.semantics import get_semantics_version
 from app.assets.semantics import run_pending_semantics_steps
 from app.assets.semantics.reproject_derived import reproject_derived_state
-from app.assets.semantics.step import SemanticsStep, SemanticsStepInterrupted
+from app.assets.semantics.step import (
+    SemanticsStep,
+    SemanticsStepInterrupted,
+    StepResult,
+)
 from app.assets.services.file_utils import get_mtime_ns
 
 
@@ -419,6 +423,9 @@ class TestFileState:
         assert ref.is_missing is True
         assert ref.loader_path == "stale/gone.safetensors"
         assert summary.absent_files == 1
+        assert summary.complete, (
+            "a file that is simply gone is the scanner's business, not unfinished work"
+        )
 
     def test_path_outside_every_known_root_is_left_alone(self, session, comfy_dirs):
         path = _write(comfy_dirs["elsewhere"], "model.safetensors")
@@ -439,6 +446,9 @@ class TestFileState:
             "model_type:checkpoints": "automatic",
         }, "a root missing from the config must not strip tags off its assets"
         assert summary.unclassified_paths == 1
+        assert not summary.complete, (
+            "the row is unrepaired, so the step has not finished its work"
+        )
 
 
 class TestIdempotence:
@@ -542,6 +552,70 @@ class TestRunner:
         assert get_semantics_version(session) == semantics.CURRENT_SEMANTICS_VERSION
         assert session.get(AssetReference, "ref-1").loader_path == "model.safetensors"
 
+    def test_unclassified_row_withholds_the_stamp(self, session, comfy_dirs):
+        """Skipping a row must not also stamp past it -- nothing else repairs one."""
+        _register(
+            session,
+            _write(comfy_dirs["elsewhere"], "unconfigured.safetensors"),
+            "ref-outside",
+            loader_path=None,
+        )
+        _register(
+            session,
+            _write(comfy_dirs["checkpoints"], "configured.safetensors"),
+            "ref-inside",
+            loader_path=None,
+        )
+
+        assert run_pending_semantics_steps() == 0
+
+        session.expire_all()
+        assert get_semantics_version(session) == 0, (
+            "a pass that could not classify every row must run again"
+        )
+        assert (
+            session.get(AssetReference, "ref-inside").loader_path
+            == "configured.safetensors"
+        ), "the rows it could classify are still repaired"
+
+    def test_restoring_a_root_repairs_the_rows_it_had_hidden(
+        self, session, comfy_dirs
+    ):
+        """The point of withholding the stamp: a re-added root gets reprojected."""
+        hidden = _write(comfy_dirs["elsewhere"], "unconfigured.safetensors")
+        _register(session, hidden, "ref-outside", loader_path=None)
+
+        run_pending_semantics_steps()
+
+        with patch(
+            "app.assets.services.path_utils.get_comfy_models_folders",
+            return_value=[
+                ("checkpoints", [str(comfy_dirs["checkpoints"])], {".safetensors"}),
+                ("loras", [str(comfy_dirs["loras"])], {".safetensors"}),
+                ("vae", [str(comfy_dirs["elsewhere"])], {".safetensors"}),
+            ],
+        ):
+            assert run_pending_semantics_steps() == 1
+
+        session.expire_all()
+        assert get_semantics_version(session) == 1
+        assert (
+            session.get(AssetReference, "ref-outside").loader_path
+            == "unconfigured.safetensors"
+        )
+
+    def test_fully_classified_pass_stamps(self, session, comfy_dirs):
+        _register(
+            session,
+            _write(comfy_dirs["checkpoints"], "model.safetensors"),
+            "ref-1",
+            loader_path=None,
+        )
+
+        assert run_pending_semantics_steps() == 1
+        session.expire_all()
+        assert get_semantics_version(session) == 1
+
     def test_stamped_database_does_not_walk_again(self, session, comfy_dirs):
         run_pending_semantics_steps()
 
@@ -586,7 +660,7 @@ class TestRunner:
         self, session, comfy_dirs
     ):
         def _ok(_interrupt_check):
-            return "fine"
+            return StepResult()
 
         def _explode(_interrupt_check):
             raise RuntimeError("step failed")
@@ -610,7 +684,7 @@ class TestRunner:
         def _record(version):
             def _apply(_interrupt_check):
                 applied.append(version)
-                return version
+                return StepResult()
 
             return _apply
 

--- a/tests-unit/assets_test/test_semantics_reset.py
+++ b/tests-unit/assets_test/test_semantics_reset.py
@@ -381,6 +381,32 @@ class TestTagReprojection:
         )
         assert "model_type:checkpoints" in _tags(session, "ref-1")
 
+    def test_vocabulary_matches_tags_as_the_database_stores_them(
+        self, session, comfy_dirs
+    ):
+        """Stored names arrive normalized, so a raw vocabulary entry never matches."""
+        path = _write(comfy_dirs["checkpoints"], "model.safetensors")
+        _register(
+            session,
+            path,
+            "ref-1",
+            tags={"model_type:loras": "automatic"},
+        )
+
+        with patch(
+            "app.assets.services.path_utils.get_comfy_models_folders",
+            return_value=[
+                ("checkpoints", [str(comfy_dirs["checkpoints"])], {".safetensors"}),
+                ("loras ", [str(comfy_dirs["loras"])], {".safetensors"}),
+            ],
+        ):
+            reproject_derived_state()
+
+        assert "model_type:loras" not in _tags(session, "ref-1"), (
+            "a category name with stray whitespace must not smuggle an entry "
+            "past the vocabulary and leave the stale tag in place"
+        )
+
     def test_automatic_tag_outside_the_vocabulary_is_left_alone(
         self, session, comfy_dirs
     ):

--- a/tests-unit/assets_test/test_semantics_reset.py
+++ b/tests-unit/assets_test/test_semantics_reset.py
@@ -392,8 +392,6 @@ class TestTagReprojection:
             tags={"model_type:loras": "automatic"},
         )
 
-        # Leading whitespace lands after "model_type:", where a strip of the
-        # finished tag cannot reach it; trailing whitespace a strip would catch.
         for registered in (" loras", "loras "):
             with patch(
                 "app.assets.services.path_utils.get_comfy_models_folders",

--- a/tests-unit/assets_test/test_semantics_reset.py
+++ b/tests-unit/assets_test/test_semantics_reset.py
@@ -392,7 +392,7 @@ class TestTagReprojection:
             tags={"model_type:loras": "automatic"},
         )
 
-        for registered in (" loras", "loras "):
+        for position, registered in (("leading", " loras"), ("trailing", "loras ")):
             with patch(
                 "app.assets.services.path_utils.get_comfy_models_folders",
                 return_value=[
@@ -407,7 +407,7 @@ class TestTagReprojection:
                 reproject_derived_state()
 
             assert "model_type:loras" not in _tags(session, "ref-1"), (
-                f"a category registered as {registered!r} must not smuggle an "
+                f"{position} whitespace in {registered!r} must not smuggle an "
                 "entry past the vocabulary and leave the stale tag in place"
             )
 

--- a/tests-unit/assets_test/test_semantics_reset.py
+++ b/tests-unit/assets_test/test_semantics_reset.py
@@ -428,7 +428,6 @@ class TestFileState:
         )
 
     def test_unclassified_row_is_not_flagged_for_verify(self, session, comfy_dirs):
-        """needs_verify is a write like any other; it must skip out-of-view rows too."""
         _register(
             session,
             _write(comfy_dirs["elsewhere"], "model.safetensors"),
@@ -642,7 +641,6 @@ class TestRunner:
             assert run_pending_semantics_steps() == 0
 
     def test_stamp_failure_does_not_escape_to_the_caller(self, session, comfy_dirs):
-        """The seeder calls this; a transient lock here must not abort its scan."""
         _register(
             session,
             _write(comfy_dirs["checkpoints"], "model.safetensors"),

--- a/tests-unit/assets_test/test_semantics_reset.py
+++ b/tests-unit/assets_test/test_semantics_reset.py
@@ -392,19 +392,26 @@ class TestTagReprojection:
             tags={"model_type:loras": "automatic"},
         )
 
-        with patch(
-            "app.assets.services.path_utils.get_comfy_models_folders",
-            return_value=[
-                ("checkpoints", [str(comfy_dirs["checkpoints"])], {".safetensors"}),
-                ("loras ", [str(comfy_dirs["loras"])], {".safetensors"}),
-            ],
-        ):
-            reproject_derived_state()
+        # Leading whitespace lands after "model_type:", where a strip of the
+        # finished tag cannot reach it; trailing whitespace a strip would catch.
+        for registered in (" loras", "loras "):
+            with patch(
+                "app.assets.services.path_utils.get_comfy_models_folders",
+                return_value=[
+                    (
+                        "checkpoints",
+                        [str(comfy_dirs["checkpoints"])],
+                        {".safetensors"},
+                    ),
+                    (registered, [str(comfy_dirs["loras"])], {".safetensors"}),
+                ],
+            ):
+                reproject_derived_state()
 
-        assert "model_type:loras" not in _tags(session, "ref-1"), (
-            "a category name with stray whitespace must not smuggle an entry "
-            "past the vocabulary and leave the stale tag in place"
-        )
+            assert "model_type:loras" not in _tags(session, "ref-1"), (
+                f"a category registered as {registered!r} must not smuggle an "
+                "entry past the vocabulary and leave the stale tag in place"
+            )
 
     def test_automatic_tag_outside_the_vocabulary_is_left_alone(
         self, session, comfy_dirs

--- a/tests-unit/assets_test/test_semantics_reset.py
+++ b/tests-unit/assets_test/test_semantics_reset.py
@@ -570,7 +570,7 @@ class TestRunner:
 
         session.expire_all()
         assert get_semantics_version(session) == 0, (
-            "a pass that could not classify every row must run again"
+            "skipping a row must not stamp past it -- nothing else repairs one"
         )
         assert (
             session.get(AssetReference, "ref-inside").loader_path
@@ -600,7 +600,7 @@ class TestRunner:
         assert (
             session.get(AssetReference, "ref-outside").loader_path
             == "unconfigured.safetensors"
-        )
+        ), "withholding the stamp is what lets a re-added root get reprojected"
 
     def test_fully_classified_pass_stamps(self, session, comfy_dirs):
         _register(

--- a/tests-unit/assets_test/test_semantics_reset.py
+++ b/tests-unit/assets_test/test_semantics_reset.py
@@ -381,35 +381,33 @@ class TestTagReprojection:
         )
         assert "model_type:checkpoints" in _tags(session, "ref-1")
 
+    @pytest.mark.parametrize(
+        ("position", "registered"),
+        [("leading", " loras"), ("trailing", "loras ")],
+    )
     def test_vocabulary_matches_tags_as_the_database_stores_them(
-        self, session, comfy_dirs
+        self, session, comfy_dirs, position, registered
     ):
-        path = _write(comfy_dirs["checkpoints"], "model.safetensors")
         _register(
             session,
-            path,
+            _write(comfy_dirs["checkpoints"], "model.safetensors"),
             "ref-1",
             tags={"model_type:loras": "automatic"},
         )
 
-        for position, registered in (("leading", " loras"), ("trailing", "loras ")):
-            with patch(
-                "app.assets.services.path_utils.get_comfy_models_folders",
-                return_value=[
-                    (
-                        "checkpoints",
-                        [str(comfy_dirs["checkpoints"])],
-                        {".safetensors"},
-                    ),
-                    (registered, [str(comfy_dirs["loras"])], {".safetensors"}),
-                ],
-            ):
-                reproject_derived_state()
+        with patch(
+            "app.assets.services.path_utils.get_comfy_models_folders",
+            return_value=[
+                ("checkpoints", [str(comfy_dirs["checkpoints"])], {".safetensors"}),
+                (registered, [str(comfy_dirs["loras"])], {".safetensors"}),
+            ],
+        ):
+            reproject_derived_state()
 
-            assert "model_type:loras" not in _tags(session, "ref-1"), (
-                f"{position} whitespace in {registered!r} must not smuggle an "
-                "entry past the vocabulary and leave the stale tag in place"
-            )
+        assert "model_type:loras" not in _tags(session, "ref-1"), (
+            f"{position} whitespace in {registered!r} must not smuggle an entry "
+            "past the vocabulary and leave the stale tag in place"
+        )
 
     def test_automatic_tag_outside_the_vocabulary_is_left_alone(
         self, session, comfy_dirs

--- a/tests-unit/assets_test/test_semantics_reset.py
+++ b/tests-unit/assets_test/test_semantics_reset.py
@@ -33,15 +33,19 @@ def autoclean_unit_test_assets():
     yield
 
 
-@pytest.fixture
-def session_factory():
+def _engine_shared_across_sessions():
     engine = create_engine(
         "sqlite:///:memory:",
         poolclass=StaticPool,
         connect_args={"check_same_thread": False},
     )
     Base.metadata.create_all(engine)
-    factory = sessionmaker(bind=engine)
+    return engine
+
+
+@pytest.fixture
+def session_factory():
+    factory = sessionmaker(bind=_engine_shared_across_sessions())
     with (
         patch("app.assets.semantics.reproject_derived.create_session", factory),
         patch("app.assets.semantics.create_session", factory),
@@ -82,6 +86,9 @@ def comfy_dirs():
             yield dirs
 
 
+ANY_UNIQUE_HASH = "<any unique hash>"
+
+
 def _write(directory: Path, name: str, content: bytes = b"\x00" * 100) -> str:
     path = directory / name
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -95,7 +102,7 @@ def _register(
     ref_id: str,
     *,
     loader_path: str | None = None,
-    asset_hash: str | None = "",
+    asset_hash: str | None = ANY_UNIQUE_HASH,
     size_bytes: int = 100,
     mtime_ns: int | None = None,
     is_missing: bool = False,
@@ -106,7 +113,7 @@ def _register(
     job_id: str | None = None,
     tags: dict[str, str] | None = None,
 ) -> AssetReference:
-    if asset_hash == "":
+    if asset_hash == ANY_UNIQUE_HASH:
         asset_hash = f"blake3:{ref_id}"
     if mtime_ns is None:
         mtime_ns = get_mtime_ns(os.stat(file_path, follow_symlinks=True))
@@ -151,7 +158,7 @@ def _tags(session: Session, ref_id: str) -> dict[str, str]:
     return {name: origin for name, origin in rows}
 
 
-def _snapshot(session: Session) -> list[tuple]:
+def _state_the_reset_could_touch(session: Session) -> list[tuple]:
     session.expire_all()
     refs = session.execute(select(AssetReference).order_by(AssetReference.id)).scalars()
     rows = [
@@ -185,7 +192,9 @@ class TestLoaderPathReprojection:
 
         session.expire_all()
         ref = session.get(AssetReference, "ref-1")
-        assert ref.loader_path == "flux/model.safetensors"
+        assert ref.loader_path == "flux/model.safetensors", (
+            "0006 added the column with no backfill, and nothing has filled it since"
+        )
 
     def test_stale_loader_path_is_rewritten(self, session, comfy_dirs):
         path = _write(comfy_dirs["input"], "sub/photo.png")
@@ -212,7 +221,9 @@ class TestLoaderPathReprojection:
         reproject_derived_state()
 
         session.expire_all()
-        assert session.get(AssetReference, "ref-1").loader_path is None
+        assert session.get(AssetReference, "ref-1").loader_path is None, (
+            "a file its category cannot load must not advertise a loader path"
+        )
 
     def test_reference_without_file_path_is_skipped(self, session, comfy_dirs):
         session.add(Asset(id="asset-api", hash="blake3:abc", size_bytes=10))
@@ -265,7 +276,9 @@ class TestHashPreservation:
         session.expire_all()
         assert session.get(Asset, "asset-ref-1").hash == "blake3:original"
         assert session.get(Asset, "asset-ref-1").size_bytes == 100
-        assert session.get(AssetReference, "ref-1").needs_verify is True
+        assert session.get(AssetReference, "ref-1").needs_verify is True, (
+            "a file that moved on goes to the verify path rather than being re-read"
+        )
         assert summary.changed_files == 1
 
     def test_changed_file_still_gets_its_path_state_reprojected(
@@ -315,7 +328,9 @@ class TestIntentIsPreserved:
         tags = _tags(session, "ref-1")
         assert tags["favourite"] == "manual"
         assert tags["uploaded"] == "upload"
-        assert ref.loader_path == "curated.safetensors"
+        assert ref.loader_path == "curated.safetensors", (
+            "preserving intent must not cost the reprojection around it"
+        )
 
     def test_manual_tag_inside_the_derived_vocabulary_is_not_removed(
         self, session, comfy_dirs
@@ -325,7 +340,9 @@ class TestIntentIsPreserved:
 
         reproject_derived_state()
 
-        assert _tags(session, "ref-1")["models"] == "manual"
+        assert _tags(session, "ref-1")["models"] == "manual", (
+            "a person may tag an input file 'models'; that is their business"
+        )
 
 
 class TestTagReprojection:
@@ -355,7 +372,9 @@ class TestTagReprojection:
 
         reproject_derived_state()
 
-        assert "model_type:loras" not in _tags(session, "ref-1")
+        assert "model_type:loras" not in _tags(session, "ref-1"), (
+            "an older rule tagged by directory alone; extensions now gate the tag"
+        )
         assert "model_type:checkpoints" in _tags(session, "ref-1")
 
     def test_automatic_tag_outside_the_vocabulary_is_left_alone(
@@ -366,7 +385,9 @@ class TestTagReprojection:
 
         reproject_derived_state()
 
-        assert "missing" in _tags(session, "ref-1")
+        assert "missing" in _tags(session, "ref-1"), (
+            "'missing' is automatic but not path-derived, so the scanner owns it"
+        )
 
 
 class TestFileState:
@@ -416,7 +437,7 @@ class TestFileState:
         assert _tags(session, "ref-1") == {
             "models": "automatic",
             "model_type:checkpoints": "automatic",
-        }
+        }, "a root missing from the config must not strip tags off its assets"
         assert summary.unclassified_paths == 1
 
 
@@ -451,10 +472,12 @@ class TestIdempotence:
         )
 
         reproject_derived_state()
-        after_first = _snapshot(session)
+        after_first = _state_the_reset_could_touch(session)
 
         second = reproject_derived_state()
-        assert _snapshot(session) == after_first
+        assert _state_the_reset_could_touch(session) == after_first, (
+            "a second pass must be indistinguishable from one"
+        )
         assert second.loader_paths_rewritten == 0
         assert second.tags_added == 0
         assert second.tags_removed == 0
@@ -481,7 +504,7 @@ class TestIdempotence:
             assert _tags(session, f"ref-{index}") == {
                 "models": "automatic",
                 "model_type:checkpoints": "automatic",
-            }
+            }, "chunking by bind-param limit must not drop or duplicate a tag"
 
     def test_walk_crosses_batch_boundaries(self, session, comfy_dirs):
         for index in range(7):
@@ -492,7 +515,7 @@ class TestIdempotence:
                 loader_path=None,
             )
 
-        with patch("app.assets.semantics.reproject_derived._BATCH_SIZE", 2):
+        with patch("app.assets.semantics.reproject_derived._ROWS_PER_TRANSACTION", 2):
             summary = reproject_derived_state()
 
         assert summary.scanned == 7
@@ -620,7 +643,7 @@ class TestRunner:
             return calls["n"] > 1
 
         with (
-            patch("app.assets.semantics.reproject_derived._BATCH_SIZE", 2),
+            patch("app.assets.semantics.reproject_derived._ROWS_PER_TRANSACTION", 2),
             patch.object(
                 semantics,
                 "SEMANTICS_STEPS",

--- a/tests-unit/assets_test/test_semantics_reset.py
+++ b/tests-unit/assets_test/test_semantics_reset.py
@@ -553,7 +553,6 @@ class TestRunner:
         assert session.get(AssetReference, "ref-1").loader_path == "model.safetensors"
 
     def test_unclassified_row_withholds_the_stamp(self, session, comfy_dirs):
-        """Skipping a row must not also stamp past it -- nothing else repairs one."""
         _register(
             session,
             _write(comfy_dirs["elsewhere"], "unconfigured.safetensors"),
@@ -581,7 +580,6 @@ class TestRunner:
     def test_restoring_a_root_repairs_the_rows_it_had_hidden(
         self, session, comfy_dirs
     ):
-        """The point of withholding the stamp: a re-added root gets reprojected."""
         hidden = _write(comfy_dirs["elsewhere"], "unconfigured.safetensors")
         _register(session, hidden, "ref-outside", loader_path=None)
 

--- a/tests-unit/assets_test/test_semantics_reset.py
+++ b/tests-unit/assets_test/test_semantics_reset.py
@@ -652,7 +652,10 @@ class TestRunner:
             "app.assets.semantics.set_semantics_version",
             side_effect=RuntimeError("database is locked"),
         ):
-            assert run_pending_semantics_steps() == 0
+            assert run_pending_semantics_steps() == 0, (
+                "the seeder calls this, so a transient lock here must return "
+                "rather than abort its whole scan"
+            )
 
         session.expire_all()
         assert get_semantics_version(session) == 0

--- a/tests-unit/assets_test/test_semantics_reset.py
+++ b/tests-unit/assets_test/test_semantics_reset.py
@@ -427,6 +427,24 @@ class TestFileState:
             "a file that is simply gone is the scanner's business, not unfinished work"
         )
 
+    def test_unclassified_row_is_not_flagged_for_verify(self, session, comfy_dirs):
+        """needs_verify is a write like any other; it must skip out-of-view rows too."""
+        _register(
+            session,
+            _write(comfy_dirs["elsewhere"], "model.safetensors"),
+            "ref-1",
+            mtime_ns=1,
+        )
+
+        summary = reproject_derived_state()
+
+        session.expire_all()
+        assert session.get(AssetReference, "ref-1").needs_verify is False, (
+            "the one write that did not skip made 'leaves it alone' untrue"
+        )
+        assert summary.unclassified_paths == 1
+        assert summary.changed_files == 0
+
     def test_path_outside_every_known_root_is_left_alone(self, session, comfy_dirs):
         path = _write(comfy_dirs["elsewhere"], "model.safetensors")
         _register(
@@ -622,6 +640,27 @@ class TestRunner:
             side_effect=AssertionError("a stamped database must not be walked"),
         ):
             assert run_pending_semantics_steps() == 0
+
+    def test_stamp_failure_does_not_escape_to_the_caller(self, session, comfy_dirs):
+        """The seeder calls this; a transient lock here must not abort its scan."""
+        _register(
+            session,
+            _write(comfy_dirs["checkpoints"], "model.safetensors"),
+            "ref-1",
+            loader_path=None,
+        )
+
+        with patch(
+            "app.assets.semantics.set_semantics_version",
+            side_effect=RuntimeError("database is locked"),
+        ):
+            assert run_pending_semantics_steps() == 0
+
+        session.expire_all()
+        assert get_semantics_version(session) == 0
+        assert (
+            session.get(AssetReference, "ref-1").loader_path == "model.safetensors"
+        ), "the step's own committed work survives a failed stamp"
 
     def test_stamp_is_not_advanced_when_a_step_raises(self, session, comfy_dirs):
         def _explode(_interrupt_check):

--- a/tests-unit/seeder_test/test_seeder.py
+++ b/tests-unit/seeder_test/test_seeder.py
@@ -563,6 +563,93 @@ class TestSeederSemanticsReset:
         assert captured["check"]() is True
 
 
+    def test_semantics_reset_suspends_on_pause(self, fresh_seeder: _AssetSeeder):
+        """A pause must stop the walk between batches, not just a cancel.
+
+        The seeder is paused while a prompt runs, so a check that ignores pause
+        keeps statting the whole asset table during generation.
+        """
+        captured = {}
+
+        with (
+            patch("app.assets.seeder.dependencies_available", return_value=True),
+            patch(
+                "app.assets.seeder.run_pending_semantics_steps",
+                side_effect=lambda interrupt_check=None: captured.update(
+                    check=interrupt_check
+                ),
+            ),
+            patch("app.assets.seeder.sync_root_safely", return_value=set()),
+            patch("app.assets.seeder.collect_paths_for_roots", return_value=[]),
+            patch("app.assets.seeder.build_asset_specs", return_value=([], set(), 0)),
+            patch("app.assets.seeder.insert_asset_specs", return_value=0),
+            patch("app.assets.seeder.get_unenriched_assets_for_roots", return_value=[]),
+            patch("app.assets.seeder.enrich_assets_batch", return_value=(0, 0)),
+        ):
+            fresh_seeder.start(roots=("models",))
+            fresh_seeder.wait(timeout=5.0)
+
+        check = captured.get("check")
+        assert check is not None
+
+        fresh_seeder._run_gate.clear()
+        returned = threading.Event()
+
+        def _call_check():
+            check()
+            returned.set()
+
+        threading.Thread(target=_call_check, daemon=True).start()
+        assert not returned.wait(timeout=0.5), (
+            "the interrupt check must block while paused, not report 'keep going'"
+        )
+
+        fresh_seeder._run_gate.set()
+        assert returned.wait(timeout=5.0)
+
+    def test_cancel_during_semantics_reset_stops_before_pruning(
+        self, fresh_seeder: _AssetSeeder
+    ):
+        """A cancelled reset must not fall through into the prune's writes."""
+        calls = []
+
+        def _cancel_during_reset(interrupt_check=None):
+            calls.append("reset")
+            fresh_seeder._cancel_event.set()
+
+        with (
+            patch("app.assets.seeder.dependencies_available", return_value=True),
+            patch(
+                "app.assets.seeder.run_pending_semantics_steps",
+                side_effect=_cancel_during_reset,
+            ),
+            patch("app.assets.seeder.get_owned_prefixes", return_value=["/models"]),
+            patch(
+                "app.assets.seeder.mark_missing_outside_prefixes_safely",
+                side_effect=lambda prefixes: calls.append("prune") or 0,
+            ),
+            patch(
+                "app.assets.seeder.sync_temp_references_safely",
+                side_effect=lambda: calls.append("sync_temp"),
+            ),
+            patch(
+                "app.assets.seeder.sync_root_safely",
+                side_effect=lambda root: calls.append("sync") or set(),
+            ),
+            patch("app.assets.seeder.collect_paths_for_roots", return_value=[]),
+            patch("app.assets.seeder.build_asset_specs", return_value=([], set(), 0)),
+            patch("app.assets.seeder.insert_asset_specs", return_value=0),
+            patch("app.assets.seeder.get_unenriched_assets_for_roots", return_value=[]),
+            patch("app.assets.seeder.enrich_assets_batch", return_value=(0, 0)),
+        ):
+            fresh_seeder.start(roots=("models",), prune_first=True)
+            fresh_seeder.wait(timeout=5.0)
+
+        assert calls == ["reset"], (
+            f"cancel must stop the scan before the prune's writes, got {calls}"
+        )
+
+
 class TestSeederPhases:
     """Test phased scanning behavior."""
 

--- a/tests-unit/seeder_test/test_seeder.py
+++ b/tests-unit/seeder_test/test_seeder.py
@@ -596,7 +596,8 @@ class TestSeederSemanticsReset:
 
         threading.Thread(target=_call_check, daemon=True).start()
         assert not returned.wait(timeout=0.5), (
-            "the interrupt check must block while paused, not report 'keep going'"
+            "the seeder is paused while a prompt runs, so the walk must block "
+            "between batches rather than keep statting the whole table"
         )
 
         fresh_seeder._run_gate.set()

--- a/tests-unit/seeder_test/test_seeder.py
+++ b/tests-unit/seeder_test/test_seeder.py
@@ -498,7 +498,6 @@ class TestSeederMarkMissing:
 
 
 class TestSeederSemanticsReset:
-    """The scan brings stale rows forward before it reads or extends them."""
 
     def test_semantics_reset_runs_before_any_scan_work(
         self, fresh_seeder: _AssetSeeder

--- a/tests-unit/seeder_test/test_seeder.py
+++ b/tests-unit/seeder_test/test_seeder.py
@@ -23,6 +23,7 @@ def mock_dependencies():
     """Mock all external dependencies for isolated testing."""
     with (
         patch("app.assets.seeder.dependencies_available", return_value=True),
+        patch("app.assets.seeder.run_pending_semantics_steps", return_value=0),
         patch("app.assets.seeder.sync_root_safely", return_value=set()),
         patch("app.assets.seeder.collect_paths_for_roots", return_value=[]),
         patch("app.assets.seeder.build_asset_specs", return_value=([], set(), 0)),
@@ -454,6 +455,7 @@ class TestSeederMarkMissing:
 
         with (
             patch("app.assets.seeder.dependencies_available", return_value=True),
+            patch("app.assets.seeder.run_pending_semantics_steps", return_value=0),
             patch("app.assets.seeder.get_owned_prefixes", return_value=["/models"]),
             patch("app.assets.seeder.mark_missing_outside_prefixes_safely", side_effect=track_mark),
             patch("app.assets.seeder.sync_temp_references_safely"),
@@ -475,6 +477,7 @@ class TestSeederMarkMissing:
     ):
         with (
             patch("app.assets.seeder.dependencies_available", return_value=True),
+            patch("app.assets.seeder.run_pending_semantics_steps", return_value=0),
             patch("app.assets.seeder.get_owned_prefixes", return_value=["/models"]),
             patch("app.assets.seeder.mark_missing_outside_prefixes_safely", return_value=0),
             patch("app.assets.seeder.sync_temp_references_safely") as sync_temp,
@@ -492,6 +495,73 @@ class TestSeederMarkMissing:
                 "temp is not a scan root, so the scan must reconcile it explicitly "
                 "or files wiped at startup stay listed"
             )
+
+
+class TestSeederSemanticsReset:
+    """The scan brings stale rows forward before it reads or extends them."""
+
+    def test_semantics_reset_runs_before_any_scan_work(
+        self, fresh_seeder: _AssetSeeder
+    ):
+        call_order = []
+
+        with (
+            patch("app.assets.seeder.dependencies_available", return_value=True),
+            patch(
+                "app.assets.seeder.run_pending_semantics_steps",
+                side_effect=lambda interrupt_check=None: call_order.append("reset"),
+            ),
+            patch("app.assets.seeder.get_owned_prefixes", return_value=["/models"]),
+            patch(
+                "app.assets.seeder.mark_missing_outside_prefixes_safely",
+                side_effect=lambda prefixes: call_order.append("prune") or 0,
+            ),
+            patch(
+                "app.assets.seeder.sync_temp_references_safely",
+                side_effect=lambda: call_order.append("sync_temp"),
+            ),
+            patch(
+                "app.assets.seeder.sync_root_safely",
+                side_effect=lambda root: call_order.append("sync") or set(),
+            ),
+            patch("app.assets.seeder.collect_paths_for_roots", return_value=[]),
+            patch("app.assets.seeder.build_asset_specs", return_value=([], set(), 0)),
+            patch("app.assets.seeder.insert_asset_specs", return_value=0),
+            patch("app.assets.seeder.get_unenriched_assets_for_roots", return_value=[]),
+            patch("app.assets.seeder.enrich_assets_batch", return_value=(0, 0)),
+        ):
+            fresh_seeder.start(roots=("models",), prune_first=True)
+            fresh_seeder.wait(timeout=5.0)
+
+        assert call_order[0] == "reset", (
+            "reprojection must finish before the scan reads or extends those rows"
+        )
+
+    def test_semantics_reset_can_be_cancelled(self, fresh_seeder: _AssetSeeder):
+        captured = {}
+
+        with (
+            patch("app.assets.seeder.dependencies_available", return_value=True),
+            patch(
+                "app.assets.seeder.run_pending_semantics_steps",
+                side_effect=lambda interrupt_check=None: captured.update(
+                    check=interrupt_check
+                ),
+            ),
+            patch("app.assets.seeder.sync_root_safely", return_value=set()),
+            patch("app.assets.seeder.collect_paths_for_roots", return_value=[]),
+            patch("app.assets.seeder.build_asset_specs", return_value=([], set(), 0)),
+            patch("app.assets.seeder.insert_asset_specs", return_value=0),
+            patch("app.assets.seeder.get_unenriched_assets_for_roots", return_value=[]),
+            patch("app.assets.seeder.enrich_assets_batch", return_value=(0, 0)),
+        ):
+            fresh_seeder.start(roots=("models",))
+            fresh_seeder.wait(timeout=5.0)
+
+        assert captured.get("check") is not None
+        assert captured["check"]() is False
+        fresh_seeder._cancel_event.set()
+        assert captured["check"]() is True
 
 
 class TestSeederPhases:

--- a/tests-unit/seeder_test/test_seeder.py
+++ b/tests-unit/seeder_test/test_seeder.py
@@ -564,11 +564,6 @@ class TestSeederSemanticsReset:
 
 
     def test_semantics_reset_suspends_on_pause(self, fresh_seeder: _AssetSeeder):
-        """A pause must stop the walk between batches, not just a cancel.
-
-        The seeder is paused while a prompt runs, so a check that ignores pause
-        keeps statting the whole asset table during generation.
-        """
         captured = {}
 
         with (
@@ -610,7 +605,6 @@ class TestSeederSemanticsReset:
     def test_cancel_during_semantics_reset_stops_before_pruning(
         self, fresh_seeder: _AssetSeeder
     ):
-        """A cancelled reset must not fall through into the prune's writes."""
         calls = []
 
         def _cancel_during_reset(interrupt_check=None):


### PR DESCRIPTION
## Problem

Asset records can be structurally current and semantically stale at the same time, and nothing ever repairs them.

`loader_path` is the clearest case. The column was added to existing databases with no backfill, and it is only ever written when a reference is first created — the scan computes it for paths it has not seen before, and the enricher computes it but hands it to metadata extraction without writing it back. So every reference older than that column serves `loader_path: null` forever, while the API response documents `loader_path` as the field clients should prefer over `name`.

It is not the only one. The rules that derive `model_type:<folder>` tags gained extension matching, so a file tagged under the older directory-only rule still advertises a category that cannot load it. References under the temp directory could be flagged missing while their file sat on disk, and the reconciliation that would clear that flag excludes already-missing rows, so those stay wrong too.

## Cause

Alembic migrates the shape of the assets tables. Nothing migrates their meaning. There was no record of which generation of the derivation logic produced a row's values, and no maintenance path that could bring an old row forward.

## Change

A semantics version, tracked separately from the Alembic schema version because the two move independently: a column can be added without changing how existing values were computed, and the rules that compute a value can change without touching any column. It lives in its own table rather than `PRAGMA user_version` so it stays portable and carries an `updated_at`, which answers "when was this database last repaired?".

Reset steps are an ordered registry, modelled on Alembic: numbered, applied in order from the stored version, each stamped only once it finishes. An interrupted run resumes instead of half-applying. The registry is the durable part — a future step can be as surgical as its particular drift calls for.

**Step one re-derives what a file's location implies** and leaves everything else alone:

- Recomputes `loader_path`, the backend tags a path carries, and clears `is_missing` for a file that is on disk.
- **Reads no file contents.** `verify_file_unchanged` says whether a row's recorded hash and size still describe the file; a file that has moved on goes to the existing `needs_verify` path rather than being re-read. An untouched model library costs one `stat` per file and no hashing.
- **Never touches intent**: manual and upload-origin tags, `user_metadata`, `preview_id`, `deleted_at`, `job_id`, `name`. Only automatic-origin tags inside the vocabulary the current rules can emit are re-derived; the origin guard is asserted both when selecting and in the `DELETE`.
- **Leaves alone** references whose file is gone (the scan's existing missing/retire rules own those) and references whose path is under no root this install currently knows about — so a misconfigured `extra_model_paths.yaml` cannot strip tags off assets that are merely out of view.

A pass that could not classify every reference **is not stamped**, so it runs again. Otherwise skipping a row would make the skip permanent: nothing else re-derives an existing reference's `loader_path`, so restoring a root would repair nothing. A file that is simply gone does not count as unfinished work — that is the scan's business under its own missing rules.

It runs at the start of a scan, before the prune and before anything reads or extends those rows, in the thread that already exists for scanning. It takes the seeder's pause-aware checkpoint, so a pause — which happens while a prompt runs — suspends the walk between batches rather than leaving it statting the whole table; a cancel stops the scan before the prune's writes. A database already at the current version costs one indexed row read: no filesystem is walked to discover there is nothing to do, which is the common case, since most databases have the assets schema and no asset rows. The walk is keyset-paginated and commits per batch, so a kill mid-walk leaves committed batches reprojected and the rest untouched — both states the next run handles.

Nothing changes about what the scanner or the enricher do in steady state.

Three things it deliberately does not do: guard the stamp against concurrent writers (`init_db` takes an exclusive file lock, so two ComfyUI processes cannot share a database), interrupt the per-row `stat` (the scan already stats every reference the same way), or guess at the stored version when reading it fails — it skips and retries on the next start.

## Tests

36 new: `tests-unit/assets_test/test_semantics_reset.py` (32) and `tests-unit/seeder_test/test_seeder.py` (4). The reset tests use in-memory SQLite and run standalone.

```
$ pytest tests-unit/assets_test/test_semantics_reset.py tests-unit/seeder_test/ --noconftest -q
76 passed in 1.57s
```

Existing assets suites are unchanged: 137 in `queries`, 178 in `services`, 42 standalone.

The cases that carry the design: an unchanged file keeps its hash and is not re-hashed (a hashing call raises if reached); a pass that leaves a reference unclassified withholds the stamp, and a later run with that root configured repairs it; manual tags, `user_metadata`, `preview_id`, `deleted_at` and `job_id` survive alongside a reprojection that still happens; a manual tag inside the derived vocabulary is not removed while a superseded `model_type:` one is; an interrupted walk resumes without the stamp advancing.

Each was checked against deliberately broken code — 19 mutations of the reprojection, the runner, the seeder wiring and the query chunking — and every mutation that changes behaviour is caught by the test named for it.

The migration upgrades, downgrades and re-upgrades against a file-backed database, and the Alembic-built schema matches `Base.metadata` for the new table, so the in-memory `create_all` path agrees with the migrated one.

