### PR TITLE
Make KSampler sigma schedules reachable from custom sampling

### DIFF
--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -1396,10 +1396,31 @@ def sampler_object(name):
         sampler = ksampler(name)
     return sampler
 
+DISCARD_PENULTIMATE_SIGMA_SAMPLERS = ("dpm_2", "dpm_2_ancestral", "uni_pc", "uni_pc_bh2")
+
+
+def calculate_sigmas_for_sampler(model_sampling: object, scheduler_name: str, steps: int, sampler_name: str) -> torch.Tensor:
+    """Sigmas for a named sampler, matching what KSampler.calculate_sigmas builds.
+
+    The samplers in DISCARD_PENULTIMATE_SIGMA_SAMPLERS expect the schedule built with one extra
+    step and the penultimate sigma dropped; custom sampling paths that consume sigmas directly
+    need the same adjustment to produce identical results to KSampler.
+    """
+    discard_penultimate_sigma = False
+    if sampler_name in DISCARD_PENULTIMATE_SIGMA_SAMPLERS:
+        steps += 1
+        discard_penultimate_sigma = True
+
+    sigmas = calculate_sigmas(model_sampling, scheduler_name, steps)
+
+    if discard_penultimate_sigma:
+        sigmas = torch.cat([sigmas[:-2], sigmas[-1:]])
+    return sigmas
+
 class KSampler:
     SCHEDULERS = SCHEDULER_NAMES
     SAMPLERS = SAMPLER_NAMES
-    DISCARD_PENULTIMATE_SIGMA_SAMPLERS = set(('dpm_2', 'dpm_2_ancestral', 'uni_pc', 'uni_pc_bh2'))
+    DISCARD_PENULTIMATE_SIGMA_SAMPLERS = DISCARD_PENULTIMATE_SIGMA_SAMPLERS
 
     def __init__(self, model, steps, device, sampler=None, scheduler=None, denoise=None, model_options={}):
         self.model = model
@@ -1415,18 +1436,7 @@ class KSampler:
         self.model_options = model_options
 
     def calculate_sigmas(self, steps):
-        sigmas = None
-
-        discard_penultimate_sigma = False
-        if self.sampler in self.DISCARD_PENULTIMATE_SIGMA_SAMPLERS:
-            steps += 1
-            discard_penultimate_sigma = True
-
-        sigmas = calculate_sigmas(self.model.get_model_object("model_sampling"), self.scheduler, steps)
-
-        if discard_penultimate_sigma:
-            sigmas = torch.cat([sigmas[:-2], sigmas[-1:]])
-        return sigmas
+        return calculate_sigmas_for_sampler(self.model.get_model_object("model_sampling"), self.scheduler, steps, self.sampler)
 
     def set_steps(self, steps, denoise=None):
         self.steps = steps

--- a/comfy_extras/nodes_custom_sampler.py
+++ b/comfy_extras/nodes_custom_sampler.py
@@ -22,6 +22,8 @@ class BasicScheduler(io.ComfyNode):
             category="model/sampling/schedulers",
             inputs=[
                 io.Model.Input("model"),
+                io.Combo.Input("sampler_name", options=["none"] + list(comfy.samplers.SAMPLER_NAMES), optional=True,
+                               tooltip="Set this to the sampler you will feed these sigmas to. Samplers like dpm_2 and uni_pc need a slightly different schedule than the plain one, matching what KSampler builds internally. Leave as none for the old behavior."),
                 io.Combo.Input("scheduler", options=comfy.samplers.SCHEDULER_NAMES),
                 io.Int.Input("steps", default=20, min=1, max=10000),
                 io.Float.Input("denoise", default=1.0, min=0.0, max=1.0, step=0.01),
@@ -30,14 +32,17 @@ class BasicScheduler(io.ComfyNode):
         )
 
     @classmethod
-    def execute(cls, model, scheduler, steps, denoise) -> io.NodeOutput:
+    def execute(cls, model, scheduler, steps, denoise, sampler_name="none") -> io.NodeOutput:
         total_steps = steps
         if denoise < 1.0:
             if denoise <= 0.0:
                 return io.NodeOutput(torch.FloatTensor([]))
             total_steps = int(steps/denoise)
 
-        sigmas = comfy.samplers.calculate_sigmas(model.get_model_object("model_sampling"), scheduler, total_steps).cpu()
+        if sampler_name == "none":
+            sigmas = comfy.samplers.calculate_sigmas(model.get_model_object("model_sampling"), scheduler, total_steps).cpu()
+        else:
+            sigmas = comfy.samplers.calculate_sigmas_for_sampler(model.get_model_object("model_sampling"), scheduler, total_steps, sampler_name).cpu()
         sigmas = sigmas[-(steps + 1):]
         return io.NodeOutput(sigmas)
 

--- a/tests/test_sigma_sampler_consistency.py
+++ b/tests/test_sigma_sampler_consistency.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+
+import torch
+
+from comfy.samplers import (
+    DISCARD_PENULTIMATE_SIGMA_SAMPLERS,
+    calculate_sigmas,
+    calculate_sigmas_for_sampler,
+)
+
+MS = SimpleNamespace(sigma_min=0.0292, sigma_max=14.6146)
+
+
+def test_discard_set_exposes_known_samplers():
+    assert "dpm_2" in DISCARD_PENULTIMATE_SIGMA_SAMPLERS
+    assert "euler" not in DISCARD_PENULTIMATE_SIGMA_SAMPLERS
+
+
+def test_helper_matches_ksampler_trim():
+    # KSampler builds steps+1 sigmas and drops the penultimate one for these samplers;
+    # the shared helper must produce exactly that schedule.
+    expected = calculate_sigmas(MS, "karras", 11)
+    expected = torch.cat([expected[:-2], expected[-1:]])
+
+    got = calculate_sigmas_for_sampler(MS, "karras", 10, "dpm_2")
+
+    assert torch.allclose(got, expected)
+
+
+def test_non_discard_sampler_stays_untrimmed():
+    plain = calculate_sigmas(MS, "karras", 10)
+
+    got = calculate_sigmas_for_sampler(MS, "karras", 10, "euler")
+
+    assert torch.allclose(got, plain)
+
+
+def test_basic_scheduler_can_match_ksampler_schedule():
+    from comfy_extras.nodes_custom_sampler import BasicScheduler
+
+    model = SimpleNamespace(get_model_object=lambda _key: MS)
+
+    out = BasicScheduler.execute(model=model, scheduler="karras", steps=10, denoise=1.0, sampler_name="dpm_2")
+
+    sigmas = out.result[0]
+    assert torch.allclose(sigmas, calculate_sigmas_for_sampler(MS, "karras", 10, "dpm_2"))
+
+
+def test_basic_scheduler_default_matches_old_behavior():
+    from comfy_extras.nodes_custom_sampler import BasicScheduler
+
+    model = SimpleNamespace(get_model_object=lambda _key: MS)
+
+    out = BasicScheduler.execute(model=model, scheduler="karras", steps=10, denoise=1.0)
+
+    assert torch.allclose(out.result[0], calculate_sigmas(MS, "karras", 10))

--- a/tests/test_sigma_sampler_consistency.py
+++ b/tests/test_sigma_sampler_consistency.py
@@ -4,9 +4,11 @@ import torch
 
 from comfy.samplers import (
     DISCARD_PENULTIMATE_SIGMA_SAMPLERS,
+    KSampler,
     calculate_sigmas,
     calculate_sigmas_for_sampler,
 )
+from comfy_extras.nodes_custom_sampler import BasicScheduler
 
 MS = SimpleNamespace(sigma_min=0.0292, sigma_max=14.6146)
 
@@ -36,19 +38,15 @@ def test_non_discard_sampler_stays_untrimmed():
 
 
 def test_basic_scheduler_can_match_ksampler_schedule():
-    from comfy_extras.nodes_custom_sampler import BasicScheduler
-
     model = SimpleNamespace(get_model_object=lambda _key: MS)
 
+    ks = KSampler(model=model, steps=10, device="cpu", sampler="dpm_2", scheduler="karras", denoise=1.0)
     out = BasicScheduler.execute(model=model, scheduler="karras", steps=10, denoise=1.0, sampler_name="dpm_2")
 
-    sigmas = out.result[0]
-    assert torch.allclose(sigmas, calculate_sigmas_for_sampler(MS, "karras", 10, "dpm_2"))
+    assert torch.allclose(out.result[0], ks.sigmas.cpu())
 
 
 def test_basic_scheduler_default_matches_old_behavior():
-    from comfy_extras.nodes_custom_sampler import BasicScheduler
-
     model = SimpleNamespace(get_model_object=lambda _key: MS)
 
     out = BasicScheduler.execute(model=model, scheduler="karras", steps=10, denoise=1.0)


### PR DESCRIPTION
Fixes #4367

## Problem

`KSampler.calculate_sigmas` builds a slightly different schedule for `dpm_2`, `dpm_2_ancestral`, `uni_pc` and `uni_pc_bh2` (steps+1 with the penultimate sigma dropped), but `BasicScheduler` had no way to produce that schedule. Identical sampler+scheduler+steps therefore produced different images depending on whether sampling went through KSampler or SamplerCustom + sigmas nodes.

## Change

- Move the adjustment into a shared `calculate_sigmas_for_sampler()` in `comfy/samplers.py`; `KSampler.calculate_sigmas` now delegates to it (behavior unchanged).
- Give `BasicScheduler` an optional `sampler_name` combo (default `"none"` = exactly the old output). Set it to the downstream sampler to get the same schedule KSampler would build.
- The discard list is now module-level; the class attribute remains as an alias.

## Tests

New `tests/test_sigma_sampler_consistency.py` (5 tests): helper matches the KSampler trim bit-for-bit, non-discard samplers untouched, BasicScheduler with sampler_name=dpm_2 equals the KSampler schedule, default input reproduces old output.

Environment: Python 3.12 / torch 2.11 CPU, current master (`82f839f5`).