### PR TITLE
Fix masked composites with negative offsets

### DIFF
--- a/comfy_extras/nodes_mask.py
+++ b/comfy_extras/nodes_mask.py
@@ -29,21 +29,26 @@ def composite(destination, source, x, y, mask = None, multiplier = 8, resize_sou
         mask = torch.nn.functional.interpolate(mask.reshape((-1, 1, mask.shape[-2], mask.shape[-1])), size=(source.shape[-2], source.shape[-1]), mode="bilinear")
         mask = comfy.utils.repeat_to_batch_size(mask, source.shape[0])
 
-    # calculate the bounds of the source that will be overlapping the destination
-    # this prevents the source trying to overwrite latent pixels that are out of bounds
-    # of the destination
-    visible_width, visible_height = (destination.shape[-1] - left + min(0, x), destination.shape[-2] - top + min(0, y),)
+    source_left = max(0, -left)
+    source_top = max(0, -top)
+    source_right = min(source.shape[-1], destination.shape[-1] - left)
+    source_bottom = min(source.shape[-2], destination.shape[-2] - top)
 
-    mask = mask[:, :, :visible_height, :visible_width]
+    destination_left = max(0, left)
+    destination_top = max(0, top)
+    destination_right = min(destination.shape[-1], right)
+    destination_bottom = min(destination.shape[-2], bottom)
+
+    mask = mask[..., source_top:source_bottom, source_left:source_right]
     if mask.ndim < source.ndim:
         mask = mask.unsqueeze(1)
 
     inverse_mask = torch.ones_like(mask) - mask
 
-    source_portion = mask * source[..., :visible_height, :visible_width]
-    destination_portion = inverse_mask  * destination[..., top:bottom, left:right]
+    source_portion = mask * source[..., source_top:source_bottom, source_left:source_right]
+    destination_portion = inverse_mask * destination[..., destination_top:destination_bottom, destination_left:destination_right]
 
-    destination[..., top:bottom, left:right] = source_portion + destination_portion
+    destination[..., destination_top:destination_bottom, destination_left:destination_right] = source_portion + destination_portion
     return destination
 
 
@@ -58,8 +63,8 @@ class LatentCompositeMasked(IO.ComfyNode):
             inputs=[
                 IO.Latent.Input("destination"),
                 IO.Latent.Input("source"),
-                IO.Int.Input("x", default=0, min=0, max=nodes.MAX_RESOLUTION, step=8),
-                IO.Int.Input("y", default=0, min=0, max=nodes.MAX_RESOLUTION, step=8),
+                IO.Int.Input("x", default=0, min=-nodes.MAX_RESOLUTION, max=nodes.MAX_RESOLUTION, step=8, tooltip="Negative values move the source left."),
+                IO.Int.Input("y", default=0, min=-nodes.MAX_RESOLUTION, max=nodes.MAX_RESOLUTION, step=8, tooltip="Negative values move the source up."),
                 IO.Boolean.Input("resize_source", default=False),
                 IO.Mask.Input("mask", optional=True),
             ],
@@ -88,8 +93,8 @@ class ImageCompositeMasked(IO.ComfyNode):
             inputs=[
                 IO.Image.Input("destination"),
                 IO.Image.Input("source"),
-                IO.Int.Input("x", default=0, min=0, max=nodes.MAX_RESOLUTION, step=1),
-                IO.Int.Input("y", default=0, min=0, max=nodes.MAX_RESOLUTION, step=1),
+                IO.Int.Input("x", default=0, min=-nodes.MAX_RESOLUTION, max=nodes.MAX_RESOLUTION, step=1, tooltip="Negative values move the source left."),
+                IO.Int.Input("y", default=0, min=-nodes.MAX_RESOLUTION, max=nodes.MAX_RESOLUTION, step=1, tooltip="Negative values move the source up."),
                 IO.Boolean.Input("resize_source", default=False),
                 IO.Mask.Input("mask", optional=True),
             ],

--- a/tests-unit/comfy_extras_test/nodes_mask_test.py
+++ b/tests-unit/comfy_extras_test/nodes_mask_test.py
@@ -90,8 +90,9 @@ def test_positive_offsets_continue_to_clip_to_destination(composite):
 def test_non_overlapping_composite_returns_destination_unchanged(composite):
     destination = torch.arange(16, dtype=torch.float32).reshape(1, 1, 4, 4)
     source = torch.ones(1, 1, 2, 2)
+    mask = torch.ones_like(source)
 
-    result = composite(destination.clone(), source, -2, -4, multiplier=1)
+    result = composite(destination.clone(), source, -2, -4, mask=mask, multiplier=1)
 
     assert torch.equal(result, destination)
 

--- a/tests-unit/comfy_extras_test/nodes_mask_test.py
+++ b/tests-unit/comfy_extras_test/nodes_mask_test.py
@@ -1,0 +1,108 @@
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+import comfy
+
+
+def _repeat_to_batch_size(tensor, batch_size):
+    return tensor
+
+
+mock_utils = MagicMock()
+mock_utils.repeat_to_batch_size = _repeat_to_batch_size
+
+mock_nodes = MagicMock()
+mock_nodes.MAX_RESOLUTION = 16384
+
+_utils_sentinel = object()
+_prior_utils = getattr(comfy, "utils", _utils_sentinel)
+comfy.utils = mock_utils
+
+with patch.dict(
+    "sys.modules",
+    {
+        "nodes": mock_nodes,
+        "comfy.model_management": MagicMock(),
+        "comfy.utils": mock_utils,
+    },
+):
+    sys.modules.pop("comfy_extras.nodes_mask", None)
+    from comfy_extras import nodes_mask
+
+if _prior_utils is _utils_sentinel:
+    delattr(comfy, "utils")
+else:
+    comfy.utils = _prior_utils
+
+
+@pytest.fixture()
+def composite(monkeypatch):
+    monkeypatch.setattr(nodes_mask, "comfy", SimpleNamespace(utils=mock_utils))
+    return nodes_mask.composite
+
+
+@pytest.mark.parametrize("multiplier,x,y", [(1, -1, -1), (8, -8, -8)])
+def test_negative_offsets_composite_the_visible_source_rectangle(
+    composite, multiplier, x, y
+):
+    destination = torch.arange(16, dtype=torch.float32).reshape(1, 1, 4, 4)
+    source = torch.ones(1, 1, 2, 2)
+    expected = destination.clone()
+    expected[0, 0, 0, 0] = 1.0
+
+    result = composite(destination.clone(), source, x, y, multiplier=multiplier)
+
+    assert torch.equal(result, expected)
+
+
+def test_negative_offsets_crop_mask_with_source(composite):
+    destination = torch.zeros(1, 1, 4, 4)
+    source = torch.full((1, 1, 2, 2), 2.0)
+    mask = torch.tensor(
+        [
+            [0.0, 0.0],
+            [0.0, 1.0],
+        ]
+    ).reshape(1, 1, 2, 2)
+
+    result = composite(destination.clone(), source, -1, -1, mask=mask, multiplier=1)
+
+    assert result[0, 0, 0, 0].item() == pytest.approx(2.0)
+    assert result[0, 0, 1, 0].item() == pytest.approx(0.0)
+    assert torch.count_nonzero(result).item() == 1
+
+
+def test_positive_offsets_continue_to_clip_to_destination(composite):
+    destination = torch.arange(16, dtype=torch.float32).reshape(1, 1, 4, 4)
+    source = torch.ones(1, 1, 2, 2)
+    expected = destination.clone()
+    expected[0, 0, 3, 3] = 1.0
+
+    result = composite(destination.clone(), source, 3, 3, multiplier=1)
+
+    assert torch.equal(result, expected)
+
+
+def test_non_overlapping_composite_returns_destination_unchanged(composite):
+    destination = torch.arange(16, dtype=torch.float32).reshape(1, 1, 4, 4)
+    source = torch.ones(1, 1, 2, 2)
+
+    result = composite(destination.clone(), source, -2, -4, multiplier=1)
+
+    assert torch.equal(result, destination)
+
+
+@pytest.mark.parametrize(
+    "node_class",
+    [nodes_mask.LatentCompositeMasked, nodes_mask.ImageCompositeMasked],
+)
+def test_composite_widgets_accept_negative_coordinates(node_class):
+    schema = node_class.define_schema()
+    inputs = {item.id: item for item in schema.inputs}
+
+    assert inputs["x"].min == -mock_nodes.MAX_RESOLUTION
+    assert inputs["y"].min == -mock_nodes.MAX_RESOLUTION


### PR DESCRIPTION
## Summary
- Clip the source, mask, and destination to their actual intersection before blending.
- Preserve correct output for negative, positive, and non-overlapping offsets.
- Allow negative X/Y widget values for both image and latent masked composites.

Fixes #5477

## Tests
- `pytest tests-unit/comfy_extras_test/nodes_mask_test.py -q`
- `pytest tests-unit/comfy_extras_test -q --ignore=tests-unit/comfy_extras_test/compositor_node_test.py --ignore=tests-unit/comfy_extras_test/nodes_math_test.py --ignore-glob=tests-unit/comfy_extras_test/test_seedvr2_*.py`
- `ruff check comfy_extras/nodes_mask.py tests-unit/comfy_extras_test/nodes_mask_test.py`
- `git diff --check`