### PR TITLE
Add mask blur node

### DIFF
--- a/comfy_extras/nodes_mask.py
+++ b/comfy_extras/nodes_mask.py
@@ -348,6 +348,40 @@ class FeatherMask(IO.ComfyNode):
     feather = execute  # TODO: remove
 
 
+class BlurMask(IO.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return IO.Schema(
+            node_id="BlurMask",
+            search_aliases=["soft mask", "gaussian mask", "smooth mask"],
+            display_name="Blur Mask",
+            category="image/mask",
+            description="Apply a Gaussian blur to each mask while preserving soft values.",
+            inputs=[
+                IO.Mask.Input("mask"),
+                IO.Float.Input("sigma", default=1.0, min=0.0, max=100.0, step=0.01),
+            ],
+            outputs=[IO.Mask.Output()],
+        )
+
+    @classmethod
+    def execute(cls, mask, sigma) -> IO.NodeOutput:
+        mask = mask.reshape((-1, mask.shape[-2], mask.shape[-1]))
+        if sigma == 0:
+            return IO.NodeOutput(mask)
+
+        output = []
+        for m in mask:
+            blurred = scipy.ndimage.gaussian_filter(
+                m.detach().cpu().numpy(), sigma=sigma, mode="nearest"
+            )
+            output.append(
+                torch.from_numpy(blurred).to(device=mask.device, dtype=mask.dtype)
+            )
+
+        return IO.NodeOutput(torch.stack(output, dim=0))
+
+
 class GrowMask(IO.ComfyNode):
     @classmethod
     def define_schema(cls):
@@ -447,6 +481,7 @@ class MaskExtension(ComfyExtension):
             CropMask,
             MaskComposite,
             FeatherMask,
+            BlurMask,
             GrowMask,
             ThresholdMask,
             MaskPreview,

--- a/tests-unit/comfy_extras_test/nodes_mask_test.py
+++ b/tests-unit/comfy_extras_test/nodes_mask_test.py
@@ -1,0 +1,52 @@
+import asyncio
+
+import torch
+
+from comfy.cli_args import args
+
+args.cpu = True
+
+from comfy_extras.nodes_mask import BlurMask, MaskExtension
+
+
+def blur_mask(mask, sigma):
+    return BlurMask.execute(mask, sigma)[0]
+
+
+def test_blur_mask_softens_hard_mask_edges():
+    mask = torch.zeros(1, 9, 9)
+    mask[:, :, :4] = 1.0
+
+    result = blur_mask(mask, 1.0)
+
+    assert result.shape == mask.shape
+    assert 0.1 < float(result[0, 4, 3]) < 0.9
+    assert 0.1 < float(result[0, 4, 4]) < 0.9
+    assert float(result[0, 4, 0]) > 0.99
+    assert float(result[0, 4, 8]) < 0.01
+
+
+def test_blur_mask_zero_sigma_returns_original_values():
+    mask = torch.linspace(0.0, 1.0, 16).reshape(1, 4, 4)
+
+    result = blur_mask(mask, 0.0)
+
+    assert torch.equal(result, mask)
+
+
+def test_blur_mask_preserves_batch_and_intermediate_values():
+    mask = torch.zeros(2, 5, 5)
+    mask[:, :, :2] = 0.5
+
+    result = blur_mask(mask, 0.5)
+
+    assert result.shape == mask.shape
+    assert torch.all((result >= 0.0) & (result <= 1.0))
+    assert torch.all(result[:, :, 1] > 0.0)
+    assert torch.all(result[:, :, 3] > 0.0)
+
+
+def test_blur_mask_is_registered():
+    nodes = asyncio.run(MaskExtension().get_node_list())
+
+    assert BlurMask in nodes


### PR DESCRIPTION
### Summary

- Add a `BlurMask` node that applies Gaussian blur independently to each mask.
- Preserve mask batch shape, device, dtype, and values in the `[0, 1]` range.
- Return the original mask unchanged when sigma is zero.
- Keep `FeatherMask` behavior unchanged; it continues to feather image borders as documented by its inputs.

This provides a native way to soften the actual edges of arbitrary masks, including masks with soft or intermediate values.

Addresses #1570.

### Validation

On a CPU-only environment:

```text
$ python -m pytest -q tests-unit/comfy_extras_test/nodes_mask_test.py
4 passed in 14.29s

$ python -m ruff check comfy_extras/nodes_mask.py tests-unit/comfy_extras_test/nodes_mask_test.py
All checks passed!
```

The new test module failed on master because `BlurMask` did not exist before this change.