### PR TITLE
Cache prepared ControlNet hints per hint size

### DIFF
--- a/comfy/controlnet.py
+++ b/comfy/controlnet.py
@@ -943,7 +943,7 @@ class T2IAdapter(ControlBase):
         if x_noisy.shape[0] != cond_hint.shape[0]:
             cond_hint = broadcast_image_to(cond_hint, x_noisy.shape[0], batched_number)
 
-        control_input = self.control_inputs.get((x_noisy.shape[2], x_noisy.shape[3], x_noisy.shape[0], batched_number))
+        control_input = self.control_inputs.get((x_noisy.shape[2], x_noisy.shape[3], x_noisy.shape[0], batched_number, x_noisy.dtype))
         if control_input is None:
             self.t2i_model.to(x_noisy.dtype)
             self.t2i_model.to(self.device)
@@ -951,7 +951,7 @@ class T2IAdapter(ControlBase):
             self.t2i_model.cpu()
             while len(self.control_inputs) >= 2:
                 self.control_inputs.pop(next(iter(self.control_inputs)))
-            self.control_inputs[(x_noisy.shape[2], x_noisy.shape[3], x_noisy.shape[0], batched_number)] = control_input
+            self.control_inputs[(x_noisy.shape[2], x_noisy.shape[3], x_noisy.shape[0], batched_number, x_noisy.dtype)] = control_input
 
         out = {}
         for k in control_input:

--- a/comfy/controlnet.py
+++ b/comfy/controlnet.py
@@ -82,6 +82,7 @@ class ControlBase:
         self.cond_hint_original = None
         self.cond_hint = None
         self.cond_hints = {}
+        self.control_inputs = {}
         self.strength = 1.0
         self.timestep_percent_range = (0.0, 1.0)
         self.latent_format = None
@@ -112,6 +113,8 @@ class ControlBase:
         self.extra_concat_orig = extra_concat.copy()
         if self.concat_mask and len(self.extra_concat_orig) == 0:
             self.extra_concat_orig.append(torch.tensor([[[[1.0]]]]))
+        self.cond_hints.clear()
+        self.control_inputs.clear()
         return self
 
     def pre_run(self, model, percent_to_timestep_function):
@@ -131,6 +134,7 @@ class ControlBase:
                 device_cnet.cleanup()
         self.cond_hint = None
         self.cond_hints.clear()
+        self.control_inputs.clear()
         self.extra_concat = None
         self.timestep_range = None
 
@@ -903,7 +907,6 @@ class T2IAdapter(ControlBase):
         super().__init__()
         self.t2i_model = t2i_model
         self.channels_in = channels_in
-        self.control_input = None
         self.compression_ratio = compression_ratio
         self.upscale_algorithm = upscale_algorithm
         if device is None:
@@ -939,17 +942,22 @@ class T2IAdapter(ControlBase):
             self.cond_hints[(x_noisy.shape[2], x_noisy.shape[3])] = cond_hint
         if x_noisy.shape[0] != cond_hint.shape[0]:
             cond_hint = broadcast_image_to(cond_hint, x_noisy.shape[0], batched_number)
-        if self.control_input is None:
+
+        control_input = self.control_inputs.get((x_noisy.shape[2], x_noisy.shape[3]))
+        if control_input is None:
             self.t2i_model.to(x_noisy.dtype)
             self.t2i_model.to(self.device)
-            self.control_input = self.t2i_model(cond_hint.to(x_noisy.dtype))
+            control_input = self.t2i_model(cond_hint.to(x_noisy.dtype))
             self.t2i_model.cpu()
+            while len(self.control_inputs) >= 2:
+                self.control_inputs.pop(next(iter(self.control_inputs)))
+            self.control_inputs[(x_noisy.shape[2], x_noisy.shape[3])] = control_input
 
-        control_input = {}
-        for k in self.control_input:
-            control_input[k] = list(map(lambda a: None if a is None else a.clone(), self.control_input[k]))
+        out = {}
+        for k in control_input:
+            out[k] = list(map(lambda a: None if a is None else a.clone(), control_input[k]))
 
-        return self.control_merge(control_input, control_prev, x_noisy.dtype)
+        return self.control_merge(out, control_prev, x_noisy.dtype)
 
     def copy(self):
         c = T2IAdapter(self.t2i_model, self.channels_in, self.compression_ratio, self.upscale_algorithm)

--- a/comfy/controlnet.py
+++ b/comfy/controlnet.py
@@ -81,6 +81,7 @@ class ControlBase:
     def __init__(self):
         self.cond_hint_original = None
         self.cond_hint = None
+        self.cond_hints = {}
         self.strength = 1.0
         self.timestep_percent_range = (0.0, 1.0)
         self.latent_format = None
@@ -129,6 +130,7 @@ class ControlBase:
             with ControlIsolation(device_cnet):
                 device_cnet.cleanup()
         self.cond_hint = None
+        self.cond_hints.clear()
         self.extra_concat = None
         self.timestep_range = None
 
@@ -266,38 +268,42 @@ class ControlNet(ControlBase):
         if self.manual_cast_dtype is not None:
             dtype = self.manual_cast_dtype
 
-        if self.cond_hint is None or x_noisy.shape[2] * self.compression_ratio != self.cond_hint.shape[2] or x_noisy.shape[3] * self.compression_ratio != self.cond_hint.shape[3]:
-            if self.cond_hint is not None:
-                del self.cond_hint
-            self.cond_hint = None
+        # Keep a couple of prepared hints around: with area composition the same controlnet is
+        # called with alternating crop sizes every step, and rebuilding (upscale + VAE encode)
+        # each time dominated the step time.
+        cond_hint = self.cond_hints.get((x_noisy.shape[2], x_noisy.shape[3]))
+        if cond_hint is None:
             compression_ratio = self.compression_ratio
             if self.vae is not None:
                 compression_ratio *= self.vae.spacial_compression_encode()
             else:
                 if self.latent_format is not None:
                     raise ValueError("This Controlnet needs a VAE but none was provided, please use a ControlNetApply node with a VAE input and connect it.")
-            self.cond_hint = comfy.utils.common_upscale(self.cond_hint_original, x_noisy.shape[-1] * compression_ratio, x_noisy.shape[-2] * compression_ratio, self.upscale_algorithm, "center")
-            self.cond_hint = self.preprocess_image(self.cond_hint)
+            cond_hint = comfy.utils.common_upscale(self.cond_hint_original, x_noisy.shape[-1] * compression_ratio, x_noisy.shape[-2] * compression_ratio, self.upscale_algorithm, "center")
+            cond_hint = self.preprocess_image(cond_hint)
             if self.vae is not None:
                 loaded_models = comfy.model_management.loaded_models(only_currently_used=True)
-                self.cond_hint = self.vae.encode(self.cond_hint.movedim(1, -1))
+                cond_hint = self.vae.encode(cond_hint.movedim(1, -1))
                 comfy.model_management.load_models_gpu(loaded_models)
             if self.latent_format is not None:
-                self.cond_hint = self.latent_format.process_in(self.cond_hint)
+                cond_hint = self.latent_format.process_in(cond_hint)
             if len(self.extra_concat_orig) > 0:
                 to_concat = []
                 for c in self.extra_concat_orig:
-                    c = c.to(self.cond_hint.device)
-                    c = comfy.utils.common_upscale(c, self.cond_hint.shape[-1], self.cond_hint.shape[-2], self.upscale_algorithm, "center")
-                    if c.ndim < self.cond_hint.ndim:
+                    c = c.to(cond_hint.device)
+                    c = comfy.utils.common_upscale(c, cond_hint.shape[-1], cond_hint.shape[-2], self.upscale_algorithm, "center")
+                    if c.ndim < cond_hint.ndim:
                         c = c.unsqueeze(2)
-                        c = comfy.utils.repeat_to_batch_size(c, self.cond_hint.shape[2], dim=2)
-                    to_concat.append(comfy.utils.repeat_to_batch_size(c, self.cond_hint.shape[0]))
-                self.cond_hint = torch.cat([self.cond_hint] + to_concat, dim=1)
+                        c = comfy.utils.repeat_to_batch_size(c, cond_hint.shape[2], dim=2)
+                    to_concat.append(comfy.utils.repeat_to_batch_size(c, cond_hint.shape[0]))
+                cond_hint = torch.cat([cond_hint] + to_concat, dim=1)
 
-            self.cond_hint = self.cond_hint.to(device=x_noisy.device, dtype=dtype)
-        if x_noisy.shape[0] != self.cond_hint.shape[0]:
-            self.cond_hint = broadcast_image_to(self.cond_hint, x_noisy.shape[0], batched_number)
+            cond_hint = cond_hint.to(device=x_noisy.device, dtype=dtype)
+            while len(self.cond_hints) >= 2:
+                self.cond_hints.pop(next(iter(self.cond_hints)))
+            self.cond_hints[(x_noisy.shape[2], x_noisy.shape[3])] = cond_hint
+        if x_noisy.shape[0] != cond_hint.shape[0]:
+            cond_hint = broadcast_image_to(cond_hint, x_noisy.shape[0], batched_number)
 
         context = cond.get('crossattn_controlnet', cond['c_crossattn'])
         extra = self.extra_args.copy()
@@ -309,7 +315,7 @@ class ControlNet(ControlBase):
         timestep = self.model_sampling_current.timestep(t)
         x_noisy = self.model_sampling_current.calculate_input(t, x_noisy)
 
-        control = self.control_model(x=x_noisy.to(dtype), hint=self.cond_hint, timesteps=timestep.to(dtype), context=comfy.model_management.cast_to_device(context, x_noisy.device, dtype), **extra)
+        control = self.control_model(x=x_noisy.to(dtype), hint=cond_hint, timesteps=timestep.to(dtype), context=comfy.model_management.cast_to_device(context, x_noisy.device, dtype), **extra)
         return self.control_merge(control, control_prev, output_dtype=None)
 
     def copy(self):
@@ -922,21 +928,21 @@ class T2IAdapter(ControlBase):
                 else:
                     return None
 
-        if self.cond_hint is None or x_noisy.shape[2] * self.compression_ratio != self.cond_hint.shape[2] or x_noisy.shape[3] * self.compression_ratio != self.cond_hint.shape[3]:
-            if self.cond_hint is not None:
-                del self.cond_hint
-            self.control_input = None
-            self.cond_hint = None
+        cond_hint = self.cond_hints.get((x_noisy.shape[2], x_noisy.shape[3]))
+        if cond_hint is None:
             width, height = self.scale_image_to(x_noisy.shape[3] * self.compression_ratio, x_noisy.shape[2] * self.compression_ratio)
-            self.cond_hint = comfy.utils.common_upscale(self.cond_hint_original, width, height, self.upscale_algorithm, "center").float().to(self.device)
-            if self.channels_in == 1 and self.cond_hint.shape[1] > 1:
-                self.cond_hint = torch.mean(self.cond_hint, 1, keepdim=True)
-        if x_noisy.shape[0] != self.cond_hint.shape[0]:
-            self.cond_hint = broadcast_image_to(self.cond_hint, x_noisy.shape[0], batched_number)
+            cond_hint = comfy.utils.common_upscale(self.cond_hint_original, width, height, self.upscale_algorithm, "center").float().to(self.device)
+            if self.channels_in == 1 and cond_hint.shape[1] > 1:
+                cond_hint = torch.mean(cond_hint, 1, keepdim=True)
+            while len(self.cond_hints) >= 2:
+                self.cond_hints.pop(next(iter(self.cond_hints)))
+            self.cond_hints[(x_noisy.shape[2], x_noisy.shape[3])] = cond_hint
+        if x_noisy.shape[0] != cond_hint.shape[0]:
+            cond_hint = broadcast_image_to(cond_hint, x_noisy.shape[0], batched_number)
         if self.control_input is None:
             self.t2i_model.to(x_noisy.dtype)
             self.t2i_model.to(self.device)
-            self.control_input = self.t2i_model(self.cond_hint.to(x_noisy.dtype))
+            self.control_input = self.t2i_model(cond_hint.to(x_noisy.dtype))
             self.t2i_model.cpu()
 
         control_input = {}

--- a/comfy/controlnet.py
+++ b/comfy/controlnet.py
@@ -943,7 +943,7 @@ class T2IAdapter(ControlBase):
         if x_noisy.shape[0] != cond_hint.shape[0]:
             cond_hint = broadcast_image_to(cond_hint, x_noisy.shape[0], batched_number)
 
-        control_input = self.control_inputs.get((x_noisy.shape[2], x_noisy.shape[3]))
+        control_input = self.control_inputs.get((x_noisy.shape[2], x_noisy.shape[3], x_noisy.shape[0], batched_number))
         if control_input is None:
             self.t2i_model.to(x_noisy.dtype)
             self.t2i_model.to(self.device)
@@ -951,7 +951,7 @@ class T2IAdapter(ControlBase):
             self.t2i_model.cpu()
             while len(self.control_inputs) >= 2:
                 self.control_inputs.pop(next(iter(self.control_inputs)))
-            self.control_inputs[(x_noisy.shape[2], x_noisy.shape[3])] = control_input
+            self.control_inputs[(x_noisy.shape[2], x_noisy.shape[3], x_noisy.shape[0], batched_number)] = control_input
 
         out = {}
         for k in control_input:

--- a/tests/test_controlnet_hint_cache.py
+++ b/tests/test_controlnet_hint_cache.py
@@ -1,0 +1,90 @@
+from types import SimpleNamespace
+
+import torch
+
+import comfy.utils
+from comfy.controlnet import ControlNet
+
+
+class FakeControlModel:
+    dtype = torch.float32
+
+    def __call__(self, **kw):
+        self.last_hint = kw["hint"]
+        return torch.zeros((1, 4))
+
+
+def make_cn():
+    cn = ControlNet()
+    cn.control_model = FakeControlModel()
+    cn.model_sampling_current = SimpleNamespace(
+        timestep=lambda t: t,
+        calculate_input=lambda t, x: x,
+    )
+    # focus these tests on hint preparation, not output merging
+    cn.control_merge = lambda control, control_prev, output_dtype=None: control
+    cn.cond_hint_original = torch.zeros((1, 3, 16, 16))
+    return cn
+
+
+def call(cn, h, w, batch=1):
+    x = torch.zeros((batch, 4, h, w))
+    cond = {"c_crossattn": torch.zeros((1, 1, 1))}
+    return cn.get_control(x, torch.tensor([999.0]), cond, 1, {})
+
+
+def test_alternating_area_sizes_prepare_hint_once_per_size(monkeypatch):
+    prep_calls = []
+    real_upscale = comfy.utils.common_upscale
+
+    def spy_upscale(samples, width, height, *a, **k):
+        prep_calls.append((width, height))
+        return real_upscale(samples, width, height, *a, **k)
+
+    monkeypatch.setattr(comfy.utils, "common_upscale", spy_upscale)
+    cn = make_cn()
+
+    call(cn, 8, 8)
+    call(cn, 4, 4)
+    call(cn, 8, 8)
+
+    # Area composition alternates two sizes every step; each size should be
+    # prepared once instead of re-upscaling (and re-VAE-encoding) per step.
+    assert len(prep_calls) == 2, f"hint prepared {len(prep_calls)} times"
+
+
+def test_cached_hints_are_bounded():
+    cn = make_cn()
+    call(cn, 8, 8)
+    call(cn, 4, 4)
+    call(cn, 6, 6)
+
+    assert len(cn.cond_hints) <= 2
+
+
+def test_cleanup_releases_cached_hints():
+    cn = make_cn()
+    call(cn, 8, 8)
+
+    cn.cleanup()
+
+    assert len(cn.cond_hints) == 0
+
+
+def test_batch_broadcast_does_not_pollute_cache(monkeypatch):
+    prep_calls = []
+    real_upscale = comfy.utils.common_upscale
+
+    def spy_upscale(samples, width, height, *a, **k):
+        prep_calls.append((width, height))
+        return real_upscale(samples, width, height, *a, **k)
+
+    monkeypatch.setattr(comfy.utils, "common_upscale", spy_upscale)
+    cn = make_cn()
+    call(cn, 8, 8, batch=1)
+    call(cn, 8, 8, batch=2)
+
+    assert len(prep_calls) == 1
+    # the cached copy keeps its original pre-broadcast batch size so later
+    # calls with any batch count can reuse it
+    assert cn.cond_hints[(8, 8)].shape[0] == cn.cond_hint_original.shape[0]

--- a/tests/test_controlnet_hint_cache.py
+++ b/tests/test_controlnet_hint_cache.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 import torch
 
 import comfy.utils
-from comfy.controlnet import ControlNet
+from comfy.controlnet import ControlNet, T2IAdapter
 
 
 class FakeControlModel:
@@ -88,3 +88,73 @@ def test_batch_broadcast_does_not_pollute_cache(monkeypatch):
     # the cached copy keeps its original pre-broadcast batch size so later
     # calls with any batch count can reuse it
     assert cn.cond_hints[(8, 8)].shape[0] == cn.cond_hint_original.shape[0]
+
+
+class FakeT2IModel:
+    unshuffle_amount = 8
+
+    def __init__(self):
+        self.calls = []
+
+    def to(self, *a, **k):
+        return self
+
+    def cpu(self):
+        return self
+
+    def __call__(self, hint):
+        self.calls.append(tuple(hint.shape))
+        return {"output": [hint]}
+
+
+def make_t2i():
+    adapter = object.__new__(T2IAdapter)
+    adapter.cond_hint_original = torch.zeros((1, 3, 64, 64))
+    adapter.compression_ratio = 8
+    adapter.upscale_algorithm = "nearest-exact"
+    adapter.channels_in = 3
+    adapter.t2i_model = FakeT2IModel()
+    adapter.device = torch.device("cpu")
+    adapter.previous_controlnet = None
+    adapter.timestep_range = None
+    adapter.cond_hints = {}
+    adapter.control_inputs = {}
+    adapter.control_merge = lambda control, control_prev, output_dtype=None: control
+    return adapter
+
+
+def test_t2i_alternating_sizes_recompute_adapter():
+    adapter = make_t2i()
+
+    out_1 = call(adapter, 8, 8)
+    out_2 = call(adapter, 4, 4)
+    out_3 = call(adapter, 8, 8)
+
+    # the adapter runs once per size; the second 8x8 step reuses the cached
+    # result instead of rerunning t2i_model
+    assert adapter.t2i_model.calls == [((1, 3, 64, 64)), ((1, 3, 32, 32))]
+    assert len(adapter.control_inputs) == 2
+    assert out_1["output"][0].shape == (1, 3, 64, 64)
+    assert out_2["output"][0].shape == (1, 3, 32, 32)
+    assert out_3["output"][0].shape == (1, 3, 64, 64)
+
+
+def test_set_cond_hint_invalidates_cache(monkeypatch):
+    prep_calls = []
+    real_upscale = comfy.utils.common_upscale
+
+    def spy_upscale(samples, width, height, *a, **k):
+        prep_calls.append((width, height))
+        return real_upscale(samples, width, height, *a, **k)
+
+    monkeypatch.setattr(comfy.utils, "common_upscale", spy_upscale)
+    cn = make_cn()
+
+    call(cn, 8, 8)
+    assert len(prep_calls) == 1
+
+    cn.set_cond_hint(torch.zeros((1, 3, 32, 32)))
+    call(cn, 8, 8)
+
+    # a new hint image must not be served from the per-size cache
+    assert len(prep_calls) == 2

--- a/tests/test_controlnet_hint_cache.py
+++ b/tests/test_controlnet_hint_cache.py
@@ -27,8 +27,8 @@ def make_cn():
     return cn
 
 
-def call(cn, h, w, batch=1, batched_number=1):
-    x = torch.zeros((batch, 4, h, w))
+def call(cn, h, w, batch=1, batched_number=1, dtype=torch.float32):
+    x = torch.zeros((batch, 4, h, w), dtype=dtype)
     cond = {"c_crossattn": torch.zeros((1, 1, 1))}
     return cn.get_control(x, torch.tensor([999.0]), cond, batched_number, {})
 
@@ -154,6 +154,18 @@ def test_t2i_same_size_different_batch_recomputes():
     # repeating the first configuration is served from the cache again
     call(adapter, 8, 8, batch=2)
     assert adapter.t2i_model.calls == [((2, 3, 64, 64)), ((4, 3, 64, 64))]
+
+
+def test_t2i_same_size_different_dtype_recomputes():
+    adapter = make_t2i()
+
+    call(adapter, 8, 8, dtype=torch.float32)
+    call(adapter, 8, 8, dtype=torch.float16)
+
+    # the model is cast to x_noisy.dtype on a miss; a cached fp32 result must
+    # not be served when the next step runs in fp16
+    assert len(adapter.t2i_model.calls) == 2
+    assert {k[4] for k in adapter.control_inputs} == {torch.float32, torch.float16}
 
 
 def test_set_cond_hint_invalidates_cache(monkeypatch):

--- a/tests/test_controlnet_hint_cache.py
+++ b/tests/test_controlnet_hint_cache.py
@@ -27,10 +27,10 @@ def make_cn():
     return cn
 
 
-def call(cn, h, w, batch=1):
+def call(cn, h, w, batch=1, batched_number=1):
     x = torch.zeros((batch, 4, h, w))
     cond = {"c_crossattn": torch.zeros((1, 1, 1))}
-    return cn.get_control(x, torch.tensor([999.0]), cond, 1, {})
+    return cn.get_control(x, torch.tensor([999.0]), cond, batched_number, {})
 
 
 def test_alternating_area_sizes_prepare_hint_once_per_size(monkeypatch):
@@ -137,6 +137,23 @@ def test_t2i_alternating_sizes_recompute_adapter():
     assert out_1["output"][0].shape == (1, 3, 64, 64)
     assert out_2["output"][0].shape == (1, 3, 32, 32)
     assert out_3["output"][0].shape == (1, 3, 64, 64)
+
+
+def test_t2i_same_size_different_batch_recomputes():
+    adapter = make_t2i()
+    adapter.cond_hint_original = torch.zeros((2, 3, 16, 16))
+
+    call(adapter, 8, 8, batch=2)
+    call(adapter, 8, 8, batch=4, batched_number=2)
+
+    # same spatial size, but cond_hint is broadcast differently per call, so
+    # the cached control_input from the first shape must not be reused
+    assert adapter.t2i_model.calls == [((2, 3, 64, 64)), ((4, 3, 64, 64))]
+    assert len(adapter.control_inputs) == 2
+
+    # repeating the first configuration is served from the cache again
+    call(adapter, 8, 8, batch=2)
+    assert adapter.t2i_model.calls == [((2, 3, 64, 64)), ((4, 3, 64, 64))]
 
 
 def test_set_cond_hint_invalidates_cache(monkeypatch):


### PR DESCRIPTION
Fixes #2540

## Problem

With area composition, both area conditionings reference the same `ControlBase` instance, and each step crops `input_x` to a different area. The single-slot `cond_hint` cache keyed only on the last seen size therefore missed on every call — every step re-ran `common_upscale`, and a full VAE encode when the apply node had a VAE attached.

## Change

Replace the single slot with a small per-size map (kept at two entries, FIFO eviction). The prepared hint is cached before broadcasting, so batch-size changes reuse it as well. `cleanup()` clears the map as before. `T2IAdapter.get_control` had the same pattern and gets the same fix.

Memory impact is bounded: at most two prepared hints are held instead of one, released by the existing cleanup path.

## Tests

New `tests/test_controlnet_hint_cache.py` (4 tests): alternating area sizes prepare the hint once per size, cache stays bounded, cleanup releases entries, broadcast does not pollute the cached copy.

Environment: Python 3.12 / torch 2.11 CPU, current master (`82f839f5`).