### PR TITLE
Preserve quantized parameters in inference mode

### DIFF
--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -1099,9 +1099,9 @@ def _quantized_apply(module, fn, recurse=True):
         if param is None:
             continue
         p = fn(param)
-        if (not torch.is_inference_mode_enabled()) and p.is_inference():
-            p = p.clone()
-        module.register_parameter(key, torch.nn.Parameter(p, requires_grad=False))
+        if p is param and (torch.is_inference_mode_enabled() or not p.is_inference()):
+            continue
+        module.register_parameter(key, comfy.utils.make_param(p))
     for key, buf in module._buffers.items():
         if buf is not None:
             module._buffers[key] = fn(buf)

--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -970,12 +970,32 @@ def set_attr(obj, attr, value):
         setattr(obj, name, value)
     return prev
 
+def make_param(value):
+    # Custom tensor wrappers created outside inference mode cannot be detached
+    # by Parameter while inference mode is active. Recreate the wrapper in the
+    # current mode while sharing its component storage.
+    if torch.is_inference_mode_enabled():
+        if (
+            not value.is_inference()
+            and type(value) is not torch.Tensor
+            and hasattr(value, "__tensor_flatten__")
+        ):
+            attrs, unflatten_ctx = value.__tensor_flatten__()
+            components = {attr: getattr(value, attr) for attr in attrs}
+            value = type(value).__tensor_unflatten__(
+                components, unflatten_ctx, value.shape, value.stride()
+            )
+    elif value.is_inference():
+        # Inference tensors have a frozen version counter and cannot be used
+        # directly as a normal parameter.
+        value = value.clone()
+    return torch.nn.Parameter(value, requires_grad=False)
+
+
 def set_attr_param(obj, attr, value):
     # Clone inference tensors (created under torch.inference_mode) since
     # their version counter is frozen and nn.Parameter() cannot wrap them.
-    if (not torch.is_inference_mode_enabled()) and value.is_inference():
-        value = value.clone()
-    return set_attr(obj, attr, torch.nn.Parameter(value, requires_grad=False))
+    return set_attr(obj, attr, make_param(value))
 
 def set_attr_buffer(obj, attr, value):
     obj, name = resolve_attr(obj, attr)

--- a/tests-unit/comfy_quant/test_mixed_precision.py
+++ b/tests-unit/comfy_quant/test_mixed_precision.py
@@ -337,5 +337,51 @@ class TestMixedPrecisionOps(unittest.TestCase):
         self.assertEqual(saved_conf["linear_dtype"], "int8")
         self.assertNotIn("quant_group_size", saved_conf)
 
+    def test_quantized_apply_noop_preserves_parameter_in_inference_mode(self):
+        weight = QuantizedTensor.from_float(
+            torch.ones(4, 4), "TensorCoreFP8E4M3Layout"
+        )
+        module = torch.nn.Module()
+        parameter = torch.nn.Parameter(weight, requires_grad=False)
+        module.weight = parameter
+
+        with torch.inference_mode():
+            ops._quantized_apply(module, lambda tensor: tensor)
+
+        self.assertIs(module.weight, parameter)
+
+    def test_quantized_apply_rewraps_normal_wrapper_in_inference_mode(self):
+        original = QuantizedTensor.from_float(
+            torch.ones(4, 4), "TensorCoreFP8E4M3Layout"
+        )
+        replacement = QuantizedTensor.from_float(
+            torch.full((4, 4), 2.0), "TensorCoreFP8E4M3Layout"
+        )
+        module = torch.nn.Module()
+        module.weight = torch.nn.Parameter(original, requires_grad=False)
+
+        with torch.inference_mode():
+            ops._quantized_apply(module, lambda tensor: replacement)
+
+        self.assertIsInstance(module.weight, QuantizedTensor)
+        self.assertTrue(module.weight.is_inference())
+        self.assertTrue(
+            torch.equal(module.weight.dequantize(), replacement.dequantize())
+        )
+
+    def test_set_attr_param_rewraps_normal_wrapper_in_inference_mode(self):
+        weight = QuantizedTensor.from_float(
+            torch.ones(4, 4), "TensorCoreFP8E4M3Layout"
+        )
+        module = torch.nn.Module()
+
+        with torch.inference_mode():
+            comfy.utils.set_attr_param(module, "weight", weight)
+
+        self.assertIsInstance(module.weight, QuantizedTensor)
+        self.assertTrue(module.weight.is_inference())
+        self.assertTrue(torch.equal(module.weight.dequantize(), weight.dequantize()))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Summary

- Preserve an existing quantized parameter when `_quantized_apply` receives the same tensor back, which is common for a no-op device move.
- Recreate custom tensor wrappers under the active inference mode before wrapping them as parameters, sharing their existing component storage.
- Keep the existing behavior that clones inference tensors when restoring parameters outside inference mode.
- Add focused regressions for no-op moves, replacement tensors, and `set_attr_param`.

This prevents `RuntimeError: Cannot set version_counter for inference tensor` when a quantized model loaded outside inference mode is moved or restored later while inference mode is active.

Fixes #15733.

### Validation

On a CPU-only PyTorch 2.13 environment:

```text
$ python -m pytest -q tests-unit/comfy_quant/test_mixed_precision.py -k "inference_mode"
3 passed, 7 deselected in 7.15s

$ python -m pytest -q tests-unit/comfy_quant/test_mixed_precision.py
10 passed in 7.53s

$ python -m ruff check comfy/utils.py comfy/ops.py tests-unit/comfy_quant/test_mixed_precision.py
All checks passed!
```

The two new `_quantized_apply` tests failed on master with the reported `Cannot set version_counter for inference tensor` error before the fix.