### PR TITLE
Keep ANGLE library symbols local

### DIFF
--- a/comfy_extras/nodes_glsl.py
+++ b/comfy_extras/nodes_glsl.py
@@ -25,7 +25,9 @@ def _preload_angle():
         os.add_dll_directory(angle_dir)
         os.environ["PATH"] = angle_dir + os.pathsep + os.environ.get("PATH", "")
 
-    mode = 0 if sys.platform == "win32" else ctypes.RTLD_GLOBAL
+    # Keep ANGLE's symbols local. libGLESv2 exports its own libffi symbols,
+    # and loading them globally can replace the libffi used by cffi.
+    mode = ctypes.RTLD_LOCAL
     ctypes.CDLL(str(egl_path), mode=mode)
     ctypes.CDLL(str(gles_path), mode=mode)
 

--- a/tests/test_nodes_glsl.py
+++ b/tests/test_nodes_glsl.py
@@ -1,0 +1,41 @@
+import sys
+
+import pytest
+
+import comfy.options
+
+
+def _import_nodes_glsl_on_cpu():
+    original_argv = sys.argv[:]
+    comfy.options.enable_args_parsing(True)
+    sys.argv = [sys.argv[0], "--cpu"]
+    try:
+        return pytest.importorskip("comfy_extras.nodes_glsl")
+    finally:
+        sys.argv = original_argv
+        comfy.options.enable_args_parsing(False)
+
+
+nodes_glsl = _import_nodes_glsl_on_cpu()
+
+
+def test_preload_angle_keeps_libraries_local(monkeypatch):
+    loaded = []
+
+    def load_library(name, mode=0):
+        loaded.append((name, mode))
+        return object()
+
+    monkeypatch.setattr(nodes_glsl.ctypes, "RTLD_GLOBAL", 0x100)
+    monkeypatch.setattr(nodes_glsl.ctypes, "RTLD_LOCAL", 0)
+    monkeypatch.setattr(nodes_glsl.ctypes, "CDLL", load_library)
+    monkeypatch.setattr(nodes_glsl.sys, "platform", "linux")
+    monkeypatch.setattr(nodes_glsl.comfy_angle, "get_egl_path", lambda: "libEGL.so")
+    monkeypatch.setattr(
+        nodes_glsl.comfy_angle, "get_glesv2_path", lambda: "libGLESv2.so"
+    )
+
+    nodes_glsl._preload_angle()
+
+    modes = [mode for _, mode in loaded]
+    assert modes == [0, 0]


### PR DESCRIPTION
## Summary
- Load ANGLE EGL and GLESv2 with `RTLD_LOCAL` on every platform.
- Prevent the bundled libffi symbols exported by `libGLESv2` from globally interposing on the libffi implementation used later by cffi-based libraries.
- Add a regression test that captures the dlopen modes used by `_preload_angle()`.

Fixes #15134.

## Testing
- `python -m pytest tests/test_nodes_glsl.py -q` — 1 passed.
- `python -m ruff check comfy_extras/nodes_glsl.py tests/test_nodes_glsl.py` — all checks passed.
- On Linux, loading ANGLE globally before importing cffi reproduced `ffi_prep_closure(): bad user_data`; loading both libraries locally allowed the callback to execute (`cffi callback: 7`), and the PyOpenGL EGL/GLES3 imports still succeeded.