### PR TITLE
Replace invalid audio samples with silence when saving videos

### DIFF
--- a/comfy_api/latest/_input_impl/video_types.py
+++ b/comfy_api/latest/_input_impl/video_types.py
@@ -890,7 +890,7 @@ class VideoFromComponents(VideoInput):
             output.mux(packet)
 
             if audio_stream and self.__components.audio:
-                frame = av.AudioFrame.from_ndarray(waveform.float().cpu().contiguous().numpy(), format='fltp', layout=layout)
+                frame = av.AudioFrame.from_ndarray(waveform.cpu().contiguous().numpy(), format='fltp', layout=layout)
                 frame.sample_rate = audio_sample_rate
                 frame.pts = 0
                 output.mux(audio_stream.encode(frame))

--- a/comfy_api/latest/_input_impl/video_types.py
+++ b/comfy_api/latest/_input_impl/video_types.py
@@ -868,6 +868,7 @@ class VideoFromComponents(VideoInput):
                 audio_sample_rate = int(self.__components.audio['sample_rate'])
                 waveform = self.__components.audio['waveform']
                 waveform = waveform[0, :, :math.ceil((audio_sample_rate / frame_rate) * self.__components.images.shape[0])]
+                waveform = waveform.float().nan_to_num(nan=0.0, posinf=0.0, neginf=0.0)
                 layout = {1: 'mono', 2: 'stereo', 6: '5.1'}.get(waveform.shape[0], 'stereo')
                 audio_stream = output.add_stream('aac', rate=audio_sample_rate, layout=layout)
 

--- a/tests-unit/comfy_api_test/video_types_test.py
+++ b/tests-unit/comfy_api_test/video_types_test.py
@@ -262,6 +262,7 @@ def test_save_to_replaces_nonfinite_audio_with_silence(tmp_path):
     waveform = torch.zeros(1, 2, 2048, dtype=torch.float32)
     waveform[0, 0, 1:4] = torch.tensor([float("nan"), float("inf"), float("-inf")])
     waveform[0, 1, 4:1028] = torch.linspace(0.2, 0.4, 1024, dtype=torch.float32)
+    original_waveform = waveform.clone()
     components = VideoComponents(
         images=torch.zeros(2, 2, 2, 3),
         audio=AudioInput({"waveform": waveform, "sample_rate": 24000}),
@@ -271,7 +272,7 @@ def test_save_to_replaces_nonfinite_audio_with_silence(tmp_path):
 
     VideoFromComponents(components).save_to(str(path))
 
-    assert torch.isnan(waveform[0, 0, 1]).item()
+    torch.testing.assert_close(waveform, original_waveform, equal_nan=True)
     with av.open(str(path)) as container:
         decoded = torch.cat(
             [torch.from_numpy(frame.to_ndarray()) for frame in container.decode(container.streams.audio[0])],

--- a/tests-unit/comfy_api_test/video_types_test.py
+++ b/tests-unit/comfy_api_test/video_types_test.py
@@ -258,6 +258,30 @@ def test_save_to_h264_crf_controls_quality(tmp_path):
     assert os.path.getsize(transcoded) < os.path.getsize(high_quality)
 
 
+def test_save_to_replaces_nonfinite_audio_with_silence(tmp_path):
+    waveform = torch.zeros(1, 2, 2048, dtype=torch.float32)
+    waveform[0, 0, 1:4] = torch.tensor([float("nan"), float("inf"), float("-inf")])
+    waveform[0, 1, 4:1028] = torch.linspace(0.2, 0.4, 1024, dtype=torch.float32)
+    components = VideoComponents(
+        images=torch.zeros(2, 2, 2, 3),
+        audio=AudioInput({"waveform": waveform, "sample_rate": 24000}),
+        frame_rate=Fraction(1),
+    )
+    path = tmp_path / "nonfinite-audio.mp4"
+
+    VideoFromComponents(components).save_to(str(path))
+
+    assert torch.isnan(waveform[0, 0, 1]).item()
+    with av.open(str(path)) as container:
+        decoded = torch.cat(
+            [torch.from_numpy(frame.to_ndarray()) for frame in container.decode(container.streams.audio[0])],
+            dim=1,
+        )
+    assert decoded.shape[0] == 2
+    assert torch.isfinite(decoded).all()
+    assert decoded.abs().max() > 0.1
+
+
 def test_save_to_mp4_writes_metadata_before_media(video_components, tmp_path):
     encoded = tmp_path / "encoded.mp4"
     remuxed = tmp_path / "remuxed.mp4"


### PR DESCRIPTION
## Summary
- Convert NaN and infinite component-audio samples to silence before building the AAC frame.
- Add a CPU regression covering NaN, positive infinity, and negative infinity samples, successful saving, finite decoded output, and preservation of the source tensor.

## Testing
- `python -m pytest tests-unit/comfy_api_test -q` (51 passed, 1 skipped)
- `python -m ruff check .`
- `python -m py_compile comfy_api/latest/_input_impl/video_types.py tests-unit/comfy_api_test/video_types_test.py`
- `git diff --check`

Fixes #14617