### PR TITLE
Return empty LoadImage masks at image resolution

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1759,7 +1759,8 @@ class LoadImage:
 
         components = InputImpl.VideoFromFile(image_path).get_components()
         if components.images.shape[0] > 0:
-            return (components.images.to(device=device, dtype=dtype), (1.0 - components.alpha[..., -1]).to(device=device, dtype=dtype) if components.alpha is not None else torch.zeros((components.images.shape[0], 64, 64), dtype=dtype, device=device))
+            empty_mask = torch.zeros(components.images.shape[:-1], dtype=dtype, device=device)
+            return (components.images.to(device=device, dtype=dtype), (1.0 - components.alpha[..., -1]).to(device=device, dtype=dtype) if components.alpha is not None else empty_mask)
 
         # This code is left here to handle animated webp which pyav does not support loading
         img = node_helpers.pillow(Image.open, image_path)
@@ -1786,7 +1787,7 @@ class LoadImage:
                 mask = np.array(i.getchannel('A')).astype(np.float32) / 255.0
                 mask = 1. - torch.from_numpy(mask)
             else:
-                mask = torch.zeros((64, 64), dtype=torch.float32, device="cpu")
+                mask = torch.zeros(image.shape[1:3], dtype=torch.float32, device="cpu")
             output_images.append(image.to(dtype=dtype))
             output_masks.append(mask.unsqueeze(0).to(dtype=dtype))
 

--- a/tests/test_load_image_mask.py
+++ b/tests/test_load_image_mask.py
@@ -1,0 +1,41 @@
+import sys
+from types import SimpleNamespace
+
+from PIL import Image
+import pytest
+import torch
+
+import comfy.options
+
+
+# LoadImage imports ComfyUI's device management, which must be initialized in
+# CPU mode on CPU-only test environments.
+comfy.options.args_parsing = True
+pytest_argv = sys.argv
+sys.argv = [sys.argv[0], "--cpu"]
+
+import nodes
+
+sys.argv = pytest_argv
+comfy.options.args_parsing = False
+
+
+class EmptyVideoComponents:
+    def get_components(self):
+        return SimpleNamespace(images=torch.empty(0), alpha=None)
+
+
+@pytest.mark.parametrize("use_video_loader", [True, False])
+def test_empty_mask_matches_image_dimensions(tmp_path, monkeypatch, use_video_loader):
+    image_path = tmp_path / "rgb.png"
+    Image.new("RGB", (37, 23), (128, 64, 32)).save(image_path)
+
+    if not use_video_loader:
+        monkeypatch.setattr(nodes.InputImpl, "VideoFromFile", lambda _: EmptyVideoComponents())
+    monkeypatch.setattr(nodes.folder_paths, "get_annotated_filepath", lambda _: str(image_path))
+
+    image, mask = nodes.LoadImage().load_image("rgb.png")
+
+    assert image.shape == (1, 23, 37, 3)
+    assert mask.shape == (1, 23, 37)
+    assert torch.equal(mask, torch.zeros_like(mask))


### PR DESCRIPTION
## Summary
- Return the empty mask from `LoadImage` with the same batch and spatial dimensions as the loaded image when the image has no alpha channel.
- Apply the same behavior to both the standard image/video loader and the Pillow fallback used for formats PyAV cannot decode.
- Add regression tests for both loader paths.

## Context
Fixes #8667. This also addresses the arbitrary 64x64 mask dimensions reported in #7301 while preserving the existing contract that `LoadImage` always returns a mask.

## Testing
- `python -m pytest tests/test_load_image_mask.py -q`
  - `2 passed in 21.55s`
- `ruff check nodes.py tests/test_load_image_mask.py`
  - `All checks passed!`