### PR TITLE
Handle missing PyAV frame rotation metadata

### DIFF
--- a/comfy_api/latest/_input_impl/video_types.py
+++ b/comfy_api/latest/_input_impl/video_types.py
@@ -62,6 +62,11 @@ def video_stream_bit_depth(stream) -> int:
     return max(component.bits for component in stream.format.components)
 
 
+def frame_rotation(frame):
+    """Some PyAV versions do not expose rotation on every decoded frame."""
+    return getattr(frame, "rotation", 0)
+
+
 def last_decodable_audio_stream(container: InputContainer):
     """Streams FFmpeg has no decoder for have no codec context, and decoding their
     packets crashes the process (e.g. APAC spatial-audio track in iPhone)."""
@@ -397,8 +402,9 @@ class VideoFromFile(VideoInput):
                             img = np.ascontiguousarray(align_graph[2].pull().to_ndarray(format=image_format)[:frame.height, :frame.width])
                         else:
                             img = frame.to_ndarray(format=image_format)
-                        if frame.rotation != 0:
-                            k = int(round(frame.rotation // 90))
+                        rotation = frame_rotation(frame)
+                        if rotation != 0:
+                            k = int(round(rotation // 90))
                             img = np.rot90(img, k=k, axes=(0, 1)).copy()
                         if alphas is None:
                             frames.append(torch.from_numpy(img))
@@ -649,7 +655,8 @@ class VideoFromFile(VideoInput):
                         if end_pts is not None and frame.pts is not None:
                             frame_duration = min(frame_duration, end_pts - frame.pts)
                         if output is None:
-                            rotation_k = int(round(frame.rotation // 90)) % 4 if frame.rotation else 0
+                            rotation = frame_rotation(frame)
+                            rotation_k = int(round(rotation // 90)) % 4 if rotation else 0
                             if rotation_k % 2:
                                 out_width, out_height = frame.height, frame.width
                             else:

--- a/tests-unit/comfy_api_test/video_types_test.py
+++ b/tests-unit/comfy_api_test/video_types_test.py
@@ -124,6 +124,46 @@ def test_video_from_file_get_duration(simple_video_file):
     assert duration == pytest.approx(0.1, abs=0.01)
 
 
+def test_get_components_handles_frames_without_rotation_attribute(monkeypatch):
+    """Frames decoded by PyAV versions without VideoFrame.rotation still load."""
+    class LegacyFrame:
+        format = type("Format", (), {"name": "rgb24", "components": ()})()
+        pts = 0
+        width = 2
+        height = 2
+
+        def to_ndarray(self, format="rgb24"):
+            assert format == "rgb24"
+            return torch.full((self.height, self.width, 3), 7, dtype=torch.uint8).numpy()
+
+    class LegacyPacket:
+        stream = type("Stream", (), {"type": "video"})()
+
+        def decode(self):
+            return [LegacyFrame()]
+
+    class LegacyContainer:
+        streams = type("Streams", (), {"audio": ()})()
+        metadata = {}
+        streams.video = [type("VideoStream", (), {
+            "type": "video",
+            "time_base": Fraction(1, 30),
+            "average_rate": Fraction(30, 1),
+        })()]
+
+        def demux(self, *streams):
+            assert streams
+            return [LegacyPacket()]
+
+    video = VideoFromFile("legacy-frame.mp4")
+    monkeypatch.setattr(video, "get_active_trim_window", lambda: (0.0, 1.0))
+
+    components = video.get_components_internal(LegacyContainer())
+
+    assert components.images.shape == (1, 2, 2, 3)
+    assert torch.all(components.images == 7 / 255)
+
+
 def test_video_from_file_get_dimensions(simple_video_file):
     """Dimensions read from stream without decoding frames"""
     video = VideoFromFile(simple_video_file)


### PR DESCRIPTION
## Summary
- Treat `VideoFrame.rotation` as optional when decoding components.
- Use the same compatibility helper in the streaming transcode path.
- Add a regression test for frames returned by PyAV versions without the attribute.

## Tests
- `pytest tests-unit/comfy_api_test/video_types_test.py::test_get_components_handles_frames_without_rotation_attribute tests-unit/comfy_api_test/video_types_test.py::test_save_to_transcode_bakes_rotation -q`
- `pytest tests-unit/comfy_api_test/video_types_test.py -q`
- `ruff check comfy_api/latest/_input_impl/video_types.py tests-unit/comfy_api_test/video_types_test.py`

Fixes #13616