### PR TITLE
Fix non-finite prompt metadata

### DIFF
--- a/comfy_execution/graph.py
+++ b/comfy_execution/graph.py
@@ -22,6 +22,7 @@ class DynamicPrompt:
     def __init__(self, original_prompt):
         # The original prompt provided by the user
         self.original_prompt = original_prompt
+        self.raw_is_changed = {}
         # Any extra pieces of the graph created during execution
         self.ephemeral_prompt = {}
         self.ephemeral_parents = {}

--- a/execution.py
+++ b/execution.py
@@ -2,6 +2,7 @@ import copy
 import heapq
 import inspect
 import logging
+import math
 import psutil
 import sys
 import threading
@@ -57,6 +58,13 @@ class ExecutionResult(Enum):
 class DuplicateNodeError(Exception):
     pass
 
+def _json_compatible_float(value):
+    if isinstance(value, float) and not math.isfinite(value):
+        if math.isnan(value):
+            return "NaN"
+        return "Infinity" if value > 0 else "-Infinity"
+    return value
+
 class IsChangedCache:
     def __init__(self, prompt_id: str, dynprompt: DynamicPrompt, outputs_cache: BasicCache):
         self.prompt_id = prompt_id
@@ -92,12 +100,13 @@ class IsChangedCache:
         try:
             is_changed = await _async_map_node_over_list(self.prompt_id, node_id, class_def, input_data_all, is_changed_name, v3_data=v3_data)
             is_changed = await resolve_map_node_over_list_results(is_changed)
-            node["is_changed"] = [None if isinstance(x, ExecutionBlocker) else x for x in is_changed]
+            self.is_changed[node_id] = [None if isinstance(x, ExecutionBlocker) else x for x in is_changed]
+            node["is_changed"] = [_json_compatible_float(x) for x in self.is_changed[node_id]]
         except Exception as e:
             logging.warning("WARNING: {}".format(e))
             node["is_changed"] = float("NaN")
-        finally:
             self.is_changed[node_id] = node["is_changed"]
+            node["is_changed"] = "NaN"
         return self.is_changed[node_id]
 
 

--- a/execution.py
+++ b/execution.py
@@ -76,6 +76,10 @@ class IsChangedCache:
         if node_id in self.is_changed:
             return self.is_changed[node_id]
 
+        if node_id in self.dynprompt.raw_is_changed:
+            self.is_changed[node_id] = self.dynprompt.raw_is_changed[node_id]
+            return self.is_changed[node_id]
+
         node = self.dynprompt.get_node(node_id)
         class_type = node["class_type"]
         class_def = nodes.NODE_CLASS_MAPPINGS[class_type]
@@ -100,12 +104,15 @@ class IsChangedCache:
         try:
             is_changed = await _async_map_node_over_list(self.prompt_id, node_id, class_def, input_data_all, is_changed_name, v3_data=v3_data)
             is_changed = await resolve_map_node_over_list_results(is_changed)
-            self.is_changed[node_id] = [None if isinstance(x, ExecutionBlocker) else x for x in is_changed]
+            raw_is_changed = [None if isinstance(x, ExecutionBlocker) else x for x in is_changed]
+            self.dynprompt.raw_is_changed[node_id] = raw_is_changed
+            self.is_changed[node_id] = raw_is_changed
             node["is_changed"] = [_json_compatible_float(x) for x in self.is_changed[node_id]]
         except Exception as e:
             logging.warning("WARNING: {}".format(e))
             node["is_changed"] = float("NaN")
             self.is_changed[node_id] = node["is_changed"]
+            self.dynprompt.raw_is_changed[node_id] = node["is_changed"]
             node["is_changed"] = "NaN"
         return self.is_changed[node_id]
 

--- a/tests-unit/execution_test/test_is_changed_metadata.py
+++ b/tests-unit/execution_test/test_is_changed_metadata.py
@@ -53,6 +53,13 @@ def test_is_changed_metadata_is_valid_json(monkeypatch, value, expected):
     metadata = json.dumps(prompt, allow_nan=False)
     assert json.loads(metadata)["node"]["is_changed"] == [expected]
 
+    reused_cache = execution.IsChangedCache("prompt", cache.dynprompt, None)
+    reused_value = asyncio.run(reused_cache.get("node"))
+    if expected == "NaN":
+        assert math.isnan(reused_value[0])
+    else:
+        assert reused_value[0] == value
+
 
 def test_is_changed_evaluation_error_metadata_is_valid_json(monkeypatch):
     prompt = {"node": {"class_type": "TestNode", "inputs": {}}}

--- a/tests-unit/execution_test/test_is_changed_metadata.py
+++ b/tests-unit/execution_test/test_is_changed_metadata.py
@@ -1,0 +1,71 @@
+import asyncio
+import json
+import math
+
+import pytest
+
+from comfy.cli_args import args
+
+args.cpu = True
+
+import execution
+from comfy_execution.graph import DynamicPrompt
+
+
+class TestNode:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {}}
+
+    @classmethod
+    def IS_CHANGED(cls, *args, **kwargs):
+        return None
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (float("nan"), "NaN"),
+        (float("inf"), "Infinity"),
+        (float("-inf"), "-Infinity"),
+    ],
+)
+def test_is_changed_metadata_is_valid_json(monkeypatch, value, expected):
+    prompt = {"node": {"class_type": "TestNode", "inputs": {}}}
+    monkeypatch.setitem(execution.nodes.NODE_CLASS_MAPPINGS, "TestNode", TestNode)
+
+    async def map_node(*args, **kwargs):
+        return [value]
+
+    async def resolve_result(result):
+        return result
+
+    monkeypatch.setattr(execution, "_async_map_node_over_list", map_node)
+    monkeypatch.setattr(execution, "resolve_map_node_over_list_results", resolve_result)
+
+    cache = execution.IsChangedCache("prompt", DynamicPrompt(prompt), None)
+    cache_value = asyncio.run(cache.get("node"))
+
+    if expected == "NaN":
+        assert math.isnan(cache_value[0])
+    else:
+        assert cache_value[0] == value
+    metadata = json.dumps(prompt, allow_nan=False)
+    assert json.loads(metadata)["node"]["is_changed"] == [expected]
+
+
+def test_is_changed_evaluation_error_metadata_is_valid_json(monkeypatch):
+    prompt = {"node": {"class_type": "TestNode", "inputs": {}}}
+    monkeypatch.setitem(execution.nodes.NODE_CLASS_MAPPINGS, "TestNode", TestNode)
+
+    async def map_node(*args, **kwargs):
+        raise RuntimeError("evaluation failed")
+
+    monkeypatch.setattr(execution, "_async_map_node_over_list", map_node)
+
+    cache = execution.IsChangedCache("prompt", DynamicPrompt(prompt), None)
+    cache_value = asyncio.run(cache.get("node"))
+
+    assert math.isnan(cache_value)
+    metadata = json.dumps(prompt, allow_nan=False)
+    assert json.loads(metadata)["node"]["is_changed"] == "NaN"

--- a/tests-unit/execution_test/test_is_changed_metadata.py
+++ b/tests-unit/execution_test/test_is_changed_metadata.py
@@ -33,8 +33,11 @@ class TestNode:
 def test_is_changed_metadata_is_valid_json(monkeypatch, value, expected):
     prompt = {"node": {"class_type": "TestNode", "inputs": {}}}
     monkeypatch.setitem(execution.nodes.NODE_CLASS_MAPPINGS, "TestNode", TestNode)
+    evaluator_calls = 0
 
     async def map_node(*args, **kwargs):
+        nonlocal evaluator_calls
+        evaluator_calls += 1
         return [value]
 
     async def resolve_result(result):
@@ -55,6 +58,7 @@ def test_is_changed_metadata_is_valid_json(monkeypatch, value, expected):
 
     reused_cache = execution.IsChangedCache("prompt", cache.dynprompt, None)
     reused_value = asyncio.run(reused_cache.get("node"))
+    assert evaluator_calls == 1
     if expected == "NaN":
         assert math.isnan(reused_value[0])
     else:
@@ -64,8 +68,11 @@ def test_is_changed_metadata_is_valid_json(monkeypatch, value, expected):
 def test_is_changed_evaluation_error_metadata_is_valid_json(monkeypatch):
     prompt = {"node": {"class_type": "TestNode", "inputs": {}}}
     monkeypatch.setitem(execution.nodes.NODE_CLASS_MAPPINGS, "TestNode", TestNode)
+    evaluator_calls = 0
 
     async def map_node(*args, **kwargs):
+        nonlocal evaluator_calls
+        evaluator_calls += 1
         raise RuntimeError("evaluation failed")
 
     monkeypatch.setattr(execution, "_async_map_node_over_list", map_node)
@@ -74,5 +81,9 @@ def test_is_changed_evaluation_error_metadata_is_valid_json(monkeypatch):
     cache_value = asyncio.run(cache.get("node"))
 
     assert math.isnan(cache_value)
+    reused_cache = execution.IsChangedCache("prompt", cache.dynprompt, None)
+    reused_value = asyncio.run(reused_cache.get("node"))
+    assert evaluator_calls == 1
+    assert math.isnan(reused_value)
     metadata = json.dumps(prompt, allow_nan=False)
     assert json.loads(metadata)["node"]["is_changed"] == "NaN"


### PR DESCRIPTION
## Summary
- Keep non-finite `IS_CHANGED` values as internal cache sentinels while writing JSON-compatible strings into prompt metadata.
- Cover both returned non-finite values and evaluation errors.
- Add strict JSON regression tests for `NaN`, `Infinity`, and `-Infinity`.

Fixes #6915

## Testing
- `pytest tests-unit/execution_test/test_is_changed_metadata.py tests-unit/execution_test/test_cache_provider.py tests-unit/execution_test/test_enrich_output.py tests-unit/execution_test/validate_node_input_test.py -q`
- `ruff check .`
- `pylint comfy_api_nodes`
- `git diff --check`