### PR TITLE
Support DynamicCombo values in GraphBuilder

### DIFF
--- a/comfy_execution/graph_utils.py
+++ b/comfy_execution/graph_utils.py
@@ -9,6 +9,40 @@ def is_link(obj):
         return False
     return True
 
+
+def _flatten_dynamic_input(root: str, path: str, values: dict):
+    flattened = {}
+    for key, value in values.items():
+        if key == root:
+            flattened[path] = value
+            continue
+
+        child_path = f"{path}.{key}"
+        if isinstance(value, dict) and key in value:
+            flattened.update(_flatten_dynamic_input(key, child_path, value))
+        else:
+            flattened[child_path] = value
+    return flattened
+
+
+def _flatten_dynamic_inputs(inputs: dict):
+    # DynamicCombo values contain their own selector key. Flatten those values to
+    # the dotted input names used by the prompt format while preserving regular
+    # dictionary values.
+    flattened = {}
+    for name, value in inputs.items():
+        if isinstance(value, dict) and name in value:
+            values = _flatten_dynamic_input(name, name, value)
+        else:
+            values = {name: value}
+
+        for key, item in values.items():
+            if key in flattened:
+                raise ValueError(f"conflicting input '{key}'")
+            flattened[key] = item
+    return flattened
+
+
 # The GraphBuilder is just a utility class that outputs graphs in the form expected by the ComfyUI back-end
 class GraphBuilder:
     _default_prefix_root = ""
@@ -49,7 +83,7 @@ class GraphBuilder:
         if id in self.nodes:
             return self.nodes[id]
 
-        node = Node(id, class_type, kwargs)
+        node = Node(id, class_type, _flatten_dynamic_inputs(kwargs))
         self.nodes[id] = node
         return node
 

--- a/tests-unit/comfy_execution_test/graph_utils_test.py
+++ b/tests-unit/comfy_execution_test/graph_utils_test.py
@@ -1,0 +1,60 @@
+import pytest
+
+from comfy_execution.graph_utils import GraphBuilder
+
+
+def test_node_flattens_dynamic_combo_inputs():
+    builder = GraphBuilder(prefix="dynamic_combo")
+
+    builder.node(
+        "ResizeImageMaskNode",
+        resize_type={"resize_type": "scale by multiplier", "multiplier": 2.0},
+    )
+
+    assert builder.finalize()["dynamic_combo1"]["inputs"] == {
+        "resize_type": "scale by multiplier",
+        "resize_type.multiplier": 2.0,
+    }
+
+
+def test_node_flattens_nested_dynamic_combo_inputs():
+    builder = GraphBuilder(prefix="nested_dynamic_combo")
+
+    builder.node(
+        "NestedDynamicComboNode",
+        combo={
+            "combo": "option4",
+            "subcombo": {
+                "subcombo": "opt1",
+                "float_x": 1.5,
+                "float_y": 2.5,
+            },
+        },
+    )
+
+    assert builder.finalize()["nested_dynamic_combo1"]["inputs"] == {
+        "combo": "option4",
+        "combo.subcombo": "opt1",
+        "combo.subcombo.float_x": 1.5,
+        "combo.subcombo.float_y": 2.5,
+    }
+
+
+def test_node_preserves_regular_dict_inputs():
+    builder = GraphBuilder(prefix="regular_dict")
+    value = {"key": "value"}
+
+    builder.node("TestNode", value=value)
+
+    assert builder.finalize()["regular_dict1"]["inputs"]["value"] == value
+
+
+def test_node_rejects_conflicting_dynamic_combo_keys():
+    builder = GraphBuilder(prefix="conflict")
+
+    with pytest.raises(ValueError, match="conflicting input 'combo.string'"):
+        builder.node(
+            "NestedDynamicComboNode",
+            combo={"combo": "option1", "string": "hello"},
+            **{"combo.string": "conflict"},
+        )

--- a/tests/execution/test_execution.py
+++ b/tests/execution/test_execution.py
@@ -236,6 +236,24 @@ class TestExecution:
     def builder(self, request):
         yield GraphBuilder(prefix=request.node.name)
 
+    def test_dynamic_combo_graph_builder(self, client: ComfyClient, builder: GraphBuilder):
+        g = builder
+        mask = g.node("SolidMask", value=1.0, height=32, width=32, batch_size=1)
+        node = g.node(
+            "ResizeImageMaskNode",
+            input=mask.out(0),
+            resize_type={
+                "resize_type": "scale by multiplier",
+                "multiplier": 2.0,
+            },
+            scale_method="lanczos",
+        )
+        image = g.node("MaskToImage", mask=node.out(0))
+        g.node("PreviewImage", images=image.out(0))
+
+        result = client.run(g)
+        assert result.did_run(node)
+
     def test_lazy_input(self, client: ComfyClient, builder: GraphBuilder):
         g = builder
         input1 = g.node("StubImage", content="BLACK", height=512, width=512, batch_size=1)


### PR DESCRIPTION
Fixes #12566.

## Summary
- Flatten DynamicCombo dictionary arguments passed to `GraphBuilder.node()` into the dotted input names used by prompts.
- Handle nested DynamicCombo values recursively.
- Preserve ordinary dictionary inputs and reject conflicting generated input names.

## Tests
- `python -m pytest tests-unit/comfy_execution_test/graph_utils_test.py -q` — 4 passed.
- CPU execution check with `SolidMask -> ResizeImageMaskNode -> MaskToImage -> PreviewImage` — the resized node executed and received `resize_type` plus `resize_type.multiplier`.
- `python -m ruff check comfy_execution/graph_utils.py tests-unit/comfy_execution_test/graph_utils_test.py tests/execution/test_execution.py` — all checks passed.