### PR TITLE
Add MiniMax H3 AV latent builder

### DIFF
--- a/comfy_extras/nodes_minimax_h3.py
+++ b/comfy_extras/nodes_minimax_h3.py
@@ -109,6 +109,49 @@ class EmptyMiniMaxH3LatentAV(io.ComfyNode):
         return io.NodeOutput(latent)
 
 
+class MiniMaxH3AVLatent(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="MiniMaxH3AVLatent",
+            display_name="MiniMax H3 AV Latent",
+            category="model/latent/minimax",
+            description="Combine separately encoded MiniMax H3 video and audio latents into the model's joint AV latent.",
+            inputs=[
+                io.Latent.Input("video_latent"),
+                io.Latent.Input("audio_latent"),
+            ],
+            outputs=[io.Latent.Output()],
+        )
+
+    @classmethod
+    def execute(cls, video_latent, audio_latent) -> io.NodeOutput:
+        video = video_latent.get("samples") if isinstance(video_latent, dict) else None
+        audio = audio_latent.get("samples") if isinstance(audio_latent, dict) else None
+        if not torch.is_tensor(video):
+            raise ValueError("video_latent must contain a tensor in samples")
+        if not torch.is_tensor(audio):
+            raise ValueError("audio_latent must contain a tensor in samples")
+
+        if video.ndim != 5 or video.shape[1] != 24 or any(size <= 0 for size in (video.shape[0], *video.shape[2:])):
+            raise ValueError(f"MiniMax H3 video latent must have shape [B, 24, T, H, W] with positive dimensions, got {tuple(video.shape)}")
+        if audio.ndim != 4 or audio.shape[1] != 32 or audio.shape[2] != 2 or any(size <= 0 for size in (audio.shape[0], audio.shape[3])):
+            raise ValueError(f"MiniMax H3 audio latent must have shape [B, 32, 2, T] with positive dimensions, got {tuple(audio.shape)}")
+        if video.shape[0] != audio.shape[0]:
+            raise ValueError(f"MiniMax H3 video and audio latent batch sizes must match, got {video.shape[0]} and {audio.shape[0]}")
+
+        cycles, remainder = divmod(video.shape[2], len(FRAME_PER_TOKEN))
+        frame_count = cycles * sum(FRAME_PER_TOKEN) + sum(FRAME_PER_TOKEN[:remainder])
+        expected_audio_t = round(frame_count / FPS * AUDIO_LATENT_FPS)
+        if abs(audio.shape[3] - expected_audio_t) > 1:
+            raise ValueError(
+                f"MiniMax H3 video/audio latent timelines do not match: video T={video.shape[2]} "
+                f"represents {frame_count} frames and expects audio T={expected_audio_t} (±1), got {audio.shape[3]}"
+            )
+
+        return io.NodeOutput({"samples": comfy.nested_tensor.NestedTensor((video, audio))})
+
+
 class MiniMaxH3ImageToVideo(io.ComfyNode):
     """t2va and fl2va: prompt (+ optional first/last keyframes) -> conditioning + AV latent."""
 
@@ -403,6 +446,7 @@ class MiniMaxH3Extension(ComfyExtension):
     async def get_node_list(self):
         return [
             EmptyMiniMaxH3LatentAV,
+            MiniMaxH3AVLatent,
             MiniMaxH3ImageToVideo,
             MiniMaxH3AddGuide,
             MiniMaxH3ReferenceToVideo,

--- a/tests-unit/comfy_extras_test/test_minimax_h3_av_latent.py
+++ b/tests-unit/comfy_extras_test/test_minimax_h3_av_latent.py
@@ -1,0 +1,62 @@
+import asyncio
+
+import pytest
+import torch
+
+import comfy.nested_tensor
+from comfy_extras.nodes_minimax_h3 import MiniMaxH3AVLatent, MiniMaxH3Extension
+
+
+def make_latents(video_shape=(1, 24, 107, 2, 3), audio_shape=(1, 32, 2, 603)):
+    return {"samples": torch.zeros(video_shape)}, {"samples": torch.zeros(audio_shape)}
+
+
+def test_builds_minimax_h3_nested_av_latent():
+    video_latent, audio_latent = make_latents()
+
+    output = MiniMaxH3AVLatent.execute(video_latent, audio_latent)[0]
+
+    assert isinstance(output["samples"], comfy.nested_tensor.NestedTensor)
+    video, audio = output["samples"].unbind()
+    assert video is video_latent["samples"]
+    assert audio is audio_latent["samples"]
+
+
+@pytest.mark.parametrize(
+    ("video_shape", "audio_shape", "message"),
+    [
+        ((1, 24, 107, 2), (1, 32, 2, 603), "video latent must have shape"),
+        ((1, 16, 107, 2, 3), (1, 32, 2, 603), "video latent must have shape"),
+        ((1, 24, 107, 2, 3), (1, 32, 603), "audio latent must have shape"),
+        ((1, 24, 107, 2, 3), (1, 16, 2, 603), "audio latent must have shape"),
+        ((1, 24, 107, 2, 3), (1, 32, 1, 603), "audio latent must have shape"),
+    ],
+)
+def test_rejects_invalid_stream_shapes(video_shape, audio_shape, message):
+    video_latent, audio_latent = make_latents(video_shape, audio_shape)
+
+    with pytest.raises(ValueError, match=message):
+        MiniMaxH3AVLatent.execute(video_latent, audio_latent)
+
+
+def test_rejects_mismatched_batch_sizes():
+    video_latent, audio_latent = make_latents(audio_shape=(2, 32, 2, 603))
+
+    with pytest.raises(ValueError, match="batch sizes must match"):
+        MiniMaxH3AVLatent.execute(video_latent, audio_latent)
+
+
+def test_accepts_one_tick_rounding_difference_and_rejects_obvious_timeline_mismatch():
+    video_latent, audio_latent = make_latents(audio_shape=(1, 32, 2, 604))
+    assert MiniMaxH3AVLatent.execute(video_latent, audio_latent)[0]["samples"].unbind()[1] is audio_latent["samples"]
+
+    video_latent, audio_latent = make_latents(audio_shape=(1, 32, 2, 600))
+    with pytest.raises(ValueError, match="timelines do not match"):
+        MiniMaxH3AVLatent.execute(video_latent, audio_latent)
+
+
+def test_node_is_registered_next_to_empty_av_latent():
+    node_list = asyncio.run(MiniMaxH3Extension().get_node_list())
+
+    index = node_list.index(MiniMaxH3AVLatent)
+    assert node_list[index - 1].__name__ == "EmptyMiniMaxH3LatentAV"


### PR DESCRIPTION
## Summary

- add a native `MiniMax H3 AV Latent` node for assembling separately encoded video and audio latents into the official H3 `NestedTensor` format
- validate MiniMax H3 stream shapes, matching batch sizes, and video/audio temporal compatibility using the existing H3 timing constants
- register the node next to `Empty MiniMax H3 AV Latent` and add focused CPU-only tests

## Testing

- `9 passed` — focused AV latent tests
- `224 passed, 0 skipped, 0 failed` — `tests-unit/comfy_extras_test`
- Ruff passed for touched files
- target `compileall` passed
- `git diff --check` passed
- import, schema, execution, and extension registration validation passed