### PR TITLE
Resolve the default database URL from the effective user directory

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -265,10 +265,7 @@ parser.add_argument(
     help="Set the base URL for the ComfyUI API.  (default: https://api.comfy.org)",
 )
 
-database_default_path = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), "..", "user", "comfyui.db")
-)
-parser.add_argument("--database-url", type=str, default=f"sqlite:///{database_default_path}", help="Specify the database URL, e.g. for an in-memory database you can use 'sqlite:///:memory:'.")
+parser.add_argument("--database-url", type=str, default=None, help="Specify the database URL, e.g. for an in-memory database you can use 'sqlite:///:memory:'.")
 parser.add_argument("--enable-assets", action="store_true", help="Enable the assets system (API routes, database synchronization, and background scanning).")
 parser.add_argument("--enable-asset-hashing", action="store_true", help="Compute blake3 content hashes when scanning assets. Hashing enables future asset-portability features (deduplication, cross-machine model resolution) but adds startup cost and per-output cost on large models directories. Off by default; enable to opt in.")
 parser.add_argument("--feature-flag", type=str, action='append', default=[], metavar="KEY[=VALUE]", help="Set a server feature flag. Use KEY=VALUE to set an explicit value, or bare KEY to set it to true. Can be specified multiple times. Boolean values (true/false) and numbers are auto-converted. Examples: --feature-flag show_signin_button=true  or  --feature-flag show_signin_button")
@@ -278,6 +275,19 @@ if comfy.options.args_parsing:
     args = parser.parse_args()
 else:
     args = parser.parse_args([])
+
+def get_default_database_url(base_directory: str | None = None, user_directory: str | None = None) -> str:
+    """Resolve the default SQLite database URL inside the effective user directory."""
+    if user_directory is not None:
+        user_dir = os.path.abspath(user_directory)
+    elif base_directory is not None:
+        user_dir = os.path.join(os.path.abspath(base_directory), "user")
+    else:
+        user_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "user"))
+    return f"sqlite:///{os.path.join(user_dir, 'comfyui.db')}"
+
+if args.database_url is None:
+    args.database_url = get_default_database_url(args.base_directory, args.user_directory)
 
 if args.cache_ram is not None and len(args.cache_ram) > 2:
     parser.error("--cache-ram accepts at most two values: active GB and inactive GB")

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from comfy import cli_args
+
+PYTHON = sys.executable
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def run_cli_args(argv: list[str]) -> str:
+    script = (
+        "import sys; "
+        "import comfy.options; comfy.options.enable_args_parsing(); "
+        "sys.argv = ['ComfyUI'] + sys.argv[1:]; "
+        "from comfy.cli_args import args; "
+        "print(args.database_url)"
+    )
+    result = subprocess.run(
+        [PYTHON, "-c", script, *argv],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        check=True,
+    )
+    return result.stdout.strip().splitlines()[-1]
+
+
+def test_default_database_url_is_in_repo_user_directory() -> None:
+    url = cli_args.get_default_database_url()
+    expected = os.path.abspath(os.path.join(REPO_ROOT, "user", "comfyui.db"))
+    assert url == f"sqlite:///{expected}"
+
+
+def test_default_database_url_respects_base_directory(tmp_path: Path) -> None:
+    url = cli_args.get_default_database_url(base_directory=str(tmp_path))
+    assert url == f"sqlite:///{tmp_path / 'user' / 'comfyui.db'}"
+
+
+def test_default_database_url_prefers_user_directory(tmp_path: Path) -> None:
+    base = tmp_path / "base"
+    user = tmp_path / "custom-user"
+    url = cli_args.get_default_database_url(
+        base_directory=str(base), user_directory=str(user)
+    )
+    assert url == f"sqlite:///{user / 'comfyui.db'}"
+
+
+def test_parsed_base_directory_changes_default_database_url(tmp_path: Path) -> None:
+    base = tmp_path / "out-of-tree"
+    base.mkdir()
+    url = run_cli_args(["--base-directory", str(base)])
+    assert url == f"sqlite:///{base / 'user' / 'comfyui.db'}"
+
+
+def test_parsed_user_directory_changes_default_database_url(tmp_path: Path) -> None:
+    base = tmp_path / "out-of-tree"
+    user = tmp_path / "custom-user"
+    base.mkdir()
+    user.mkdir()
+    url = run_cli_args(["--base-directory", str(base), "--user-directory", str(user)])
+    assert url == f"sqlite:///{user / 'comfyui.db'}"
+
+
+def test_explicit_database_url_wins(tmp_path: Path) -> None:
+    base = tmp_path / "out-of-tree"
+    base.mkdir()
+    url = run_cli_args(
+        ["--base-directory", str(base), "--database-url", "sqlite:///:memory:"]
+    )
+    assert url == "sqlite:///:memory:"


### PR DESCRIPTION
## Problem

The default `--database-url` is computed from the repository checkout at parser construction time (`<repo>/user/comfyui.db`), so `--base-directory` and `--user-directory` only relocate the user directory that `UserManager` creates. The SQLite database still points inside the checkout:

- If `<repo>/user` does not exist, startup logs `sqlite3.OperationalError: unable to open database file`.
- If it does exist, the database is silently created there instead of under the requested base directory.

This undermines the fully out-of-tree execution setup that `--base-directory` provides (see the discussion in #10914).

Fixes #11233

## Changes

- `--database-url` now defaults to `None` and is resolved after argument parsing from the effective user directory: `--user-directory` wins, then `<base-directory>/user`, then the previous `<repo>/user` default. This mirrors how `folder_paths` resolves the user directory.
- An explicit `--database-url` still takes precedence and is left untouched.

## Testing

- New `tests/test_cli_args.py` covering default resolution, `--base-directory`, `--user-directory`, precedence between the two, parse-time integration via subprocess, and explicit URL override.
- Before the fix, the new default-resolution tests fail with `AttributeError` and the subprocess tests resolve the database under `<repo>/user`; after the fix all 6 pass.
- End-to-end check with `main.py --base-directory <tmp> --quick-test-for-ci --disable-all-custom-nodes --cpu`: database migrations run and `comfyui.db` is created at `<tmp>/user/comfyui.db`, with no database created in the repository checkout.
- `ruff check` passes on the changed files.