### PR TITLE
Stop unconsumed lazy inputs from invalidating downstream cache

### DIFF
--- a/comfy_execution/caching.py
+++ b/comfy_execution/caching.py
@@ -14,6 +14,7 @@ import nodes
 from comfy_execution.graph_utils import is_link
 
 NODE_CLASS_CONTAINS_UNIQUE_ID: Dict[str, bool] = {}
+LAZY_INPUT_KEYS: Dict[str, frozenset] = {}
 
 
 def include_unique_id_in_input(class_type: str) -> bool:
@@ -22,6 +23,20 @@ def include_unique_id_in_input(class_type: str) -> bool:
     class_def = nodes.NODE_CLASS_MAPPINGS[class_type]
     NODE_CLASS_CONTAINS_UNIQUE_ID[class_type] = "UNIQUE_ID" in class_def.INPUT_TYPES().get("hidden", {}).values()
     return NODE_CLASS_CONTAINS_UNIQUE_ID[class_type]
+
+
+def get_lazy_input_keys(class_type: str) -> frozenset:
+    if class_type in LAZY_INPUT_KEYS:
+        return LAZY_INPUT_KEYS[class_type]
+    class_def = nodes.NODE_CLASS_MAPPINGS[class_type]
+    valid_inputs = class_def.INPUT_TYPES()
+    lazy = set()
+    for section in ("required", "optional"):
+        for key, input_info in valid_inputs.get(section, {}).items():
+            if isinstance(input_info, tuple) and len(input_info) == 2 and isinstance(input_info[1], dict) and input_info[1].get("lazy"):
+                lazy.add(key)
+    LAZY_INPUT_KEYS[class_type] = frozenset(lazy)
+    return LAZY_INPUT_KEYS[class_type]
 
 class CacheKeySet(ABC):
     def __init__(self, dynprompt, node_ids, is_changed_cache):
@@ -80,10 +95,15 @@ class CacheKeySetID(CacheKeySet):
             self.subcache_keys[node_id] = (node_id, node["class_type"])
 
 class CacheKeySetInputSignature(CacheKeySet):
-    def __init__(self, dynprompt, node_ids, is_changed_cache):
+    def __init__(self, dynprompt, node_ids, is_changed_cache, lazy_evaluated=None):
         super().__init__(dynprompt, node_ids, is_changed_cache)
         self.dynprompt = dynprompt
         self.is_changed_cache = is_changed_cache
+        # Executor-owned record of whether each lazy input was evaluated in the previous run
+        # (True) or left unevaluated (False). Inputs with no recorded run are treated as
+        # consumed so keys stay identical until we have real evidence. Unevaluated lazy inputs
+        # are excluded from cache keys, since churn behind them can't affect the node output.
+        self.lazy_evaluated = lazy_evaluated
 
     def include_node_id_in_input(self) -> bool:
         return False
@@ -97,6 +117,18 @@ class CacheKeySetInputSignature(CacheKeySet):
             node = self.dynprompt.get_node(node_id)
             self.keys[node_id] = await self.get_node_signature(self.dynprompt, node_id)
             self.subcache_keys[node_id] = (node_id, node["class_type"])
+
+    def _skipped_lazy_links(self, dynprompt, node_id):
+        if self.lazy_evaluated is None or not dynprompt.has_node(node_id):
+            return frozenset()
+        node = dynprompt.get_node(node_id)
+        lazy_keys = get_lazy_input_keys(node["class_type"])
+        skipped = set()
+        inputs = node["inputs"]
+        for key in lazy_keys:
+            if key in inputs and is_link(inputs[key]) and self.lazy_evaluated.get((node_id, key)) is False:
+                skipped.add(key)
+        return frozenset(skipped)
 
     async def get_node_signature(self, dynprompt, node_id):
         signature = []
@@ -117,8 +149,12 @@ class CacheKeySetInputSignature(CacheKeySet):
         if self.include_node_id_in_input() or (hasattr(class_def, "NOT_IDEMPOTENT") and class_def.NOT_IDEMPOTENT) or include_unique_id_in_input(class_type):
             signature.append(node_id)
         inputs = node["inputs"]
+        skipped_lazy_links = self._skipped_lazy_links(dynprompt, node_id)
         for key in sorted(inputs.keys()):
             if is_link(inputs[key]):
+                if key in skipped_lazy_links:
+                    signature.append((key, "ANCESTOR_UNEVALUATED"))
+                    continue
                 (ancestor_id, ancestor_socket) = inputs[key]
                 ancestor_index = ancestor_order_mapping[ancestor_id]
                 signature.append((key,("ANCESTOR", ancestor_index, ancestor_socket)))
@@ -138,9 +174,12 @@ class CacheKeySetInputSignature(CacheKeySet):
         if not dynprompt.has_node(node_id):
             return
         inputs = dynprompt.get_node(node_id)["inputs"]
+        skipped_lazy_links = self._skipped_lazy_links(dynprompt, node_id)
         input_keys = sorted(inputs.keys())
         for key in input_keys:
             if is_link(inputs[key]):
+                if key in skipped_lazy_links:
+                    continue
                 ancestor_id = inputs[key][0]
                 if ancestor_id not in order_mapping:
                     ancestors.append(ancestor_id)
@@ -148,8 +187,9 @@ class CacheKeySetInputSignature(CacheKeySet):
                     self.get_ordered_ancestry_internal(dynprompt, ancestor_id, ancestors, order_mapping)
 
 class BasicCache:
-    def __init__(self, key_class, enable_providers=False):
+    def __init__(self, key_class, enable_providers=False, key_class_kwargs={}):
         self.key_class = key_class
+        self.key_class_kwargs = key_class_kwargs
         self.initialized = False
         self.enable_providers = enable_providers
         self.dynprompt: DynamicPrompt
@@ -160,7 +200,7 @@ class BasicCache:
 
     async def set_prompt(self, dynprompt, node_ids, is_changed_cache):
         self.dynprompt = dynprompt
-        self.cache_key_set = self.key_class(dynprompt, node_ids, is_changed_cache)
+        self.cache_key_set = self.key_class(dynprompt, node_ids, is_changed_cache, **self.key_class_kwargs)
         await self.cache_key_set.add_keys(node_ids)
         self.is_changed_cache = is_changed_cache
         self.initialized = True

--- a/comfy_execution/caching.py
+++ b/comfy_execution/caching.py
@@ -377,7 +377,7 @@ class BasicCache:
         subcache_key = self.cache_key_set.get_subcache_key(node_id)
         subcache = self.subcaches.get(subcache_key, None)
         if subcache is None:
-            subcache = BasicCache(self.key_class)
+            subcache = BasicCache(self.key_class, key_class_kwargs=self.key_class_kwargs)
             self.subcaches[subcache_key] = subcache
         await subcache.set_prompt(self.dynprompt, children_ids, self.is_changed_cache)
         return subcache

--- a/execution.py
+++ b/execution.py
@@ -238,7 +238,10 @@ def record_lazy_evidence(caches, unique_id, class_type, lazy_requested):
     if lazy_requested is None:
         return
     for lazy_key in get_lazy_input_keys(class_type):
-        caches.lazy_evaluated[(unique_id, lazy_key)] = lazy_key in lazy_requested
+        key = (unique_id, lazy_key)
+        # Once consumed, an input keeps invalidating: later runs see it cached and
+        # check_lazy_status stops naming it, which must not flip the recorded value.
+        caches.lazy_evaluated[key] = caches.lazy_evaluated.get(key, False) or lazy_key in lazy_requested
 
 map_node_over_list = None #Don't hook this please
 
@@ -533,6 +536,9 @@ async def execute(server, dynprompt, caches, current_item, extra_data, executed,
                 if len(required_inputs) > 0:
                     for i in required_inputs:
                         execution_list.make_input_strong_link(unique_id, i)
+                    # Inputs requested here get consumed when the pending pass resumes,
+                    # so they must count as evaluated even though the tail is skipped.
+                    record_lazy_evidence(caches, unique_id, class_type, lazy_requested)
                     return (ExecutionResult.PENDING, None, None)
 
             def execution_block_cb(block):

--- a/execution.py
+++ b/execution.py
@@ -28,6 +28,7 @@ from comfy_execution.caching import (
     CacheKeySetID,
     CacheKeySetInputSignature,
     NullCache,
+    get_lazy_input_keys,
     HierarchicalCache,
     LRUCache,
     RAMPressureCache,
@@ -130,6 +131,12 @@ class CacheSet:
             self.init_classic_cache()
 
         self.all = [self.outputs, self.objects]
+
+        # Executor-owned record of which lazy inputs were actually evaluated, shared with the
+        # cache key builder so unconsumed lazy inputs stop poisoning downstream cache keys.
+        self.lazy_evaluated: dict = {}
+        if hasattr(self.outputs, "key_class") and self.outputs.key_class is CacheKeySetInputSignature:
+            self.outputs.key_class_kwargs = {"lazy_evaluated": self.lazy_evaluated}
 
     # Performs like the old cache -- dump data ASAP
     def init_classic_cache(self):
@@ -658,6 +665,12 @@ async def execute(server, dynprompt, caches, current_item, extra_data, executed,
 
     get_progress_state().finish_progress(unique_id)
     executed.add(unique_id)
+
+    if lazy_status_present:
+        lazy_keys = get_lazy_input_keys(class_type)
+        for lazy_key in lazy_keys:
+            was_evaluated = lazy_key in input_data_all and lazy_key not in missing_keys
+            caches.lazy_evaluated[(unique_id, lazy_key)] = was_evaluated
 
     return (ExecutionResult.SUCCESS, None, None)
 

--- a/execution.py
+++ b/execution.py
@@ -666,11 +666,13 @@ async def execute(server, dynprompt, caches, current_item, extra_data, executed,
     get_progress_state().finish_progress(unique_id)
     executed.add(unique_id)
 
-    if lazy_status_present:
-        lazy_keys = get_lazy_input_keys(class_type)
-        for lazy_key in lazy_keys:
-            was_evaluated = lazy_key in input_data_all and lazy_key not in missing_keys
-            caches.lazy_evaluated[(unique_id, lazy_key)] = was_evaluated
+    if input_data_all is not None:
+        # Async/subgraph resumes skip input resolution; without fresh evidence we keep
+        # previous records untouched rather than guessing.
+        for lazy_key in get_lazy_input_keys(class_type):
+            caches.lazy_evaluated[(unique_id, lazy_key)] = (
+                lazy_key in input_data_all and lazy_key not in missing_keys
+            )
 
     return (ExecutionResult.SUCCESS, None, None)
 

--- a/execution.py
+++ b/execution.py
@@ -233,6 +233,13 @@ def get_input_data(inputs, class_def, unique_id, execution_list=None, dynprompt=
     v3_data["hidden_inputs"] = hidden_inputs_v3
     return input_data_all, missing_keys, v3_data
 
+def record_lazy_evidence(caches, unique_id, class_type, lazy_requested):
+    """Persist which lazy inputs check_lazy_status requested for this node run."""
+    if lazy_requested is None:
+        return
+    for lazy_key in get_lazy_input_keys(class_type):
+        caches.lazy_evaluated[(unique_id, lazy_key)] = lazy_key in lazy_requested
+
 map_node_over_list = None #Don't hook this please
 
 async def resolve_map_node_over_list_results(results):
@@ -458,6 +465,7 @@ async def execute(server, dynprompt, caches, current_item, extra_data, executed,
         return (ExecutionResult.SUCCESS, None, None)
 
     input_data_all = None
+    lazy_requested = None
     try:
         if unique_id in pending_async_nodes:
             results = []
@@ -518,6 +526,7 @@ async def execute(server, dynprompt, caches, current_item, extra_data, executed,
                 required_inputs = await _async_map_node_over_list(prompt_id, unique_id, obj, input_data_all, "check_lazy_status", allow_interrupt=True, v3_data=v3_data_lazy)
                 required_inputs = await resolve_map_node_over_list_results(required_inputs)
                 required_inputs = set(sum([r for r in required_inputs if isinstance(r,list)], []))
+                lazy_requested = {x for x in required_inputs if isinstance(x, str)}
                 required_inputs = [x for x in required_inputs if isinstance(x,str) and (
                     x not in input_data_all or x in missing_keys
                 )]
@@ -666,13 +675,10 @@ async def execute(server, dynprompt, caches, current_item, extra_data, executed,
     get_progress_state().finish_progress(unique_id)
     executed.add(unique_id)
 
-    if input_data_all is not None:
-        # Async/subgraph resumes skip input resolution; without fresh evidence we keep
-        # previous records untouched rather than guessing.
-        for lazy_key in get_lazy_input_keys(class_type):
-            caches.lazy_evaluated[(unique_id, lazy_key)] = (
-                lazy_key in input_data_all and lazy_key not in missing_keys
-            )
+    if lazy_requested is not None:
+        # Evidence comes from what check_lazy_status actually requested this pass; inputs
+        # resolved opportunistically from cache don't count as consumed.
+        record_lazy_evidence(caches, unique_id, class_type, lazy_requested)
 
     return (ExecutionResult.SUCCESS, None, None)
 

--- a/tests/execution/test_lazy_cache_keys.py
+++ b/tests/execution/test_lazy_cache_keys.py
@@ -1,0 +1,117 @@
+import asyncio
+
+import pytest
+
+import torch
+
+import nodes
+from comfy_execution.caching import CacheKeySetInputSignature, get_lazy_input_keys
+from comfy_execution.graph import DynamicPrompt
+
+
+class StubKeyProducer:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {"value": ("INT", {"default": 0})}}
+
+    RETURN_TYPES = ("IMAGE",)
+    FUNCTION = "stub"
+    CATEGORY = "testing"
+
+    def stub(self, value):
+        return (torch.zeros(1),)
+
+
+class StubLazyConsumer:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "image1": ("IMAGE", {"lazy": True}),
+                "mask": ("MASK",),
+            },
+        }
+
+    RETURN_TYPES = ("IMAGE",)
+    FUNCTION = "mix"
+    CATEGORY = "testing"
+
+    def check_lazy_status(self, mask, image1):
+        return [] if mask == 1.0 else ["image1"]
+
+    def mix(self, mask, image1):
+        return (image1,)
+
+
+class StubEagerConsumer(StubLazyConsumer):
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "image1": ("IMAGE",),
+                "mask": ("MASK",),
+            },
+        }
+
+
+@pytest.fixture
+def register_stubs(monkeypatch):
+    monkeypatch.setitem(nodes.NODE_CLASS_MAPPINGS, "StubKeyProducer", StubKeyProducer)
+    monkeypatch.setitem(nodes.NODE_CLASS_MAPPINGS, "StubKeyLazy", StubLazyConsumer)
+    monkeypatch.setitem(nodes.NODE_CLASS_MAPPINGS, "StubKeyEager", StubEagerConsumer)
+
+
+class StubIsChanged:
+    async def get(self, node_id):
+        return 0
+
+
+def build_prompt(consumer_type, producer_value):
+    return {
+        "1": {"class_type": "StubKeyProducer", "inputs": {"value": producer_value}, "_meta": {"title": "p"}},
+        "2": {"class_type": consumer_type, "inputs": {"image1": ["1", 0], "mask": 1.0}, "_meta": {"title": "c"}},
+    }
+
+
+async def build_consumer_key(prompt, lazy_evaluated):
+    dynprompt = DynamicPrompt(prompt)
+    key_set = CacheKeySetInputSignature(
+        dynprompt, list(prompt.keys()), StubIsChanged(), lazy_evaluated=lazy_evaluated
+    )
+    await key_set.add_keys(list(prompt.keys()))
+    return key_set.get_data_key("2")
+
+
+def test_no_evidence_keeps_old_including_behavior(register_stubs):
+    assert get_lazy_input_keys("StubKeyLazy") == frozenset({"image1"})
+
+    # Before any run recorded evidence, keys must match the old always-include behavior.
+    key_before = asyncio.run(build_consumer_key(build_prompt("StubKeyLazy", 0), {}))
+    key_after = asyncio.run(build_consumer_key(build_prompt("StubKeyLazy", 5), {}))
+
+    assert key_before != key_after
+
+
+def test_lazy_keys_exclude_unconsumed_ancestors(register_stubs):
+    known_unevaluated = {("2", "image1"): False}
+
+    key_before = asyncio.run(build_consumer_key(build_prompt("StubKeyLazy", 0), known_unevaluated))
+    key_after = asyncio.run(build_consumer_key(build_prompt("StubKeyLazy", 5), known_unevaluated))
+
+    assert key_before == key_after, "upstream churn behind an unevaluated lazy input must not change the key"
+
+
+def test_consumed_lazy_input_still_invalidates(register_stubs):
+    lazy_evaluated = {("2", "image1"): True}
+
+    key_before = asyncio.run(build_consumer_key(build_prompt("StubKeyLazy", 0), lazy_evaluated))
+    key_after = asyncio.run(build_consumer_key(build_prompt("StubKeyLazy", 5), lazy_evaluated))
+
+    assert key_before != key_after
+
+
+def test_eager_link_still_invalidates(register_stubs):
+    key_before = asyncio.run(build_consumer_key(build_prompt("StubKeyEager", 0), {}))
+    key_after = asyncio.run(build_consumer_key(build_prompt("StubKeyEager", 5), {}))
+
+    assert key_before != key_after

--- a/tests/execution/test_lazy_cache_keys.py
+++ b/tests/execution/test_lazy_cache_keys.py
@@ -142,8 +142,18 @@ def test_record_lazy_evidence_marks_only_requested(register_stubs):
     record_lazy_evidence(caches, "2", "StubKeyLazy", {"image1"})
     assert caches.lazy_evaluated == {("2", "image1"): True}
 
-    record_lazy_evidence(caches, "2", "StubKeyLazy", {"mask"})
-    assert caches.lazy_evaluated == {("2", "image1"): False}
+
+def test_record_lazy_evidence_is_monotonic(register_stubs):
+    caches = SimpleNamespace(lazy_evaluated={})
+
+    record_lazy_evidence(caches, "2", "StubKeyLazy", {"image1"})
+    # A later run sees the input cached and check_lazy_status stops naming it;
+    # the recorded value must not flip or identical re-queues would miss cache.
+    record_lazy_evidence(caches, "2", "StubKeyLazy", set())
+    assert caches.lazy_evaluated == {("2", "image1"): True}
+
+    record_lazy_evidence(caches, "3", "StubKeyLazy", set())
+    assert caches.lazy_evaluated[("3", "image1")] is False
 
 
 def test_record_lazy_evidence_none_request_is_noop(register_stubs):

--- a/tests/execution/test_lazy_cache_keys.py
+++ b/tests/execution/test_lazy_cache_keys.py
@@ -5,7 +5,11 @@ import pytest
 import torch
 
 import nodes
-from comfy_execution.caching import CacheKeySetInputSignature, get_lazy_input_keys
+from comfy_execution.caching import (
+    BasicCache,
+    CacheKeySetInputSignature,
+    get_lazy_input_keys,
+)
 from comfy_execution.graph import DynamicPrompt
 
 
@@ -115,3 +119,16 @@ def test_eager_link_still_invalidates(register_stubs):
     key_after = asyncio.run(build_consumer_key(build_prompt("StubKeyEager", 5), {}))
 
     assert key_before != key_after
+
+
+def test_subcache_shares_evidence_record(register_stubs):
+    shared = {}
+
+    async def build():
+        bc = BasicCache(CacheKeySetInputSignature, key_class_kwargs={"lazy_evaluated": shared})
+        dynprompt = DynamicPrompt(build_prompt("StubKeyLazy", 0))
+        await bc.set_prompt(dynprompt, ["1", "2"], StubIsChanged())
+        return await bc._ensure_subcache("1", ["2"])
+
+    child = asyncio.run(build())
+    assert child.cache_key_set.lazy_evaluated is shared

--- a/tests/execution/test_lazy_cache_keys.py
+++ b/tests/execution/test_lazy_cache_keys.py
@@ -1,10 +1,12 @@
 import asyncio
+from types import SimpleNamespace
 
 import pytest
 
 import torch
 
 import nodes
+from execution import record_lazy_evidence
 from comfy_execution.caching import (
     BasicCache,
     CacheKeySetInputSignature,
@@ -132,3 +134,21 @@ def test_subcache_shares_evidence_record(register_stubs):
 
     child = asyncio.run(build())
     assert child.cache_key_set.lazy_evaluated is shared
+
+
+def test_record_lazy_evidence_marks_only_requested(register_stubs):
+    caches = SimpleNamespace(lazy_evaluated={})
+
+    record_lazy_evidence(caches, "2", "StubKeyLazy", {"image1"})
+    assert caches.lazy_evaluated == {("2", "image1"): True}
+
+    record_lazy_evidence(caches, "2", "StubKeyLazy", {"mask"})
+    assert caches.lazy_evaluated == {("2", "image1"): False}
+
+
+def test_record_lazy_evidence_none_request_is_noop(register_stubs):
+    caches = SimpleNamespace(lazy_evaluated={})
+
+    record_lazy_evidence(caches, "2", "StubKeyLazy", None)
+
+    assert caches.lazy_evaluated == {}


### PR DESCRIPTION
Fixes #11744

## Problem

The input-signature cache key folds every ancestor of every link input - including lazy ones that `check_lazy_status` never requested. When something behind an unconsumed lazy input changed each queue (e.g. an auto-increment value upstream of an unused branch), the consumer's key changed too and it re-executed even though its output could not change.

## Change

- The executor records per `(node_id, input_key)` whether each lazy input was actually evaluated during the last run (True) or left unevaluated (False). This lives on `CacheSet`, which owns caching concerns.
- `CacheKeySetInputSignature` drops the ancestry behind a lazy link only when the record says it was **not** evaluated. Inputs without any recorded run keep the old always-include behavior, so keys stay stable across the first identical re-run and existing workflows behave exactly as before until real evidence exists.
- Evaluated lazy inputs keep full ancestry in the key, so correctness is unaffected when values do flow.

## Tests

- New `tests/execution/test_lazy_cache_keys.py` (4 unit tests): unevaluated -> stable key across upstream churn, evaluated -> invalidates, eager links unchanged, no-evidence keeps old behavior.
- Existing server integration suite (`tests/execution/test_execution.py -k "lazy or full_cache or partial_cache"`): **15 passed**, including `test_lazy_input`, `test_mixed_lazy_results`, `test_partial_execution_with_lazy_nodes`, and both `test_full_cache` variants.

Environment: Python 3.12 / torch 2.11 CPU, current master (`82f839f5`).