### PR TITLE
test(userdata): add regression tests for atomic write and invalid filename fixes

### DIFF
--- a/tests-unit/prompt_server_test/user_manager_test.py
+++ b/tests-unit/prompt_server_test/user_manager_test.py
@@ -276,6 +276,33 @@ async def test_listuserdata_v2_normalized_separators(aiohttp_client, app, tmp_pa
         assert "/" in item["path"]
         assert "\\" not in item["path"]\
 
+async def test_post_userdata_invalid_filename_returns_400(aiohttp_client, app, tmp_path):
+    client = await aiohttp_client(app)
+    # A filename long enough to exceed the filesystem's max name length raises
+    # OSError (ENAMETOOLONG), which should be reported as a 400, not a 500.
+    long_name = "a" * 300
+    resp = await client.post(f"/userdata/{long_name}", data=b"content")
+
+    assert resp.status == 400
+    assert not os.path.exists(tmp_path / long_name)
+
+
+async def test_post_userdata_atomic_write_preserves_original_on_failure(aiohttp_client, app, tmp_path):
+    with open(tmp_path / "test.txt", "w") as f:
+        f.write("original content")
+
+    client = await aiohttp_client(app)
+    with patch("os.replace", side_effect=OSError("simulated failure")):
+        resp = await client.post("/userdata/test.txt", data=b"new content")
+
+    assert resp.status == 400
+
+    # Original file must be untouched, and no leftover temp file left behind.
+    with open(tmp_path / "test.txt", "r") as f:
+        assert f.read() == "original content"
+    assert os.listdir(tmp_path) == ["test.txt"]
+
+
 async def test_listuserdata_v2_url_encoded_path(aiohttp_client, app, tmp_path):
     # Create a directory with a space in its name and a file inside
     os.makedirs(tmp_path / "my dir")


### PR DESCRIPTION
## Summary

#15814 audits recent bug-fix history and lists six merged fixes that shipped
without regression tests. This PR adds tests for the two items whose commits
I could verify still exist and are still relevant on `master`:

- **Non-atomic userdata writes** (`9a870b510`) — `POST /userdata/{file}` writes
  to a temp file and `os.replace()`s it into place so a mid-write failure
  can't truncate the original file.
- **Invalid workflow filenames** (`0737b7e0d`) — an `OSError` while writing
  (e.g. a filename that's too long, or contains characters the filesystem
  rejects) is now reported as `400`, not an unhandled `500`.

The other four items in the issue (`24dc581dc`, `136c93cb4`, `8e2c99e3c`,
`89f15894d`) either already have a passing regression handled by `exist_ok=True`
with nothing meaningfully new to assert, or reference commit hashes that don't
exist in this repository's history — I couldn't find the code they describe,
so I left them out rather than guess.

## Test plan

New tests added to `tests-unit/prompt_server_test/user_manager_test.py`:
- `test_post_userdata_invalid_filename_returns_400`
- `test_post_userdata_atomic_write_preserves_original_on_failure`

Verified each test fails without its corresponding fix, by checking out
`app/user_manager.py` from the commit before each fix and re-running:

```
$ git checkout 0737b7e0d^ -- app/user_manager.py
$ python -m pytest tests-unit/prompt_server_test/user_manager_test.py -k invalid_filename -v
...
FAILED ...test_post_userdata_invalid_filename_returns_400 - AssertionError: assert 500 == 400

$ git checkout 9a870b510^ -- app/user_manager.py
$ python -m pytest tests-unit/prompt_server_test/user_manager_test.py -k atomic_write -v
...
FAILED ...test_post_userdata_atomic_write_preserves_original_on_failure - AssertionError: assert 200 == 400
```

And that both pass, along with the full existing file, on current `master`:

```
$ python -m pytest tests-unit/prompt_server_test/user_manager_test.py -v
...
21 passed in 0.16s
```

Lint:
```
$ ruff check tests-unit/prompt_server_test/user_manager_test.py
All checks passed!
```

## AI disclosure

This PR was prepared with the assistance of an AI coding agent (Claude),
including the analysis of which issue items were still reproducible and the
test implementation. All test runs and diffs shown above were executed and
verified directly.
