### PR TITLE
Fix VAEEncodeForInpaint mask growing on non-CPU or non-float32 masks

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -435,7 +435,7 @@ class VAEEncodeForInpaint:
         if grow_mask_by == 0:
             mask_erosion = mask
         else:
-            kernel_tensor = torch.ones((1, 1, grow_mask_by, grow_mask_by))
+            kernel_tensor = torch.ones((1, 1, grow_mask_by, grow_mask_by), device=mask.device, dtype=mask.dtype)
             padding = math.ceil((grow_mask_by - 1) / 2)
 
             mask_erosion = torch.clamp(torch.nn.functional.conv2d(mask.round(), kernel_tensor, padding=padding), 0, 1)


### PR DESCRIPTION
### What

`VAEEncodeForInpaint` builds its mask-growing kernel as

```python
kernel_tensor = torch.ones((1, 1, grow_mask_by, grow_mask_by))
```

which is always CPU / float32, and convolves it with `mask` on the next line. Whenever the incoming mask isn't CPU float32, the node raises instead of encoding. This builds the kernel with the mask's own device and dtype.

### Two ways users hit it

**Mask on CUDA** — `Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!`

That's #2556, open since January 2024, with a traceback pointing straight at this node; the only answer on the thread is a workaround (rebuild the node's internals by hand). `--gpu-only` is a reliable way in, since it keeps intermediates on the GPU — the same flag @rattus128 identified as the minimum reproducer for the sibling report in #11412.

**Half-precision mask** — `Input type (torch.HalfTensor) and weight type (torch.FloatTensor) should be the same`

### Reproducing without a GPU

The dtype half needs no CUDA, so it's easy to check both before and after:

```python
import math, torch

def grow(mask, n=6):
    k = torch.ones((1, 1, n, n))                      # current
    # k = torch.ones((1, 1, n, n), device=mask.device, dtype=mask.dtype)   # this PR
    return torch.clamp(
        torch.nn.functional.conv2d(mask.round(), k, padding=math.ceil((n - 1) / 2)), 0, 1)

grow(torch.rand((1, 1, 64, 64)))                      # ok
grow(torch.rand((1, 1, 64, 64), dtype=torch.float16)) # RuntimeError on master, ok with this PR
```

### Why it's safe

The kernel is all ones, so moving where it's allocated changes nothing about the result — `mask_erosion` is the same tensor it was, just computed next to its input. A CPU float32 mask takes exactly the path it took before; this only adds the cases that currently raise.

Verified on Linux aarch64 (NVIDIA GB10 / DGX Spark, torch 2.11.0+cu130) for the dtype case and CPU-unchanged case. I did not re-run the 2024 workflow from #2556, so I'd describe this as fixing the reported failure mode rather than certifying that whole thread.
