### PR TITLE
Add a check for node input changes that break stored API prompts

### DIFF
--- a/.github/scripts/node_input_compat.py
+++ b/.github/scripts/node_input_compat.py
@@ -1,0 +1,246 @@
+"""Check node input schemas for API-format workflow compatibility.
+
+API-format prompts are frozen at the time they were saved, so a node's input
+schema is a public contract. Two ways we break it today:
+
+- Adding a required input to an existing node. Every stored prompt for that node
+  is rejected by validation with `required_input_missing` (execution.py).
+- Adding an optional input that the node cannot actually run without. Validation
+  passes, then `get_input_data` never passes the key and the call raises
+  TypeError at execution time.
+
+An optional input has to be safe to leave out one of two ways. With a default in
+its schema it just does not have to be provided, and execution fills it in. With
+no default in its schema it is a nullable value, the not-connected case, and the
+entry function has to carry the default itself.
+
+`snapshot` dumps the input surface of every registered node, `diff` compares two
+snapshots for breaking changes, and `unsafe-optionals` checks a single snapshot
+for optional inputs that cannot actually be omitted.
+"""
+
+import argparse
+import asyncio
+import inspect
+import json
+import logging
+import sys
+
+import nodes
+from comfy_api.internal import _ComfyNodeInternal
+
+
+def report(line):
+    sys.stdout.write(f"{line}\n")
+
+
+def input_spec(node_class):
+    if issubclass(node_class, _ComfyNodeInternal):
+        return node_class.GET_NODE_INFO_V1()["input"]
+    return node_class.INPUT_TYPES()
+
+
+def entry_function(node_class):
+    """The function that actually receives the node's inputs.
+
+    V3 nodes expose FUNCTION == "EXECUTE_NORMALIZED", a (*args, **kwargs)
+    trampoline, so inspecting FUNCTION would say every input is omittable.
+    """
+    if issubclass(node_class, _ComfyNodeInternal):
+        return getattr(node_class, "execute", None)
+    function_name = getattr(node_class, "FUNCTION", None)
+    if function_name is None:
+        return None
+    return getattr(node_class, function_name, None)
+
+
+def omittable_inputs(node_class):
+    """Input names the entry function can be called without, or None if all can."""
+    function = entry_function(node_class)
+    if function is None:
+        return set()
+    try:
+        signature = inspect.signature(function)
+    except (TypeError, ValueError):
+        return None
+    if any(p.kind is p.VAR_KEYWORD for p in signature.parameters.values()):
+        return None
+    omittable = set()
+    for name, parameter in signature.parameters.items():
+        if parameter.default is not inspect.Parameter.empty:
+            omittable.add(name)
+    return omittable
+
+
+def jsonable(value):
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, (list, tuple)):
+        return [jsonable(v) for v in value]
+    return repr(value)
+
+
+def node_snapshot(node_class):
+    spec = input_spec(node_class)
+    omittable = omittable_inputs(node_class)
+    inputs = {}
+    for category in ("required", "optional"):
+        for name, definition in (spec.get(category) or {}).items():
+            if not isinstance(definition, (list, tuple)) or len(definition) == 0:
+                continue
+            input_type = definition[0]
+            options = definition[1] if len(definition) > 1 and isinstance(definition[1], dict) else {}
+            entry = {
+                "category": category,
+                "type": "COMBO" if isinstance(input_type, list) else input_type,
+                "omittable": omittable is None or name in omittable,
+            }
+            if isinstance(input_type, list):
+                entry["combo_options"] = [jsonable(o) for o in input_type]
+            if "default" in options:
+                entry["default"] = jsonable(options["default"])
+            inputs[name] = entry
+    return {
+        "module": getattr(node_class, "RELATIVE_PYTHON_MODULE", "nodes"),
+        "inputs": inputs,
+    }
+
+
+def collect_snapshot():
+    asyncio.run(nodes.init_extra_nodes(init_api_nodes=True))
+    snapshot = {}
+    for name, node_class in nodes.NODE_CLASS_MAPPINGS.items():
+        try:
+            snapshot[name] = node_snapshot(node_class)
+        except Exception:
+            logging.warning("Skipping %s, could not read its input schema", name, exc_info=True)
+    return snapshot
+
+
+def accepted_types(input_type):
+    """The set of type names an input accepts.
+
+    Multi-type inputs are stored as a comma separated string, and Combo and
+    DynamicCombo are the same contract as far as a stored prompt is concerned.
+    """
+    if input_type == "COMFY_DYNAMICCOMBO_V3":
+        input_type = "COMBO"
+    return set(input_type.split(","))
+
+
+def diff_snapshots(base, head):
+    """Breaking changes between two snapshots, as human-readable lines."""
+    breaks = []
+    for node, head_node in sorted(head.items()):
+        base_node = base.get(node)
+        if base_node is None:
+            continue
+        base_inputs = base_node["inputs"]
+        for name, head_input in sorted(head_node["inputs"].items()):
+            base_input = base_inputs.get(name)
+            if head_input["category"] == "required" and base_input is None:
+                breaks.append(f"{node}.{name}: new required input on an existing node")
+                continue
+            if base_input is None:
+                continue
+            if head_input["category"] == "required" and base_input["category"] == "optional":
+                breaks.append(f"{node}.{name}: optional input became required")
+            dropped_types = accepted_types(base_input["type"]) - accepted_types(head_input["type"])
+            if dropped_types:
+                breaks.append(
+                    f"{node}.{name}: no longer accepts {', '.join(sorted(dropped_types))}"
+                )
+            removed = [
+                option
+                for option in base_input.get("combo_options", [])
+                if option not in head_input.get("combo_options", [])
+            ]
+            if removed:
+                breaks.append(f"{node}.{name}: combo options removed: {', '.join(map(str, removed))}")
+    return breaks
+
+
+def unsafe_optionals(snapshot):
+    """Optional inputs a stored prompt cannot omit without an error."""
+    unsafe = []
+    for node, node_entry in sorted(snapshot.items()):
+        for name, entry in sorted(node_entry["inputs"].items()):
+            if entry["category"] != "optional":
+                continue
+            if not entry["omittable"] and "default" not in entry:
+                unsafe.append(
+                    f"{node}.{name}: nullable input with no default in the {node_entry['module']} entry function"
+                )
+    return unsafe
+
+
+def load(path):
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def run_snapshot(args):
+    snapshot = collect_snapshot()
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(snapshot, f, indent=1, sort_keys=True)
+    report(f"Wrote {len(snapshot)} node schemas to {args.output}")
+    return 0
+
+
+def run_diff(args):
+    breaks = diff_snapshots(load(args.base), load(args.head))
+    if not breaks:
+        report("No breaking node input changes.")
+        return 0
+    report(f"{len(breaks)} breaking node input change(s):")
+    for line in breaks:
+        report(f"  {line}")
+    report("")
+    report("Stored API-format prompts do not have these inputs and will be rejected.")
+    report("Add the input to 'optional' with a Python default instead, or register a new node.")
+    return 1
+
+
+def run_unsafe_optionals(args):
+    unsafe = unsafe_optionals(load(args.snapshot))
+    known = set(load(args.allowlist)) if args.allowlist else set()
+    new = [line for line in unsafe if line.split(":")[0] not in known]
+    fixed = sorted(known - {line.split(":")[0] for line in unsafe})
+    if new:
+        report(f"{len(new)} optional input(s) that a stored prompt cannot omit:")
+        for line in new:
+            report(f"  {line}")
+        report("")
+        report("An optional input with no default in its schema is a nullable value.")
+        report("Give its parameter a default in the entry function for the not-connected case.")
+    if fixed:
+        report(f"{len(fixed)} allowlisted entr(ies) are fixed and must be removed from {args.allowlist}:")
+        for name in fixed:
+            report(f"  {name}")
+    return 1 if new or fixed else 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    snapshot_parser = subparsers.add_parser("snapshot", help="dump every node's input surface")
+    snapshot_parser.add_argument("--output", required=True)
+    snapshot_parser.set_defaults(func=run_snapshot)
+
+    diff_parser = subparsers.add_parser("diff", help="compare two snapshots for breaking changes")
+    diff_parser.add_argument("base")
+    diff_parser.add_argument("head")
+    diff_parser.set_defaults(func=run_diff)
+
+    optionals_parser = subparsers.add_parser("unsafe-optionals", help="find optional inputs that cannot be omitted")
+    optionals_parser.add_argument("snapshot")
+    optionals_parser.add_argument("--allowlist")
+    optionals_parser.set_defaults(func=run_unsafe_optionals)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/node_input_compat.py
+++ b/.github/scripts/node_input_compat.py
@@ -23,12 +23,11 @@ import argparse
 import asyncio
 import inspect
 import json
-import logging
 import sys
 
-from comfy.cli_args import args
+from comfy.cli_args import args as comfy_args
 
-args.cpu = True  # reading schemas never touches a device, and CI torch has no CUDA
+comfy_args.cpu = True  # reading schemas never touches a device, and CI torch has no CUDA
 
 import nodes
 from comfy_api.internal import _ComfyNodeInternal
@@ -111,14 +110,10 @@ def node_snapshot(node_class):
 
 
 def collect_snapshot():
+    # A node that cannot be read is left out of the snapshot, which would hide any
+    # breaking change to it, so let it fail here instead.
     asyncio.run(nodes.init_extra_nodes(init_api_nodes=True))
-    snapshot = {}
-    for name, node_class in nodes.NODE_CLASS_MAPPINGS.items():
-        try:
-            snapshot[name] = node_snapshot(node_class)
-        except Exception:
-            logging.warning("Skipping %s, could not read its input schema", name, exc_info=True)
-    return snapshot
+    return {name: node_snapshot(node_class) for name, node_class in nodes.NODE_CLASS_MAPPINGS.items()}
 
 
 def accepted_types(input_type):

--- a/.github/scripts/node_input_compat.py
+++ b/.github/scripts/node_input_compat.py
@@ -26,6 +26,10 @@ import json
 import logging
 import sys
 
+from comfy.cli_args import args
+
+args.cpu = True  # reading schemas never touches a device, and CI torch has no CUDA
+
 import nodes
 from comfy_api.internal import _ComfyNodeInternal
 

--- a/.github/scripts/node_optional_input_allowlist.json
+++ b/.github/scripts/node_optional_input_allowlist.json
@@ -1,0 +1,14 @@
+[
+ "ViduImageToVideoNode.movement_amplitude",
+ "ViduImageToVideoNode.resolution",
+ "ViduReferenceVideoNode.aspect_ratio",
+ "ViduReferenceVideoNode.movement_amplitude",
+ "ViduReferenceVideoNode.resolution",
+ "ViduStartEndToVideoNode.movement_amplitude",
+ "ViduStartEndToVideoNode.prompt",
+ "ViduStartEndToVideoNode.resolution",
+ "ViduTextToVideoNode.aspect_ratio",
+ "ViduTextToVideoNode.movement_amplitude",
+ "ViduTextToVideoNode.resolution",
+ "WanPhantomSubjectToVideo.images"
+]

--- a/.github/workflows/node-input-compat.yml
+++ b/.github/workflows/node-input-compat.yml
@@ -8,6 +8,8 @@ jobs:
   node-input-compat:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'breaking-node-change') }}
     runs-on: ubuntu-latest
+    env:
+      PYTHONPATH: .
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/node-input-compat.yml
+++ b/.github/workflows/node-input-compat.yml
@@ -32,7 +32,10 @@ jobs:
     - name: Snapshot the base branch
       run: |
         cp .github/scripts/node_input_compat.py ${{ runner.temp }}/
+        # A pinned dependency the PR bumps can leave the base checkout unimportable
+        git diff --quiet ${{ github.event.pull_request.base.sha }} HEAD -- requirements.txt && same_reqs=1 || same_reqs=0
         git checkout ${{ github.event.pull_request.base.sha }}
+        if [ "$same_reqs" = "0" ]; then pip install -r requirements.txt; fi
         python ${{ runner.temp }}/node_input_compat.py snapshot --output ${{ runner.temp }}/base.json
     - name: Compare against the base branch
       run: python ${{ runner.temp }}/node_input_compat.py diff ${{ runner.temp }}/base.json ${{ runner.temp }}/head.json

--- a/.github/workflows/node-input-compat.yml
+++ b/.github/workflows/node-input-compat.yml
@@ -1,0 +1,36 @@
+name: Node Input Compatibility
+
+on:
+  pull_request:
+    branches: [ main, master, release/** ]
+
+jobs:
+  node-input-compat:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'breaking-node-change') }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: Install requirements
+      run: |
+        python -m pip install --upgrade pip
+        pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+        pip install -r requirements.txt
+    - name: Snapshot this branch
+      run: python .github/scripts/node_input_compat.py snapshot --output ${{ runner.temp }}/head.json
+    - name: Check optional inputs can be omitted
+      run: |
+        python .github/scripts/node_input_compat.py unsafe-optionals ${{ runner.temp }}/head.json \
+          --allowlist .github/scripts/node_optional_input_allowlist.json
+    - name: Snapshot the base branch
+      run: |
+        cp .github/scripts/node_input_compat.py ${{ runner.temp }}/
+        git checkout ${{ github.event.pull_request.base.sha }}
+        python ${{ runner.temp }}/node_input_compat.py snapshot --output ${{ runner.temp }}/base.json
+    - name: Compare against the base branch
+      run: python ${{ runner.temp }}/node_input_compat.py diff ${{ runner.temp }}/base.json ${{ runner.temp }}/head.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -320,7 +320,8 @@
   and execution fills it in. An optional input with no default in its schema is
   a nullable value, so its parameter in the entry function must carry the
   default for the not-connected case. The Node Input Compatibility workflow
-  checks both against the base branch.
+  diffs the input surface against the base branch, and checks the nullable rule
+  on the branch itself.
 - Model implementations should add the minimal number of ComfyUI nodes required
   to run the model. Reuse existing nodes as much as possible; adapting the model
   to work with existing nodes is strongly preferred over creating new nodes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,6 +313,14 @@
   advertised combo options or prompt validation.
 - Keep node changes backward compatible by default. Add inputs with sensible
   defaults and avoid changing output types unless the request requires it.
+- A new input on an existing node must go in `optional`. Stored API-format
+  prompts do not carry it, and a required input is rejected by validation with
+  `required_input_missing`.
+- An optional input with a default in its schema does not have to be provided,
+  and execution fills it in. An optional input with no default in its schema is
+  a nullable value, so its parameter in the entry function must carry the
+  default for the not-connected case. The Node Input Compatibility workflow
+  checks both against the base branch.
 - Model implementations should add the minimal number of ComfyUI nodes required
   to run the model. Reuse existing nodes as much as possible; adapting the model
   to work with existing nodes is strongly preferred over creating new nodes.

--- a/tests-unit/utils/node_input_compat_test.py
+++ b/tests-unit/utils/node_input_compat_test.py
@@ -1,0 +1,114 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / ".github" / "scripts" / "node_input_compat.py"
+ALLOWLIST = SCRIPT.parent / "node_optional_input_allowlist.json"
+
+spec = importlib.util.spec_from_file_location("node_input_compat", SCRIPT)
+node_input_compat = importlib.util.module_from_spec(spec)
+sys.modules["node_input_compat"] = node_input_compat
+spec.loader.exec_module(node_input_compat)
+
+
+def node(inputs):
+    return {"module": "comfy_extras.nodes_test", "inputs": inputs}
+
+
+def widget(category, **extra):
+    return {"category": category, "type": "INT", "omittable": True, "default": 0, **extra}
+
+
+def test_new_required_input_is_breaking():
+    base = {"Sampler": node({"steps": widget("required")})}
+    head = {"Sampler": node({"steps": widget("required"), "shift": widget("required")})}
+    assert node_input_compat.diff_snapshots(base, head) == [
+        "Sampler.shift: new required input on an existing node"
+    ]
+
+
+def test_new_optional_input_is_fine():
+    base = {"Sampler": node({"steps": widget("required")})}
+    head = {"Sampler": node({"steps": widget("required"), "shift": widget("optional")})}
+    assert node_input_compat.diff_snapshots(base, head) == []
+
+
+def test_new_node_is_fine():
+    head = {"Sampler": node({"steps": widget("required")})}
+    assert node_input_compat.diff_snapshots({}, head) == []
+
+
+def test_optional_becoming_required_is_breaking():
+    base = {"Sampler": node({"shift": widget("optional")})}
+    head = {"Sampler": node({"shift": widget("required")})}
+    assert node_input_compat.diff_snapshots(base, head) == [
+        "Sampler.shift: optional input became required"
+    ]
+
+
+def test_required_becoming_optional_is_fine():
+    base = {"Sampler": node({"shift": widget("required")})}
+    head = {"Sampler": node({"shift": widget("optional")})}
+    assert node_input_compat.diff_snapshots(base, head) == []
+
+
+def test_dropping_an_accepted_type_is_breaking():
+    base = {"Save": node({"mesh": widget("required", type="MESH,FILE_3D_GLB")})}
+    head = {"Save": node({"mesh": widget("required", type="MESH")})}
+    assert node_input_compat.diff_snapshots(base, head) == [
+        "Save.mesh: no longer accepts FILE_3D_GLB"
+    ]
+
+
+def test_widening_accepted_types_is_fine():
+    base = {"Latent": node({"frame_rate": widget("required", type="INT")})}
+    head = {"Latent": node({"frame_rate": widget("required", type="FLOAT,INT")})}
+    assert node_input_compat.diff_snapshots(base, head) == []
+
+
+def test_combo_becoming_dynamic_combo_is_fine():
+    base = {"SaveVideo": node({"codec": widget("required", type="COMBO", combo_options=["h264"])})}
+    head = {
+        "SaveVideo": node(
+            {"codec": widget("required", type="COMFY_DYNAMICCOMBO_V3", combo_options=["h264"])}
+        )
+    }
+    assert node_input_compat.diff_snapshots(base, head) == []
+
+
+def test_removing_a_combo_option_is_breaking():
+    base = {"Save": node({"codec": widget("required", type="COMBO", combo_options=["h264", "av1"])})}
+    head = {"Save": node({"codec": widget("required", type="COMBO", combo_options=["h264"])})}
+    assert node_input_compat.diff_snapshots(base, head) == [
+        "Save.codec: combo options removed: av1"
+    ]
+
+
+def test_nullable_input_without_a_python_default_is_unsafe():
+    """No default in the schema means nullable, so the function has to carry one."""
+    snapshot = {"Wan": node({"images": {"category": "optional", "type": "IMAGE", "omittable": False}})}
+    assert node_input_compat.unsafe_optionals(snapshot) == [
+        "Wan.images: nullable input with no default in the comfy_extras.nodes_test entry function"
+    ]
+
+
+def test_nullable_input_with_a_python_default_is_fine():
+    snapshot = {"Wan": node({"images": {"category": "optional", "type": "IMAGE", "omittable": True}})}
+    assert node_input_compat.unsafe_optionals(snapshot) == []
+
+
+def test_schema_default_without_a_python_default_is_fine():
+    """Execution fills these in, so the function does not need its own default."""
+    snapshot = {"Sampler": node({"seed": widget("optional", omittable=False)})}
+    assert node_input_compat.unsafe_optionals(snapshot) == []
+
+
+def test_required_inputs_are_not_checked_for_defaults():
+    snapshot = {"Sampler": node({"seed": widget("required", omittable=False)})}
+    assert node_input_compat.unsafe_optionals(snapshot) == []
+
+
+def test_allowlist_is_sorted_and_unique():
+    allowlist = json.loads(ALLOWLIST.read_text())
+    assert allowlist == sorted(set(allowlist))


### PR DESCRIPTION
Adding an input to an existing node breaks every API-format prompt already saved for it: validation rejects a new required input with `required_input_missing`, and an optional input the entry function has no default for passes validation and then raises TypeError. This adds a PR check that snapshots every node's input surface, diffs it against the base branch, and fails on a new required input, an optional input turning required, a dropped accepted type, or a removed combo option. It also checks that optional inputs with no schema default carry one in the entry function. Type comparison is set-based so widening does not trip it, and `breaking-node-change` on a PR skips the job. Related: #11833.

The 12 nullable inputs that fail the rule today are allowlisted; the allowlist is a ratchet, so a fixed entry left behind also fails.

The schema-default half of the rule depends on #15740, which fills those inputs in at execution. Until that lands, the 75 optional inputs with a schema default and no default in the entry function still raise TypeError and this check does not flag them.

Caught a deliberate break in CI ([run](https://github.com/Comfy-Org/ComfyUI/actions/runs/32322071811)), adding a required `trim_result` to `RegexReplace`:

```
1 breaking node input change(s):
  RegexReplace.trim_result: new required input on an existing node

Stored API-format prompts do not have these inputs and will be rejected.
Add the input to 'optional' with a Python default instead, or register a new node.
```

Backtested against a three-month-old base, 11 real breaks and no false positives:

```
$ python .github/scripts/node_input_compat.py diff base.json head.json
11 breaking node input change(s):
  ChromaRadianceOptions.force_sequential_txt_ids: new required input on an existing node
  ContextWindowsManual.latent_retain_index_list: new required input on an existing node
  LoadTrainingDataset.folder_name: no longer accepts STRING
  ResolutionSelector.multiple: new required input on an existing node
  SDPoseDrawKeypoints.draw_head: new required input on an existing node
  SaveImageDataSetToFolder.mode: new required input on an existing node
  SaveImageTextDataSetToFolder.mode: new required input on an existing node
  WanContextWindowsManual.retain_first_frame: new required input on an existing node
  WanContextWindowsManual.split_conds_to_windows: new required input on an existing node
  WanSCAILToVideo.previous_frame_count: new required input on an existing node
  WanSCAILToVideo.video_frame_offset: new required input on an existing node
```

Also `pytest tests-unit/utils/node_input_compat_test.py`, 14 cases over the diff and allowlist rules.
