### PR TITLE
Include bfloat16 in the macOS attention-upcast workaround

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -1741,7 +1741,7 @@ def force_upcast_attention_dtype():
         upcast = True
 
     if upcast:
-        return {torch.float16: torch.float32}
+        return {torch.float16: torch.float32, torch.bfloat16: torch.float32}
     else:
         return None
 

--- a/tests-unit/comfy_test/force_upcast_attention_dtype_test.py
+++ b/tests-unit/comfy_test/force_upcast_attention_dtype_test.py
@@ -2,7 +2,11 @@ import torch
 
 from comfy.cli_args import args as cli_args
 
-if not torch.cuda.is_available():
+# Only force CPU state when neither CUDA nor MPS is available (plain
+# CPU-only CI runners), where model_management would otherwise crash at
+# import time. Leaving real MPS machines alone avoids permanently
+# stamping cpu_state as CPU for the rest of the test session.
+if not torch.cuda.is_available() and not torch.backends.mps.is_available():
     cli_args.cpu = True
 
 import comfy.model_management as model_management

--- a/tests-unit/comfy_test/force_upcast_attention_dtype_test.py
+++ b/tests-unit/comfy_test/force_upcast_attention_dtype_test.py
@@ -1,5 +1,10 @@
 import torch
 
+from comfy.cli_args import args as cli_args
+
+if not torch.cuda.is_available():
+    cli_args.cpu = True
+
 import comfy.model_management as model_management
 
 

--- a/tests-unit/comfy_test/force_upcast_attention_dtype_test.py
+++ b/tests-unit/comfy_test/force_upcast_attention_dtype_test.py
@@ -1,0 +1,18 @@
+import torch
+
+import comfy.model_management as model_management
+
+
+def test_force_upcast_includes_bfloat16_on_affected_macos(monkeypatch):
+    """LTX 2.5 ships bf16-only checkpoints and renders black frames on MPS
+    without this upcast (issue: black video unless --use-split-cross-attention).
+    bfloat16 has less mantissa precision than float16, so it needs the same
+    macOS attention-upcast workaround as float16."""
+    monkeypatch.setattr(model_management, "mac_version", lambda: (15, 5))
+    monkeypatch.setattr(model_management.args, "force_upcast_attention", False)
+
+    result = model_management.force_upcast_attention_dtype()
+
+    assert result is not None
+    assert result.get(torch.bfloat16) == torch.float32
+    assert result.get(torch.float16) == torch.float32


### PR DESCRIPTION
Fixes #15818.

## Problem

On macOS (MPS), LTX 2.5 (a bf16-only checkpoint) renders all-black video with
the default attention backend and with `--use-quad-cross-attention`.
`--use-split-cross-attention` is the only workaround.

`force_upcast_attention_dtype()` in `comfy/model_management.py` exists
specifically to work around a known "black image" bug on macOS >= 14.5 by
upcasting attention math to float32. Since commit `96d891cb` ("Speedup on some
models by not upcasting bfloat16 to float32 on mac."), the returned map only
contains `torch.float16 -> torch.float32` — `torch.bfloat16` was dropped for a
speed win. That change predates bf16-only models such as LTX 2.5.

bfloat16 has fewer mantissa bits (7) than float16 (10), so it is at least as
susceptible to the same MPS precision bug that this workaround targets. Both
the default backend (`attention_sub_quad`) and `--use-quad-cross-attention`
resolve to the same code path (`comfy/ldm/modules/attention.py`, the
`use_quad_cross_attention` flag is checked in `model_management.py` for
enabling PyTorch attention but is never read when selecting between
split/sub-quad, so both paths currently fall back to `attention_sub_quad`),
which is why the report shows both producing black frames while
`--use-split-cross-attention` (a different, non-upcast-dependent
implementation) does not.

## Fix

Add `torch.bfloat16: torch.float32` back to the map returned by
`force_upcast_attention_dtype()`. This only changes behavior on macOS >= 14.5
(or with the existing `--force-upcast-attention` flag) — it does not affect
CUDA/ROCm/XPU users, since `force_upcast_attention_dtype()` is gated on
`mac_version()`.

Note this reverts the bf16 half of `96d891cb`'s speedup unconditionally for
*all* bf16 models on affected macOS, not just LTX 2.5 — any other bf16
workflow that previously skipped the upcast for speed on mac >= 14.5 will go
back to being upcast (slower, more memory). That trade-off is the same one
that existed for float16 before 96d891cb; given the black-video report, I
think correctness should win here for bf16 too, but flagging the scope
explicitly since the code change itself doesn't limit to LTX.

## Test plan

Added `tests-unit/comfy_test/force_upcast_attention_dtype_test.py`, which
patches `mac_version()` to a macOS version in the affected range and asserts
the returned dtype map upcasts both `float16` and `bfloat16`. Like the
sibling `test_seedvr2_dtype.py`, it forces `cli_args.cpu = True` before
importing `comfy.model_management` when CUDA isn't available, since that
module does `torch.cuda.current_device()` at import time and otherwise
aborts test collection on a CPU-only torch build (e.g. CI's
ubuntu-latest/windows-2022 legs).

Ran with `torch==2.13.0+cpu` (no CUDA), matching CI's
`pip install torch torchvision torchaudio --index-url .../whl/cpu`:

Fails without the fix (`git checkout HEAD~1 -- comfy/model_management.py`,
keeping the new test file):

```
$ python -m pytest tests-unit/comfy_test/force_upcast_attention_dtype_test.py -q
...
>       assert result.get(torch.bfloat16) == torch.float32
E       assert None == torch.float32
E        +  where None = <built-in method get of dict object at 0x7f60da5d82c0>(torch.bfloat16)
E        +    where <built-in method get of dict object at 0x7f60da5d82c0> = {torch.float16: torch.float32}.get
1 failed in 2.60s
```

Passes with the fix applied:

```
$ python -m pytest tests-unit/comfy_test/force_upcast_attention_dtype_test.py -q
.
1 passed in 2.60s
```

`ruff check comfy/model_management.py tests-unit/comfy_test/force_upcast_attention_dtype_test.py` passes with no findings.

I do not have access to Apple Silicon hardware, so I could not reproduce the
black-video output directly; this fix is based on tracing the code path
described in the issue back to the specific commit that narrowed the existing
macOS black-image workaround to exclude bfloat16.

---
This PR was prepared with AI assistance (Claude) and reviewed by a human before submission.
