### PR TITLE
Skip non-finite SDPose keypoints when drawing

### DIFF
--- a/comfy_extras/nodes_sdpose.py
+++ b/comfy_extras/nodes_sdpose.py
@@ -240,6 +240,7 @@ class KeypointDraw:
             canvas: The canvas with keypoints drawn
         """
         H, W, C = canvas.shape
+        finite_keypoints = np.isfinite(np.asarray(keypoints)[:, :2]).all(axis=1)
 
         # Draw body limbs & head connections
         if (draw_body or draw_head) and len(keypoints) >= 18:
@@ -256,6 +257,8 @@ class KeypointDraw:
                 idx1, idx2 = limb[0] - 1, limb[1] - 1
 
                 if idx1 >= 18 or idx2 >= 18:
+                    continue
+                if not finite_keypoints[idx1] or not finite_keypoints[idx2]:
                     continue
 
                 if scores is not None:
@@ -285,6 +288,8 @@ class KeypointDraw:
                     continue
                 if not draw_body and i not in head_keypoints and i != neck_point:
                     continue
+                if not finite_keypoints[i]:
+                    continue
                 if scores is not None and scores[i] < threshold:
                     continue
                 x, y = int(keypoints[i][0]), int(keypoints[i][1])
@@ -294,6 +299,8 @@ class KeypointDraw:
         # Draw foot keypoints (18-23, 6 keypoints)
         if draw_feet and len(keypoints) >= 24:
             for i in range(18, 24):
+                if not finite_keypoints[i]:
+                    continue
                 if scores is not None and scores[i] < threshold:
                     continue
                 x, y = int(keypoints[i][0]), int(keypoints[i][1])
@@ -305,6 +312,8 @@ class KeypointDraw:
             eps = 0.01
             for ie, edge in enumerate(self.hand_edges):
                 idx1, idx2 = 92 + edge[0], 92 + edge[1]
+                if not finite_keypoints[idx1] or not finite_keypoints[idx2]:
+                    continue
                 if scores is not None:
                     if scores[idx1] < threshold or scores[idx2] < threshold:
                         continue
@@ -321,6 +330,8 @@ class KeypointDraw:
 
             # Draw right hand keypoints
             for i in range(92, 113):
+                if not finite_keypoints[i]:
+                    continue
                 if scores is not None and scores[i] < threshold:
                     continue
                 x, y = int(keypoints[i][0]), int(keypoints[i][1])
@@ -332,6 +343,8 @@ class KeypointDraw:
             eps = 0.01
             for ie, edge in enumerate(self.hand_edges):
                 idx1, idx2 = 113 + edge[0], 113 + edge[1]
+                if not finite_keypoints[idx1] or not finite_keypoints[idx2]:
+                    continue
                 if scores is not None:
                     if scores[idx1] < threshold or scores[idx2] < threshold:
                         continue
@@ -348,6 +361,8 @@ class KeypointDraw:
 
             # Draw left hand keypoints
             for i in range(113, 134):
+                if not finite_keypoints[i]:
+                    continue
                 if scores is not None and i < len(scores) and scores[i] < threshold:
                     continue
                 x, y = int(keypoints[i][0]), int(keypoints[i][1])
@@ -358,6 +373,8 @@ class KeypointDraw:
         if draw_face and len(keypoints) >= 92:
             eps = 0.01
             for i in range(24, 92):
+                if not finite_keypoints[i]:
+                    continue
                 if scores is not None and scores[i] < threshold:
                     continue
                 x, y = int(keypoints[i][0]), int(keypoints[i][1])

--- a/tests/test_sdpose_keypoints.py
+++ b/tests/test_sdpose_keypoints.py
@@ -1,0 +1,30 @@
+import sys
+
+import numpy as np
+import pytest
+
+import comfy.options
+
+
+# The drawing helper does not need an accelerator, but importing this module
+# initializes ComfyUI's device management on CPU-only test environments.
+comfy.options.args_parsing = True
+pytest_argv = sys.argv
+sys.argv = [sys.argv[0], "--cpu"]
+
+from comfy_extras.nodes_sdpose import KeypointDraw
+
+sys.argv = pytest_argv
+comfy.options.args_parsing = False
+
+
+@pytest.mark.parametrize("index", [0, 10, 18, 24, 92, 113])
+def test_draw_wholebody_skips_nonfinite_keypoints(index):
+    keypoints = np.zeros((134, 2), dtype=np.float32)
+    keypoints[index] = np.nan
+    scores = np.ones(134, dtype=np.float32)
+    canvas = np.zeros((64, 64, 3), dtype=np.uint8)
+
+    result = KeypointDraw().draw_wholebody_keypoints(canvas, keypoints, scores)
+
+    assert result is canvas


### PR DESCRIPTION
## Summary
- Compute a finite-coordinate mask once for the SDPose keypoint array.
- Skip non-finite body, foot, face, and hand coordinates before converting them to integers or drawing edges.

Closes #13149

## Test plan
- `pytest tests/test_sdpose_keypoints.py -q`
- `ruff check comfy_extras/nodes_sdpose.py tests/test_sdpose_keypoints.py`
- `python -m py_compile comfy_extras/nodes_sdpose.py tests/test_sdpose_keypoints.py`
- `git diff --check`