### PR TITLE
Defer Kornia imports until nodes execute

### DIFF
--- a/comfy_extras/nodes_canny.py
+++ b/comfy_extras/nodes_canny.py
@@ -1,4 +1,3 @@
-from kornia.filters import canny
 from typing_extensions import override
 
 import comfy.model_management
@@ -30,6 +29,8 @@ class Canny(io.ComfyNode):
 
     @classmethod
     def execute(cls, image, low_threshold, high_threshold) -> io.NodeOutput:
+        from kornia.filters import canny
+
         output = canny(image.to(device=comfy.model_management.get_torch_device(), dtype=torch.float32).movedim(-1, 1), low_threshold, high_threshold)
         img_out = output[1].to(device=comfy.model_management.intermediate_device(), dtype=comfy.model_management.intermediate_dtype()).repeat(1, 3, 1, 1).movedim(1, -1)
         return io.NodeOutput(img_out)

--- a/comfy_extras/nodes_morphology.py
+++ b/comfy_extras/nodes_morphology.py
@@ -3,9 +3,6 @@ import comfy.model_management
 from typing_extensions import override
 from comfy_api.latest import ComfyExtension, io
 
-from kornia.morphology import dilation, erosion, opening, closing, gradient, top_hat, bottom_hat
-import kornia.color
-
 
 class Morphology(io.ComfyNode):
     @classmethod
@@ -30,6 +27,8 @@ class Morphology(io.ComfyNode):
 
     @classmethod
     def execute(cls, image, operation, kernel_size) -> io.NodeOutput:
+        from kornia.morphology import dilation, erosion, opening, closing, gradient, top_hat, bottom_hat
+
         device = comfy.model_management.get_torch_device()
         kernel = torch.ones(kernel_size, kernel_size, device=device)
         image_k = image.to(device).movedim(-1, 1)
@@ -73,7 +72,9 @@ class ImageRGBToYUV(io.ComfyNode):
 
     @classmethod
     def execute(cls, image) -> io.NodeOutput:
-        out = kornia.color.rgb_to_ycbcr(image.movedim(-1, 1)).movedim(1, -1)
+        from kornia.color import rgb_to_ycbcr
+
+        out = rgb_to_ycbcr(image.movedim(-1, 1)).movedim(1, -1)
         return io.NodeOutput(out[..., 0:1].expand_as(image), out[..., 1:2].expand_as(image), out[..., 2:3].expand_as(image))
 
 class ImageYUVToRGB(io.ComfyNode):
@@ -96,8 +97,10 @@ class ImageYUVToRGB(io.ComfyNode):
 
     @classmethod
     def execute(cls, Y, U, V) -> io.NodeOutput:
+        from kornia.color import ycbcr_to_rgb
+
         image = torch.cat([torch.mean(Y, dim=-1, keepdim=True), torch.mean(U, dim=-1, keepdim=True), torch.mean(V, dim=-1, keepdim=True)], dim=-1)
-        out = kornia.color.ycbcr_to_rgb(image.movedim(-1, 1)).movedim(1, -1)
+        out = ycbcr_to_rgb(image.movedim(-1, 1)).movedim(1, -1)
         return io.NodeOutput(out)
 
 

--- a/comfy_extras/nodes_post_processing.py
+++ b/comfy_extras/nodes_post_processing.py
@@ -6,7 +6,6 @@ from PIL import Image
 import math
 from enum import Enum
 from typing import TypedDict, Literal
-import kornia
 
 import comfy.utils
 import comfy.model_management
@@ -697,7 +696,9 @@ class ColorTransfer(io.ComfyNode):
 
     @staticmethod
     def _to_lab(images, i, device):
-        return kornia.color.rgb_to_lab(
+        from kornia.color import rgb_to_lab
+
+        return rgb_to_lab(
             images[i:i+1].to(device, dtype=torch.float32).permute(0, 3, 1, 2))
 
     @staticmethod
@@ -873,15 +874,17 @@ class ColorTransfer(io.ComfyNode):
                 out[i] = result.permute(1, 2, 0).clamp_(0, 1).to(device=intermediate_device, dtype=intermediate_dtype)
                 pbar.update(1)
         else:
+            from kornia.color import lab_to_rgb
+
             transform = cls._build_lab_transform(image_target, image_ref, device, stats_mode, target_index, is_reinhard=method == "reinhard_lab")
 
             for i in range(B):
                 src_frame = cls._to_lab(image_target, i, device)
                 corrected = transform(src_frame.view(C, -1), frame_idx=i)
                 if strength == 1.0:
-                    result = kornia.color.lab_to_rgb(corrected.view(1, C, H, W))
+                    result = lab_to_rgb(corrected.view(1, C, H, W))
                 else:
-                    result = kornia.color.lab_to_rgb(torch.lerp(src_frame, corrected.view(1, C, H, W), strength))
+                    result = lab_to_rgb(torch.lerp(src_frame, corrected.view(1, C, H, W), strength))
                 out[i] = result.squeeze(0).permute(1, 2, 0).clamp_(0, 1).to(device=intermediate_device, dtype=intermediate_dtype)
                 pbar.update(1)
 

--- a/tests/test_kornia_lazy_import.py
+++ b/tests/test_kornia_lazy_import.py
@@ -1,0 +1,30 @@
+import ast
+from pathlib import Path
+
+import pytest
+
+
+REPOSITORY_ROOT = Path(__file__).parents[1]
+KORNIA_NODE_MODULES = (
+    "comfy_extras/nodes_canny.py",
+    "comfy_extras/nodes_morphology.py",
+    "comfy_extras/nodes_post_processing.py",
+)
+
+
+@pytest.mark.parametrize("relative_path", KORNIA_NODE_MODULES)
+def test_kornia_nodes_do_not_import_kornia_at_module_load(relative_path):
+    source_path = REPOSITORY_ROOT / relative_path
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+
+    top_level_imports = [
+        node
+        for node in tree.body
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+    ]
+
+    for node in top_level_imports:
+        modules = [alias.name for alias in node.names] if isinstance(node, ast.Import) else [node.module]
+        assert not any(module == "kornia" or module.startswith("kornia.") for module in modules), (
+            f"{relative_path} imports Kornia while node modules are loaded"
+        )


### PR DESCRIPTION
## Summary
- Remove Kornia imports from built-in node-module import time.
- Import the required Kornia functions only when Canny, morphology, color conversion, or color-transfer nodes execute.
- Add tests ensuring these node modules can be registered without a module-level Kornia import.

This keeps an architecture-specific failure in the optional Kornia binary from aborting startup before any dependent node is used.

Fixes #14107.

## Testing
- `python -m pytest tests/test_kornia_lazy_import.py -q`
- `python -m py_compile comfy_extras/nodes_canny.py comfy_extras/nodes_morphology.py comfy_extras/nodes_post_processing.py tests/test_kornia_lazy_import.py`
- `ruff check comfy_extras/nodes_canny.py comfy_extras/nodes_morphology.py comfy_extras/nodes_post_processing.py tests/test_kornia_lazy_import.py`
- CPU smoke test exercised Canny, every morphology operation, RGB/YUV conversions, and ColorTransfer.
