### PR TITLE
Pass the schema default for optional inputs a prompt leaves out

### DIFF
--- a/execution.py
+++ b/execution.py
@@ -169,6 +169,15 @@ def fill_omitted_optional_inputs(input_data_all, valid_inputs, class_def):
     without the argument. Only fill in inputs the function itself has no
     default for, so nodes that use a sentinel default still see them missing.
     """
+    omitted = {}
+    for name, input_info in valid_inputs.get("optional", {}).items():
+        if name in input_data_all or not isinstance(input_info, (list, tuple)) or len(input_info) < 2:
+            continue
+        if isinstance(input_info[1], dict) and "default" in input_info[1]:
+            omitted[name] = input_info[1]["default"]
+    if not omitted:
+        return
+
     function = entry_function(class_def)
     if function is None:
         return
@@ -176,14 +185,10 @@ def fill_omitted_optional_inputs(input_data_all, valid_inputs, class_def):
         parameters = inspect.signature(function).parameters
     except (TypeError, ValueError):
         return
-    for name, input_info in valid_inputs.get("optional", {}).items():
-        if name in input_data_all or not isinstance(input_info, (list, tuple)) or len(input_info) < 2:
-            continue
-        if not isinstance(input_info[1], dict) or "default" not in input_info[1]:
-            continue
+    for name, default in omitted.items():
         parameter = parameters.get(name)
         if parameter is not None and parameter.default is inspect.Parameter.empty:
-            input_data_all[name] = [input_info[1]["default"]]
+            input_data_all[name] = [default]
 
 def get_input_data(inputs, class_def, unique_id, execution_list=None, dynprompt=None, extra_data={}):
     is_v3 = issubclass(class_def, _ComfyNodeInternal)

--- a/execution.py
+++ b/execution.py
@@ -156,6 +156,35 @@ class CacheSet:
 
 SENSITIVE_EXTRA_DATA_KEYS = ("auth_token_comfy_org", "api_key_comfy_org")
 
+def entry_function(class_def):
+    if issubclass(class_def, _ComfyNodeInternal):
+        return class_def.execute
+    return getattr(class_def, class_def.FUNCTION, None)
+
+def fill_omitted_optional_inputs(input_data_all, valid_inputs, class_def):
+    """Pass the schema default for optional inputs the prompt left out.
+
+    An API-format prompt saved before an input was added does not carry it, and
+    get_input_data only passes keys the prompt has, so the node is called
+    without the argument. Only fill in inputs the function itself has no
+    default for, so nodes that use a sentinel default still see them missing.
+    """
+    function = entry_function(class_def)
+    if function is None:
+        return
+    try:
+        parameters = inspect.signature(function).parameters
+    except (TypeError, ValueError):
+        return
+    for name, input_info in valid_inputs.get("optional", {}).items():
+        if name in input_data_all or not isinstance(input_info, (list, tuple)) or len(input_info) < 2:
+            continue
+        if not isinstance(input_info[1], dict) or "default" not in input_info[1]:
+            continue
+        parameter = parameters.get(name)
+        if parameter is not None and parameter.default is inspect.Parameter.empty:
+            input_data_all[name] = [input_info[1]["default"]]
+
 def get_input_data(inputs, class_def, unique_id, execution_list=None, dynprompt=None, extra_data={}):
     is_v3 = issubclass(class_def, _ComfyNodeInternal)
     v3_data: io.V3Data = {}
@@ -188,6 +217,8 @@ def get_input_data(inputs, class_def, unique_id, execution_list=None, dynprompt=
             input_data_all[x] = obj
         elif input_category is not None or (is_v3 and class_def.ACCEPT_ALL_INPUTS):
             input_data_all[x] = [input_data]
+
+    fill_omitted_optional_inputs(input_data_all, valid_inputs, class_def)
 
     if is_v3:
         if hidden is not None:

--- a/tests-unit/execution_test/omitted_optional_input_test.py
+++ b/tests-unit/execution_test/omitted_optional_input_test.py
@@ -1,0 +1,100 @@
+from comfy_api.latest import io
+from execution import get_input_data
+
+MISSING = object()
+
+
+class OptionalWidgetNode:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {"image": ("IMAGE",)},
+            "optional": {
+                "seed": ("INT", {"default": 7}),
+                "mode": (["fast", "slow"], {"default": "slow"}),
+                "mask": ("MASK",),
+            },
+        }
+
+    RETURN_TYPES = ("IMAGE",)
+    FUNCTION = "run"
+
+    def run(self, image, seed, mode, mask=None):
+        return (image,)
+
+
+class SentinelDefaultNode:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {}, "optional": {"seed": ("INT", {"default": 7})}}
+
+    RETURN_TYPES = ("INT",)
+    FUNCTION = "run"
+
+    def run(self, seed=MISSING):
+        return (seed,)
+
+
+class KwargsNode:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {}, "optional": {"seed": ("INT", {"default": 7})}}
+
+    RETURN_TYPES = ("INT",)
+    FUNCTION = "run"
+
+    def run(self, **kwargs):
+        return (kwargs.get("seed"),)
+
+
+class V3OptionalNode(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="V3OptionalNode",
+            inputs=[
+                io.Image.Input("image"),
+                io.Int.Input("seed", optional=True, default=7),
+            ],
+            outputs=[io.Image.Output()],
+        )
+
+    @classmethod
+    def execute(cls, image, seed) -> io.NodeOutput:
+        return io.NodeOutput(image)
+
+
+def input_data(class_def, inputs):
+    input_data_all, _, _ = get_input_data(inputs, class_def, "1")
+    return input_data_all
+
+
+def test_omitted_optional_widget_gets_its_schema_default():
+    """A prompt saved before the input existed does not carry it."""
+    data = input_data(OptionalWidgetNode, {"image": ["2", 0]})
+    assert data["seed"] == [7]
+    assert data["mode"] == ["slow"]
+
+
+def test_provided_value_wins():
+    data = input_data(OptionalWidgetNode, {"image": ["2", 0], "seed": 42})
+    assert data["seed"] == [42]
+
+
+def test_optional_socket_is_left_out():
+    """Sockets have no schema default and must stay absent so the node can tell."""
+    assert "mask" not in input_data(OptionalWidgetNode, {"image": ["2", 0]})
+
+
+def test_sentinel_default_is_left_alone():
+    """SoftSwitchNode and friends use their own default to detect a missing input."""
+    assert "seed" not in input_data(SentinelDefaultNode, {})
+
+
+def test_kwargs_only_node_is_left_alone():
+    assert "seed" not in input_data(KwargsNode, {})
+
+
+def test_v3_node_uses_its_execute_signature():
+    """V3 FUNCTION is a (*args, **kwargs) trampoline, execute is the real signature."""
+    assert input_data(V3OptionalNode, {"image": ["2", 0]})["seed"] == [7]

--- a/tests/execution/test_omitted_optional_input.py
+++ b/tests/execution/test_omitted_optional_input.py
@@ -1,0 +1,91 @@
+"""An API-format prompt saved before an optional input existed still has to run."""
+
+import subprocess
+import time
+
+import numpy
+import pytest
+import torch
+from pytest import fixture
+
+from comfy_execution.graph_utils import GraphBuilder
+from tests.execution.test_execution import ComfyClient
+
+
+@pytest.mark.execution
+class TestOmittedOptionalInput:
+    @fixture(scope="class", autouse=True)
+    def _server(self, args_pytest):
+        pargs = [
+            'python', 'main.py',
+            '--output-directory', args_pytest["output_dir"],
+            '--listen', args_pytest["listen"],
+            '--port', str(args_pytest["port"]),
+            '--extra-model-paths-config', 'tests/execution/extra_model_paths.yaml',
+            '--cpu',
+        ]
+        p = subprocess.Popen(pargs)
+        yield
+        p.kill()
+        torch.cuda.empty_cache()
+
+    @fixture(scope="class", autouse=True)
+    def shared_client(self, args_pytest, _server):
+        client = ComfyClient()
+        n_tries = 5
+        for i in range(n_tries):
+            time.sleep(4)
+            try:
+                client.connect(listen=args_pytest["listen"], port=args_pytest["port"])
+                break
+            except ConnectionRefusedError:
+                if i == n_tries - 1:
+                    raise
+        yield client
+        del client
+        torch.cuda.empty_cache()
+
+    @fixture
+    def client(self, shared_client, request):
+        shared_client.set_test_name(f"omitted_optional_input[{request.node.name}]")
+        yield shared_client
+
+    @fixture
+    def builder(self, request):
+        yield GraphBuilder(prefix=request.node.name)
+
+    def test_omitted_input_gets_its_schema_default(self, client: ComfyClient, builder: GraphBuilder):
+        """`scale` has a default in the schema and none in the entry function."""
+        g = builder
+        image = g.node("StubImage", content="WHITE", height=64, width=64, batch_size=1)
+        scaled = g.node("TestOmittedOptionalInput", image=image.out(0))
+        output = g.node("SaveImage", images=scaled.out(0))
+
+        result = client.run(g)
+
+        result_image = numpy.array(result.get_images(output)[0])
+        assert result_image.min() == 127 and result_image.max() == 127, "Image should be scaled by the default 0.5"
+
+    def test_provided_input_still_wins(self, client: ComfyClient, builder: GraphBuilder):
+        g = builder
+        image = g.node("StubImage", content="WHITE", height=64, width=64, batch_size=1)
+        scaled = g.node("TestOmittedOptionalInput", image=image.out(0), scale=1.0)
+        output = g.node("SaveImage", images=scaled.out(0))
+
+        result = client.run(g)
+
+        result_image = numpy.array(result.get_images(output)[0])
+        assert result_image.min() == 255 and result_image.max() == 255, "Image should keep its own scale"
+
+    def test_connected_nullable_input_is_still_delivered(self, client: ComfyClient, builder: GraphBuilder):
+        """`mask` has no default in the schema, so it stays a plain nullable socket."""
+        g = builder
+        image = g.node("StubImage", content="WHITE", height=64, width=64, batch_size=1)
+        mask = g.node("StubMask", value=0.0, height=64, width=64, batch_size=1)
+        scaled = g.node("TestOmittedOptionalInput", image=image.out(0), mask=mask.out(0))
+        output = g.node("SaveImage", images=scaled.out(0))
+
+        result = client.run(g)
+
+        result_image = numpy.array(result.get_images(output)[0])
+        assert result_image.min() == 0 and result_image.max() == 0, "Image should be masked to black"

--- a/tests/execution/testing_nodes/testing-pack/specific_tests.py
+++ b/tests/execution/testing_nodes/testing-pack/specific_tests.py
@@ -482,7 +482,34 @@ class TestOutputNodeWithSocketOutput:
         result = image * value
         return (result,)
 
+class TestOmittedOptionalInput:
+    """Stands in for a node that gained an optional input after a prompt was saved.
+
+    `scale` has a default in the schema but none in the entry function, and
+    `mask` has no default in the schema so it stays a nullable value.
+    """
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "image": ("IMAGE",),
+            },
+            "optional": {
+                "scale": ("FLOAT", {"default": 0.5, "min": 0.0, "max": 10.0}),
+                "mask": ("MASK",),
+            },
+        }
+    RETURN_TYPES = ("IMAGE",)
+    FUNCTION = "process"
+    CATEGORY = "Testing/Compatibility"
+
+    def process(self, image, scale, mask=None):
+        if mask is not None:
+            image = image * mask.unsqueeze(-1)
+        return (image * scale,)
+
 TEST_NODE_CLASS_MAPPINGS = {
+    "TestOmittedOptionalInput": TestOmittedOptionalInput,
     "TestLazyMixImages": TestLazyMixImages,
     "TestVariadicAverage": TestVariadicAverage,
     "TestCustomIsChanged": TestCustomIsChanged,
@@ -501,6 +528,7 @@ TEST_NODE_CLASS_MAPPINGS = {
 }
 
 TEST_NODE_DISPLAY_NAME_MAPPINGS = {
+    "TestOmittedOptionalInput": "Omitted Optional Input",
     "TestLazyMixImages": "Lazy Mix Images",
     "TestVariadicAverage": "Variadic Average",
     "TestCustomIsChanged": "Custom IsChanged",


### PR DESCRIPTION
An API-format prompt saved before an optional input was added does not carry it, and `get_input_data` only passes the keys the prompt has, so the node is called without the argument and raises TypeError. `INPUT_TYPES` defaults are never injected, so the value has to come from a default in the entry function, and 75 optional inputs in core do not have one. This fills those from the schema default, which makes "optional with a default" mean the input simply does not have to be provided. It only applies where the parameter has no default of its own, so a node using a sentinel to detect a missing input, like `SoftSwitchNode` with `MISSING`, still sees it missing — and a node whose schema default disagrees with its signature default keeps using the signature. Optional inputs with no schema default are untouched; those are nullable values, and the sibling PR #15739 lints that their parameter carries a default.

Reproduced against a running server with a real API-format prompt. `TestOmittedOptionalInput.scale` is optional with `{"default": 0.5}` in the schema and no default in `process()`, and the prompt omits it:

```json
{"prompt": {
  "1": {"class_type": "StubImage", "inputs": {"content": "WHITE", "height": 64, "width": 64, "batch_size": 1}},
  "2": {"class_type": "TestOmittedOptionalInput", "inputs": {"image": ["1", 0]}},
  "3": {"class_type": "SaveImage", "inputs": {"images": ["2", 0], "filename_prefix": "e2e"}}
}}
```

Before, validation accepts it and execution dies:

```
$ curl -s -X POST -d @prompt.json http://127.0.0.1:8291/prompt
{"prompt_id": "75a9a821-...", "number": 1, "node_errors": {}}

[ERROR] !!! Exception during processing !!! TestOmittedOptionalInput.process() missing 1 required positional argument: 'scale'
  File "execution.py", line 306, in process_inputs
    result = f(**inputs)
TypeError: TestOmittedOptionalInput.process() missing 1 required positional argument: 'scale'
```

After, it runs and the default arrives — a white image scaled by 0.5 is 127:

```
$ curl -s -X POST -d @prompt.json http://127.0.0.1:8291/prompt
{"prompt_id": "689703ba-...", "number": 0, "node_errors": {}}
[INFO] Prompt executed in 0.01 seconds

$ python -c "import numpy; from PIL import Image; a=numpy.array(Image.open('e2e_00001_.png')); print(a.min(), a.max())"
127 127
```

## Tests

`tests/execution/test_omitted_optional_input.py` covers that over HTTP: the omitted input gets its schema default, a provided value still wins, and a connected nullable socket is still delivered. Reverting only the `execution.py` hunk fails 2 of the 3.

```
$ pytest tests/execution/test_omitted_optional_input.py -q --port 8399   # without the change
2 failed, 1 passed

$ pytest tests/execution/test_omitted_optional_input.py -q --port 8399   # with the change
3 passed

$ pytest tests/execution -q --port 8399
277 passed, 7 skipped in 92.08s

$ pytest tests-unit -q
1257 passed, 10 skipped
```

`tests-unit/execution_test/omitted_optional_input_test.py` adds the unit-level cases, including that a V3 node resolves through `execute` rather than the `EXECUTE_NORMALIZED` trampoline.
