### PR TITLE
Detect Windows CUDA devices in isolated PyTorch process

### DIFF
--- a/cuda_malloc.py
+++ b/cuda_malloc.py
@@ -28,19 +28,19 @@ def get_gpu_names():
             device_info = DISPLAY_DEVICEA()
             device_info.cb = ctypes.sizeof(device_info)
             device_index = 0
-            gpu_names = []
+            gpu_names = set()
 
             while user32.EnumDisplayDevicesA(None, device_index, ctypes.byref(device_info), 0):
                 device_index += 1
-                gpu_names.append(device_info.DeviceString.decode('utf-8'))
+                gpu_names.add(device_info.DeviceString.decode('utf-8'))
             return gpu_names
         return enum_display_devices()
     else:
-        gpu_names = []
+        gpu_names = set()
         out = subprocess.check_output(['nvidia-smi', '-L'])
         for l in out.split(b'\n'):
             if len(l) > 0:
-                gpu_names.append(l.decode('utf-8').split(' (UUID')[0])
+                gpu_names.add(l.decode('utf-8').split(' (UUID')[0])
         return gpu_names
 
 blacklist = {"GeForce GTX TITAN X", "GeForce GTX 980", "GeForce GTX 970", "GeForce GTX 960", "GeForce GTX 950", "GeForce 945M",

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ if args.list_feature_flags:
 import os
 import importlib.util
 import shutil
+import subprocess
 import importlib.metadata
 import folder_paths
 import time
@@ -48,8 +49,14 @@ if __name__ == "__main__":
         device_selection = args.cuda_device
 
         try:
-            gpu_count = sum("NVIDIA" in name.upper() for name in cuda_malloc.get_gpu_names())
-        except OSError:
+            output = subprocess.check_output(
+                [sys.executable, "-c", "import torch; print(torch.cuda.device_count())"],
+                stderr=subprocess.DEVNULL,
+                text=True,
+                timeout=30,
+            )
+            gpu_count = int(output.strip())
+        except (OSError, subprocess.SubprocessError, ValueError):
             gpu_count = 0
 
         if gpu_count > 1:


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI/issues/15745

Probe torch.cuda.device_count() in a disposable subprocess so the parent can still configure the CUDA allocator before importing PyTorch. Stop treating duplicate Windows display-adapter records as separate GPUs.

Example Test conditions:

Windows, RTX5030

Before:

```
^[[1m^[[31m[ERROR]^[[0m Failed to initialize database. Please ensure you have installed the latest requirements. If the error persists, please report this as in future the database will be required: (sqlite3.OperationalError) unable to open database file
(Background on this error at: https://sqlalche.me/e/20/e3q8)
^[[32m[INFO]^[[0m Using RAM pressure cache.
^[[1m^[[33m[WARNING]^[[0m ________________________________________________________________________
WARNING WARNING WARNING WARNING WARNING

Multiple NVIDIA GPUs detected. ComfyUI will use GPU 0 only on Windows by default. To restore all GPUs, pass --cuda-device all --disable-pinned-memory.
________________________________________________________________________
^[[32m[INFO]^[[0m Starting server

^[[32m[INFO]^[[0m To see the GUI go to: http://0.0.0.0:8188

```

After:

```
^[[1m^[[31m[ERROR]^[[0m Failed to initialize database. Please ensure you have installed the latest requirements. If the error persists, please report this as in future the database will be required: (sqlite3.OperationalError) unable to open database file
(Background on this error at: https://sqlalche.me/e/20/e3q8)
^[[32m[INFO]^[[0m Using RAM pressure cache.
^[[32m[INFO]^[[0m Starting server

^[[32m[INFO]^[[0m To see the GUI go to: http://0.0.0.0:8188

```

Regression Test:

Windows RTX5080+RTX5060

```
...
^[[32m[INFO]^[[0m Asset seeder disabled
^[[32m[INFO]^[[0m No OpenGL_accelerate module loaded: No module named 'OpenGL_accelerate'
^[[32m[INFO]^[[0m ComfyUI-GGUF: Allowing full torch compile
^[[32m[INFO]^[[0m
Import times for custom nodes:
^[[32m[INFO]^[[0m    0.0 seconds: C:\Users\rattu\comfy-base\custom_nodes\ComfyUI-MemoryVisualization
^[[32m[INFO]^[[0m    0.0 seconds: C:\Users\rattu\comfy-base\custom_nodes\ComfyUI-GGUF
^[[32m[INFO]^[[0m
^[[32m[INFO]^[[0m Context impl SQLiteImpl.
^[[32m[INFO]^[[0m Will assume non-transactional DDL.
^[[32m[INFO]^[[0m Using RAM pressure cache.
^[[1m^[[33m[WARNING]^[[0m ________________________________________________________________________
WARNING WARNING WARNING WARNING WARNING

Multiple NVIDIA GPUs detected. ComfyUI will use GPU 0 only on Windows by default. To restore all GPUs, pass --cuda-device all --disable-pinned-memory.
________________________________________________________________________
^[[32m[INFO]^[[0m Starting server

^[[32m[INFO]^[[0m To see the GUI go to: http://0.0.0.0:8188
```