### PR TITLE
Fix empty latent channel handling in AddNoise

### DIFF
--- a/comfy_extras/nodes_custom_sampler.py
+++ b/comfy_extras/nodes_custom_sampler.py
@@ -1098,6 +1098,9 @@ class AddNoise(io.ComfyNode):
 
         latent = latent_image
         latent_image = latent["samples"]
+        latent = latent.copy()
+        latent_image = comfy.sample.fix_empty_latent_channels(model, latent_image, latent.get("downscale_ratio_spacial", None), latent.get("downscale_ratio_temporal", None))
+        latent["samples"] = latent_image
 
         noisy = noise.generate_noise(latent)
 

--- a/tests-unit/comfy_extras_test/nodes_custom_sampler_test.py
+++ b/tests-unit/comfy_extras_test/nodes_custom_sampler_test.py
@@ -1,0 +1,53 @@
+import torch
+
+from comfy.cli_args import args
+
+if not torch.cuda.is_available():
+    args.cpu = True
+
+from comfy.latent_formats import SD3
+from comfy_extras.nodes_custom_sampler import AddNoise
+
+
+class _Identity:
+    def __call__(self, value):
+        return value
+
+
+class _ModelSampling:
+    def noise_scaling(self, sigma, noise, latent_image):
+        return noise * sigma
+
+
+class _Model:
+    def __init__(self):
+        self.objects = {
+            "latent_format": SD3(),
+            "model_sampling": _ModelSampling(),
+            "process_latent_in": _Identity(),
+            "process_latent_out": _Identity(),
+        }
+
+    def get_model_object(self, name):
+        return self.objects[name]
+
+
+class _OnesNoise:
+    def generate_noise(self, latent):
+        return torch.ones_like(latent["samples"])
+
+
+def test_add_noise_expands_an_empty_latent_to_the_model_channel_count():
+    latent = {"samples": torch.zeros(1, 4, 2, 2)}
+
+    result = AddNoise.add_noise(_Model(), _OnesNoise(), torch.tensor([1.0, 0.0]), latent)
+
+    assert result[0]["samples"].shape == (1, 16, 2, 2)
+
+
+def test_add_noise_preserves_the_channels_of_a_non_empty_latent():
+    latent = {"samples": torch.ones(1, 4, 2, 2)}
+
+    result = AddNoise.add_noise(_Model(), _OnesNoise(), torch.tensor([1.0, 0.0]), latent)
+
+    assert result[0]["samples"].shape == (1, 4, 2, 2)


### PR DESCRIPTION
## Description

`AddNoise` generated noise from the original empty latent shape. The output therefore stayed at four channels, and the later sampler could no longer recognize it as an empty latent that needed expansion to a model-specific channel count such as SD3's 16 channels.

The node now applies the existing `fix_empty_latent_channels()` normalization before creating noise, matching `SamplerCustom` and `SamplerCustomAdvanced`. Non-empty latents keep their original shape.

Fixes #4740.

## Testing

- New CPU-only regression covers:
  - an empty 4-channel latent expanding to 16 channels for an SD3-like model;
  - a non-empty 4-channel latent remaining 4 channels.
- The new test failed on clean `master` with `4 != 16` and passes with the fix.
- `pytest tests-unit/comfy_extras_test/nodes_custom_sampler_test.py -q` — 2 passed
- Related helper regression plus the new test — 3 passed
- `ruff check` on changed files — passes
- `git diff --check` — passes
