### PR TITLE
Limit Windows multi-GPU visibility (CORE-391)

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -74,7 +74,7 @@ parser.add_argument("--temp-directory", type=str, default=None, help="Set the Co
 parser.add_argument("--input-directory", type=str, default=None, help="Set the ComfyUI input directory. Overrides --base-directory.")
 parser.add_argument("--auto-launch", action="store_true", help="Automatically launch ComfyUI in the default browser.")
 parser.add_argument("--disable-auto-launch", action="store_true", help="Disable auto launching the browser.")
-parser.add_argument("--cuda-device", type=str, default=None, metavar="DEVICE_ID", help="Set the ids of cuda devices this instance will use, as a comma-separated list (e.g. '0' or '0,1'). All other devices will not be visible.")
+parser.add_argument("--cuda-device", type=str, default=None, metavar="DEVICE_ID", help="Set the ids of cuda devices this instance will use, as a comma-separated list (e.g. '0' or '0,1'), or 'all' to leave all currently visible devices available. All other devices will not be visible.")
 parser.add_argument("--default-device", type=int, default=None, metavar="DEFAULT_DEVICE_ID", help="Set the id of the default device, all other devices will stay visible.")
 cm_group = parser.add_mutually_exclusive_group()
 cm_group.add_argument("--cuda-malloc", action="store_true", help="Enable cudaMallocAsync (enabled by default for torch 2.0 and up).")

--- a/cuda_malloc.py
+++ b/cuda_malloc.py
@@ -28,19 +28,19 @@ def get_gpu_names():
             device_info = DISPLAY_DEVICEA()
             device_info.cb = ctypes.sizeof(device_info)
             device_index = 0
-            gpu_names = set()
+            gpu_names = []
 
             while user32.EnumDisplayDevicesA(None, device_index, ctypes.byref(device_info), 0):
                 device_index += 1
-                gpu_names.add(device_info.DeviceString.decode('utf-8'))
+                gpu_names.append(device_info.DeviceString.decode('utf-8'))
             return gpu_names
         return enum_display_devices()
     else:
-        gpu_names = set()
+        gpu_names = []
         out = subprocess.check_output(['nvidia-smi', '-L'])
         for l in out.split(b'\n'):
             if len(l) > 0:
-                gpu_names.add(l.decode('utf-8').split(' (UUID')[0])
+                gpu_names.append(l.decode('utf-8').split(' (UUID')[0])
         return gpu_names
 
 blacklist = {"GeForce GTX TITAN X", "GeForce GTX 980", "GeForce GTX 970", "GeForce GTX 960", "GeForce GTX 950", "GeForce 945M",

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ import importlib.metadata
 import folder_paths
 import time
 from comfy.cli_args import enables_dynamic_vram
-from app.logger import setup_logger
+from app.logger import setup_logger, log_startup_warning
 console_log_level = get_console_log_level(args.verbose)
 file_log_outputs = get_file_log_outputs(args.verbose)
 setup_logger(log_level=console_log_level, file_outputs=file_log_outputs, use_stdout=args.log_stdout)
@@ -40,6 +40,44 @@ if __name__ == "__main__":
     #NOTE: These do not do anything on core ComfyUI, they are for custom nodes.
     os.environ['HF_HUB_DISABLE_TELEMETRY'] = '1'
     os.environ['DO_NOT_TRACK'] = '1'
+
+    import cuda_malloc
+
+    if os.name == "nt":
+        cuda_visibility = os.environ.get("CUDA_VISIBLE_DEVICES")
+        device_selection = args.cuda_device
+
+        try:
+            gpu_count = sum("NVIDIA" in name.upper() for name in cuda_malloc.get_gpu_names())
+        except OSError:
+            gpu_count = 0
+
+        if gpu_count > 1:
+            warning = None
+            multiple_visible = False
+            if device_selection is None and args.default_device is None and cuda_visibility is None:
+                os.environ["CUDA_VISIBLE_DEVICES"] = "0"
+                warning = "Multiple NVIDIA GPUs detected. ComfyUI will use GPU 0 only on Windows by default. To restore all GPUs, pass --cuda-device all --disable-pinned-memory."
+            elif device_selection == "all":
+                multiple_visible = cuda_visibility is None or "," in cuda_visibility
+            elif device_selection is not None:
+                multiple_visible = "," in device_selection
+            elif args.default_device is not None:
+                multiple_visible = True
+            else:
+                multiple_visible = "," in cuda_visibility
+
+            if multiple_visible and not args.disable_pinned_memory:
+                warning = "Multiple NVIDIA GPUs are visible on Windows with pinned memory enabled. Restart with --disable-pinned-memory to avoid CUDA host-transfer failures."
+
+            if warning:
+                log_startup_warning(f"""
+________________________________________________________________________
+WARNING WARNING WARNING WARNING WARNING
+
+{warning}
+________________________________________________________________________
+""".strip())
 
 faulthandler.enable(file=sys.stderr, all_threads=args.debug_hang)
 if __name__ == "__main__" and args.debug_hang:
@@ -74,7 +112,7 @@ if os.name == "nt":
 
 if __name__ == "__main__":
     os.environ['TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL'] = '1'
-    if args.default_device is not None:
+    if args.default_device is not None and args.cuda_device != "all":
         default_dev = args.default_device
         devices = list(range(32))
         devices.remove(default_dev)
@@ -83,7 +121,9 @@ if __name__ == "__main__":
         os.environ['CUDA_VISIBLE_DEVICES'] = str(devices)
         os.environ['HIP_VISIBLE_DEVICES'] = str(devices)
 
-    if args.cuda_device is not None:
+    if args.cuda_device == "all":
+        logging.info("Set cuda devices to all")
+    elif args.cuda_device is not None:
         os.environ['CUDA_VISIBLE_DEVICES'] = str(args.cuda_device)
         os.environ['HIP_VISIBLE_DEVICES'] = str(args.cuda_device)
         os.environ["ASCEND_RT_VISIBLE_DEVICES"] = str(args.cuda_device)
@@ -97,7 +137,6 @@ if __name__ == "__main__":
         if 'CUBLAS_WORKSPACE_CONFIG' not in os.environ:
             os.environ['CUBLAS_WORKSPACE_CONFIG'] = ":4096:8"
 
-    import cuda_malloc
     if "rocm" in cuda_malloc.get_torch_version_noimport():
         os.environ['OCL_SET_SVM_SIZE'] = '262144'  # set at the request of AMD
 


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI/issues/15255

Default to just the first GPU when multiple nvidia GPUs are detected. This is a workaround to a confirmed at-large in Cuda when multiple GPUs are initialized. Add the all mode to --cuda-devices as a way to opt-back.

Example test Conditions:

Windows, RTX5080+RTX5060, 32GB RAM
Flux2
Refresh frontend before running

<img width="1622" height="532" alt="image" src="https://github.com/user-attachments/assets/73a73227-c02c-4174-a3db-44a1fb4fa8f6" />

Before:

```
  File "C:\Users\rattu\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\python_embeded\Lib\site-packages\aiohttp\web_middlewares.py", line 117, in impl
    return await handler(request)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\rattu\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\ComfyUI\middleware\cache_middleware.py", line 27, in cache_control
    response: web.Response = await handler(request)
                             ^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\rattu\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\ComfyUI\server.py", line 98, in deprecation_warning
    response: web.Response = await handler(request)
                             ^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\rattu\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\ComfyUI\server.py", line 193, in origin_only_middleware
    response = await handler(request)
               ^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\rattu\comfy-base\custom_nodes\ComfyUI-MemoryVisualization\__init__.py", line 435, in aimdo_vram_status
    cuda_free, cuda_total = torch.cuda.mem_get_info(device)
                            ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "C:\Users\rattu\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\python_embeded\Lib\site-packages\torch\cuda\memory.py", line 862, in mem_get_info
    return torch.cuda.cudart().cudaMemGetInfo(device)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
torch.AcceleratorError: CUDA error: out of memory
Search for `cudaErrorMemoryAllocation' in https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html for more information.
For more detailed error information, run with CUDA_LOG_FILE=stderr

...
Search for `cudaErrorMemoryAllocation' in https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html for more information.
For more detailed error information, run with CUDA_LOG_FILE=stderr

```

<img width="364" height="488" alt="image" src="https://github.com/user-attachments/assets/519db879-3157-4fcd-ab05-628816a976c0" />

After:

```
[INFO] setup plugin alembic.autogenerate.schemas
[INFO] setup plugin alembic.autogenerate.tables
[INFO] setup plugin alembic.autogenerate.types
[INFO] setup plugin alembic.autogenerate.constraints
[INFO] setup plugin alembic.autogenerate.defaults
[INFO] setup plugin alembic.autogenerate.comments
[WARNING] ________________________________________________________________________
WARNING WARNING WARNING WARNING WARNING

Multiple NVIDIA GPUs detected. ComfyUI will use GPU 0 only on Windows by default. To restore all GPUs, pass --cuda-device all --disable-pinned-memory.
________________________________________________________________________
[INFO] Setting base directory to: C:\Users\rattu\comfy-base
[INFO] Found comfy_kitchen backend eager: {'available': True, 'disabled': False, 'unavailable_reason': None, 'capabilities': ['adaln', 'apply_rope', 'apply_rope1', 'apply_rope1_', 'apply_rope_', 'apply_rope_split_half', 'apply_rope_split_half1', 'apply_rope_split_half1_', 'apply_rope_split_half_', 'convrot_w4a4_linear', 'dequantize_convrot_w4a4_weight', 'dequantize_int8_convrot_weight', 'dequantize_int8_convrot_weight_dtype', 'dequantize_int8_embedding', 'dequantize_int8_simple', 'dequantize_int8_simple_dtype', 'dequantize_mxfp8', 'dequantize_nvfp4', 'dequantize_per_tensor_fp8', 'dequantize_w4a8_int8_weight', 'gemv_awq_w4a16', 'int8_linear', 'na3d',
...
[INFO] 
Import times for custom nodes:
[INFO]    0.0 seconds: C:\Users\rattu\comfy-base\custom_nodes\ComfyUI-MemoryVisualization
[INFO]    0.0 seconds: C:\Users\rattu\comfy-base\custom_nodes\ComfyUI-GGUF
[INFO] 
[INFO] Context impl SQLiteImpl.
[INFO] Will assume non-transactional DDL.
[INFO] Using RAM pressure cache.
[WARNING] ________________________________________________________________________
WARNING WARNING WARNING WARNING WARNING

Multiple NVIDIA GPUs detected. ComfyUI will use GPU 0 only on Windows by default. To restore all GPUs, pass --cuda-device all --disable-pinned-memory.
________________________________________________________________________
[WARNING] ________________________________________________________________________
WARNING WARNING WARNING WARNING WARNING

Installed comfyui-frontend-package version 1.45.21 is lower than the recommended version 1.49.6.
Installed comfyui-workflow-templates version 0.11.9 is lower than the recommended version 0.11.43.
Installed comfyui-embedded-docs version 0.5.8 is lower than the recommended version 0.5.10.

Please install the updated requirements.txt file by running:
C:\Users\rattu\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\python_embeded\python.exe -s -m pip install -r C:\Users\rattu\ComfyUI_windows_portable_nvidia\ComfyUI_windows_portable\ComfyUI\requirements.txt
If you are on the portable package you can run: update\update_comfyui.bat to solve this problem.
________________________________________________________________________
[INFO] Starting server

[INFO] To see the GUI go to: http://0.0.0.0:8188
```

```
[INFO] got prompt
[INFO] Model Flux2 prepared for dynamic VRAM loading. 33813MB Staged. 0 patches attached. Force pre-loaded 256 weights: 71 KB.
100%|##########| 20/20 [01:03<00:00,  3.19s/it]
[INFO] Requested to load AutoencoderKL
[INFO] 0 models unloaded.
[INFO] Model AutoencoderKL prepared for dynamic VRAM loading. 160MB Staged. 0 patches attached. Force pre-loaded 110 weights: 187 KB.
[INFO] Prompt executed in 65.78 seconds
```

<img width="355" height="681" alt="image" src="https://github.com/user-attachments/assets/ad674a38-5944-4193-8380-9fde2361351d" />
