### PR TITLE
Fix LoRA alpha not applied when the trainer stores it in file metadata

### DIFF
--- a/comfy/lora.py
+++ b/comfy/lora.py
@@ -22,6 +22,7 @@ import comfy.model_management
 import comfy.model_base
 import comfy.weight_adapter as weight_adapter
 import logging
+import math
 import torch
 
 LORA_CLIP_MAP = {
@@ -39,18 +40,30 @@ def load_lora(lora, to_load, log_missing=True, metadata=None):
     loaded_keys = set()
     # Some trainers (SimpleTuner and other PEFT/diffusers-based ones) store alpha/rank only in
     # the safetensors file metadata instead of a per-key .alpha tensor.
-    meta_alpha = None
-    meta_rank = None
+    pairs = {}
     if metadata is not None:
         for k, v in metadata.items():
-            short = k.rsplit(".", 1)[-1]
+            parts = k.rsplit(".", 1)
+            ns = parts[0] if len(parts) == 2 else ""
+            short = parts[-1]
             try:
-                if short == "lora_alpha" and meta_alpha is None:
-                    meta_alpha = float(v)
-                elif short in ("r", "rank", "lora_rank") and meta_rank is None:
-                    meta_rank = float(v)
-            except ValueError:
-                pass
+                val = float(v)
+            except (ValueError, TypeError):
+                continue
+            if not math.isfinite(val):
+                continue
+            if short == "lora_alpha":
+                pairs.setdefault(ns, [None, None])[0] = val
+            elif short in ("r", "rank", "lora_rank") and val > 0:
+                pairs.setdefault(ns, [None, None])[1] = val
+
+    meta_alpha = None
+    meta_rank = None
+    found = {(a, r) for a, r in pairs.values() if a is not None and r is not None}
+    if len(found) > 1:
+        logging.warning("Multiple LoRA alpha/rank pairs in file metadata; ignoring metadata fallback.")
+    elif len(found) == 1:
+        meta_alpha, meta_rank = found.pop()
 
     for x in to_load:
         alpha_name = "{}.alpha".format(x)

--- a/comfy/lora.py
+++ b/comfy/lora.py
@@ -34,15 +34,32 @@ LORA_CLIP_MAP = {
 }
 
 
-def load_lora(lora, to_load, log_missing=True):
+def load_lora(lora, to_load, log_missing=True, metadata=None):
     patch_dict = {}
     loaded_keys = set()
+    # Some trainers (SimpleTuner and other PEFT/diffusers-based ones) store alpha/rank only in
+    # the safetensors file metadata instead of a per-key .alpha tensor.
+    meta_alpha = None
+    meta_rank = None
+    if metadata is not None:
+        for k, v in metadata.items():
+            short = k.rsplit(".", 1)[-1]
+            try:
+                if short == "lora_alpha" and meta_alpha is None:
+                    meta_alpha = float(v)
+                elif short in ("r", "rank", "lora_rank") and meta_rank is None:
+                    meta_rank = float(v)
+            except ValueError:
+                pass
+
     for x in to_load:
         alpha_name = "{}.alpha".format(x)
         alpha = None
         if alpha_name in lora.keys():
             alpha = lora[alpha_name].item()
             loaded_keys.add(alpha_name)
+        elif meta_alpha is not None and meta_rank:
+            alpha = meta_alpha / meta_rank
 
         dora_scale_name = "{}.dora_scale".format(x)
         dora_scale = None

--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -107,7 +107,7 @@ def load_lora_for_models(model, clip, lora, strength_model, strength_clip, lora_
         key_map = comfy.lora.model_lora_keys_clip(clip.cond_stage_model, key_map)
 
     lora = comfy.lora_convert.convert_lora(lora)
-    loaded = comfy.lora.load_lora(lora, key_map)
+    loaded = comfy.lora.load_lora(lora, key_map, metadata=lora_metadata)
     if model is not None:
         new_modelpatcher = model.clone()
         k = new_modelpatcher.add_patches(loaded, strength_model)

--- a/tests/test_lora_alpha_metadata.py
+++ b/tests/test_lora_alpha_metadata.py
@@ -1,0 +1,67 @@
+import torch
+
+from comfy.lora import load_lora
+
+
+def make_lora_dict(prefix="test_layer", rank=4, in_dim=8):
+    return {
+        "{}.lora_down.weight".format(prefix): torch.zeros((rank, in_dim)),
+        "{}.lora_up.weight".format(prefix): torch.zeros((in_dim, rank)),
+    }
+
+
+def get_adapter(load_result, target="model.test_layer"):
+    return load_result[target]
+
+
+def test_metadata_alpha_used_when_tensor_missing():
+    lora = make_lora_dict()
+    key_map = {"test_layer": "model.test_layer"}
+    # SimpleTuner-style file: alpha/rank only in safetensors metadata,
+    # namespaced ("transformer.r", "transformer.lora_alpha").
+    metadata = {"transformer.r": "16", "transformer.lora_alpha": "64"}
+
+    loaded = load_lora(lora, key_map, metadata=metadata)
+
+    adapter = get_adapter(loaded)
+    assert adapter.weights[2] == 64.0 / 16.0
+
+
+def test_metadata_plain_keys_also_work():
+    lora = make_lora_dict()
+    key_map = {"test_layer": "model.test_layer"}
+    metadata = {"r": "8", "lora_alpha": "24"}
+
+    loaded = load_lora(lora, key_map, metadata=metadata)
+
+    assert get_adapter(loaded).weights[2] == 3.0
+
+
+def test_explicit_alpha_tensor_wins_over_metadata():
+    lora = make_lora_dict()
+    lora["test_layer.alpha"] = torch.tensor(2.0)
+    key_map = {"test_layer": "model.test_layer"}
+    metadata = {"r": "16", "lora_alpha": "64"}
+
+    loaded = load_lora(lora, key_map, metadata=metadata)
+
+    assert get_adapter(loaded).weights[2] == 2.0
+
+
+def test_no_metadata_keeps_old_behavior():
+    lora = make_lora_dict()
+    key_map = {"test_layer": "model.test_layer"}
+
+    loaded = load_lora(lora, key_map)
+
+    assert get_adapter(loaded).weights[2] is None
+
+
+def test_malformed_metadata_ignored():
+    lora = make_lora_dict()
+    key_map = {"test_layer": "model.test_layer"}
+    metadata = {"transformer.r": "sixteen", "transformer.lora_alpha": "x"}
+
+    loaded = load_lora(lora, key_map, metadata=metadata)
+
+    assert get_adapter(loaded).weights[2] is None

--- a/tests/test_lora_alpha_metadata.py
+++ b/tests/test_lora_alpha_metadata.py
@@ -65,3 +65,42 @@ def test_malformed_metadata_ignored():
     loaded = load_lora(lora, key_map, metadata=metadata)
 
     assert get_adapter(loaded).weights[2] is None
+
+
+def test_ambiguous_namespaces_skip_fallback():
+    lora = make_lora_dict()
+    key_map = {"test_layer": "model.test_layer"}
+    metadata = {
+        "text_encoder.lora_alpha": "8",
+        "text_encoder.r": "8",
+        "transformer.lora_alpha": "64",
+        "transformer.r": "16",
+    }
+
+    loaded = load_lora(lora, key_map, metadata=metadata)
+
+    assert get_adapter(loaded).weights[2] is None
+
+
+def test_non_finite_metadata_ignored():
+    lora = make_lora_dict()
+    key_map = {"test_layer": "model.test_layer"}
+
+    loaded = load_lora(lora, key_map, metadata={"transformer.r": "16", "transformer.lora_alpha": "nan"})
+    assert get_adapter(loaded).weights[2] is None
+
+    loaded = load_lora(lora, key_map, metadata={"transformer.r": "16", "transformer.lora_alpha": "inf"})
+    assert get_adapter(loaded).weights[2] is None
+
+    loaded = load_lora(lora, key_map, metadata={"transformer.r": "0", "transformer.lora_alpha": "64"})
+    assert get_adapter(loaded).weights[2] is None
+
+
+def test_integer_metadata_values_accepted():
+    lora = make_lora_dict()
+    key_map = {"test_layer": "model.test_layer"}
+    metadata = {"r": 16, "lora_alpha": 64}
+
+    loaded = load_lora(lora, key_map, metadata=metadata)
+
+    assert get_adapter(loaded).weights[2] == 4.0


### PR DESCRIPTION
Fixes #12191

## Problem

Trainers in the PEFT/diffusers family (e.g. SimpleTuner) store `alpha` and `rank` only in the safetensors **header metadata** (`transformer.lora_alpha=64`, `transformer.r=16`) instead of a per-key `.alpha` tensor. `load_lora` only looked at the tensor, so these LoRAs silently ran at scale 1.0 instead of alpha/rank — users compensated with strength 3-4x, which distorts the trained result.

## Change

- `comfy/lora.py`: `load_lora` gains an optional `metadata` argument; when a key has no `.alpha` tensor, fall back to `lora_alpha / r` read from that metadata (plain and namespaced keys both handled; malformed values ignored).
- `comfy/sd.py`: thread the already-available `lora_metadata` through `load_lora_for_models`.
- Explicit `.alpha` tensors still win over metadata; behavior without metadata is unchanged.

## Tests

New `tests/test_lora_alpha_metadata.py` (5 tests): namespaced fallback, plain-key fallback, explicit-tensor precedence, no-metadata unchanged, malformed-metadata ignored.

Environment: Python 3.12 / torch 2.11 CPU, current master (`82f839f5`).

---

## Review updates (ee6bfd2d)

Both findings addressed:
- Metadata grouped into namespace pairs; fallback applies only when exactly one complete alpha+rank pair exists across namespaces, otherwise skipped (one short warning when ambiguous) — cross-namespace mixing impossible.
- Values failing float() (incl. TypeError), non-finite values, and ranks <= 0 rejected.
- Tests added: ambiguous-namespaces skip, nan/inf/rank<=0 ignored, integer metadata accepted. Suite: 8 passed.