### PR TITLE
Merge Python `.gitignore` template with project ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,13 @@
+# =====================
+# Byte-compiled / optimized / DLL files
+# =====================
 __pycache__/
-*.py[cod]
+*.py[codz]
+*$py.class
+
+# =====================
+# Project-specific
+# =====================
 /output/
 /input/
 !/input/example.png
@@ -24,3 +32,166 @@ web_custom_versions/
 filtered-openapi.yaml
 uv.lock
 .comfy_environment
+
+# =====================
+# Python template
+# =====================
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py.cover
+*.lcov
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask
+instance/
+.webassets-cache
+
+# Scrapy
+.scrapy
+
+# Sphinx
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pdm
+.pdm-python
+.pdm-build/
+
+# pixi
+.pixi/*
+!.pixi/config.toml
+
+# PEP 582
+__pypackages__/
+
+# Celery
+celerybeat-schedule*
+celerybeat.pid
+
+# Redis
+*.rdb
+*.aof
+*.pid
+
+# RabbitMQ
+mnesia/
+rabbitmq/
+rabbitmq-data/
+
+# ActiveMQ
+activemq-data/
+
+# SageMath
+*.sage.py
+
+# Environments
+.env
+.envrc
+env/
+ENV/
+env.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# Abstra
+.abstra/
+
+# Visual Studio Code temp file
+tempCodeRunnerFile.py
+
+# Ruff
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/
+
+# Streamlit
+.streamlit/secrets.toml


### PR DESCRIPTION
## Summary
Merged the existing project `.gitignore` with the standard Python `.gitignore` template.

## Changes
- Added standard Python ignores for caches, environments, coverage, build artifacts, etc.
- Kept all existing project-specific entries and negations, including:
  - `!/input/example.png`
  - `!custom_nodes/example_node.py.example`
  - `!/web/extensions/logging.js.example`
  - `!/web/extensions/core/`
- Removed duplicate entries and adopted the broader `*.py[codz]` pattern.
- Reorganized the file into clear sections for project-specific and Python-template entries.

## Test plan
No functional code changes. Verify ignored files still behave as expected locally.

<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [ ] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [x] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [x] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**