### PR TITLE
Fix WebcamCapture raising "Invalid file path" on run

### DIFF
--- a/comfy_extras/nodes_webcam.py
+++ b/comfy_extras/nodes_webcam.py
@@ -1,5 +1,4 @@
 import nodes
-import folder_paths
 
 MAX_RESOLUTION = nodes.MAX_RESOLUTION
 
@@ -22,7 +21,7 @@ class WebcamCapture(nodes.LoadImage):
     CATEGORY = "image"
 
     def load_capture(self, image, **kwargs):
-        return super().load_image(folder_paths.get_annotated_filepath(image))
+        return super().load_image(image)
 
     @classmethod
     def IS_CHANGED(cls, image, width, height, capture_on_queue):

--- a/tests-unit/comfy_extras_test/nodes_webcam_test.py
+++ b/tests-unit/comfy_extras_test/nodes_webcam_test.py
@@ -13,6 +13,7 @@ decode, which is irrelevant to this bug. It is stubbed here with a class
 that reproduces only the one line that matters: resolving the ``image``
 argument through folder_paths.get_annotated_filepath().
 """
+import importlib
 import os
 import sys
 from unittest.mock import MagicMock, patch
@@ -34,8 +35,16 @@ mock_nodes = MagicMock()
 mock_nodes.MAX_RESOLUTION = 16384
 mock_nodes.LoadImage = _FakeLoadImage
 
-with patch.dict(sys.modules, {"nodes": mock_nodes}):
-    from comfy_extras.nodes_webcam import WebcamCapture
+
+@pytest.fixture
+def webcam_capture_cls():
+    with patch.dict(sys.modules, {"nodes": mock_nodes}):
+        sys.modules.pop("comfy_extras.nodes_webcam", None)
+        module = importlib.import_module("comfy_extras.nodes_webcam")
+    try:
+        yield module.WebcamCapture
+    finally:
+        sys.modules.pop("comfy_extras.nodes_webcam", None)
 
 
 @pytest.fixture
@@ -58,6 +67,6 @@ def sandbox(tmp_path):
     folder_paths.set_temp_directory(orig_temp)
 
 
-def test_load_capture_resolves_temp_annotated_image(sandbox):
-    result = WebcamCapture().load_capture(image="webcam/capture.png [temp]")
+def test_load_capture_resolves_temp_annotated_image(sandbox, webcam_capture_cls):
+    result = webcam_capture_cls().load_capture(image="webcam/capture.png [temp]")
     assert result == os.path.join(sandbox["temp"], "webcam", "capture.png")

--- a/tests-unit/comfy_extras_test/nodes_webcam_test.py
+++ b/tests-unit/comfy_extras_test/nodes_webcam_test.py
@@ -1,0 +1,63 @@
+"""Regression test for https://github.com/Comfy-Org/ComfyUI/issues/15756
+
+WebcamCapture.load_capture resolved the incoming ``[temp]``-annotated image
+name via folder_paths.get_annotated_filepath(), then handed the resulting
+*absolute* path to LoadImage.load_image(), which resolves it again. The
+second resolution sees a plain absolute path with no annotation suffix, so
+it defaults to checking containment against the input directory instead of
+the temp directory the file actually lives in, and the path-traversal guard
+in folder_paths.get_annotated_filepath() rejects it.
+
+nodes.LoadImage.load_image() pulls in torch/PIL/av for the actual image
+decode, which is irrelevant to this bug. It is stubbed here with a class
+that reproduces only the one line that matters: resolving the ``image``
+argument through folder_paths.get_annotated_filepath().
+"""
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import folder_paths
+from comfy.options import enable_args_parsing
+
+enable_args_parsing()
+
+
+class _FakeLoadImage:
+    def load_image(self, image):
+        return folder_paths.get_annotated_filepath(image)
+
+
+mock_nodes = MagicMock()
+mock_nodes.MAX_RESOLUTION = 16384
+mock_nodes.LoadImage = _FakeLoadImage
+
+with patch.dict(sys.modules, {"nodes": mock_nodes}):
+    from comfy_extras.nodes_webcam import WebcamCapture
+
+
+@pytest.fixture
+def sandbox(tmp_path):
+    base = os.path.realpath(str(tmp_path))
+    input_dir = os.path.join(base, "input")
+    temp_dir = os.path.join(base, "temp")
+    os.makedirs(input_dir, exist_ok=True)
+    os.makedirs(temp_dir, exist_ok=True)
+
+    orig_input = folder_paths.get_input_directory()
+    orig_temp = folder_paths.get_temp_directory()
+
+    folder_paths.set_input_directory(input_dir)
+    folder_paths.set_temp_directory(temp_dir)
+
+    yield {"input": input_dir, "temp": temp_dir}
+
+    folder_paths.set_input_directory(orig_input)
+    folder_paths.set_temp_directory(orig_temp)
+
+
+def test_load_capture_resolves_temp_annotated_image(sandbox):
+    result = WebcamCapture().load_capture(image="webcam/capture.png [temp]")
+    assert result == os.path.join(sandbox["temp"], "webcam", "capture.png")


### PR DESCRIPTION
Fixes #15756

## Problem

Running a `Webcam Capture` node raises:

```
ValueError: Invalid file path: 'E:\\ComfyUI\\temp\\webcam\\1787243980405.png'
  File "comfy_extras/nodes_webcam.py", line 25, in load_capture
    return super().load_image(folder_paths.get_annotated_filepath(image))
  File "nodes.py", line 1755, in load_image
    image_path = folder_paths.get_annotated_filepath(image)
  File "folder_paths.py", line 356, in get_annotated_filepath
    raise ValueError("Invalid file path: {!r}".format(name))
```

## Root cause

`WebcamCapture.load_capture` resolved the incoming `[temp]`-annotated
image name via `folder_paths.get_annotated_filepath()`, and then passed
the resulting **absolute** path into `LoadImage.load_image()`, which
resolves the path a *second* time internally.

The first resolution correctly reads the `[temp]` suffix and validates
containment against the temp directory, returning an absolute path like
`.../temp/webcam/171....png`. That absolute path has no annotation
suffix, so the second resolution (inside `LoadImage.load_image`) falls
back to checking containment against the *input* directory instead —
and since the file actually lives under `temp/`, the path-traversal
guard added for GHSA-779p-m5rp-r4h4 (#14734) rejects it.

`IS_CHANGED` on the same class already passes the raw annotated `image`
straight through to `super().IS_CHANGED(image)` with a single
resolution; this makes `load_capture` do the same instead of
pre-resolving and double-processing the path.

## Fix

Drop the redundant outer `folder_paths.get_annotated_filepath()` call in
`load_capture` and let `LoadImage.load_image()` resolve the raw
annotated image name itself, exactly as `IS_CHANGED` already does. The
general path-traversal protection in `folder_paths.get_annotated_filepath`
is untouched.

## Test plan

Added `tests-unit/comfy_extras_test/nodes_webcam_test.py`, which stubs
out the torch/PIL/av-dependent parts of `LoadImage.load_image` (irrelevant
to this bug) while keeping the real `folder_paths` path-resolution logic,
and asserts that a `[temp]`-annotated capture path resolves successfully
instead of raising.

Confirmed the test fails on the pre-fix code and passes after the fix:

```
$ git checkout HEAD~1 -- comfy_extras/nodes_webcam.py
$ python3 -m pytest tests-unit/comfy_extras_test/nodes_webcam_test.py -v
...
FAILED tests-unit/comfy_extras_test/nodes_webcam_test.py::test_load_capture_resolves_temp_annotated_image - ValueError: Invalid file path: '.../temp/webcam/capture.png'
1 failed in 0.08s

$ git checkout HEAD -- comfy_extras/nodes_webcam.py
$ python3 -m pytest tests-unit/comfy_extras_test/nodes_webcam_test.py -v
...
tests-unit/comfy_extras_test/nodes_webcam_test.py::test_load_capture_resolves_temp_annotated_image PASSED
1 passed in 0.05s
```

Also ran the related existing suites to confirm no regressions:

```
$ python3 -m pytest tests-unit/comfy_extras_test/nodes_webcam_test.py \
    tests-unit/security_test/test_ghsa_779p_03_annotated_traversal.py \
    tests-unit/security_test/test_ghsa_779p_05_dangerous_content_types.py \
    tests-unit/folder_paths_test -v
...
56 passed in 0.12s
```

(The other two `security_test` modules fail to collect in this
environment for an unrelated reason — missing `aiohttp`/`yarl`
packages — not touched by this change.)

`ruff check comfy_extras/nodes_webcam.py tests-unit/comfy_extras_test/nodes_webcam_test.py` passes with no issues.

## AI disclosure

This change was authored with the assistance of an AI coding agent (Claude), with the diagnosis, fix, and test verified by running the reproduction and regression tests shown above.
