### PR TITLE
Fix LoKr updates with strided Tucker factors

### DIFF
--- a/comfy/weight_adapter/lokr.py
+++ b/comfy/weight_adapter/lokr.py
@@ -85,7 +85,7 @@ class LokrDiff(WeightAdapterTrainBase):
         # Unsqueeze w1 to match w2 dims for proper kron product (like LyCORIS make_kron)
         for _ in range(w2.dim() - w1.dim()):
             w1 = w1.unsqueeze(-1)
-        diff = torch.kron(w1, w2)
+        diff = torch.kron(w1, w2.contiguous())
         return w + diff.reshape(w.shape).to(w)
 
     def h(self, x: torch.Tensor, base_out: torch.Tensor) -> torch.Tensor:
@@ -346,7 +346,8 @@ class LoKrAdapter(WeightAdapterBase):
             alpha = 1.0
 
         try:
-            lora_diff = torch.kron(w1, w2).reshape(weight.shape)
+            # Tucker convolutions produce a non-contiguous right operand.
+            lora_diff = torch.kron(w1, w2.contiguous()).reshape(weight.shape)
             if dora_scale is not None:
                 weight = weight_decompose(
                     dora_scale,

--- a/tests-unit/comfy_test/lokr_adapter_test.py
+++ b/tests-unit/comfy_test/lokr_adapter_test.py
@@ -1,0 +1,53 @@
+import pytest
+import torch
+
+from comfy.cli_args import args
+
+
+@pytest.fixture(autouse=True)
+def use_cpu():
+    previous_cpu = args.cpu
+    args.cpu = True
+    yield
+    args.cpu = previous_cpu
+
+
+def test_tucker_convolution_with_non_contiguous_factor_storage_is_applied():
+    # This import must follow use_cpu so model management initializes on CPU.
+    from comfy.weight_adapter.lokr import LoKrAdapter
+
+    tucker_w2 = torch.einsum(
+        "i j k l, j r, i p -> p r k l",
+        torch.ones(4, 3, 3, 3),
+        torch.ones(3, 3),
+        torch.ones(4, 4),
+    )
+    w2 = tucker_w2.transpose(1, 2).contiguous().transpose(1, 2)
+    lora = {
+        "layer.lokr_w1": torch.arange(4, dtype=torch.float32).reshape(2, 2) + 1,
+        "layer.lokr_w2": w2,
+    }
+    loaded_keys = set()
+    adapter = LoKrAdapter.load("layer", lora, 3.0, None, loaded_keys)
+
+    weight = torch.zeros(8, 6, 3, 3)
+    result = adapter.calculate_weight(
+        weight,
+        "layer.weight",
+        strength=1.0,
+        strength_model=1.0,
+        offset=None,
+        function=lambda value: value,
+    )
+
+    expected_diff = torch.kron(
+        lora["layer.lokr_w1"].unsqueeze(2).unsqueeze(2), w2.contiguous()
+    ).reshape(weight.shape)
+
+    assert loaded_keys == {"layer.lokr_w1", "layer.lokr_w2"}
+    assert not w2.is_contiguous()
+    assert torch.equal(result, expected_diff)
+    train_adapter = adapter.to_train()
+    assert not train_adapter.w2.is_contiguous()
+    train_result = train_adapter(torch.zeros_like(weight))
+    assert torch.equal(train_result, expected_diff)


### PR DESCRIPTION
## Summary
- Materialize the Tucker-rebuilt LoKr factor before calling `torch.kron`, without changing its value.
- Keep both the loading and training LoKr update paths from dropping an update after a stride-view error.
- Add a deterministic CPU regression covering the non-contiguous factor and both update paths.

The regression fails on current master because `calculate_weight` catches the view-stride error and returns the unchanged weight; it passes with a contiguous right operand.

## Testing
- `pytest tests-unit/comfy_test -q` — 86 passed
- `pytest tests-unit/comfy_test/lokr_adapter_test.py tests-unit/comfy_quant/test_mixed_precision.py -q` — 8 passed
- `python -m py_compile comfy/weight_adapter/lokr.py tests-unit/comfy_test/lokr_adapter_test.py`
- `ruff check comfy/weight_adapter/lokr.py tests-unit/comfy_test/lokr_adapter_test.py`
- `ruff format --check comfy/weight_adapter/lokr.py tests-unit/comfy_test/lokr_adapter_test.py`
- `git diff --check`

Fixes #11245.