### PR TITLE
Use system Git for SSH fetches in the Windows updater

### DIFF
--- a/.ci/update_windows/update.py
+++ b/.ci/update_windows/update.py
@@ -4,11 +4,24 @@ import sys
 import os
 import shutil
 import filecmp
+import subprocess
+
+
+def _fetch_remote(repo, remote, branch):
+    try:
+        remote.fetch()
+    except pygit2.GitError as error:
+        # Some libgit2 builds do not include SSH support. Let the system Git
+        # client handle those remotes so users can keep their SSH configuration.
+        if "unsupported URL protocol" not in str(error):
+            raise
+        refspec = "+refs/heads/%s:refs/remotes/%s/%s" % (branch, remote.name, branch)
+        subprocess.run(["git", "-C", repo.workdir, "fetch", "--", remote.name, refspec], check=True)
 
 def pull(repo, remote_name='origin', branch='master'):
     for remote in repo.remotes:
         if remote.name == remote_name:
-            remote.fetch()
+            _fetch_remote(repo, remote, branch)
             remote_master_id = repo.lookup_reference('refs/remotes/origin/%s' % (branch)).target
             merge_result, _ = repo.merge_analysis(remote_master_id)
             # Up to date, do nothing
@@ -79,7 +92,7 @@ if branch is None:
         print("fetching.")  # noqa: T201
         for remote in repo.remotes:
             if remote.name == "origin":
-                remote.fetch()
+                _fetch_remote(repo, remote, "master")
         ref = repo.lookup_reference('refs/remotes/origin/master')
     repo.checkout(ref)
     branch = repo.lookup_branch('master')

--- a/tests/test_windows_update.py
+++ b/tests/test_windows_update.py
@@ -1,0 +1,76 @@
+import ast
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+
+UPDATE_SCRIPT = Path(__file__).parents[1] / ".ci" / "update_windows" / "update.py"
+
+
+class FakePygit2:
+    class GitError(Exception):
+        pass
+
+
+def load_update_function(name):
+    """Load one helper without running the standalone updater script."""
+    tree = ast.parse(UPDATE_SCRIPT.read_text(encoding="utf-8"))
+    function = next(node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == name)
+    namespace = {"pygit2": FakePygit2, "subprocess": subprocess}
+    exec(  # noqa: S102
+        compile(ast.Module(body=[function], type_ignores=[]), str(UPDATE_SCRIPT), "exec"), namespace
+    )
+    return namespace[name]
+
+
+def test_ssh_fetch_falls_back_to_system_git():
+    fetch_remote = load_update_function("_fetch_remote")
+    commands = []
+
+    def fake_run(command, check):
+        commands.append((command, check))
+        return SimpleNamespace(returncode=0)
+
+    namespace = {"pygit2": FakePygit2, "subprocess": SimpleNamespace(run=fake_run)}
+    function = type(fetch_remote)(fetch_remote.__code__, namespace)
+    repo = SimpleNamespace(workdir="E:/ComfyUI")
+    remote = SimpleNamespace(
+        name="origin",
+        url="git@github.com:Comfy-Org/ComfyUI.git",
+        fetch=lambda: (_ for _ in ()).throw(FakePygit2.GitError("unsupported URL protocol")),
+    )
+
+    function(repo, remote, "master")
+
+    assert commands == [
+        (
+            [
+                "git",
+                "-C",
+                "E:/ComfyUI",
+                "fetch",
+                "--",
+                "origin",
+                "+refs/heads/master:refs/remotes/origin/master",
+            ],
+            True,
+        )
+    ]
+
+
+def test_other_pygit2_fetch_errors_are_not_swallowed():
+    fetch_remote = load_update_function("_fetch_remote")
+    namespace = {"pygit2": FakePygit2, "subprocess": SimpleNamespace(run=lambda *_: None)}
+    function = type(fetch_remote)(fetch_remote.__code__, namespace)
+    remote = SimpleNamespace(
+        name="origin",
+        url="git@github.com:Comfy-Org/ComfyUI.git",
+        fetch=lambda: (_ for _ in ()).throw(FakePygit2.GitError("authentication failed")),
+    )
+
+    try:
+        function(SimpleNamespace(workdir="E:/ComfyUI"), remote, "master")
+    except FakePygit2.GitError as error:
+        assert str(error) == "authentication failed"
+    else:
+        raise AssertionError("expected the original pygit2 error")


### PR DESCRIPTION
## Summary
- Keep the existing pygit2 fetch path for normal remotes.
- If libgit2 reports that it cannot handle the remote protocol, retry through the system Git client with an explicit refspec.
- Reuse the fallback in both updater fetch paths so installations without a local `master` branch are covered.

Closes #12842

## Test plan
- `pytest tests/test_windows_update.py -q`
- `ruff check .ci/update_windows/update.py tests/test_windows_update.py`
- `git diff --check`