### PR TITLE
Fix Windows physical GPU detection

### DIFF
--- a/cuda_malloc.py
+++ b/cuda_malloc.py
@@ -4,16 +4,39 @@ from comfy.cli_args import args, PerformanceFeature
 import subprocess
 import re
 
+def _get_nvidia_smi_path():
+    """Resolve nvidia-smi across supported Windows driver layouts."""
+    if os.name == 'nt':
+        system_root = os.environ.get('SystemRoot')
+        program_files = os.environ.get('ProgramW6432') or os.environ.get('ProgramFiles')
+        paths = []
+        if system_root:
+            paths.append(os.path.join(system_root, 'System32', 'nvidia-smi.exe'))
+        if program_files:
+            paths.append(os.path.join(program_files, 'NVIDIA Corporation', 'NVSMI', 'nvidia-smi.exe'))
+        for path in paths:
+            if os.path.isfile(path):
+                return path
+    return 'nvidia-smi'
+
 def get_nvidia_gpu_names():
+    """Return physical NVIDIA GPU names, or None when detection fails."""
     gpu_names = []
     try:
-        out = subprocess.check_output(['nvidia-smi', '-L'])
+        out = subprocess.check_output([_get_nvidia_smi_path(), '-L'], timeout=5)
     except (OSError, subprocess.SubprocessError):
-        return gpu_names
-    for line in out.split(b'\n'):
+        return None
+    for line in out.splitlines():
         if line.startswith(b'GPU '):
-            gpu_names.append(line.decode('utf-8').split(': ', 1)[1].split(' (UUID', 1)[0])
-    return gpu_names
+            _, separator, gpu = line.partition(b': ')
+            name, uuid_separator, _ = gpu.partition(b' (UUID')
+            if not separator or not uuid_separator:
+                return None
+            try:
+                gpu_names.append(name.decode('utf-8'))
+            except UnicodeDecodeError:
+                return None
+    return gpu_names or None
 
 #Can't use pytorch to get the GPU names because the cuda malloc has to be set before the first import.
 def get_gpu_names():
@@ -47,7 +70,17 @@ def get_gpu_names():
             return gpu_names
         return enum_display_devices()
     else:
-        return get_nvidia_gpu_names()
+        return get_nvidia_gpu_names() or []
+
+def get_nvidia_gpu_count():
+    """Count physical NVIDIA GPUs, falling back to Windows display devices."""
+    gpu_names = get_nvidia_gpu_names()
+    if gpu_names is not None:
+        return len(gpu_names)
+    try:
+        return sum("NVIDIA" in name.upper() for name in get_gpu_names())
+    except (OSError, UnicodeError):
+        return 0
 
 blacklist = {"GeForce GTX TITAN X", "GeForce GTX 980", "GeForce GTX 970", "GeForce GTX 960", "GeForce GTX 950", "GeForce 945M",
                 "GeForce 940M", "GeForce 930M", "GeForce 920M", "GeForce 910M", "GeForce GTX 750", "GeForce GTX 745", "Quadro K620",

--- a/cuda_malloc.py
+++ b/cuda_malloc.py
@@ -4,6 +4,17 @@ from comfy.cli_args import args, PerformanceFeature
 import subprocess
 import re
 
+def get_nvidia_gpu_names():
+    gpu_names = []
+    try:
+        out = subprocess.check_output(['nvidia-smi', '-L'])
+    except (OSError, subprocess.SubprocessError):
+        return gpu_names
+    for line in out.split(b'\n'):
+        if line.startswith(b'GPU '):
+            gpu_names.append(line.decode('utf-8').split(': ', 1)[1].split(' (UUID', 1)[0])
+    return gpu_names
+
 #Can't use pytorch to get the GPU names because the cuda malloc has to be set before the first import.
 def get_gpu_names():
     if os.name == 'nt':
@@ -36,12 +47,7 @@ def get_gpu_names():
             return gpu_names
         return enum_display_devices()
     else:
-        gpu_names = []
-        out = subprocess.check_output(['nvidia-smi', '-L'])
-        for l in out.split(b'\n'):
-            if len(l) > 0:
-                gpu_names.append(l.decode('utf-8').split(' (UUID')[0])
-        return gpu_names
+        return get_nvidia_gpu_names()
 
 blacklist = {"GeForce GTX TITAN X", "GeForce GTX 980", "GeForce GTX 970", "GeForce GTX 960", "GeForce GTX 950", "GeForce 945M",
                 "GeForce 940M", "GeForce 930M", "GeForce 920M", "GeForce 910M", "GeForce GTX 750", "GeForce GTX 745", "Quadro K620",

--- a/main.py
+++ b/main.py
@@ -47,10 +47,7 @@ if __name__ == "__main__":
         cuda_visibility = os.environ.get("CUDA_VISIBLE_DEVICES")
         device_selection = args.cuda_device
 
-        try:
-            gpu_count = sum("NVIDIA" in name.upper() for name in cuda_malloc.get_gpu_names())
-        except OSError:
-            gpu_count = 0
+        gpu_count = len(cuda_malloc.get_nvidia_gpu_names())
 
         if gpu_count > 1:
             warning = None

--- a/main.py
+++ b/main.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
         cuda_visibility = os.environ.get("CUDA_VISIBLE_DEVICES")
         device_selection = args.cuda_device
 
-        gpu_count = len(cuda_malloc.get_nvidia_gpu_names())
+        gpu_count = cuda_malloc.get_nvidia_gpu_count()
 
         if gpu_count > 1:
             warning = None

--- a/tests-unit/cuda_malloc_test.py
+++ b/tests-unit/cuda_malloc_test.py
@@ -1,0 +1,32 @@
+import subprocess
+from unittest.mock import patch
+
+import cuda_malloc
+
+
+@patch("cuda_malloc.subprocess.check_output")
+def test_get_nvidia_gpu_names_uses_physical_gpu_records(check_output):
+    check_output.return_value = b"""GPU 0: NVIDIA A100-SXM4-40GB (UUID: GPU-a)
+  MIG 1g.5gb Device 0: (UUID: MIG-a)
+GPU 1: NVIDIA A100-SXM4-40GB (UUID: GPU-b)
+"""
+
+    assert cuda_malloc.get_nvidia_gpu_names() == [
+        "NVIDIA A100-SXM4-40GB",
+        "NVIDIA A100-SXM4-40GB",
+    ]
+    check_output.assert_called_once_with(["nvidia-smi", "-L"])
+
+
+@patch("cuda_malloc.subprocess.check_output")
+def test_get_nvidia_gpu_names_reports_one_physical_gpu(check_output):
+    check_output.return_value = b"GPU 0: NVIDIA GeForce RTX 4060 Ti (UUID: GPU-a)\n"
+
+    assert cuda_malloc.get_nvidia_gpu_names() == ["NVIDIA GeForce RTX 4060 Ti"]
+
+
+@patch("cuda_malloc.subprocess.check_output")
+def test_get_nvidia_gpu_names_handles_nvidia_smi_failure(check_output):
+    check_output.side_effect = subprocess.CalledProcessError(1, ["nvidia-smi", "-L"])
+
+    assert cuda_malloc.get_nvidia_gpu_names() == []

--- a/tests-unit/cuda_malloc_test.py
+++ b/tests-unit/cuda_malloc_test.py
@@ -1,11 +1,29 @@
 import subprocess
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import cuda_malloc
 
 
+@patch("cuda_malloc.os.path.isfile")
+def test_get_nvidia_smi_path_uses_standard_windows_driver_location(isfile):
+    system_root = r"C:\Windows"
+    program_files = r"C:\Program Files"
+    system_path = cuda_malloc.os.path.join(system_root, "System32", "nvidia-smi.exe")
+    standard_path = cuda_malloc.os.path.join(program_files, "NVIDIA Corporation", "NVSMI", "nvidia-smi.exe")
+    isfile.side_effect = lambda path: path == standard_path
+
+    with (
+        patch.object(cuda_malloc.os, "name", "nt"),
+        patch.dict(cuda_malloc.os.environ, {"SystemRoot": system_root, "ProgramW6432": program_files}, clear=True),
+    ):
+        assert cuda_malloc._get_nvidia_smi_path() == standard_path
+
+    assert isfile.call_args_list == [call(system_path), call(standard_path)]
+
+
+@patch("cuda_malloc._get_nvidia_smi_path", return_value="nvidia-smi")
 @patch("cuda_malloc.subprocess.check_output")
-def test_get_nvidia_gpu_names_uses_physical_gpu_records(check_output):
+def test_get_nvidia_gpu_names_uses_physical_gpu_records(check_output, get_nvidia_smi_path):
     check_output.return_value = b"""GPU 0: NVIDIA A100-SXM4-40GB (UUID: GPU-a)
   MIG 1g.5gb Device 0: (UUID: MIG-a)
 GPU 1: NVIDIA A100-SXM4-40GB (UUID: GPU-b)
@@ -15,7 +33,8 @@ GPU 1: NVIDIA A100-SXM4-40GB (UUID: GPU-b)
         "NVIDIA A100-SXM4-40GB",
         "NVIDIA A100-SXM4-40GB",
     ]
-    check_output.assert_called_once_with(["nvidia-smi", "-L"])
+    check_output.assert_called_once_with(["nvidia-smi", "-L"], timeout=5)
+    get_nvidia_smi_path.assert_called_once_with()
 
 
 @patch("cuda_malloc.subprocess.check_output")
@@ -29,4 +48,44 @@ def test_get_nvidia_gpu_names_reports_one_physical_gpu(check_output):
 def test_get_nvidia_gpu_names_handles_nvidia_smi_failure(check_output):
     check_output.side_effect = subprocess.CalledProcessError(1, ["nvidia-smi", "-L"])
 
-    assert cuda_malloc.get_nvidia_gpu_names() == []
+    assert cuda_malloc.get_nvidia_gpu_names() is None
+
+
+@patch("cuda_malloc.subprocess.check_output")
+def test_get_nvidia_gpu_names_handles_nvidia_smi_timeout(check_output):
+    check_output.side_effect = subprocess.TimeoutExpired(["nvidia-smi", "-L"], 5)
+
+    assert cuda_malloc.get_nvidia_gpu_names() is None
+
+
+@patch("cuda_malloc.subprocess.check_output")
+def test_get_nvidia_gpu_names_handles_unexpected_output(check_output):
+    for output in (
+        b"No devices were found\n",
+        b"GPU 0 NVIDIA GeForce RTX 4070\n",
+        b"GPU 0: NVIDIA GeForce RTX \xff (UUID: GPU-a)\n",
+    ):
+        check_output.return_value = output
+        assert cuda_malloc.get_nvidia_gpu_names() is None
+
+
+@patch("cuda_malloc.get_gpu_names")
+@patch("cuda_malloc.get_nvidia_gpu_names", return_value=None)
+def test_get_nvidia_gpu_count_falls_back_to_windows_display_devices(get_nvidia_gpu_names, get_gpu_names):
+    get_gpu_names.return_value = [
+        "NVIDIA GeForce RTX 5080",
+        "NVIDIA GeForce RTX 5060",
+        "AMD Radeon Graphics",
+    ]
+
+    assert cuda_malloc.get_nvidia_gpu_count() == 2
+
+
+@patch("cuda_malloc.get_gpu_names")
+@patch(
+    "cuda_malloc.get_nvidia_gpu_names",
+    return_value=["NVIDIA GeForce RTX 5080", "NVIDIA GeForce RTX 5060"],
+)
+def test_get_nvidia_gpu_count_prefers_physical_gpu_records(get_nvidia_gpu_names, get_gpu_names):
+    assert cuda_malloc.get_nvidia_gpu_count() == 2
+    get_gpu_names.assert_not_called()


### PR DESCRIPTION
Fixes #15745.

Windows multi-GPU protection currently counts GDI display-adapter entries, which may contain duplicate records for one physical NVIDIA GPU.

Use top-level physical GPU records from nvidia-smi -L instead. This preserves two same-model GPUs and falls back cleanly when nvidia-smi is unavailable.

Tests:
- pytest tests-unit/cuda_malloc_test.py -q (3 passed with mocked command output)
- ruff check cuda_malloc.py main.py tests-unit/cuda_malloc_test.py