### PR TITLE
Increase MiniMaxH3 memory usage factor to avoid OOM

### DIFF
--- a/comfy/supported_models.py
+++ b/comfy/supported_models.py
@@ -970,7 +970,7 @@ class MiniMaxH3(supported_models_base.BASE):
     unet_extra_config = {}
     latent_format = latent_formats.MiniMaxH3AV
 
-    memory_usage_factor = 0.114
+    memory_usage_factor = 0.17
 
     supported_inference_dtypes = [torch.bfloat16, torch.float32]
 

--- a/tests-unit/comfy_test/test_minimax_h3_memory.py
+++ b/tests-unit/comfy_test/test_minimax_h3_memory.py
@@ -1,0 +1,32 @@
+import torch
+
+from comfy.cli_args import args as cli_args
+
+if not torch.cuda.is_available():
+    cli_args.cpu = True
+
+import comfy.model_base  # noqa: E402
+import comfy.model_management  # noqa: E402
+import comfy.supported_models  # noqa: E402
+
+
+def test_minimax_h3_memory_usage_factor_covers_measured_shortfall(monkeypatch):
+    monkeypatch.setattr(comfy.model_management, "xformers_enabled", lambda: False)
+    monkeypatch.setattr(comfy.model_management, "pytorch_attention_flash_attention", lambda: False)
+
+    model = comfy.model_base.MiniMaxH3.__new__(comfy.model_base.MiniMaxH3)
+    model.memory_usage_factor_conds = ()
+    model.memory_usage_shape_process = {}
+
+    input_shape = (1, 32, 49, 92, 144)
+
+    model.memory_usage_factor = 0.114
+    old_estimate = model.memory_required(input_shape)
+
+    model.memory_usage_factor = comfy.supported_models.MiniMaxH3.memory_usage_factor
+    new_estimate = model.memory_required(input_shape)
+
+    # Issue #15781: factor 0.114 underestimated the real sampling working set
+    # by ~1.45x on a 24GB card, so load_models_gpu() pinned too much of the
+    # DiT weights and sampling OOM'd.
+    assert new_estimate >= old_estimate * 1.45

--- a/tests-unit/comfy_test/test_minimax_h3_memory.py
+++ b/tests-unit/comfy_test/test_minimax_h3_memory.py
@@ -2,12 +2,15 @@ import torch
 
 from comfy.cli_args import args as cli_args
 
+_original_cli_args_cpu = cli_args.cpu
 if not torch.cuda.is_available():
     cli_args.cpu = True
 
 import comfy.model_base  # noqa: E402
 import comfy.model_management  # noqa: E402
 import comfy.supported_models  # noqa: E402
+
+cli_args.cpu = _original_cli_args_cpu
 
 
 def test_minimax_h3_memory_usage_factor_covers_measured_shortfall(monkeypatch):


### PR DESCRIPTION
Fixes #15781

`MiniMaxH3.memory_usage_factor` (`comfy/supported_models.py`) was `0.114`,
which underestimates the real sampling working set by roughly 1.45x on a
24GB GPU. Since `MIN_WEIGHT_MEMORY_RATIO` is `0.0` on NVIDIA, the weight
budget computed by `load_models_gpu()` reduces to `free VRAM - estimated
inference memory` with no safety margin, so the underestimate gets spent on
resident weights instead and sampling then OOMs inside `SamplerCustomAdvanced`.

The issue reporter measured that raising the factor to `0.17` (~1.49x) makes
both of their reproduction cases (480x720x107 frames and 736x1152x192 frames
on an RTX 4090) complete instead of OOMing, with under 4% overhead from the
extra weight streaming.

## Test plan

Added `tests-unit/comfy_test/test_minimax_h3_memory.py`, which calls the real
`memory_required()` formula and asserts the new factor yields at least the
1.45x increase over `0.114` that the issue measured as necessary.

Confirmed the test fails against the unfixed value:

```
$ git checkout HEAD~1 -- comfy/supported_models.py  # 0.114
$ python -m pytest tests-unit/comfy_test/test_minimax_h3_memory.py -v
FAILED ... assert 11639717049.1392 >= (11639717049.1392 * 1.45)
$ git checkout HEAD -- comfy/supported_models.py  # 0.17
$ python -m pytest tests-unit/comfy_test/test_minimax_h3_memory.py -v
1 passed in 4.63s
```

Ran the full unit suite and ruff after the fix:

```
$ python -m pytest tests-unit -q
1379 passed, 10 skipped in 39.19s
$ ruff check comfy/supported_models.py tests-unit/comfy_test/test_minimax_h3_memory.py
All checks passed!
```

---
This change was prepared with AI assistance (Claude Code) and verified by
running the added test, the full unit test suite, and ruff as described above.
