### PR TITLE
Reject cross-drive output subpaths safely

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -340,6 +340,19 @@ def is_within_directory(directory: str, target: str) -> bool:
         return False
 
 
+def resolve_subfolder(base_dir: str, subfolder: str) -> str | None:
+    """Join a subfolder to a base directory while enforcing containment.
+
+    Returns ``None`` when the resulting path is outside ``base_dir``. This also
+    handles paths on different Windows drives, where ``os.path.commonpath``
+    raises instead of reporting that the paths are unrelated.
+    """
+    full_dir = os.path.join(base_dir, subfolder)
+    if not is_within_directory(base_dir, full_dir):
+        return None
+    return full_dir
+
+
 def get_annotated_filepath(name: str, default_dir: str | None=None) -> str:
     name, base_dir = annotated_filepath(name)
 

--- a/server.py
+++ b/server.py
@@ -490,8 +490,8 @@ class PromptServer():
                     return web.Response(status=400)
 
                 if original_ref.get("subfolder", "") != "":
-                    full_output_dir = os.path.join(output_dir, original_ref["subfolder"])
-                    if os.path.commonpath((os.path.abspath(full_output_dir), output_dir)) != output_dir:
+                    full_output_dir = folder_paths.resolve_subfolder(output_dir, original_ref["subfolder"])
+                    if full_output_dir is None:
                         return web.Response(status=403)
                     output_dir = full_output_dir
 
@@ -547,8 +547,8 @@ class PromptServer():
                         return web.Response(status=400)
 
                     if "subfolder" in request.rel_url.query:
-                        full_output_dir = os.path.join(output_dir, request.rel_url.query["subfolder"])
-                        if os.path.commonpath((os.path.abspath(full_output_dir), output_dir)) != output_dir:
+                        full_output_dir = folder_paths.resolve_subfolder(output_dir, request.rel_url.query["subfolder"])
+                        if full_output_dir is None:
                             return web.Response(status=403)
                         output_dir = full_output_dir
 

--- a/tests/test_folder_paths.py
+++ b/tests/test_folder_paths.py
@@ -1,0 +1,31 @@
+import os
+
+import folder_paths
+
+
+def test_resolve_subfolder_accepts_directory_inside_base(tmp_path):
+    base = tmp_path / "output"
+    nested = base / "images"
+    nested.mkdir(parents=True)
+
+    resolved = folder_paths.resolve_subfolder(str(base), "images")
+
+    assert resolved == os.path.join(base, "images")
+
+
+def test_resolve_subfolder_rejects_escape_from_base(tmp_path):
+    base = tmp_path / "output"
+    outside = tmp_path / "outside"
+    base.mkdir()
+    outside.mkdir()
+
+    assert folder_paths.resolve_subfolder(str(base), os.path.join("..", "outside")) is None
+
+
+def test_resolve_subfolder_handles_cross_drive_paths(monkeypatch):
+    def cross_drive_commonpath(paths):
+        raise ValueError("Paths don't have the same drive")
+
+    monkeypatch.setattr(os.path, "commonpath", cross_drive_commonpath)
+
+    assert folder_paths.resolve_subfolder(r"M:\output", r"E:\images") is None


### PR DESCRIPTION
## Summary
- Resolve output subfolders with the existing realpath containment check.
- Return `403` when a subfolder escapes the configured directory, including subfolders on another Windows drive where `os.path.commonpath` raises `ValueError`.
- Cover accepted, traversal, and cross-drive subfolder handling with unit tests.

Fixes #2025.

## Testing
- `python -m pytest tests/test_folder_paths.py -q`
- `python -m py_compile folder_paths.py server.py tests/test_folder_paths.py`
- `ruff check folder_paths.py server.py tests/test_folder_paths.py`
