### PR TITLE
Preserve multichannel audio layout in previews

### DIFF
--- a/comfy_api/latest/_ui.py
+++ b/comfy_api/latest/_ui.py
@@ -322,7 +322,7 @@ class AudioSaveHelper:
             for key, value in metadata.items():
                 output_container.metadata[key] = value
 
-            layout = "mono" if waveform.shape[0] == 1 else "stereo"
+            layout = f"{waveform.shape[0]}c"
             # Set up the output stream with appropriate properties
             if format == "opus":
                 out_stream = output_container.add_stream("libopus", rate=sample_rate, layout=layout)
@@ -337,7 +337,8 @@ class AudioSaveHelper:
                 elif quality == "320k":
                     out_stream.bit_rate = 320000
             elif format == "mp3":
-                out_stream = output_container.add_stream("libmp3lame", rate=sample_rate, layout=layout)
+                mp3_layout = "mono" if waveform.shape[0] == 1 else "stereo"
+                out_stream = output_container.add_stream("libmp3lame", rate=sample_rate, layout=mp3_layout)
                 if quality == "V0":
                     # TODO i would really love to support V3 and V5 but there doesn't seem to be a way to set the qscale level, the property below is a bool
                     out_stream.codec_context.qscale = 1
@@ -349,8 +350,8 @@ class AudioSaveHelper:
                 out_stream = output_container.add_stream("flac", rate=sample_rate, layout=layout)
 
             frame = av.AudioFrame.from_ndarray(
-                waveform.movedim(0, 1).reshape(1, -1).float().numpy(),
-                format="flt",
+                waveform.float().contiguous().numpy(),
+                format="fltp",
                 layout=layout,
             )
             frame.sample_rate = sample_rate

--- a/tests-unit/comfy_api_test/audio_save_test.py
+++ b/tests-unit/comfy_api_test/audio_save_test.py
@@ -33,3 +33,37 @@ def test_flac_preserves_audio_channels_and_duration(channels, tmp_path, monkeypa
 
     assert len(stream.layout.channels) == channels
     assert decoded_samples / stream.codec_context.sample_rate == pytest.approx(duration)
+
+
+@pytest.mark.parametrize(
+    ("audio_format", "channels", "expected_channels"),
+    [("opus", 6, 6), ("mp3", 1, 1), ("mp3", 6, 2)],
+)
+def test_opus_and_mp3_preserve_duration_and_expected_layout(
+    audio_format, channels, expected_channels, tmp_path, monkeypatch
+):
+    sample_rate = 48000
+    duration = 0.1
+    samples = int(sample_rate * duration)
+    waveform = torch.zeros((1, channels, samples), dtype=torch.float32)
+    audio = {"waveform": waveform, "sample_rate": sample_rate}
+
+    monkeypatch.setattr(
+        "comfy_api.latest._ui.folder_paths.get_save_image_path",
+        lambda *args: (str(tmp_path), "preview", 1, "", "preview"),
+    )
+
+    result = AudioSaveHelper.save_audio(
+        audio,
+        filename_prefix="preview",
+        folder_type=FolderType.temp,
+        cls=None,
+        format=audio_format,
+    )
+
+    with av.open(tmp_path / result[0].filename) as container:
+        stream = container.streams.audio[0]
+        decoded_samples = sum(frame.samples for frame in container.decode(audio=0))
+
+    assert len(stream.layout.channels) == expected_channels
+    assert decoded_samples / stream.codec_context.sample_rate == pytest.approx(duration)

--- a/tests-unit/comfy_api_test/audio_save_test.py
+++ b/tests-unit/comfy_api_test/audio_save_test.py
@@ -1,0 +1,35 @@
+import av
+import pytest
+import torch
+
+from comfy_api.latest._io import FolderType
+from comfy_api.latest._ui import AudioSaveHelper
+
+
+@pytest.mark.parametrize("channels", [1, 2, 6])
+def test_flac_preserves_audio_channels_and_duration(channels, tmp_path, monkeypatch):
+    sample_rate = 48000
+    duration = 0.1
+    samples = int(sample_rate * duration)
+    waveform = torch.zeros((1, channels, samples), dtype=torch.float32)
+    audio = {"waveform": waveform, "sample_rate": sample_rate}
+
+    monkeypatch.setattr(
+        "comfy_api.latest._ui.folder_paths.get_save_image_path",
+        lambda *args: (str(tmp_path), "preview", 1, "", "preview"),
+    )
+
+    result = AudioSaveHelper.save_audio(
+        audio,
+        filename_prefix="preview",
+        folder_type=FolderType.temp,
+        cls=None,
+        format="flac",
+    )
+
+    with av.open(tmp_path / result[0].filename) as container:
+        stream = container.streams.audio[0]
+        decoded_samples = sum(frame.samples for frame in container.decode(audio=0))
+
+    assert len(stream.layout.channels) == channels
+    assert decoded_samples / stream.codec_context.sample_rate == pytest.approx(duration)


### PR DESCRIPTION
Fixes #15816

Multi-channel waveforms were flattened and encoded with a stereo frame layout. A 5.1 input therefore produced three times as many stereo samples, making previews three times longer and play at one-third speed.

This preserves the real channel layout with planar PyAV frames. FLAC and Opus retain all channels, while MP3 keeps its mono/stereo output and lets the encoder downmix multi-channel frames.

Tests:
- 6 audio regression tests passed (mono, stereo, 5.1, and adjacent MP3 conversions)
- 120 comfy_api tests passed, 1 skipped
- Real issue AAC round trip: 5.1, 48 kHz, 15.488 seconds before and after
- Full unit suite: 1398 passed, 17 skipped; 2 unrelated Windows MIME classification failures for PPM/PGM/PBM