### PR TITLE
Report typed validation errors for out-of-range output slots

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -932,6 +932,21 @@ async def validate_inputs(prompt_id, prompt, item, validated, visiting=None):
             o_id = val[0]
             o_class_type = prompt[o_id]['class_type']
             r = nodes.NODE_CLASS_MAPPINGS[o_class_type].RETURN_TYPES
+            if val[1] < 0 or val[1] >= len(r):
+                error = {
+                    "type": "return_slot_out_of_range",
+                    "message": "Linked output slot is out of range",
+                    "details": f"{x}, slot_index({val[1]}) not in range of {len(r)} output(s)",
+                    "extra_info": {
+                        "input_name": x,
+                        "input_config": info,
+                        "received_value": val,
+                        "linked_node": val,
+                        "output_count": len(r),
+                    }
+                }
+                errors.append(error)
+                continue
             received_type = r[val[1]]
             received_types[x] = received_type
             if 'input_types' not in validate_function_inputs and not validate_node_input(received_type, input_type):

--- a/tests/execution/test_validation.py
+++ b/tests/execution/test_validation.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from comfy import cli_args
+
+# model_management probes the accelerator at import time; these tests never
+# execute nodes, so force the CPU code path before importing execution.
+cli_args.args.cpu = True
+
+import execution
+import nodes
+
+
+class ValidationTestSource:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {}}
+
+    RETURN_TYPES = ("STRING",)
+    FUNCTION = "execute"
+    CATEGORY = "testing/validation"
+
+    def execute(self):
+        return ("ok",)
+
+
+class ValidationTestOutput:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {"value": ("STRING",)}}
+
+    RETURN_TYPES = ()
+    FUNCTION = "execute"
+    CATEGORY = "testing/validation"
+    OUTPUT_NODE = True
+
+    def execute(self, value):
+        return ()
+
+
+@pytest.fixture
+def validation_nodes():
+    classes = {
+        "ValidationTestSource": ValidationTestSource,
+        "ValidationTestOutput": ValidationTestOutput,
+    }
+    for name, cls in classes.items():
+        nodes.NODE_CLASS_MAPPINGS[name] = cls
+    yield classes
+    for name in classes:
+        nodes.NODE_CLASS_MAPPINGS.pop(name, None)
+
+
+def run_validate_prompt(prompt: dict) -> tuple[bool, dict | None, list, dict]:
+    return asyncio.run(execution.validate_prompt("test-prompt", prompt, None))
+
+
+def build_prompt(slot: int) -> dict:
+    return {
+        "1": {"class_type": "ValidationTestSource", "inputs": {}},
+        "2": {"class_type": "ValidationTestOutput", "inputs": {"value": ["1", slot]}},
+    }
+
+
+def test_in_range_slot_validates(validation_nodes) -> None:
+    valid, error, _, node_errors = run_validate_prompt(build_prompt(0))
+    assert valid is True
+    assert error is None
+    assert node_errors == {}
+
+
+def test_out_of_range_slot_reports_typed_error(validation_nodes) -> None:
+    valid, error, _, node_errors = run_validate_prompt(build_prompt(1))
+
+    assert valid is False
+    assert error is not None
+    assert error["type"] == "prompt_outputs_failed_validation"
+    errors = node_errors["2"]["errors"]
+    assert errors[0]["type"] == "return_slot_out_of_range"
+    assert errors[0]["extra_info"]["linked_node"] == ["1", 1]
+    assert errors[0]["extra_info"]["output_count"] == 1
+
+
+def test_negative_slot_reports_typed_error(validation_nodes) -> None:
+    valid, _, _, node_errors = run_validate_prompt(build_prompt(-1))
+
+    assert valid is False
+    errors = node_errors["2"]["errors"]
+    assert errors[0]["type"] == "return_slot_out_of_range"


### PR DESCRIPTION
## Problem

While validating a linked input, `validate_inputs` indexes the source node's `RETURN_TYPES` with the raw slot index:

```python
received_type = r[val[1]]
```

If an API prompt references an output slot beyond what the linked node declares, this raises `IndexError` and the client only sees `exception_during_inner_validation` / `exception_during_validation` with the detail `tuple index out of range`, which says nothing about which link is broken. Negative slot indexes wrap around and silently pass type checking.

Fixes #11292

## Changes

- Bounds-check the linked slot index before indexing `RETURN_TYPES`.
- Emit a `return_slot_out_of_range` node error that names the input, the slot index, and the declared output count, instead of surfacing an exception traceback.

## Testing

- New `tests/execution/test_validation.py`:
  - an in-range slot still validates;
  - an out-of-range slot now produces `return_slot_out_of_range` (before the change this test failed with `exception_during_validation: tuple index out of range`);
  - a negative slot now produces the same typed error (before the change it silently validated).
- End-to-end check against a running server: `POST /prompt` with `SaveImage.images` linked to `LoadImage` slot 5 returns HTTP 400 with `node_errors["2"].errors[0].type == "return_slot_out_of_range"` and details `images, slot_index(5) not in range of 2 output(s)`, with no exception traceback in the response.
- `ruff check` passes on the changed files.