### PR TITLE
Fill missing required API inputs from schema defaults

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -899,7 +899,18 @@ async def validate_inputs(prompt_id, prompt, item, validated, visiting=None):
         input_type, input_category, extra_info = get_input_info(obj_class, x, class_inputs)
         assert extra_info is not None
         if x not in inputs:
-            if input_category == "required":
+            if input_category != "required":
+                continue
+
+            if "default" in extra_info:
+                default_value = extra_info["default"]
+                if isinstance(default_value, list):
+                    # List widget values use this wrapper so validation does not
+                    # mistake them for links to another node.
+                    inputs[x] = {"__value__": default_value}
+                else:
+                    inputs[x] = default_value
+            else:
                 details = f"{x}" if not v3_data else x.split(".")[-1]
                 error = {
                     "type": "required_input_missing",
@@ -910,7 +921,7 @@ async def validate_inputs(prompt_id, prompt, item, validated, visiting=None):
                     }
                 }
                 errors.append(error)
-            continue
+                continue
 
         val = inputs[x]
         info = (input_type, extra_info)

--- a/tests-unit/execution_test/validate_inputs_test.py
+++ b/tests-unit/execution_test/validate_inputs_test.py
@@ -1,0 +1,96 @@
+import asyncio
+
+from comfy.cli_args import args
+
+previous_cpu_setting = args.cpu
+args.cpu = True
+
+import execution
+import nodes
+
+args.cpu = previous_cpu_setting
+
+
+class NodeWithDefault:
+    OUTPUT_NODE = True
+    RETURN_TYPES = ()
+    FUNCTION = "execute"
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "value": ("INT", {"default": 7, "min": 0, "max": 10}),
+            }
+        }
+
+
+class NodeWithoutDefault:
+    OUTPUT_NODE = True
+    RETURN_TYPES = ()
+    FUNCTION = "execute"
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "value": ("INT", {"min": 0, "max": 10}),
+            }
+        }
+
+
+class NodeWithListDefault:
+    OUTPUT_NODE = True
+    RETURN_TYPES = ()
+    FUNCTION = "execute"
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "tags": (["alpha", "beta", "gamma"], {"default": ["alpha", "gamma"], "multiselect": True}),
+            }
+        }
+
+
+def test_required_input_with_default_is_filled(monkeypatch):
+    monkeypatch.setitem(nodes.NODE_CLASS_MAPPINGS, "NodeWithDefault", NodeWithDefault)
+    prompt = {"node": {"class_type": "NodeWithDefault", "inputs": {}}}
+
+    valid, error, outputs, node_errors = asyncio.run(
+        execution.validate_prompt("test", prompt, None)
+    )
+
+    assert valid
+    assert error is None
+    assert outputs == ["node"]
+    assert node_errors == {}
+    assert prompt["node"]["inputs"]["value"] == 7
+
+
+def test_required_input_without_default_is_not_filled(monkeypatch):
+    monkeypatch.setitem(nodes.NODE_CLASS_MAPPINGS, "NodeWithoutDefault", NodeWithoutDefault)
+    prompt = {"node": {"class_type": "NodeWithoutDefault", "inputs": {}}}
+
+    valid, _, _, node_errors = asyncio.run(
+        execution.validate_prompt("test", prompt, None)
+    )
+
+    assert not valid
+    assert node_errors["node"]["errors"][0]["type"] == "required_input_missing"
+    assert "value" not in prompt["node"]["inputs"]
+
+
+def test_list_default_is_not_treated_as_a_link(monkeypatch):
+    monkeypatch.setitem(nodes.NODE_CLASS_MAPPINGS, "NodeWithListDefault", NodeWithListDefault)
+    prompt = {"node": {"class_type": "NodeWithListDefault", "inputs": {}}}
+
+    valid, error, outputs, node_errors = asyncio.run(
+        execution.validate_prompt("test", prompt, None)
+    )
+
+    assert valid
+    assert error is None
+    assert outputs == ["node"]
+    assert node_errors == {}
+    assert prompt["node"]["inputs"]["tags"] == ["alpha", "gamma"]


### PR DESCRIPTION
## Summary
- Fill a missing required input from its schema default before running the normal value checks.
- Preserve list defaults as widget values rather than treating them as node links.
- Preserve the existing required-input error when no default is declared.
- Add focused coverage for scalar defaults, list defaults, and the no-default case.

Fixes #11833

## Testing
- `python -m pytest tests-unit/execution_test/validate_inputs_test.py tests-unit/execution_test/validate_node_input_test.py -q` (18 passed)
- `ruff check execution.py tests-unit/execution_test/validate_inputs_test.py`
- `python -m py_compile execution.py tests-unit/execution_test/validate_inputs_test.py`
- `git diff --check`