### PR TITLE
Treat near-neutral style strengths as neutral

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1140,7 +1140,7 @@ class StyleModelApply:
             (txt, keys) = t
             keys = keys.copy()
             # even if the strength is 1.0 (i.e, no change), if there's already a mask, we have to add to it
-            if "attention_mask" in keys or (strength_type == "attn_bias" and strength != 1.0):
+            if "attention_mask" in keys or (strength_type == "attn_bias" and not math.isclose(strength, 1.0)):
                 # math.log raises an error if the argument is zero
                 # torch.log returns -inf, which is what we want
                 attn_bias = torch.log(torch.Tensor([strength if strength_type == "attn_bias" else 1.0]))

--- a/tests-unit/comfy_extras_test/style_model_apply_test.py
+++ b/tests-unit/comfy_extras_test/style_model_apply_test.py
@@ -1,0 +1,38 @@
+import pytest
+import torch
+
+import nodes
+
+
+class FakeStyleModel:
+    def get_cond(self, clip_vision_output):
+        return torch.zeros(1, 2, 3)
+
+
+def _conditioning():
+    return [(torch.zeros(1, 1, 3), {})]
+
+
+@pytest.mark.parametrize("strength", [1.0, 1.0000000000000002])
+def test_attn_bias_neutral_strength_does_not_create_a_mask(strength):
+    result = nodes.StyleModelApply().apply_stylemodel(
+        _conditioning(),
+        FakeStyleModel(),
+        object(),
+        strength,
+        "attn_bias",
+    )
+
+    assert "attention_mask" not in result[0][0][1]
+
+
+def test_attn_bias_non_neutral_strength_creates_a_mask():
+    result = nodes.StyleModelApply().apply_stylemodel(
+        _conditioning(),
+        FakeStyleModel(),
+        object(),
+        1.001,
+        "attn_bias",
+    )
+
+    assert "attention_mask" in result[0][0][1]


### PR DESCRIPTION
## Summary
- Compare attn-bias style strength with 1.0 using a floating-point tolerance.
- Prevent serialized round-trip drift from creating an unnecessary attention mask.
- Add regression coverage for neutral, near-neutral, and non-neutral strengths.

Fixes #8515

## Testing
- `pytest tests-unit/comfy_extras_test/style_model_apply_test.py -q` — 3 passed
- `ruff check nodes.py tests-unit/comfy_extras_test/style_model_apply_test.py`
- `git diff --check`