### PR TITLE
Sanitize argv in /system_stats to prevent leaking CLI arguments

### DIFF
--- a/server.py
+++ b/server.py
@@ -730,7 +730,7 @@ class PromptServer():
                     "pytorch_version": comfy.model_management.torch_version,
                     "embedded_python": os.path.split(os.path.split(sys.executable)[0])[1] == "python_embeded",
                     "deploy_environment": get_deploy_environment(),
-                    "argv": sys.argv
+                    "argv": [sys.argv[0]] if len(sys.argv) > 0 else []
                 },
                 "devices": device_entries
             }

--- a/tests-unit/prompt_server_test/system_stats_argv_test.py
+++ b/tests-unit/prompt_server_test/system_stats_argv_test.py
@@ -22,13 +22,15 @@ def _restore_cli_args():
     global server
     original_cpu = cli_args.cpu
     original_front_end_root = cli_args.front_end_root
-    cli_args.cpu = True
-    cli_args.front_end_root = "."
-    import server as _server
-    server = _server
-    yield
-    cli_args.cpu = original_cpu
-    cli_args.front_end_root = original_front_end_root
+    try:
+        cli_args.cpu = True
+        cli_args.front_end_root = "."
+        import server as _server
+        server = _server
+        yield
+    finally:
+        cli_args.cpu = original_cpu
+        cli_args.front_end_root = original_front_end_root
 
 
 async def _get_system_stats_argv(aiohttp_client):

--- a/tests-unit/prompt_server_test/system_stats_argv_test.py
+++ b/tests-unit/prompt_server_test/system_stats_argv_test.py
@@ -10,20 +10,25 @@ from aiohttp import web
 
 from comfy.cli_args import args as cli_args
 
+# Must be set before importing server/nodes, which probe cli_args.cpu at
+# import time to pick a torch device. Restored after this module's tests
+# via _restore_cli_args so other test modules aren't affected.
+_original_cpu = cli_args.cpu
+_original_front_end_root = cli_args.front_end_root
 cli_args.cpu = True
 cli_args.front_end_root = "."
 
 import server
 
 
-@pytest.mark.asyncio
-async def test_system_stats_does_not_leak_argv(aiohttp_client, monkeypatch):
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["main.py", "--extra-model-paths-config", "/secret/models.yaml", "--output-directory", "/secret/renders"],
-    )
+@pytest.fixture(autouse=True, scope="module")
+def _restore_cli_args():
+    yield
+    cli_args.cpu = _original_cpu
+    cli_args.front_end_root = _original_front_end_root
 
+
+async def _get_system_stats_argv(aiohttp_client):
     loop = asyncio.get_running_loop()
     prompt_server = server.PromptServer(loop)
     route = next(r for r in prompt_server.routes if getattr(r, "path", None) == "/system_stats")
@@ -36,4 +41,22 @@ async def test_system_stats_does_not_leak_argv(aiohttp_client, monkeypatch):
     assert resp.status == 200
 
     data = await resp.json()
-    assert data["system"]["argv"] == ["main.py"]
+    return data["system"]["argv"]
+
+
+@pytest.mark.asyncio
+async def test_system_stats_does_not_leak_argv(aiohttp_client, monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["main.py", "--extra-model-paths-config", "/secret/models.yaml", "--output-directory", "/secret/renders"],
+    )
+
+    assert await _get_system_stats_argv(aiohttp_client) == ["main.py"]
+
+
+@pytest.mark.asyncio
+async def test_system_stats_argv_empty(aiohttp_client, monkeypatch):
+    monkeypatch.setattr(sys, "argv", [])
+
+    assert await _get_system_stats_argv(aiohttp_client) == []

--- a/tests-unit/prompt_server_test/system_stats_argv_test.py
+++ b/tests-unit/prompt_server_test/system_stats_argv_test.py
@@ -10,22 +10,25 @@ from aiohttp import web
 
 from comfy.cli_args import args as cli_args
 
-# Must be set before importing server/nodes, which probe cli_args.cpu at
-# import time to pick a torch device. Restored after this module's tests
-# via _restore_cli_args so other test modules aren't affected.
-_original_cpu = cli_args.cpu
-_original_front_end_root = cli_args.front_end_root
-cli_args.cpu = True
-cli_args.front_end_root = "."
-
-import server
+server = None
 
 
 @pytest.fixture(autouse=True, scope="module")
 def _restore_cli_args():
+    # Must be set before importing server/nodes, which probe cli_args.cpu at
+    # import time to pick a torch device. Done here (fixture setup), not at
+    # module level, so the mutation only affects this module's own tests
+    # instead of leaking into whatever else pytest collects first.
+    global server
+    original_cpu = cli_args.cpu
+    original_front_end_root = cli_args.front_end_root
+    cli_args.cpu = True
+    cli_args.front_end_root = "."
+    import server as _server
+    server = _server
     yield
-    cli_args.cpu = _original_cpu
-    cli_args.front_end_root = _original_front_end_root
+    cli_args.cpu = original_cpu
+    cli_args.front_end_root = original_front_end_root
 
 
 async def _get_system_stats_argv(aiohttp_client):

--- a/tests-unit/prompt_server_test/system_stats_argv_test.py
+++ b/tests-unit/prompt_server_test/system_stats_argv_test.py
@@ -1,0 +1,39 @@
+"""Regression test for /system_stats leaking full sys.argv (including secrets
+passed as CLI flags, such as --extra-model-paths-config paths) to any
+unauthenticated client."""
+
+import asyncio
+import sys
+
+import pytest
+from aiohttp import web
+
+from comfy.cli_args import args as cli_args
+
+cli_args.cpu = True
+cli_args.front_end_root = "."
+
+import server
+
+
+@pytest.mark.asyncio
+async def test_system_stats_does_not_leak_argv(aiohttp_client, monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["main.py", "--extra-model-paths-config", "/secret/models.yaml", "--output-directory", "/secret/renders"],
+    )
+
+    loop = asyncio.get_running_loop()
+    prompt_server = server.PromptServer(loop)
+    route = next(r for r in prompt_server.routes if getattr(r, "path", None) == "/system_stats")
+
+    app = web.Application()
+    app.add_routes([route])
+    client = await aiohttp_client(app)
+
+    resp = await client.get("/system_stats")
+    assert resp.status == 200
+
+    data = await resp.json()
+    assert data["system"]["argv"] == ["main.py"]


### PR DESCRIPTION
## Problem

Fixes #15821.

The `/system_stats` endpoint returned the raw, unmasked `sys.argv` list in
its JSON response. This is an unauthenticated endpoint, so any client that
can reach it (including in the default single-user, no-auth setup) could
read every command-line flag ComfyUI was launched with — for example
`--extra-model-paths-config` or `--output-directory`, which can contain
private local filesystem paths.

## Fix

`server.py`'s `/system_stats` handler now reports only the executable name
(`sys.argv[0]`) instead of the full argument vector, matching the fix
proposed in the issue.

```diff
-                    "argv": sys.argv
+                    "argv": [sys.argv[0]] if len(sys.argv) > 0 else []
```

## Testing

Added `tests-unit/prompt_server_test/system_stats_argv_test.py`, which
instantiates the real `PromptServer` route for `/system_stats`, sets
`sys.argv` to include sensitive-looking flags, and asserts the JSON
response's `system.argv` only contains the script name.

Confirmed the test fails without the fix (`git checkout HEAD~1 -- server.py`)
and passes with it:

```
# without the fix:
FAILED tests-unit/prompt_server_test/system_stats_argv_test.py::test_system_stats_does_not_leak_argv
AssertionError: assert ['main.py', '...cret/renders'] == ['main.py']

# with the fix:
tests-unit/prompt_server_test/system_stats_argv_test.py::test_system_stats_does_not_leak_argv PASSED
1 passed in 5.82s
```

Also ran the full `tests-unit` suite (`1405 passed, 10 skipped`) and
`ruff check server.py tests-unit/prompt_server_test/system_stats_argv_test.py`
(all checks passed) to confirm no regressions.

## AI assistance disclosure

This change was prepared with AI assistance (an autonomous coding agent),
with the diff reviewed and tested before submission.
