### PR TITLE
Let subgraphs act as cache boundaries (--disable-subgraph-caching)

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -142,6 +142,7 @@ cache_group.add_argument("--cache-classic", action="store_true", help="Use the o
 cache_group.add_argument("--cache-lru", type=int, default=0, help="Use LRU caching with a maximum of N node results cached. May use more RAM/VRAM.")
 cache_group.add_argument("--cache-none", action="store_true", help="Reduced RAM/VRAM usage at the expense of executing every node for each run.")
 cache_group.add_argument("--high-ram", action="store_true", help="Can improve performance slightly on high RAM or on systems where pagefile use is preferred over model loading.")
+parser.add_argument("--disable-subgraph-caching", action="store_true", help="Experimental: do not keep outputs of nodes inside subgraphs in the cache between runs. Values leaving a subgraph and output nodes still cache normally. Composes with any cache mode.")
 
 attn_group = parser.add_mutually_exclusive_group()
 attn_group.add_argument("--use-split-cross-attention", action="store_true", help="Use the split cross attention optimization. Ignored when xformers is used.")

--- a/comfy_execution/caching.py
+++ b/comfy_execution/caching.py
@@ -95,7 +95,9 @@ class CacheKeySetInputSignature(CacheKeySet):
             if not self.dynprompt.has_node(node_id):
                 continue
             node = self.dynprompt.get_node(node_id)
-            self.keys[node_id] = await self.get_node_signature(self.dynprompt, node_id)
+            # No data key for "no_cache" nodes; the subcache key stays so expansion under them works.
+            if not node.get("no_cache", False):
+                self.keys[node_id] = await self.get_node_signature(self.dynprompt, node_id)
             self.subcache_keys[node_id] = (node_id, node["class_type"])
 
     async def get_node_signature(self, dynprompt, node_id):
@@ -203,6 +205,8 @@ class BasicCache:
         if not self.initialized:
             return None
         cache_key = self.cache_key_set.get_data_key(node_id)
+        if cache_key is None:
+            return None
         if cache_key in self.cache:
             return self.cache[cache_key]
         return None
@@ -210,11 +214,15 @@ class BasicCache:
     def set_local(self, node_id, value):
         assert self.initialized
         cache_key = self.cache_key_set.get_data_key(node_id)
+        if cache_key is None:
+            return
         self.cache[cache_key] = value
 
     async def _set_immediate(self, node_id, value):
         assert self.initialized
         cache_key = self.cache_key_set.get_data_key(node_id)
+        if cache_key is None:
+            return
         self.cache[cache_key] = value
 
         await self._notify_providers_store(node_id, cache_key, value)
@@ -223,6 +231,8 @@ class BasicCache:
         if not self.initialized:
             return None
         cache_key = self.cache_key_set.get_data_key(node_id)
+        if cache_key is None:
+            return None
 
         if cache_key in self.cache:
             return self.cache[cache_key]

--- a/comfy_execution/graph.py
+++ b/comfy_execution/graph.py
@@ -148,6 +148,10 @@ class TopologicalSort:
             self.blockCount[unique_id] = 0
             self.blocking[unique_id] = {}
 
+            if self.is_cached(unique_id):
+                # A cached node never reads its inputs, so don't pull uncached ancestors in for nothing.
+                continue
+
             inputs = self.dynprompt.get_node(unique_id)["inputs"]
             for input_name in inputs:
                 value = inputs[input_name]

--- a/execution.py
+++ b/execution.py
@@ -154,6 +154,44 @@ class CacheSet:
         }
         return result
 
+# The frontend flattens UI subgraphs into colon-joined node ids ("12:5" is node 5 inside subgraph node 12).
+SUBGRAPH_ID_SEPARATOR = ":"
+
+def subgraph_scope_of(node_id):
+    if SUBGRAPH_ID_SEPARATOR not in node_id:
+        return ""
+    return node_id.rsplit(SUBGRAPH_ID_SEPARATOR, 1)[0]
+
+def mark_subgraph_internal_nodes_no_cache(prompt):
+    """Sets "no_cache" on nodes whose outputs never leave their subgraph, returns the marked ids."""
+    consumer_scopes_by_producer = {}
+    for consumer_id, node in prompt.items():
+        consumer_scope = subgraph_scope_of(consumer_id)
+        for input_value in node.get("inputs", {}).values():
+            if is_link(input_value):
+                producer_id = input_value[0]
+                consumer_scopes_by_producer.setdefault(producer_id, set()).add(consumer_scope)
+
+    marked_node_ids = []
+    for node_id, node in prompt.items():
+        scope = subgraph_scope_of(node_id)
+        if scope == "":
+            continue
+        class_def = nodes.NODE_CLASS_MAPPINGS.get(node.get("class_type"))
+        if class_def is not None and getattr(class_def, "OUTPUT_NODE", False):
+            # Output nodes stay cached so unchanged re-queues stay no-ops.
+            continue
+        value_escapes_subgraph = False
+        for consumer_scope in consumer_scopes_by_producer.get(node_id, ()):
+            consumer_stays_inside = consumer_scope == scope or consumer_scope.startswith(scope + SUBGRAPH_ID_SEPARATOR)
+            if not consumer_stays_inside:
+                value_escapes_subgraph = True
+                break
+        if not value_escapes_subgraph:
+            node["no_cache"] = True
+            marked_node_ids.append(node_id)
+    return marked_node_ids
+
 SENSITIVE_EXTRA_DATA_KEYS = ("auth_token_comfy_org", "api_key_comfy_org")
 
 def get_input_data(inputs, class_def, unique_id, execution_list=None, dynprompt=None, extra_data={}):
@@ -614,7 +652,8 @@ async def execute(server, dynprompt, caches, current_item, extra_data, executed,
 
         cache_entry = CacheEntry(ui=ui_outputs.get(unique_id), outputs=output_data)
         execution_list.cache_update(unique_id, cache_entry)
-        await caches.outputs.set(unique_id, cache_entry)
+        if not dynprompt.get_node(unique_id).get("no_cache", False):
+            await caches.outputs.set(unique_id, cache_entry)
 
     except comfy.model_management.InterruptProcessingException as iex:
         logging.info("Processing interrupted")
@@ -749,6 +788,11 @@ class PromptExecutor:
 
         try:
             with torch.inference_mode():
+                if args.disable_subgraph_caching:
+                    no_cache_node_ids = mark_subgraph_internal_nodes_no_cache(prompt)
+                    if len(no_cache_node_ids) > 0:
+                        logging.info(f"Skipping persistent cache for {len(no_cache_node_ids)} subgraph-internal nodes")
+                        logging.debug(f"Subgraph-internal nodes not cached: {sorted(no_cache_node_ids)}")
                 dynamic_prompt = DynamicPrompt(prompt)
                 reset_progress_state(prompt_id, dynamic_prompt)
                 add_progress_handler(WebUIProgressHandler(self.server))

--- a/tests/execution/test_subgraph_cache.py
+++ b/tests/execution/test_subgraph_cache.py
@@ -1,0 +1,167 @@
+"""Tests for --disable-subgraph-caching and the per-node "no_cache" prompt key.
+
+The frontend flattens UI subgraphs into colon-joined node ids ("12:5" is node 5
+inside the subgraph instance with node id 12), so these tests fake subgraph
+membership with explicit colon ids. See mark_subgraph_internal_nodes_no_cache
+in execution.py for the marking rules being tested.
+"""
+import pytest
+import subprocess
+import time
+
+from pytest import fixture
+from comfy_execution.graph_utils import GraphBuilder
+from tests.execution.test_execution import ComfyClient, run_warmup
+
+
+class GraphWithNoCacheKeys:
+    """Wraps a GraphBuilder so finalize() stamps "no_cache" on chosen nodes."""
+    def __init__(self, graph, no_cache_ids):
+        self.graph = graph
+        self.nodes = graph.nodes
+        self.no_cache_ids = no_cache_ids
+
+    def finalize(self):
+        prompt = self.graph.finalize()
+        for node_id in self.no_cache_ids:
+            prompt[node_id]["no_cache"] = True
+        return prompt
+
+
+@pytest.mark.execution
+class TestSubgraphInternalCache:
+    @fixture(scope="class", autouse=True, params=[
+        [],
+        ["--cache-classic"],
+    ])
+    def _server(self, args_pytest, request):
+        pargs = [
+            'python','main.py',
+            '--output-directory', args_pytest["output_dir"],
+            '--listen', args_pytest["listen"],
+            '--port', str(args_pytest["port"]),
+            '--extra-model-paths-config', 'tests/execution/extra_model_paths.yaml',
+            '--cpu',
+            '--disable-subgraph-caching',
+        ]
+        pargs += request.param
+        print("Running server with args:", pargs)  # noqa: T201
+        p = subprocess.Popen(pargs)
+        yield
+        p.kill()
+
+    @fixture(scope="class", autouse=True)
+    def shared_client(self, args_pytest, _server):
+        client = ComfyClient()
+        n_tries = 5
+        for i in range(n_tries):
+            time.sleep(4)
+            try:
+                client.connect(listen=args_pytest["listen"], port=args_pytest["port"])
+            except ConnectionRefusedError as e:
+                print(e)  # noqa: T201
+                print(f"({i+1}/{n_tries}) Retrying...")  # noqa: T201
+            else:
+                break
+        run_warmup(client)
+        yield client
+        del client
+
+    @fixture
+    def client(self, shared_client, request):
+        shared_client.set_test_name(f"subgraph_cache[{request.node.name}]")
+        yield shared_client
+
+    @fixture
+    def builder(self, request):
+        yield GraphBuilder(prefix=request.node.name)
+
+    def build_subgraph_chain(self, g):
+        """Two top-level sources feeding a two-stage mix chain inside a faked
+        subgraph, with the second stage's output consumed at the top level."""
+        src = g.node("StubImage", id="src", content="BLACK", height=32, width=32, batch_size=1)
+        white = g.node("StubImage", id="white", content="WHITE", height=32, width=32, batch_size=1)
+        stage1_mask = g.node("StubMask", id="sg:stage1_mask", value=0.5, height=32, width=32, batch_size=1)
+        boundary_mask = g.node("StubMask", id="sg:boundary_mask", value=0.5, height=32, width=32, batch_size=1)
+        stage1 = g.node("TestLazyMixImages", id="sg:stage1", image1=src.out(0), image2=white.out(0), mask=stage1_mask.out(0))
+        boundary = g.node("TestLazyMixImages", id="sg:boundary", image1=stage1.out(0), image2=white.out(0), mask=boundary_mask.out(0))
+        top_preview = g.node("PreviewImage", id="top_preview", images=boundary.out(0))
+        return src, white, stage1_mask, boundary_mask, stage1, boundary, top_preview
+
+    def test_unchanged_requeue_is_noop_without_caching_internals(self, client: ComfyClient, builder: GraphBuilder):
+        g = builder
+        src, white, stage1_mask, boundary_mask, stage1, boundary, top_preview = self.build_subgraph_chain(g)
+
+        client.run(g)
+        result = client.run(g)
+
+        for node in (src, white, stage1_mask, boundary_mask, stage1, boundary, top_preview):
+            assert not result.did_run(node), f"{node.id} should not re-run on unchanged re-queue"
+        assert result.was_cached(boundary), "boundary node's value leaves the subgraph, must stay cached"
+        assert result.was_cached(src)
+        assert result.was_cached(white)
+        assert not result.was_cached(stage1), "subgraph-internal node must not be in the persistent cache"
+        assert not result.was_cached(stage1_mask), "subgraph-internal node must not be in the persistent cache"
+
+    def test_output_node_inside_subgraph_stays_cached(self, client: ComfyClient, builder: GraphBuilder):
+        # Also regression-tests the ExecutionList change: a cached output node
+        # must not pull its uncached in-subgraph ancestors into execution.
+        g = builder
+        _, _, _, _, stage1, _, _ = self.build_subgraph_chain(g)
+        inner_preview = g.node("PreviewImage", id="sg:preview", images=stage1.out(0))
+
+        client.run(g)
+        result = client.run(g)
+
+        assert result.was_cached(inner_preview), "output nodes inside subgraphs stay cached so re-queues stay no-ops"
+        assert not result.did_run(inner_preview)
+        assert not result.did_run(stage1), "cached output node must not drag its uncached ancestor into execution"
+        assert not result.was_cached(stage1)
+
+    def test_internal_edit_reruns_chain_from_inside(self, client: ComfyClient, builder: GraphBuilder):
+        g = builder
+        src, white, stage1_mask, _, stage1, boundary, top_preview = self.build_subgraph_chain(g)
+
+        client.run(g)
+        stage1_mask.inputs["value"] = 0.7
+        result = client.run(g)
+
+        assert result.did_run(stage1_mask)
+        assert result.did_run(stage1)
+        assert result.did_run(boundary)
+        assert result.did_run(top_preview)
+        assert result.was_cached(src)
+        assert result.was_cached(white)
+
+    def test_uncached_internal_recomputes_when_downstream_invalidated(self, client: ComfyClient, builder: GraphBuilder):
+        # The documented tradeoff: stage1 is unchanged, but its output was not
+        # kept, so invalidating only the boundary stage recomputes stage1 too.
+        g = builder
+        src, white, _, boundary_mask, stage1, boundary, _ = self.build_subgraph_chain(g)
+
+        client.run(g)
+        boundary_mask.inputs["value"] = 0.9
+        result = client.run(g)
+
+        assert result.did_run(boundary)
+        assert result.did_run(stage1), "uncached internal must recompute to feed the invalidated boundary node"
+        assert result.was_cached(src)
+        assert result.was_cached(white)
+
+    def test_explicit_no_cache_key_without_subgraph(self, client: ComfyClient, builder: GraphBuilder):
+        g = builder
+        src = g.node("StubImage", id="src", content="BLACK", height=32, width=32, batch_size=1)
+        white = g.node("StubImage", id="white", content="WHITE", height=32, width=32, batch_size=1)
+        mask = g.node("StubMask", id="mask", value=0.5, height=32, width=32, batch_size=1)
+        middle = g.node("TestLazyMixImages", id="middle", image1=src.out(0), image2=white.out(0), mask=mask.out(0))
+        final = g.node("TestLazyMixImages", id="final", image1=middle.out(0), image2=white.out(0), mask=mask.out(0))
+        preview = g.node("PreviewImage", id="preview", images=final.out(0))
+        wrapped = GraphWithNoCacheKeys(g, [middle.id])
+
+        client.run(wrapped)
+        result = client.run(wrapped)
+
+        for node in (src, white, mask, middle, final, preview):
+            assert not result.did_run(node), f"{node.id} should not re-run on unchanged re-queue"
+        assert not result.was_cached(middle), "node with no_cache key must not be in the persistent cache"
+        assert result.was_cached(final)


### PR DESCRIPTION
Video and high-res image workflows hold gigabytes of intermediate tensors in the output cache that nothing will ever reuse: every resize, pad, or crop step keeps its full output cached in memory between runs.

With this opt-in flag, nodes inside a subgraph are computed and released; only values that leave the subgraph (and output nodes such as previews) stay cached. Without the flag, behavior is unchanged.

API users can also set "no_cache": true on individual prompt nodes, independent of the flag.

### Demo:

https://github.com/user-attachments/assets/57a34f5f-673f-4c95-bc33-536f8262d702


