### PR TITLE
Fix saves silently overwriting each other when filename_prefix ends in a separator

### DIFF
--- a/folder_paths.py
+++ b/folder_paths.py
@@ -519,7 +519,10 @@ def get_filename_list(folder_name: str) -> list[str]:
 
 def get_save_image_path(filename_prefix: str, output_dir: str, image_width=0, image_height=0) -> tuple[str, str, int, str, str]:
     def map_filename(filename: str) -> tuple[int, str]:
-        prefix_len = len(os.path.basename(filename_prefix))
+        # Normalize the same way the `filename` below does: a prefix that ends in
+        # a separator ("out/") has an EMPTY os.path.basename, which would make
+        # every existing file compare as a non-match and pin the counter at 1.
+        prefix_len = len(os.path.basename(os.path.normpath(filename_prefix)))
         prefix = filename[:prefix_len + 1]
         try:
             remainder = filename[prefix_len + 1:]

--- a/tests-unit/comfy_test/folder_path_test.py
+++ b/tests-unit/comfy_test/folder_path_test.py
@@ -171,6 +171,27 @@ def test_get_save_image_path_trailing_separator_resolves_like_the_plain_prefix(t
     assert plain[3] == trailing[3]
 
 
+def test_get_save_image_path_trailing_separator_continues_the_plain_prefix_counter(temp_dir):
+    """The load-bearing case: "out/" must continue the run "out" already started.
+
+    Comparing the two on an EMPTY directory is not enough — both return 1 there,
+    so that assertion holds even with the bug present. What the bug actually does
+    is reset the counter, so the switch has to happen with files on disk.
+    """
+    with patch("folder_paths.output_directory", temp_dir):
+        assert _save_three("out", temp_dir) == [
+            "out_00001_.png",
+            "out_00002_.png",
+            "out_00003_.png",
+        ]
+        # Same folder, same filename, written through the trailing-separator form.
+        assert _save_three("out/", temp_dir) == [
+            "out_00004_.png",
+            "out_00005_.png",
+            "out_00006_.png",
+        ]
+
+
 def test_base_path_changes(set_base_dir):
     test_dir = os.path.abspath("/test/dir")
     set_base_dir(test_dir)

--- a/tests-unit/comfy_test/folder_path_test.py
+++ b/tests-unit/comfy_test/folder_path_test.py
@@ -119,6 +119,58 @@ def test_get_save_image_path(temp_dir):
         assert filename_prefix == "test"
 
 
+def _save_three(prefix, out_dir):
+    """Run the node's save loop three times and return the filenames written."""
+    written = []
+    for _ in range(3):
+        full_output_folder, filename, counter, _subfolder, _prefix = folder_paths.get_save_image_path(
+            prefix, out_dir
+        )
+        name = f"{filename}_{counter:05}_.png"
+        open(os.path.join(full_output_folder, name), "w").close()
+        written.append(name)
+    return written
+
+
+@pytest.mark.parametrize("prefix", ["out/", "sub/out/", "sub/"])
+def test_get_save_image_path_counter_advances_with_a_trailing_separator(prefix, temp_dir):
+    """A filename_prefix ending in a separator must still increment the counter.
+
+    `map_filename` sized the prefix with `os.path.basename(filename_prefix)`, which
+    is EMPTY when the prefix ends in a separator, while the caller compares against
+    `os.path.basename(os.path.normpath(filename_prefix))`. Nothing matched, the
+    counter stayed at 1, and every save silently overwrote the previous file.
+    """
+    with patch("folder_paths.output_directory", temp_dir):
+        written = _save_three(prefix, temp_dir)
+
+    assert len(set(written)) == 3, f"each save must get its own filename, got {written}"
+    assert written == sorted(written)
+
+
+@pytest.mark.parametrize("prefix", ["out", "sub/out"])
+def test_get_save_image_path_counter_still_advances_without_a_trailing_separator(
+    prefix, temp_dir
+):
+    with patch("folder_paths.output_directory", temp_dir):
+        written = _save_three(prefix, temp_dir)
+
+    assert written == ["out_00001_.png", "out_00002_.png", "out_00003_.png"]
+
+
+def test_get_save_image_path_trailing_separator_resolves_like_the_plain_prefix(temp_dir):
+    """"out/" and "out" name the same file, so they must share one counter."""
+    with patch("folder_paths.output_directory", temp_dir):
+        plain = folder_paths.get_save_image_path("out", temp_dir)
+        trailing = folder_paths.get_save_image_path("out/", temp_dir)
+
+    # full_output_folder, filename, counter, subfolder
+    assert plain[0] == trailing[0]
+    assert plain[1] == trailing[1] == "out"
+    assert plain[2] == trailing[2]
+    assert plain[3] == trailing[3]
+
+
 def test_base_path_changes(set_base_dir):
     test_dir = os.path.abspath("/test/dir")
     set_base_dir(test_dir)


### PR DESCRIPTION
## Problem

If `filename_prefix` ends in a path separator, every save silently overwrites the previous one.

`get_save_image_path()` picks the next counter by matching existing filenames against the prefix. The two halves of that comparison normalize differently:

```python
def map_filename(filename):
    prefix_len = len(os.path.basename(filename_prefix))          # 'out/'  -> ''  -> 0
    ...
filename = os.path.basename(os.path.normpath(filename_prefix))   # 'out/'  -> 'out'
...
counter = max(filter(lambda a: os.path.normcase(a[1][:-1]) == os.path.normcase(filename) ...
```

`os.path.basename('out/')` is the empty string, so `prefix` is one character of each existing filename and never equals `filename`. `max()` over an empty sequence raises `ValueError`, the handler sets `counter = 1`, and the node writes `out_00001_.png` again — on top of the file it wrote last time.

Nothing errors. The graph succeeds, the node reports a saved image, and the previous render is gone.

Three saves, same prefix, on `master` (`76135e5`):

| `filename_prefix` | files after 3 saves |
| --- | --- |
| `out` | `out_00001_.png`, `out_00002_.png`, `out_00003_.png` |
| `out/` | `out_00001_.png`, `out_00001_.png`, `out_00001_.png` ❌ |
| `sub/out` | `out_00001_.png`, `out_00002_.png`, `out_00003_.png` |
| `sub/out/` | `out_00001_.png`, `out_00001_.png`, `out_00001_.png` ❌ |
| `sub/` | `sub_00001_.png`, `sub_00001_.png`, `sub_00001_.png` ❌ |

`filename_prefix` is a free-text widget, so a trailing slash is easy to type — especially when the prefix is being used to organize output into a folder, which is exactly when losing renders hurts most. The same applies to a trailing backslash on Windows.

## Change

One line: `map_filename()` normalizes the prefix the same way the comparison does.

```python
-prefix_len = len(os.path.basename(filename_prefix))
+prefix_len = len(os.path.basename(os.path.normpath(filename_prefix)))
```

For a prefix without a trailing separator `os.path.normpath` is a no-op on the basename, so nothing changes for existing workflows. `out/` and `out` now resolve to the same folder and filename and therefore share one counter, which is what the rest of the function already assumed.

## Testing

Added to `tests-unit/comfy_test/folder_path_test.py`, driving the node's actual save loop (resolve → write the file → resolve again):

- three saves with `out/`, `sub/out/`, `sub/` each produce three distinct filenames
- three saves with `out`, `sub/out` still produce `out_00001_` … `out_00003_` — the no-regression guard
- `out/` and `out` return the same `full_output_folder`, `filename`, `counter` and `subfolder`

Reverting only `folder_paths.py`: **3 failed, 275 passed**. With the change: **278 passed, 1 skipped, 0 failed** (`pytest tests-unit/ --continue-on-collection-errors`). `ruff check` clean on both files.

One caveat, stated rather than hidden: 38 test modules fail to *collect* in my environment because torch and the other model-runtime dependencies are not installed, and that count is identical before and after. They are unaffected either way — this change is in a pure-Python path helper with no torch involvement — but I did not run them, so I am not claiming they pass.
