### PR TITLE
Fix CLIP merge ratio direction

### DIFF
--- a/comfy_extras/nodes_model_merging.py
+++ b/comfy_extras/nodes_model_merging.py
@@ -86,7 +86,7 @@ class CLIPMergeSimple:
         for k in kp:
             if k.endswith(".position_ids") or k.endswith(".logit_scale"):
                 continue
-            m.add_patches({k: kp[k]}, 1.0 - ratio, ratio)
+            m.add_patches({k: kp[k]}, ratio, 1.0 - ratio)
         return (m, )
 
 

--- a/tests-unit/comfy_extras_test/nodes_model_merging_test.py
+++ b/tests-unit/comfy_extras_test/nodes_model_merging_test.py
@@ -1,0 +1,54 @@
+import pytest
+import torch
+import torch.nn as nn
+
+from comfy.cli_args import args as cli_args
+
+if not torch.cuda.is_available():
+    cli_args.cpu = True
+
+from comfy.model_patcher import ModelPatcher
+from comfy_extras.nodes_model_merging import CLIPMergeSimple
+
+
+class TinyModel(nn.Module):
+    def __init__(self, weight):
+        super().__init__()
+        self.weight = nn.Parameter(weight)
+
+
+class TinyClip:
+    def __init__(self, patcher):
+        self.patcher = patcher
+
+    def clone(self):
+        return TinyClip(self.patcher.clone())
+
+    def get_key_patches(self):
+        return self.patcher.get_key_patches()
+
+    def add_patches(self, patches, strength_patch, strength_model):
+        return self.patcher.add_patches(patches, strength_patch, strength_model)
+
+
+@pytest.mark.parametrize(
+    ("ratio", "expected"),
+    [
+        (0.0, torch.tensor([1.0, 3.0])),
+        (0.25, torch.tensor([2.0, 4.0])),
+        (1.0, torch.tensor([5.0, 7.0])),
+    ],
+)
+def test_clip_merge_ratio_blends_from_clip1_to_clip2(ratio, expected):
+    clip1 = TinyClip(_make_patcher(torch.tensor([1.0, 3.0])))
+    clip2 = TinyClip(_make_patcher(torch.tensor([5.0, 7.0])))
+
+    merged = CLIPMergeSimple().merge(clip1, clip2, ratio)[0]
+    weight = merged.patcher.patch_weight_to_device("weight", return_weight=True)
+
+    torch.testing.assert_close(weight, expected)
+
+
+def _make_patcher(weight):
+    device = torch.device("cpu")
+    return ModelPatcher(TinyModel(weight), load_device=device, offload_device=device)


### PR DESCRIPTION
## Description

`CLIPMergeSimple` passed the ratio strengths to `ModelPatcher.add_patches` in the reverse order. As a result, ratio `0` selected `clip2`, while ratio `1` selected `clip1`, contrary to the documented interpolation direction.

This change swaps the two strength arguments so ratio `0.0` returns `clip1`, ratio `1.0` returns `clip2`, and intermediate values compute `clip1 * (1 - ratio) + clip2 * ratio`.

`ModelMergeSimple` is unchanged because its documented direction is intentionally the opposite.

Fixes #10581.

## Testing

- New CPU-only regression tests exercise the real `ModelPatcher` weight calculation path at ratios `0.0`, `0.25`, and `1.0`.
- All three tests fail on clean `master` and pass with this change.
- `python -m pytest tests-unit/comfy_extras_test/nodes_model_merging_test.py -q` — 3 passed
- `python -m ruff check comfy_extras/nodes_model_merging.py tests-unit/comfy_extras_test/nodes_model_merging_test.py` — passes
- `git diff --check` — passes
