### PR TITLE
Support launching auto-launch in a specific browser

### DIFF
--- a/comfy/browser.py
+++ b/comfy/browser.py
@@ -1,0 +1,40 @@
+import logging
+import os
+import shutil
+import subprocess
+import webbrowser
+
+
+def open_browser(
+    url: str,
+    browser_path: str | None = None,
+    browser_profile: str | None = None,
+) -> bool:
+    """Open a URL in the configured browser, falling back to the system default."""
+    if browser_path is None:
+        if browser_profile is not None:
+            logging.warning("Ignoring browser profile because no browser path was configured")
+        return webbrowser.open(url)
+
+    command = os.path.expanduser(browser_path)
+    executable = shutil.which(command)
+    if executable is None:
+        logging.warning("Browser command not found: %s; using the system default", browser_path)
+        return webbrowser.open(url)
+
+    popen_kwargs = {}
+    if os.name != "nt":
+        popen_kwargs["start_new_session"] = True
+
+    browser_args = [executable]
+    if browser_profile is not None:
+        browser_args.extend(["--profile-directory", browser_profile])
+    browser_args.append(url)
+
+    try:
+        subprocess.Popen(browser_args, **popen_kwargs)
+    except OSError as ex:
+        logging.warning("Unable to launch browser %s: %s; using the system default", executable, ex)
+        return webbrowser.open(url)
+
+    return True

--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -73,6 +73,8 @@ parser.add_argument("--output-directory", type=str, default=None, help="Set the 
 parser.add_argument("--temp-directory", type=str, default=None, help="Set the ComfyUI temp directory (default is in the ComfyUI directory). Overrides --base-directory.")
 parser.add_argument("--input-directory", type=str, default=None, help="Set the ComfyUI input directory. Overrides --base-directory.")
 parser.add_argument("--auto-launch", action="store_true", help="Automatically launch ComfyUI in the default browser.")
+parser.add_argument("--browser-path", type=str, default=None, metavar="BROWSER", help="Browser executable or command to use with --auto-launch instead of the system default.")
+parser.add_argument("--browser-profile", type=str, default=None, metavar="PROFILE_DIRECTORY", help="Chromium profile directory to use with --browser-path.")
 parser.add_argument("--disable-auto-launch", action="store_true", help="Disable auto launching the browser.")
 parser.add_argument("--cuda-device", type=str, default=None, metavar="DEVICE_ID", help="Set the ids of cuda devices this instance will use, as a comma-separated list (e.g. '0' or '0,1'). All other devices will not be visible.")
 parser.add_argument("--default-device", type=int, default=None, metavar="DEFAULT_DEVICE_ID", help="Set the id of the default device, all other devices will stay visible.")

--- a/main.py
+++ b/main.py
@@ -554,12 +554,15 @@ def start_comfyui(asyncio_loop=None):
     call_on_start = None
     if args.auto_launch:
         def startup_server(scheme, address, port):
-            import webbrowser
             if os.name == 'nt' and address == '0.0.0.0':
                 address = '127.0.0.1'
             if ':' in address:
                 address = "[{}]".format(address)
-            webbrowser.open(f"{scheme}://{address}:{port}")
+            comfy.browser.open_browser(
+                f"{scheme}://{address}:{port}",
+                browser_path=args.browser_path,
+                browser_profile=args.browser_profile,
+            )
         call_on_start = startup_server
 
     async def start_all():

--- a/tests-unit/browser_test.py
+++ b/tests-unit/browser_test.py
@@ -1,0 +1,76 @@
+import os
+
+from comfy import browser
+from comfy.cli_args import parser
+
+
+def test_custom_browser_command_is_launched(monkeypatch):
+    """A configured browser and optional Chromium profile receive the URL."""
+    monkeypatch.setattr(browser.shutil, "which", lambda command: "/resolved/browser" if command == "custom-browser" else None)
+    launched = []
+
+    def fake_popen(args, **kwargs):
+        launched.append((args, kwargs))
+        return object()
+
+    monkeypatch.setattr(browser.subprocess, "Popen", fake_popen)
+
+    assert browser.open_browser(
+        "http://127.0.0.1:8188",
+        browser_path="custom-browser",
+        browser_profile="Profile 1",
+    )
+    assert launched == [
+        (
+            ["/resolved/browser", "--profile-directory", "Profile 1", "http://127.0.0.1:8188"],
+            {} if os.name == "nt" else {"start_new_session": True},
+        )
+    ]
+
+
+def test_missing_custom_browser_falls_back_to_default(monkeypatch):
+    """A bad browser command does not prevent the UI from opening."""
+    monkeypatch.setattr(browser.shutil, "which", lambda command: None)
+    opened = []
+    monkeypatch.setattr(browser.webbrowser, "open", lambda url: opened.append(url) or True)
+
+    assert browser.open_browser("http://localhost:8188", browser_path="missing-browser")
+    assert opened == ["http://localhost:8188"]
+
+
+def test_failed_browser_launch_falls_back_to_default(monkeypatch):
+    """A launch failure is reported by falling back to the default browser."""
+    monkeypatch.setattr(browser.shutil, "which", lambda command: "/resolved/browser")
+    opened = []
+    monkeypatch.setattr(browser.webbrowser, "open", lambda url: opened.append(url) or True)
+
+    def fail_popen(args, **kwargs):
+        raise OSError("launch failed")
+
+    monkeypatch.setattr(browser.subprocess, "Popen", fail_popen)
+
+    assert browser.open_browser("http://localhost:8188", browser_path="custom-browser")
+    assert opened == ["http://localhost:8188"]
+
+
+def test_default_browser_is_used_without_custom_path(monkeypatch):
+    """Omitting a browser path retains the existing behavior."""
+    opened = []
+    monkeypatch.setattr(browser.webbrowser, "open", lambda url: opened.append(url) or True)
+
+    assert browser.open_browser("http://localhost:8188")
+    assert opened == ["http://localhost:8188"]
+
+
+def test_browser_path_cli_option():
+    """Both browser options are exposed through the startup parser."""
+    parsed = parser.parse_args([
+        "--auto-launch",
+        "--browser-path",
+        "custom-browser",
+        "--browser-profile",
+        "Profile 1",
+    ])
+    assert parsed.auto_launch
+    assert parsed.browser_path == "custom-browser"
+    assert parsed.browser_profile == "Profile 1"


### PR DESCRIPTION
## Summary
- Add `--browser-path BROWSER` for use with `--auto-launch`.
- Add `--browser-profile PROFILE_DIRECTORY` for Chromium-based browsers.
- Accept either a full executable path or a command available on `PATH`, and launch the URL without a shell.
- Fall back to the system-default browser if the configured browser cannot be found or launched, keeping the server available.
- Preserve the existing system-default browser behavior when no browser path is supplied.

Fixes #11709

## Testing
- `python -m pytest tests-unit/browser_test.py -q` (5 passed)
- `ruff check comfy/browser.py comfy/cli_args.py main.py tests-unit/browser_test.py`
- `python -m py_compile comfy/browser.py comfy/cli_args.py main.py tests-unit/browser_test.py`
- `git diff --check`