### PR TITLE
Allow Comfy API key from environment

### DIFF
--- a/comfy_api_nodes/util/_helpers.py
+++ b/comfy_api_nodes/util/_helpers.py
@@ -34,6 +34,9 @@ def get_node_id(node_cls: type[IO.ComfyNode]) -> str:
 
 
 def get_auth_header(node_cls: type[IO.ComfyNode]) -> dict[str, str]:
+    api_key = os.getenv("API_KEY_COMFY_ORG")
+    if api_key:
+        return {"X-API-KEY": api_key}
     if node_cls.hidden.auth_token_comfy_org:
         return {"Authorization": f"Bearer {node_cls.hidden.auth_token_comfy_org}"}
     if node_cls.hidden.api_key_comfy_org:

--- a/tests-unit/comfy_api_nodes_test/helpers_test.py
+++ b/tests-unit/comfy_api_nodes_test/helpers_test.py
@@ -1,0 +1,43 @@
+from types import SimpleNamespace
+
+import torch
+
+from comfy.cli_args import args
+
+if not torch.cuda.is_available():
+    args.cpu = True
+
+from comfy_api_nodes.util._helpers import get_auth_header  # noqa: E402
+
+
+def node(auth_token: str = "", api_key: str = ""):
+    return SimpleNamespace(
+        hidden=SimpleNamespace(
+            auth_token_comfy_org=auth_token,
+            api_key_comfy_org=api_key,
+        )
+    )
+
+
+def test_environment_api_key_takes_precedence(monkeypatch):
+    monkeypatch.setenv("API_KEY_COMFY_ORG", "environment-key")
+
+    assert get_auth_header(node("account-token", "request-key")) == {
+        "X-API-KEY": "environment-key"
+    }
+
+
+def test_hidden_auth_token_is_used_without_environment_key(monkeypatch):
+    monkeypatch.delenv("API_KEY_COMFY_ORG", raising=False)
+
+    assert get_auth_header(node("account-token", "request-key")) == {
+        "Authorization": "Bearer account-token"
+    }
+
+
+def test_hidden_api_key_is_used_without_environment_key(monkeypatch):
+    monkeypatch.delenv("API_KEY_COMFY_ORG", raising=False)
+
+    assert get_auth_header(node(api_key="request-key")) == {
+        "X-API-KEY": "request-key"
+    }


### PR DESCRIPTION
Fixes #12542.

## Summary
- Allow the server environment to provide a Comfy API key through `API_KEY_COMFY_ORG`.
- Use that key for the `X-API-KEY` header before falling back to request-provided credentials.

## Tests
- `python -m pytest tests-unit/comfy_api_nodes_test/helpers_test.py -q` — 3 passed.
- `python -m pytest tests-unit/comfy_api_nodes_test -q` — 18 passed.
- `python -m ruff check comfy_api_nodes/util/_helpers.py tests-unit/comfy_api_nodes_test/helpers_test.py` — all checks passed.

<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [ ] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [ ] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [ ] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**

