### PR TITLE
Fix "Cannot set version_counter for inference tensor" for quantized weights

### DIFF
--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -1099,9 +1099,7 @@ def _quantized_apply(module, fn, recurse=True):
         if param is None:
             continue
         p = fn(param)
-        if (not torch.is_inference_mode_enabled()) and p.is_inference():
-            p = p.clone()
-        module.register_parameter(key, torch.nn.Parameter(p, requires_grad=False))
+        module.register_parameter(key, comfy.utils.make_param(p))
     for key, buf in module._buffers.items():
         if buf is not None:
             module._buffers[key] = fn(buf)

--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -970,12 +970,24 @@ def set_attr(obj, attr, value):
         setattr(obj, name, value)
     return prev
 
-def set_attr_param(obj, attr, value):
+def make_param(value):
     # Clone inference tensors (created under torch.inference_mode) since
     # their version counter is frozen and nn.Parameter() cannot wrap them.
     if (not torch.is_inference_mode_enabled()) and value.is_inference():
         value = value.clone()
-    return set_attr(obj, attr, torch.nn.Parameter(value, requires_grad=False))
+    elif torch.is_inference_mode_enabled() and (not value.is_inference()) and hasattr(value, "__tensor_flatten__"):
+        # A wrapper tensor subclass (e.g. QuantizedTensor) built outside inference
+        # mode: nn.Parameter()'s detach() would rebuild it as an inference tensor
+        # while still tied to the original's (non-frozen) version counter, which
+        # torch refuses. Rebuilding the wrapper here makes it a fresh inference
+        # tensor with its own version counter instead.
+        attrs, ctx = value.__tensor_flatten__()
+        inner_tensors = {name: getattr(value, name) for name in attrs}
+        value = type(value).__tensor_unflatten__(inner_tensors, ctx, value.shape, value.stride())
+    return torch.nn.Parameter(value, requires_grad=False)
+
+def set_attr_param(obj, attr, value):
+    return set_attr(obj, attr, make_param(value))
 
 def set_attr_buffer(obj, attr, value):
     obj, name = resolve_attr(obj, attr)

--- a/tests-unit/comfy_quant/test_mixed_precision.py
+++ b/tests-unit/comfy_quant/test_mixed_precision.py
@@ -337,5 +337,30 @@ class TestMixedPrecisionOps(unittest.TestCase):
         self.assertEqual(saved_conf["linear_dtype"], "int8")
         self.assertNotIn("quant_group_size", saved_conf)
 
+    def test_quantized_weight_survives_to_call_inside_inference_mode(self):
+        """A QuantizedTensor weight built outside inference_mode must survive a
+        later .to() call made inside inference_mode (model offload/unload does
+        this) instead of raising "Cannot set version_counter for inference
+        tensor"."""
+        weight = torch.randn(16, 16, dtype=torch.bfloat16)
+        q_weight = QuantizedTensor.from_float(weight, "TensorCoreFP8E4M3Layout")
+        self.assertFalse(q_weight.is_inference())
+
+        model = torch.nn.Module()
+        model.layer = ops.mixed_precision_ops({}).Linear(16, 16, device="cpu", dtype=torch.bfloat16)
+        model.layer.weight = torch.nn.Parameter(q_weight, requires_grad=False)
+        model.layer.bias = torch.nn.Parameter(torch.randn(16, dtype=torch.bfloat16))
+        model.layer.weight_function = []
+        model.layer.bias_function = []
+
+        with torch.inference_mode():
+            model.to("cpu")
+
+        self.assertIsInstance(model.layer.weight, QuantizedTensor)
+        self.assertTrue(torch.equal(
+            model.layer.weight._qdata.view(torch.uint8),
+            q_weight._qdata.view(torch.uint8),
+        ))
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

Fixes #15733.

Running two MiniMax H3 sub-graphs back to back (or any workflow that
causes a quantized (fp8/nvfp4/int8) model to be unloaded and reloaded)
can fail with:

```
RuntimeError: Cannot set version_counter for inference tensor
```

raised from `torch.nn.Parameter(p, requires_grad=False)` inside
`comfy/ops.py`'s `_quantized_apply`, during `unpatch_model()`'s
`self.model.to(offload_device)`.

## Root cause

`QuantizedTensor` (and other wrapper tensor subclasses from
`comfy_kitchen`) built **outside** `torch.inference_mode()` (e.g. by
`unload_all_models()`, which runs in `main.py`'s worker loop after the
`inference_mode` block used during execution has already exited) end
up as normal, non-inference tensors.

The next time that weight is touched **inside** `inference_mode`
(node execution always runs under `inference_mode`), `_quantized_apply`
and `comfy.utils.set_attr_param` re-wrap it with
`torch.nn.Parameter(p, requires_grad=False)`. `Parameter.__new__` calls
`p.detach()` on custom tensor subclasses; `detach()` rebuilds the
wrapper fresh under the *current* mode (so the new wrapper is an
inference tensor), but autograd still tries to link it to the
original's (non-frozen) version counter — which torch refuses for an
inference tensor, producing the error above.

The two call sites already had a guard for the opposite case (an
inference tensor being wrapped outside inference mode gets cloned) but
nothing for this one.

## Fix

Added `comfy.utils.make_param()`, used by both `_quantized_apply` and
`set_attr_param`. When we're inside `inference_mode` and the value is a
non-inference wrapper tensor subclass, rebuild it via its own
`__tensor_flatten__`/`__tensor_unflatten__` (no data copy, same
storage) before wrapping it in a `Parameter`. The rebuilt wrapper is
created under the current mode, so it comes out as a genuine inference
tensor with its own version counter and `Parameter()` no longer touches
the original's counter.

## Testing

Reproduced the exact bug locally with the real `comfy-kitchen==0.2.31`
package and torch `2.13.0+cpu` (matching the versions in the issue) by
building a `QuantizedTensor` outside `inference_mode` and then calling
`.to()` on the owning module from inside `inference_mode` — this
reproduces the traceback in the issue verbatim.

Added `test_quantized_weight_survives_to_call_inside_inference_mode` to
`tests-unit/comfy_quant/test_mixed_precision.py`, which does exactly
that. Verified it fails on unpatched `comfy/ops.py`/`comfy/utils.py`
with the same `RuntimeError: Cannot set version_counter for inference
tensor`, and passes with the fix:

```
$ python -m pytest tests-unit/comfy_quant/test_mixed_precision.py -v
...
tests-unit/comfy_quant/test_mixed_precision.py::TestMixedPrecisionOps::test_all_layers_standard PASSED
tests-unit/comfy_quant/test_mixed_precision.py::TestMixedPrecisionOps::test_convrot_w4a4_loads_into_params PASSED
tests-unit/comfy_quant/test_mixed_precision.py::TestMixedPrecisionOps::test_error_handling_unknown_format PASSED
tests-unit/comfy_quant/test_mixed_precision.py::TestMixedPrecisionOps::test_int8_convrot_metadata_loads_into_params PASSED
tests-unit/comfy_quant/test_mixed_precision.py::TestMixedPrecisionOps::test_mixed_precision_load PASSED
tests-unit/comfy_quant/test_mixed_precision.py::TestMixedPrecisionOps::test_quantized_weight_survives_to_call_inside_inference_mode PASSED
tests-unit/comfy_quant/test_mixed_precision.py::TestMixedPrecisionOps::test_state_dict_quantized_preserved PASSED
tests-unit/comfy_quant/test_mixed_precision.py::TestMixedPrecisionOps::test_weight_function_compatibility PASSED

8 passed in 2.44s
```

Also ran the broader `tests-unit/comfy_quant` and `tests-unit/comfy_test`
suites (36 passed; the handful of collection errors there are pre-existing
environment gaps — missing `torchaudio`/`transformers` in this sandbox,
unrelated to this change) and `ruff check comfy/ops.py comfy/utils.py
tests-unit/comfy_quant/test_mixed_precision.py` (all checks passed).

## Disclosure

I used an AI coding assistant (Claude) to investigate this issue,
implement the fix, and write the test in this PR. The root-cause
analysis and fix were independently verified by reproducing the crash
and confirming the fix against the real `comfy-kitchen` package as
described above.
