### PR TITLE
Respect cgroup memory limits when reporting RAM

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -45,9 +45,14 @@ from comfy.internal_logging import detail
 # container gets OOM-killed instead of freeing anything. See #5625 and #14938.
 #
 # Taking the minimum of the cgroup limit and what psutil reports leaves the
-# non-containerised path untouched: outside a container the file is absent or "max".
+# non-containerised path untouched: with no limit in effect there is nothing to read.
+
+CGROUP_V2 = ("/sys/fs/cgroup", "memory.max", "memory.current")
+CGROUP_V1 = ("/sys/fs/cgroup/memory", "memory.limit_in_bytes", "memory.usage_in_bytes")
+
 
 def _read_cgroup_int(path):
+    """Read a cgroup file holding a byte count, or None when it is absent or unlimited."""
     try:
         with open(path, "r") as f:
             raw = f.read().strip()
@@ -61,31 +66,64 @@ def _read_cgroup_int(path):
         return None
 
 
-def _cgroup_memory_limit():
-    limit = _read_cgroup_int("/sys/fs/cgroup/memory.max")                    # cgroup v2
-    if limit is None:
-        limit = _read_cgroup_int("/sys/fs/cgroup/memory/memory.limit_in_bytes")  # cgroup v1
-    return limit
+def _cgroup_self_paths():
+    """The memory hierarchies this process belongs to, as (root, limit file, usage file, path).
+
+    The mount root is not this process's cgroup: under a host cgroup namespace
+    /sys/fs/cgroup/memory.max does not exist at all, and under systemd or Kubernetes the
+    process sits several levels down. /proc/self/cgroup gives the path to walk.
+    """
+    try:
+        with open("/proc/self/cgroup", "r") as f:
+            lines = f.read().splitlines()
+    except OSError:
+        return []
+    hierarchies = []
+    for line in lines:
+        fields = line.split(":", 2)
+        if len(fields) != 3:
+            continue
+        hierarchy_id, controllers, path = fields
+        if hierarchy_id == "0" and not controllers:
+            hierarchies.append(CGROUP_V2 + (path,))
+        elif "memory" in controllers.split(","):
+            hierarchies.append(CGROUP_V1 + (path,))
+    return hierarchies
 
 
-def _cgroup_memory_usage():
-    usage = _read_cgroup_int("/sys/fs/cgroup/memory.current")
-    if usage is None:
-        usage = _read_cgroup_int("/sys/fs/cgroup/memory/memory.usage_in_bytes")
-    return usage
+def _cgroup_memory_constraint():
+    """The smallest limit that applies to this process, with the usage file that goes with it.
+
+    A cgroup is bound by its ancestors' limits too, so every level is considered and the
+    usage is read from whichever level carries the binding limit.
+    """
+    constraint = None
+    for root, limit_file, usage_file, path in _cgroup_self_paths():
+        parts = [part for part in path.split("/") if part]
+        while True:
+            directory = os.path.join(root, *parts)
+            limit = _read_cgroup_int(os.path.join(directory, limit_file))
+            if limit is not None and (constraint is None or limit < constraint[0]):
+                constraint = (limit, os.path.join(directory, usage_file))
+            if not parts:
+                break
+            parts.pop()
+    return constraint
 
 
-# The limit cannot change while the process runs, the usage can.
-CGROUP_MEMORY_LIMIT = _cgroup_memory_limit()
+# Neither the limit nor which cgroup carries it changes while the process runs, the usage does.
+CGROUP_MEMORY = _cgroup_memory_constraint()
 
 
 def virtual_memory():
-    """virtual_memory() clamped to the cgroup limit when one applies."""
+    """psutil.virtual_memory() clamped to the cgroup limit when one applies."""
     mem = psutil.virtual_memory()
-    limit = CGROUP_MEMORY_LIMIT
-    if limit is None or limit >= mem.total:
+    if CGROUP_MEMORY is None:
         return mem
-    used = _cgroup_memory_usage()
+    limit, usage_file = CGROUP_MEMORY
+    if limit >= mem.total:
+        return mem
+    used = _read_cgroup_int(usage_file)
     if used is None:
         used = max(0, mem.total - mem.available)
     used = min(used, limit)

--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -91,14 +91,19 @@ def _cgroup_self_paths():
     return hierarchies
 
 
+# Which cgroups this process belongs to does not change while it runs, so this is read once.
+CGROUP_HIERARCHIES = _cgroup_self_paths()
+
+
 def _cgroup_memory_constraint():
     """The smallest limit that applies to this process, with the usage file that goes with it.
 
     A cgroup is bound by its ancestors' limits too, so every level is considered and the
-    usage is read from whichever level carries the binding limit.
+    usage is read from whichever level carries the binding limit. The limits themselves are
+    read every time: memory.max is writable, and a pod can be resized while it runs.
     """
     constraint = None
-    for root, limit_file, usage_file, path in _cgroup_self_paths():
+    for root, limit_file, usage_file, path in CGROUP_HIERARCHIES:
         parts = [part for part in path.split("/") if part]
         while True:
             directory = os.path.join(root, *parts)
@@ -111,16 +116,15 @@ def _cgroup_memory_constraint():
     return constraint
 
 
-# Neither the limit nor which cgroup carries it changes while the process runs, the usage does.
-CGROUP_MEMORY = _cgroup_memory_constraint()
-
-
 def virtual_memory():
     """psutil.virtual_memory() clamped to the cgroup limit when one applies."""
     mem = psutil.virtual_memory()
-    if CGROUP_MEMORY is None:
+    if not CGROUP_HIERARCHIES:
         return mem
-    limit, usage_file = CGROUP_MEMORY
+    constraint = _cgroup_memory_constraint()
+    if constraint is None:
+        return mem
+    limit, usage_file = constraint
     if limit >= mem.total:
         return mem
     used = _read_cgroup_int(usage_file)

--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -36,6 +36,66 @@ import comfy_aimdo.host_buffer
 import comfy_aimdo.vram_buffer
 from comfy.internal_logging import detail
 
+
+# --- cgroup-aware memory reporting -------------------------------------------------
+#
+# psutil reads /proc, which reports the *host* memory even when this process runs inside a
+# container with a memory limit. Every RAM pressure decision (cache eviction, model
+# unloading, pinned memory sizing) then sees memory that this process may not use, and the
+# container gets OOM-killed instead of freeing anything. See #5625 and #14938.
+#
+# Taking the minimum of the cgroup limit and what psutil reports leaves the
+# non-containerised path untouched: outside a container the file is absent or "max".
+
+def _read_cgroup_int(path):
+    try:
+        with open(path, "r") as f:
+            raw = f.read().strip()
+    except OSError:
+        return None
+    if raw == "max":
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+def _cgroup_memory_limit():
+    limit = _read_cgroup_int("/sys/fs/cgroup/memory.max")                    # cgroup v2
+    if limit is None:
+        limit = _read_cgroup_int("/sys/fs/cgroup/memory/memory.limit_in_bytes")  # cgroup v1
+    return limit
+
+
+def _cgroup_memory_usage():
+    usage = _read_cgroup_int("/sys/fs/cgroup/memory.current")
+    if usage is None:
+        usage = _read_cgroup_int("/sys/fs/cgroup/memory/memory.usage_in_bytes")
+    return usage
+
+
+# The limit cannot change while the process runs, the usage can.
+CGROUP_MEMORY_LIMIT = _cgroup_memory_limit()
+
+
+def virtual_memory():
+    """virtual_memory() clamped to the cgroup limit when one applies."""
+    mem = psutil.virtual_memory()
+    limit = CGROUP_MEMORY_LIMIT
+    if limit is None or limit >= mem.total:
+        return mem
+    used = _cgroup_memory_usage()
+    if used is None:
+        used = max(0, mem.total - mem.available)
+    used = min(used, limit)
+    available = min(mem.available, limit - used)
+    return mem._replace(total=limit, available=available, used=used,
+                        free=min(mem.free, available),
+                        percent=round(used * 100.0 / limit, 1))
+
+# -----------------------------------------------------------------------------------
+
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from comfy.model_patcher import ModelPatcher
@@ -318,7 +378,7 @@ def get_total_memory(dev=None, torch_total_too=False):
         dev = get_torch_device()
 
     if hasattr(dev, 'type') and (dev.type == 'cpu' or dev.type == 'mps'):
-        mem_total = psutil.virtual_memory().total
+        mem_total = virtual_memory().total
         mem_total_torch = mem_total
     else:
         if directml_enabled:
@@ -361,7 +421,7 @@ def mac_version():
         return None
 
 total_vram = get_total_memory(get_torch_device()) / (1024 * 1024)
-total_ram = psutil.virtual_memory().total / (1024 * 1024)
+total_ram = virtual_memory().total / (1024 * 1024)
 logging.info("Total VRAM {:0.0f} MB, total RAM {:0.0f} MB".format(total_vram, total_ram))
 
 try:
@@ -703,7 +763,7 @@ def should_free_pins_for_ram_pressure(shortfall):
         return False
     if not WINDOWS:
         return True
-    if psutil.virtual_memory().available < WINDOWS_PIN_EVICTION_EMERGENCY_AVAILABLE:
+    if virtual_memory().available < WINDOWS_PIN_EVICTION_EMERGENCY_AVAILABLE:
         return True
     try:
         return psutil.swap_memory().percent >= WINDOWS_PIN_EVICTION_SWAP_PERCENT
@@ -717,7 +777,7 @@ def ensure_pin_budget(size, evict_active=False, loaded=False):
     if args.fast_disk:
         shortfall = TOTAL_PINNED_MEMORY + size - MAX_PINNED_MEMORY
     else:
-        shortfall = size + max(comfy.memory_management.RAM_CACHE_HEADROOM / 2, 2048 * 1024 ** 2) - psutil.virtual_memory().available
+        shortfall = size + max(comfy.memory_management.RAM_CACHE_HEADROOM / 2, 2048 * 1024 ** 2) - virtual_memory().available
     if shortfall <= 0:
         return True
 
@@ -1751,7 +1811,7 @@ def get_free_memory(dev=None, torch_free_too=False):
         dev = get_torch_device()
 
     if hasattr(dev, 'type') and (dev.type == 'cpu' or dev.type == 'mps'):
-        mem_free_total = psutil.virtual_memory().available
+        mem_free_total = virtual_memory().available
         mem_free_torch = mem_free_total
     else:
         if directml_enabled:

--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -91,19 +91,16 @@ def _cgroup_self_paths():
     return hierarchies
 
 
-# Which cgroups this process belongs to does not change while it runs, so this is read once.
-CGROUP_HIERARCHIES = _cgroup_self_paths()
-
-
 def _cgroup_memory_constraint():
     """The smallest limit that applies to this process, with the usage file that goes with it.
 
     A cgroup is bound by its ancestors' limits too, so every level is considered and the
-    usage is read from whichever level carries the binding limit. The limits themselves are
-    read every time: memory.max is writable, and a pod can be resized while it runs.
+    usage is read from whichever level carries the binding limit. Nothing is cached:
+    memory.max is writable, a pod can be resized in place, and a process can be moved to
+    another cgroup while it runs.
     """
     constraint = None
-    for root, limit_file, usage_file, path in CGROUP_HIERARCHIES:
+    for root, limit_file, usage_file, path in _cgroup_self_paths():
         parts = [part for part in path.split("/") if part]
         while True:
             directory = os.path.join(root, *parts)
@@ -119,8 +116,6 @@ def _cgroup_memory_constraint():
 def virtual_memory():
     """psutil.virtual_memory() clamped to the cgroup limit when one applies."""
     mem = psutil.virtual_memory()
-    if not CGROUP_HIERARCHIES:
-        return mem
     constraint = _cgroup_memory_constraint()
     if constraint is None:
         return mem

--- a/comfy_execution/caching.py
+++ b/comfy_execution/caching.py
@@ -1,7 +1,6 @@
 import asyncio
 import bisect
 import itertools
-import psutil
 import time
 import torch
 from typing import Sequence, Mapping, Dict

--- a/comfy_execution/caching.py
+++ b/comfy_execution/caching.py
@@ -6,6 +6,7 @@ import time
 import torch
 from typing import Sequence, Mapping, Dict
 from comfy.model_patcher import is_model_patcher_output
+from comfy.model_management import virtual_memory
 from comfy_execution.graph import DynamicPrompt
 from abc import ABC, abstractmethod
 
@@ -548,7 +549,7 @@ class RAMPressureCache(LRUCache):
         super().set_local(node_id, value)
 
     def ram_release(self, target, free_active=False, min_entry_size=0):
-        if psutil.virtual_memory().available >= target:
+        if virtual_memory().available >= target:
             return 0
 
         clean_list = []
@@ -588,7 +589,7 @@ class RAMPressureCache(LRUCache):
             bisect.insort(clean_list, (oom_score, self.timestamps[key], key, ram_usage))
 
         freed = 0
-        while psutil.virtual_memory().available < target and clean_list:
+        while virtual_memory().available < target and clean_list:
             _, _, key, ram_usage = clean_list.pop()
             del self.cache[key]
             self.used_generation.pop(key, None)

--- a/execution.py
+++ b/execution.py
@@ -14,6 +14,7 @@ import asyncio
 import torch
 
 from comfy.cli_args import args, get_console_log_level
+from comfy.model_management import virtual_memory
 import comfy.memory_management
 import comfy.model_management
 import comfy.model_patcher
@@ -798,7 +799,7 @@ class PromptExecutor:
 
                     if self.cache_type == CacheType.RAM_PRESSURE:
                         ram_release_callback(ram_inactive_headroom)
-                        ram_shortfall = ram_headroom - psutil.virtual_memory().available
+                        ram_shortfall = ram_headroom - virtual_memory().available
                         if ram_shortfall > 0:
                             freed = ram_release_callback(ram_headroom, free_active=True, min_entry_size=RAM_CACHE_LARGE_INTERMEDIATE)
                             ram_shortfall -= freed

--- a/execution.py
+++ b/execution.py
@@ -2,7 +2,6 @@ import copy
 import heapq
 import inspect
 import logging
-import psutil
 import sys
 import threading
 import time

--- a/tests-unit/comfy_test/cgroup_memory_test.py
+++ b/tests-unit/comfy_test/cgroup_memory_test.py
@@ -27,14 +27,14 @@ def host_psutil():
         yield
 
 
-def write_cgroup(directory, limit, usage):
+def write_cgroup(directory, limit, usage=0):
     directory.mkdir(parents=True, exist_ok=True)
     (directory / "memory.max").write_text(f"{limit}\n")
     (directory / "memory.current").write_text(f"{usage}\n")
 
 
-def self_paths(root, path):
-    return lambda: [(str(root), "memory.max", "memory.current", path)]
+def hierarchies(root, path):
+    return [(str(root), "memory.max", "memory.current", path)]
 
 
 def test_read_cgroup_int(tmp_path):
@@ -75,8 +75,8 @@ def test_constraint_takes_the_smallest_limit_in_the_hierarchy(tmp_path):
     write_cgroup(tmp_path / "outer", 2 * 1024 ** 3, 900 * 1024 ** 2)
     write_cgroup(tmp_path / "outer" / "inner", 3 * 1024 ** 3, 100 * 1024 ** 2)
 
-    with patch.object(model_management, "_cgroup_self_paths",
-                      self_paths(tmp_path, "/outer/inner")):
+    with patch.object(model_management, "CGROUP_HIERARCHIES",
+                      hierarchies(tmp_path, "/outer/inner")):
         limit, usage_file = model_management._cgroup_memory_constraint()
 
     assert limit == 2 * 1024 ** 3
@@ -85,10 +85,10 @@ def test_constraint_takes_the_smallest_limit_in_the_hierarchy(tmp_path):
 
 def test_constraint_reads_a_cgroup_the_mount_root_does_not_expose(tmp_path):
     # Under a host cgroup namespace the mount root has no memory files at all.
-    write_cgroup(tmp_path / "docker" / "abc", CONTAINER_LIMIT, 0)
+    write_cgroup(tmp_path / "docker" / "abc", CONTAINER_LIMIT)
 
-    with patch.object(model_management, "_cgroup_self_paths",
-                      self_paths(tmp_path, "/docker/abc")):
+    with patch.object(model_management, "CGROUP_HIERARCHIES",
+                      hierarchies(tmp_path, "/docker/abc")):
         limit, _ = model_management._cgroup_memory_constraint()
 
     assert limit == CONTAINER_LIMIT
@@ -97,12 +97,12 @@ def test_constraint_reads_a_cgroup_the_mount_root_does_not_expose(tmp_path):
 def test_constraint_is_none_without_a_limit(tmp_path):
     (tmp_path / "memory.max").write_text("max\n")
 
-    with patch.object(model_management, "_cgroup_self_paths", self_paths(tmp_path, "/")):
+    with patch.object(model_management, "CGROUP_HIERARCHIES", hierarchies(tmp_path, "/")):
         assert model_management._cgroup_memory_constraint() is None
 
 
-def test_no_constraint_passes_psutil_through(host_psutil):
-    with patch.object(model_management, "CGROUP_MEMORY", None):
+def test_no_hierarchy_passes_psutil_through(host_psutil):
+    with patch.object(model_management, "CGROUP_HIERARCHIES", []):
         mem = model_management.virtual_memory()
 
     assert mem.total == HOST_TOTAL
@@ -110,7 +110,9 @@ def test_no_constraint_passes_psutil_through(host_psutil):
 
 
 def test_limit_larger_than_host_is_ignored(host_psutil, tmp_path):
-    with patch.object(model_management, "CGROUP_MEMORY", (HOST_TOTAL * 2, str(tmp_path))):
+    write_cgroup(tmp_path, HOST_TOTAL * 2)
+
+    with patch.object(model_management, "CGROUP_HIERARCHIES", hierarchies(tmp_path, "/")):
         mem = model_management.virtual_memory()
 
     assert mem.total == HOST_TOTAL
@@ -119,10 +121,9 @@ def test_limit_larger_than_host_is_ignored(host_psutil, tmp_path):
 
 def test_limit_clamps_total_and_available(host_psutil, tmp_path):
     used = 47 * 1024 ** 3
-    usage_file = tmp_path / "memory.current"
-    usage_file.write_text(f"{used}\n")
+    write_cgroup(tmp_path, CONTAINER_LIMIT, used)
 
-    with patch.object(model_management, "CGROUP_MEMORY", (CONTAINER_LIMIT, str(usage_file))):
+    with patch.object(model_management, "CGROUP_HIERARCHIES", hierarchies(tmp_path, "/")):
         mem = model_management.virtual_memory()
 
     assert mem.total == CONTAINER_LIMIT
@@ -132,11 +133,20 @@ def test_limit_clamps_total_and_available(host_psutil, tmp_path):
     assert mem.percent == pytest.approx(used * 100.0 / CONTAINER_LIMIT, abs=0.1)
 
 
-def test_usage_above_limit_does_not_go_negative(host_psutil, tmp_path):
-    usage_file = tmp_path / "memory.current"
-    usage_file.write_text(f"{CONTAINER_LIMIT * 2}\n")
+def test_limit_lowered_while_running_is_picked_up(host_psutil, tmp_path):
+    # memory.max is writable: docker update -m, or an in-place pod resize.
+    write_cgroup(tmp_path, CONTAINER_LIMIT, 1 * 1024 ** 3)
 
-    with patch.object(model_management, "CGROUP_MEMORY", (CONTAINER_LIMIT, str(usage_file))):
+    with patch.object(model_management, "CGROUP_HIERARCHIES", hierarchies(tmp_path, "/")):
+        assert model_management.virtual_memory().total == CONTAINER_LIMIT
+        (tmp_path / "memory.max").write_text(f"{CONTAINER_LIMIT // 2}\n")
+        assert model_management.virtual_memory().total == CONTAINER_LIMIT // 2
+
+
+def test_usage_above_limit_does_not_go_negative(host_psutil, tmp_path):
+    write_cgroup(tmp_path, CONTAINER_LIMIT, CONTAINER_LIMIT * 2)
+
+    with patch.object(model_management, "CGROUP_HIERARCHIES", hierarchies(tmp_path, "/")):
         mem = model_management.virtual_memory()
 
     assert mem.used == CONTAINER_LIMIT
@@ -144,9 +154,9 @@ def test_usage_above_limit_does_not_go_negative(host_psutil, tmp_path):
 
 
 def test_unreadable_usage_falls_back_to_host_figures(host_psutil, tmp_path):
-    missing = tmp_path / "memory.current"
+    (tmp_path / "memory.max").write_text(f"{CONTAINER_LIMIT}\n")  # no memory.current
 
-    with patch.object(model_management, "CGROUP_MEMORY", (CONTAINER_LIMIT, str(missing))):
+    with patch.object(model_management, "CGROUP_HIERARCHIES", hierarchies(tmp_path, "/")):
         mem = model_management.virtual_memory()
 
     assert mem.total == CONTAINER_LIMIT

--- a/tests-unit/comfy_test/cgroup_memory_test.py
+++ b/tests-unit/comfy_test/cgroup_memory_test.py
@@ -75,8 +75,8 @@ def test_constraint_takes_the_smallest_limit_in_the_hierarchy(tmp_path):
     write_cgroup(tmp_path / "outer", 2 * 1024 ** 3, 900 * 1024 ** 2)
     write_cgroup(tmp_path / "outer" / "inner", 3 * 1024 ** 3, 100 * 1024 ** 2)
 
-    with patch.object(model_management, "CGROUP_HIERARCHIES",
-                      hierarchies(tmp_path, "/outer/inner")):
+    with patch.object(model_management, "_cgroup_self_paths",
+                      lambda: hierarchies(tmp_path, "/outer/inner")):
         limit, usage_file = model_management._cgroup_memory_constraint()
 
     assert limit == 2 * 1024 ** 3
@@ -87,8 +87,8 @@ def test_constraint_reads_a_cgroup_the_mount_root_does_not_expose(tmp_path):
     # Under a host cgroup namespace the mount root has no memory files at all.
     write_cgroup(tmp_path / "docker" / "abc", CONTAINER_LIMIT)
 
-    with patch.object(model_management, "CGROUP_HIERARCHIES",
-                      hierarchies(tmp_path, "/docker/abc")):
+    with patch.object(model_management, "_cgroup_self_paths",
+                      lambda: hierarchies(tmp_path, "/docker/abc")):
         limit, _ = model_management._cgroup_memory_constraint()
 
     assert limit == CONTAINER_LIMIT
@@ -97,12 +97,12 @@ def test_constraint_reads_a_cgroup_the_mount_root_does_not_expose(tmp_path):
 def test_constraint_is_none_without_a_limit(tmp_path):
     (tmp_path / "memory.max").write_text("max\n")
 
-    with patch.object(model_management, "CGROUP_HIERARCHIES", hierarchies(tmp_path, "/")):
+    with patch.object(model_management, "_cgroup_self_paths", lambda: hierarchies(tmp_path, "/")):
         assert model_management._cgroup_memory_constraint() is None
 
 
 def test_no_hierarchy_passes_psutil_through(host_psutil):
-    with patch.object(model_management, "CGROUP_HIERARCHIES", []):
+    with patch.object(model_management, "_cgroup_self_paths", lambda: []):
         mem = model_management.virtual_memory()
 
     assert mem.total == HOST_TOTAL
@@ -112,7 +112,7 @@ def test_no_hierarchy_passes_psutil_through(host_psutil):
 def test_limit_larger_than_host_is_ignored(host_psutil, tmp_path):
     write_cgroup(tmp_path, HOST_TOTAL * 2)
 
-    with patch.object(model_management, "CGROUP_HIERARCHIES", hierarchies(tmp_path, "/")):
+    with patch.object(model_management, "_cgroup_self_paths", lambda: hierarchies(tmp_path, "/")):
         mem = model_management.virtual_memory()
 
     assert mem.total == HOST_TOTAL
@@ -123,7 +123,7 @@ def test_limit_clamps_total_and_available(host_psutil, tmp_path):
     used = 47 * 1024 ** 3
     write_cgroup(tmp_path, CONTAINER_LIMIT, used)
 
-    with patch.object(model_management, "CGROUP_HIERARCHIES", hierarchies(tmp_path, "/")):
+    with patch.object(model_management, "_cgroup_self_paths", lambda: hierarchies(tmp_path, "/")):
         mem = model_management.virtual_memory()
 
     assert mem.total == CONTAINER_LIMIT
@@ -137,16 +137,30 @@ def test_limit_lowered_while_running_is_picked_up(host_psutil, tmp_path):
     # memory.max is writable: docker update -m, or an in-place pod resize.
     write_cgroup(tmp_path, CONTAINER_LIMIT, 1 * 1024 ** 3)
 
-    with patch.object(model_management, "CGROUP_HIERARCHIES", hierarchies(tmp_path, "/")):
+    with patch.object(model_management, "_cgroup_self_paths", lambda: hierarchies(tmp_path, "/")):
         assert model_management.virtual_memory().total == CONTAINER_LIMIT
         (tmp_path / "memory.max").write_text(f"{CONTAINER_LIMIT // 2}\n")
         assert model_management.virtual_memory().total == CONTAINER_LIMIT // 2
 
 
+def test_moving_to_another_cgroup_is_picked_up(host_psutil, tmp_path):
+    # A process can be moved by a write to cgroup.procs, so where it sits is resolved on
+    # every call rather than once at import.
+    write_cgroup(tmp_path / "first", CONTAINER_LIMIT)
+    write_cgroup(tmp_path / "second", CONTAINER_LIMIT // 3)
+    cgroup = "/first"
+
+    with patch.object(model_management, "_cgroup_self_paths",
+                      lambda: hierarchies(tmp_path, cgroup)):
+        assert model_management.virtual_memory().total == CONTAINER_LIMIT
+        cgroup = "/second"
+        assert model_management.virtual_memory().total == CONTAINER_LIMIT // 3
+
+
 def test_usage_above_limit_does_not_go_negative(host_psutil, tmp_path):
     write_cgroup(tmp_path, CONTAINER_LIMIT, CONTAINER_LIMIT * 2)
 
-    with patch.object(model_management, "CGROUP_HIERARCHIES", hierarchies(tmp_path, "/")):
+    with patch.object(model_management, "_cgroup_self_paths", lambda: hierarchies(tmp_path, "/")):
         mem = model_management.virtual_memory()
 
     assert mem.used == CONTAINER_LIMIT
@@ -156,7 +170,7 @@ def test_usage_above_limit_does_not_go_negative(host_psutil, tmp_path):
 def test_unreadable_usage_falls_back_to_host_figures(host_psutil, tmp_path):
     (tmp_path / "memory.max").write_text(f"{CONTAINER_LIMIT}\n")  # no memory.current
 
-    with patch.object(model_management, "CGROUP_HIERARCHIES", hierarchies(tmp_path, "/")):
+    with patch.object(model_management, "_cgroup_self_paths", lambda: hierarchies(tmp_path, "/")):
         mem = model_management.virtual_memory()
 
     assert mem.total == CONTAINER_LIMIT

--- a/tests-unit/comfy_test/cgroup_memory_test.py
+++ b/tests-unit/comfy_test/cgroup_memory_test.py
@@ -1,6 +1,6 @@
 import pytest
 import psutil
-from unittest.mock import patch
+from unittest.mock import mock_open, patch
 
 import comfy.model_management as model_management
 
@@ -27,6 +27,16 @@ def host_psutil():
         yield
 
 
+def write_cgroup(directory, limit, usage):
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "memory.max").write_text(f"{limit}\n")
+    (directory / "memory.current").write_text(f"{usage}\n")
+
+
+def self_paths(root, path):
+    return lambda: [(str(root), "memory.max", "memory.current", path)]
+
+
 def test_read_cgroup_int(tmp_path):
     path = tmp_path / "memory.max"
 
@@ -42,26 +52,77 @@ def test_read_cgroup_int(tmp_path):
     assert model_management._read_cgroup_int(str(tmp_path / "missing")) is None
 
 
-def test_no_cgroup_limit_passes_psutil_through(host_psutil):
-    with patch.object(model_management, "CGROUP_MEMORY_LIMIT", None):
+def test_self_paths_reads_v2_and_v1_lines():
+    with patch("builtins.open", mock_open(read_data="0::/docker/abc\n")):
+        assert model_management._cgroup_self_paths() == [
+            model_management.CGROUP_V2 + ("/docker/abc",)
+        ]
+
+    with patch("builtins.open", mock_open(read_data="8:memory:/kubepods/pod1\n4:cpu:/\n")):
+        assert model_management._cgroup_self_paths() == [
+            model_management.CGROUP_V1 + ("/kubepods/pod1",)
+        ]
+
+
+def test_self_paths_ignores_controllers_without_memory():
+    with patch("builtins.open", mock_open(read_data="4:cpu,cpuacct:/some/path\n")):
+        assert model_management._cgroup_self_paths() == []
+
+
+def test_constraint_takes_the_smallest_limit_in_the_hierarchy(tmp_path):
+    # An ancestor with a lower limit binds this process, and its usage is the one that counts.
+    write_cgroup(tmp_path, 4 * 1024 ** 3, 1 * 1024 ** 3)
+    write_cgroup(tmp_path / "outer", 2 * 1024 ** 3, 900 * 1024 ** 2)
+    write_cgroup(tmp_path / "outer" / "inner", 3 * 1024 ** 3, 100 * 1024 ** 2)
+
+    with patch.object(model_management, "_cgroup_self_paths",
+                      self_paths(tmp_path, "/outer/inner")):
+        limit, usage_file = model_management._cgroup_memory_constraint()
+
+    assert limit == 2 * 1024 ** 3
+    assert usage_file == str(tmp_path / "outer" / "memory.current")
+
+
+def test_constraint_reads_a_cgroup_the_mount_root_does_not_expose(tmp_path):
+    # Under a host cgroup namespace the mount root has no memory files at all.
+    write_cgroup(tmp_path / "docker" / "abc", CONTAINER_LIMIT, 0)
+
+    with patch.object(model_management, "_cgroup_self_paths",
+                      self_paths(tmp_path, "/docker/abc")):
+        limit, _ = model_management._cgroup_memory_constraint()
+
+    assert limit == CONTAINER_LIMIT
+
+
+def test_constraint_is_none_without_a_limit(tmp_path):
+    (tmp_path / "memory.max").write_text("max\n")
+
+    with patch.object(model_management, "_cgroup_self_paths", self_paths(tmp_path, "/")):
+        assert model_management._cgroup_memory_constraint() is None
+
+
+def test_no_constraint_passes_psutil_through(host_psutil):
+    with patch.object(model_management, "CGROUP_MEMORY", None):
         mem = model_management.virtual_memory()
 
     assert mem.total == HOST_TOTAL
     assert mem.available == HOST_AVAILABLE
 
 
-def test_limit_larger_than_host_is_ignored(host_psutil):
-    with patch.object(model_management, "CGROUP_MEMORY_LIMIT", HOST_TOTAL * 2):
+def test_limit_larger_than_host_is_ignored(host_psutil, tmp_path):
+    with patch.object(model_management, "CGROUP_MEMORY", (HOST_TOTAL * 2, str(tmp_path))):
         mem = model_management.virtual_memory()
 
     assert mem.total == HOST_TOTAL
     assert mem.available == HOST_AVAILABLE
 
 
-def test_limit_clamps_total_and_available(host_psutil):
+def test_limit_clamps_total_and_available(host_psutil, tmp_path):
     used = 47 * 1024 ** 3
-    with patch.object(model_management, "CGROUP_MEMORY_LIMIT", CONTAINER_LIMIT), \
-         patch.object(model_management, "_cgroup_memory_usage", lambda: used):
+    usage_file = tmp_path / "memory.current"
+    usage_file.write_text(f"{used}\n")
+
+    with patch.object(model_management, "CGROUP_MEMORY", (CONTAINER_LIMIT, str(usage_file))):
         mem = model_management.virtual_memory()
 
     assert mem.total == CONTAINER_LIMIT
@@ -71,19 +132,21 @@ def test_limit_clamps_total_and_available(host_psutil):
     assert mem.percent == pytest.approx(used * 100.0 / CONTAINER_LIMIT, abs=0.1)
 
 
-def test_usage_above_limit_does_not_go_negative(host_psutil):
-    with patch.object(model_management, "CGROUP_MEMORY_LIMIT", CONTAINER_LIMIT), \
-         patch.object(model_management, "_cgroup_memory_usage",
-                      lambda: CONTAINER_LIMIT * 2):
+def test_usage_above_limit_does_not_go_negative(host_psutil, tmp_path):
+    usage_file = tmp_path / "memory.current"
+    usage_file.write_text(f"{CONTAINER_LIMIT * 2}\n")
+
+    with patch.object(model_management, "CGROUP_MEMORY", (CONTAINER_LIMIT, str(usage_file))):
         mem = model_management.virtual_memory()
 
     assert mem.used == CONTAINER_LIMIT
     assert mem.available == 0
 
 
-def test_unreadable_usage_falls_back_to_host_figures(host_psutil):
-    with patch.object(model_management, "CGROUP_MEMORY_LIMIT", CONTAINER_LIMIT), \
-         patch.object(model_management, "_cgroup_memory_usage", lambda: None):
+def test_unreadable_usage_falls_back_to_host_figures(host_psutil, tmp_path):
+    missing = tmp_path / "memory.current"
+
+    with patch.object(model_management, "CGROUP_MEMORY", (CONTAINER_LIMIT, str(missing))):
         mem = model_management.virtual_memory()
 
     assert mem.total == CONTAINER_LIMIT

--- a/tests-unit/comfy_test/cgroup_memory_test.py
+++ b/tests-unit/comfy_test/cgroup_memory_test.py
@@ -167,7 +167,7 @@ def test_usage_above_limit_does_not_go_negative(host_psutil, tmp_path):
     assert mem.available == 0
 
 
-def test_unreadable_usage_falls_back_to_host_figures(host_psutil, tmp_path):
+def test_missing_usage_falls_back_to_host_figures(host_psutil, tmp_path):
     (tmp_path / "memory.max").write_text(f"{CONTAINER_LIMIT}\n")  # no memory.current
 
     with patch.object(model_management, "_cgroup_self_paths", lambda: hierarchies(tmp_path, "/")):

--- a/tests-unit/comfy_test/cgroup_memory_test.py
+++ b/tests-unit/comfy_test/cgroup_memory_test.py
@@ -1,0 +1,91 @@
+import pytest
+import psutil
+from unittest.mock import patch
+
+import comfy.model_management as model_management
+
+
+HOST_TOTAL = 754 * 1024 ** 3
+HOST_AVAILABLE = 683 * 1024 ** 3
+HOST_USED = HOST_TOTAL - HOST_AVAILABLE
+CONTAINER_LIMIT = 90 * 1024 ** 3
+
+
+# Built once, from the real reading, so that patching psutil below cannot recurse.
+HOST_MEMORY = psutil.virtual_memory()._replace(
+    total=HOST_TOTAL,
+    available=HOST_AVAILABLE,
+    free=HOST_AVAILABLE,
+    used=HOST_USED,
+    percent=round(HOST_USED * 100.0 / HOST_TOTAL, 1),
+)
+
+
+@pytest.fixture
+def host_psutil():
+    with patch("psutil.virtual_memory", lambda: HOST_MEMORY):
+        yield
+
+
+def test_read_cgroup_int(tmp_path):
+    path = tmp_path / "memory.max"
+
+    path.write_text("96636764160\n")
+    assert model_management._read_cgroup_int(str(path)) == 96636764160
+
+    path.write_text("max\n")
+    assert model_management._read_cgroup_int(str(path)) is None
+
+    path.write_text("not a number\n")
+    assert model_management._read_cgroup_int(str(path)) is None
+
+    assert model_management._read_cgroup_int(str(tmp_path / "missing")) is None
+
+
+def test_no_cgroup_limit_passes_psutil_through(host_psutil):
+    with patch.object(model_management, "CGROUP_MEMORY_LIMIT", None):
+        mem = model_management.virtual_memory()
+
+    assert mem.total == HOST_TOTAL
+    assert mem.available == HOST_AVAILABLE
+
+
+def test_limit_larger_than_host_is_ignored(host_psutil):
+    with patch.object(model_management, "CGROUP_MEMORY_LIMIT", HOST_TOTAL * 2):
+        mem = model_management.virtual_memory()
+
+    assert mem.total == HOST_TOTAL
+    assert mem.available == HOST_AVAILABLE
+
+
+def test_limit_clamps_total_and_available(host_psutil):
+    used = 47 * 1024 ** 3
+    with patch.object(model_management, "CGROUP_MEMORY_LIMIT", CONTAINER_LIMIT), \
+         patch.object(model_management, "_cgroup_memory_usage", lambda: used):
+        mem = model_management.virtual_memory()
+
+    assert mem.total == CONTAINER_LIMIT
+    assert mem.used == used
+    assert mem.available == CONTAINER_LIMIT - used
+    assert mem.free <= mem.available
+    assert mem.percent == pytest.approx(used * 100.0 / CONTAINER_LIMIT, abs=0.1)
+
+
+def test_usage_above_limit_does_not_go_negative(host_psutil):
+    with patch.object(model_management, "CGROUP_MEMORY_LIMIT", CONTAINER_LIMIT), \
+         patch.object(model_management, "_cgroup_memory_usage",
+                      lambda: CONTAINER_LIMIT * 2):
+        mem = model_management.virtual_memory()
+
+    assert mem.used == CONTAINER_LIMIT
+    assert mem.available == 0
+
+
+def test_unreadable_usage_falls_back_to_host_figures(host_psutil):
+    with patch.object(model_management, "CGROUP_MEMORY_LIMIT", CONTAINER_LIMIT), \
+         patch.object(model_management, "_cgroup_memory_usage", lambda: None):
+        mem = model_management.virtual_memory()
+
+    assert mem.total == CONTAINER_LIMIT
+    assert mem.used == HOST_USED
+    assert mem.available == CONTAINER_LIMIT - HOST_USED

--- a/tests-unit/comfy_test/cgroup_memory_test.py
+++ b/tests-unit/comfy_test/cgroup_memory_test.py
@@ -1,6 +1,12 @@
 import pytest
 import psutil
+import torch
 from unittest.mock import mock_open, patch
+
+from comfy.cli_args import args
+
+if not torch.cuda.is_available():
+    args.cpu = True
 
 import comfy.model_management as model_management
 


### PR DESCRIPTION
## Summary
- `psutil.virtual_memory()` reports the host's memory inside a container, so RAM pressure decisions never fire and the container gets OOM-killed instead of evicting (#5625, #14938)
- Add `virtual_memory()` to `comfy/model_management.py`: reads the limit from this process's own cgroup (found via `/proc/self/cgroup`, v2 and v1), clamps total/available to the smallest limit in its ancestry, and returns psutil's value unchanged when no limit applies
- Use it at the RAM call sites in `comfy/model_management.py`, `comfy_execution/caching.py` and `execution.py`
- Add `tests-unit/comfy_test/cgroup_memory_test.py`

## Tests
`pytest tests-unit/comfy_test/ tests-unit/execution_test` — 189 passed before this change, 200 passed after (the 11 new ones).

Linux, cgroup v2, RTX 5090 container with a 90 GiB limit on a 754 GiB host.

`/system_stats`:

- before: `"ram_total": 810154872832` (the host's total)
- after: `"ram_total": 96636764160` (matches `/sys/fs/cgroup/memory.max`)

Ran the same four video generations with `--cache-ram 60`, reading `/sys/fs/cgroup/memory.current` after each run:

| run | before | after |
|---|---|---|
| 1 | 46.0 GiB | 29.5 GiB |
| 2 | 48.4 GiB | 29.5 GiB |
| 3 | 50.0 GiB | 29.5 GiB |
| 4 | 51.5 GiB | 29.5 GiB |

Before the change the eviction threshold resolves to 754.5 - 60 = 694 GiB, so it never fires and the cache grows on every run. After, it resolves to 90 - 60 = 30 GiB and eviction holds usage just below it.

Also checked four cgroup layouts with a 4 GiB limit: a private cgroup namespace, a host namespace (`--cgroupns=host`), a nested cgroup whose parent has the lower limit, and no limit at all. The reported limit was 4, 4, the parent's 2, and psutil's value untouched.

`RAMPressureCache.ram_release()` alone is not enough: `execution.py` computes `ram_shortfall` from `psutil.virtual_memory().available` too, and leaving that one unpatched reproduced the old behaviour.

On Windows and macOS the cgroup files are absent, so `virtual_memory()` returns psutil's value unchanged.
