### PR TITLE
Add streaming tiled decoding function to VAE

### DIFF
--- a/comfy/ldm/seedvr/vae.py
+++ b/comfy/ldm/seedvr/vae.py
@@ -270,32 +270,17 @@ def tiled_vae(
 
     sf_s = getattr(vae_model, "spatial_downsample_factor", BYTEDANCE_VAE_SPATIAL_DOWNSAMPLE)
     sf_t = getattr(vae_model, "temporal_downsample_factor", BYTEDANCE_VAE_TEMPORAL_DOWNSAMPLE)
-    if encode:
-        slicing_attr = "slicing_sample_min_size"
-        slicing_min_size = _seedvr2_temporal_slicing_min_size(temporal_size, temporal_overlap)
-    else:
-        slicing_attr = "slicing_latent_min_size"
-        slicing_min_size = _seedvr2_temporal_slicing_min_size(temporal_size, temporal_overlap, sf_t)
-    if encode:
-        ti_h, ti_w = tile_size
-        ov_h = _seedvr2_clamped_spatial_overlap(tile_overlap[0], ti_h)
-        ov_w = _seedvr2_clamped_spatial_overlap(tile_overlap[1], ti_w)
-        blend_ov_h = max(0, ov_h // sf_s)
-        blend_ov_w = max(0, ov_w // sf_s)
-        target_d = (d + sf_t - 1) // sf_t
-        target_h = (h + sf_s - 1) // sf_s
-        target_w = (w + sf_s - 1) // sf_s
-    else:
-        ti_h = max(1, tile_size[0] // sf_s)
-        ti_w = max(1, tile_size[1] // sf_s)
-        ov_h = _seedvr2_clamped_spatial_overlap(tile_overlap[0] // sf_s, ti_h)
-        ov_w = _seedvr2_clamped_spatial_overlap(tile_overlap[1] // sf_s, ti_w)
-        blend_ov_h = ov_h * sf_s
-        blend_ov_w = ov_w * sf_s
+    slicing_attr = "slicing_sample_min_size"
+    slicing_min_size = _seedvr2_temporal_slicing_min_size(temporal_size, temporal_overlap)
 
-        target_d = max(1, d * sf_t - (sf_t - 1))
-        target_h = h * sf_s
-        target_w = w * sf_s
+    ti_h, ti_w = tile_size
+    ov_h = _seedvr2_clamped_spatial_overlap(tile_overlap[0], ti_h)
+    ov_w = _seedvr2_clamped_spatial_overlap(tile_overlap[1], ti_w)
+    blend_ov_h = max(0, ov_h // sf_s)
+    blend_ov_w = max(0, ov_w // sf_s)
+    target_d = (d + sf_t - 1) // sf_t
+    target_h = (h + sf_s - 1) // sf_s
+    target_w = (w + sf_s - 1) // sf_s
 
     stride_h = max(1, ti_h - ov_h)
     stride_w = max(1, ti_w - ov_w)
@@ -314,10 +299,7 @@ def tiled_vae(
             else:
                 setattr(model, slicing_attr, slicing_min_size)
         try:
-            if encode:
-                out = model.encode(t_chunk)
-            else:
-                out = model.decode_(t_chunk)
+            out = model.encode(t_chunk)
         finally:
             if old_slicing_min_size is not None and slicing_min_size is not None:
                 setattr(model, slicing_attr, old_slicing_min_size)
@@ -376,16 +358,10 @@ def tiled_vae(
             result = torch.zeros((b_out, c_out, target_d, target_h, target_w), device=storage_device, dtype=torch.float32)
             count = torch.zeros((1, 1, 1, target_h, target_w), device=storage_device, dtype=torch.float32)
 
-        if encode:
-            ys, ye = y_idx // sf_s, (y_idx // sf_s) + tile_out.shape[3]
-            xs, xe = x_idx // sf_s, (x_idx // sf_s) + tile_out.shape[4]
-            cur_ov_h = max(0, min(blend_ov_h, tile_out.shape[3] // 2))
-            cur_ov_w = max(0, min(blend_ov_w, tile_out.shape[4] // 2))
-        else:
-            ys, ye = y_idx * sf_s, (y_idx * sf_s) + tile_out.shape[3]
-            xs, xe = x_idx * sf_s, (x_idx * sf_s) + tile_out.shape[4]
-            cur_ov_h = max(0, min(blend_ov_h, tile_out.shape[3] // 2))
-            cur_ov_w = max(0, min(blend_ov_w, tile_out.shape[4] // 2))
+        ys, ye = y_idx // sf_s, (y_idx // sf_s) + tile_out.shape[3]
+        xs, xe = x_idx // sf_s, (x_idx // sf_s) + tile_out.shape[4]
+        cur_ov_h = max(0, min(blend_ov_h, tile_out.shape[3] // 2))
+        cur_ov_w = max(0, min(blend_ov_w, tile_out.shape[4] // 2))
 
         w_h = torch.ones((tile_out.shape[3],), device=storage_device)
         w_w = torch.ones((tile_out.shape[4],), device=storage_device)
@@ -1625,6 +1601,8 @@ class VideoAutoencoderKL(nn.Module):
             yield self._decode(z)
 
     def slicing_decode(self, z: torch.Tensor) -> torch.Tensor:
+        if not (self.use_slicing and (z.shape[2] - 1) > self.slicing_latent_min_size):
+            return self._decode(z)
         return torch.cat(tuple(self.iter_slicing_decode(z)), dim=2)
 
     def forward(self, x: torch.FloatTensor, mode: Literal["encode", "decode", "all"] = "all"):

--- a/comfy/ldm/seedvr/vae.py
+++ b/comfy/ldm/seedvr/vae.py
@@ -54,6 +54,196 @@ def _seedvr2_clamped_spatial_overlap(overlap, tile_size):
     return min(overlap, tile_size - 1)
 
 
+def _seedvr2_tiled_decode_streaming(
+    x,
+    vae_model,
+    tile_size=(512, 512),
+    tile_overlap=(64, 64),
+    temporal_size=16,
+    temporal_overlap=0,
+):
+    """Decode spatial tiles while streaming causal temporal slices off the VAE device."""
+    if x.ndim != 5:
+        x = x.unsqueeze(2)
+
+    _, _, d, h, w = x.shape
+    sf_s = getattr(vae_model, "spatial_downsample_factor", BYTEDANCE_VAE_SPATIAL_DOWNSAMPLE)
+    sf_t = getattr(vae_model, "temporal_downsample_factor", BYTEDANCE_VAE_TEMPORAL_DOWNSAMPLE)
+
+    ti_h = max(1, tile_size[0] // sf_s)
+    ti_w = max(1, tile_size[1] // sf_s)
+    ov_h = _seedvr2_clamped_spatial_overlap(tile_overlap[0] // sf_s, ti_h)
+    ov_w = _seedvr2_clamped_spatial_overlap(tile_overlap[1] // sf_s, ti_w)
+    blend_ov_h = ov_h * sf_s
+    blend_ov_w = ov_w * sf_s
+
+    target_d = max(1, d * sf_t - (sf_t - 1))
+    target_h = h * sf_s
+    target_w = w * sf_s
+
+    stride_h = max(1, ti_h - ov_h)
+    stride_w = max(1, ti_w - ov_w)
+
+    # Keep the full decoded result off the VAE execution device. The outer VAE
+    # wrapper already copies owned tiled outputs to its configured output device.
+    storage_device = comfy.model_management.intermediate_device()
+    result = None
+    count = torch.zeros(
+        (1, 1, 1, target_h, target_w),
+        device=storage_device,
+        dtype=torch.float32,
+    )
+
+    slicing_min_size = _seedvr2_temporal_slicing_min_size(
+        temporal_size, temporal_overlap, sf_t
+    )
+
+    ramp_cache = {}
+
+    def get_ramp(steps, device):
+        key = (steps, device)
+        if key not in ramp_cache:
+            t = torch.linspace(0, 1, steps=steps, device=device, dtype=torch.float32)
+            ramp_cache[key] = 0.5 - 0.5 * torch.cos(t * torch.pi)
+        return ramp_cache[key]
+
+    tile_ranges = []
+    for y_idx in range(0, h, stride_h):
+        y_end = min(y_idx + ti_h, h)
+        if y_idx > 0 and (y_end - y_idx) <= ov_h:
+            continue
+        for x_idx in range(0, w, stride_w):
+            x_end = min(x_idx + ti_w, w)
+            if x_idx > 0 and (x_end - x_idx) <= ov_w:
+                continue
+            tile_ranges.append((y_idx, y_end, x_idx, x_end))
+
+    bar = ProgressBar(len(tile_ranges))
+
+    for y_idx, y_end, x_idx, x_end in tile_ranges:
+        tile_x = x[:, :, :, y_idx:y_end, x_idx:x_end].contiguous()
+
+        old_device = getattr(vae_model, "device", None)
+        old_slicing_min_size = getattr(vae_model, "slicing_latent_min_size", None)
+        vae_model.device = tile_x.device
+
+        if old_slicing_min_size is not None and slicing_min_size is not None:
+            vae_model.slicing_latent_min_size = slicing_min_size
+
+        t_pos = 0
+        final_weight = None
+        ys = ye = xs = xe = None
+
+        try:
+            for tile_out in vae_model.iter_slicing_decode(tile_x):
+                if tile_out.ndim == 4:
+                    tile_out = tile_out.unsqueeze(2)
+
+                if final_weight is None:
+                    ys = y_idx * sf_s
+                    ye = ys + tile_out.shape[3]
+                    xs = x_idx * sf_s
+                    xe = xs + tile_out.shape[4]
+
+                    cur_ov_h = max(0, min(blend_ov_h, tile_out.shape[3] // 2))
+                    cur_ov_w = max(0, min(blend_ov_w, tile_out.shape[4] // 2))
+
+                    w_h = torch.ones(
+                        (tile_out.shape[3],),
+                        device=tile_out.device,
+                        dtype=torch.float32,
+                    )
+                    w_w = torch.ones(
+                        (tile_out.shape[4],),
+                        device=tile_out.device,
+                        dtype=torch.float32,
+                    )
+
+                    if cur_ov_h > 0:
+                        r = get_ramp(cur_ov_h, tile_out.device)
+                        if y_idx > 0:
+                            w_h[:cur_ov_h] = r
+                        if y_end < h:
+                            w_h[-cur_ov_h:] = 1.0 - r
+
+                    if cur_ov_w > 0:
+                        r = get_ramp(cur_ov_w, tile_out.device)
+                        if x_idx > 0:
+                            w_w[:cur_ov_w] = r
+                        if x_end < w:
+                            w_w[-cur_ov_w:] = 1.0 - r
+
+                    final_weight = (
+                        w_h.view(1, 1, 1, -1, 1)
+                        * w_w.view(1, 1, 1, 1, -1)
+                    )
+
+                    if result is None:
+                        result = torch.zeros(
+                            (
+                                tile_out.shape[0],
+                                tile_out.shape[1],
+                                target_d,
+                                target_h,
+                                target_w,
+                            ),
+                            device=storage_device,
+                            dtype=torch.float32,
+                        )
+
+                    count[:, :, :, ys:ye, xs:xe] += final_weight.to(
+                        device=storage_device, dtype=torch.float32
+                    )
+
+                valid_d = min(tile_out.shape[2], target_d - t_pos)
+                if valid_d <= 0:
+                    continue
+
+                # Match the existing tiled path: apply the spatial blend in the
+                # decoder output dtype, then accumulate in FP32.
+                tile_slice = tile_out[:, :, :valid_d]
+                tile_slice.mul_(final_weight)
+                result[
+                    :,
+                    :,
+                    t_pos : t_pos + valid_d,
+                    ys:ye,
+                    xs:xe,
+                ] += tile_slice.to(
+                    device=storage_device,
+                    dtype=torch.float32,
+                    copy=True,
+                )
+                t_pos += valid_d
+                del tile_out, tile_slice
+
+        finally:
+            if old_slicing_min_size is not None and slicing_min_size is not None:
+                vae_model.slicing_latent_min_size = old_slicing_min_size
+            if old_device is not None:
+                vae_model.device = old_device
+
+        if t_pos != target_d:
+            raise RuntimeError(
+                "SeedVR2 tiled decode produced an unexpected temporal length: "
+                f"{t_pos} != {target_d}."
+            )
+
+        del tile_x, final_weight
+        bar.update(1)
+
+    if result is None:
+        raise RuntimeError("SeedVR2 tiled decode produced no output.")
+
+    result.div_(count.clamp(min=1e-6))
+    result = result.to(dtype=x.dtype)
+
+    if x.shape[2] == 1 and sf_t == 1:
+        result = result.squeeze(2)
+
+    return result
+
+
 def tiled_vae(
     x,
     vae_model,
@@ -63,6 +253,16 @@ def tiled_vae(
     temporal_overlap=0,
     encode=True,
 ):
+    if not encode:
+        return _seedvr2_tiled_decode_streaming(
+            x,
+            vae_model,
+            tile_size=tile_size,
+            tile_overlap=tile_overlap,
+            temporal_size=temporal_size,
+            temporal_overlap=temporal_overlap,
+        )
+
     if x.ndim != 5:
         x = x.unsqueeze(2)
 
@@ -1406,25 +1606,26 @@ class VideoAutoencoderKL(nn.Module):
         else:
             return self._encode(x)
 
-    def slicing_decode(self, z: torch.Tensor) -> torch.Tensor:
+    def iter_slicing_decode(self, z: torch.Tensor):
         if self.use_slicing and (z.shape[2] - 1) > self.slicing_latent_min_size:
             memory_cache = {}
             z_slices = z[:, :, 1:].split(split_size=self.slicing_latent_min_size, dim=2)
-            decoded_slices = [
-                self._decode(
-                    torch.cat((z[:, :, :1], z_slices[0]), dim=2),
-                    memory_state=MemoryState.INITIALIZING,
+            yield self._decode(
+                torch.cat((z[:, :, :1], z_slices[0]), dim=2),
+                memory_state=MemoryState.INITIALIZING,
+                memory_cache=memory_cache,
+            )
+            for z_slice in z_slices[1:]:
+                yield self._decode(
+                    z_slice,
+                    memory_state=MemoryState.ACTIVE,
                     memory_cache=memory_cache,
                 )
-            ]
-            for z_idx in range(1, len(z_slices)):
-                decoded_slices.append(
-                    self._decode(z_slices[z_idx], memory_state=MemoryState.ACTIVE, memory_cache=memory_cache)
-                )
-            out = torch.cat(decoded_slices, dim=2)
-            return out
         else:
-            return self._decode(z)
+            yield self._decode(z)
+
+    def slicing_decode(self, z: torch.Tensor) -> torch.Tensor:
+        return torch.cat(tuple(self.iter_slicing_decode(z)), dim=2)
 
     def forward(self, x: torch.FloatTensor, mode: Literal["encode", "decode", "all"] = "all"):
         def _unwrap(value):


### PR DESCRIPTION
# SeedVR2 tiled VAE decode scales superlinearly with video length

## Description

I  run the default comfyUI workflow   "SeedVR2 3B Int8 workflow : Upscale Video", what i observed is that the execution time is highly non linear with the input video length.
From what i understand is because SeedVR2's VAE decode keeps every temporal decode result alive until a complete spatial tile has been decoded, then accumulates that complete temporal tile into a full-video.

On my 12 GB RTX 4070 Ti this caused strongly superlinear runtime scaling without any change to the model or output resolution.

## Proposed fix

Keep the existing causal execution, but expose the temporal slices as an iterator and consume them immediately from the tiled decode path:

1. preserve one `memory_cache` for the full causal decode of each spatial tile;
2. keep the existing `INITIALIZING` -> `ACTIVE` sequence unchanged;
3. spatially weight each completed temporal slice immediately;
4. copy/accumulate that completed slice on ComfyUI's intermediate device;
5. release the large VAE-device output before decoding the next temporal slice.

The encoder path is intentionally unchanged.

This does not independently decode temporal chunks, add temporal overlap, or change the model math (in theory). It only changes output retention/accumulation.

## Reproduction / benchmark

Environment:

- ComfyUI 0.33.3
- Windows
- Python 3.13.12
- PyTorch 2.12.1+cu130
- RTX 4070 Ti 12 GB
- SeedVR2 3B INT8 ConvRot
- seedvr2_ema_vae_fp16.safetensors
- VAE Decode (Tiled): 512 tile size, 128 overlap, 64 temporal size, 8 temporal overlap
- Input : 976x544
- Output: 1952x1088 

Observed before the change:

- ~4 s/16Fps input: ~198 s workflow time
- ~9 s/16Fps input: ~13 min workflow time

With this tentative prototype:

- 4 s/16Fps 6.40 GiB peak CUDA allocation,  200.99 s
- 9 s/16Fps input: , 6.44 GiB peak CUDA allocation, 440.18 s

The long/short workload ratio is ~2.31x by causal decode calls and ~2.19x by wall time, while peak CUDA allocation is effectively flat.

Visual side-by-side comparison showed no detectable output difference.

## Final toughs

I do not know if this the right place or way to post, this propose modification seems to work and for me it is very usefull so i think it can be useful for other people but the mechanism is extremely complex (for me at least) and i am not sure how much this implementation is "comformal" to comfyui standards.....


