### PR TITLE
Return None instead of raising on a cross-drive userdata path (#15820)

### DIFF
--- a/app/user_manager.py
+++ b/app/user_manager.py
@@ -92,7 +92,16 @@ class UserManager():
 
             # prevent leaving /{type}/{user}
             path = os.path.abspath(os.path.join(user_root, file))
-            if os.path.commonpath((user_root, path)) != user_root:
+            # commonpath() raises ValueError when the two paths are on
+            # different Windows drives, so a request for an absolute path on
+            # another drive (e.g. /userdata/C:%5C... while the user directory
+            # is on D:) escaped as an unhandled 500 instead of being rejected.
+            # A path on another drive is, by definition, not inside user_root.
+            try:
+                inside_user_root = os.path.commonpath((user_root, path)) == user_root
+            except ValueError:
+                inside_user_root = False
+            if not inside_user_root:
                 return None
 
         parent = os.path.split(path)[0]

--- a/tests-unit/app_test/user_manager_cross_drive_test.py
+++ b/tests-unit/app_test/user_manager_cross_drive_test.py
@@ -15,15 +15,18 @@ intended rejection. Measured on the pre-fix build, user directory on `D:`:
     '../escape.json'                  -> None      (rejected, as it should be)
     'sub/ok.json'                     -> <path inside the user directory>
 
-The cross-drive case is Windows-only; the tests below simulate the drive
-mismatch on every platform by patching `os.path.commonpath` to raise the same
-ValueError, and additionally run the real thing on Windows when a second drive
-is actually available.
+The cross-drive case is Windows-only. To keep the guard covered on POSIX CI as
+well, the tests below drive the same ValueError out of `os.path.commonpath()`
+by call position rather than by comparing drive letters: on POSIX a leading
+`Z:` is an ordinary filename character, so the join lands inside the user
+directory and a drive-letter comparison would never fire. One test also does it
+for real on Windows when a second drive exists.
 """
 
 import os
 import sys
 import tempfile
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -52,39 +55,51 @@ def request_():
     return request
 
 
+@contextmanager
+def commonpath_raising_on_the_user_root_check():
+    """Raise a drive mismatch from the `(user_root, path)` comparison only.
+
+    Deciding when to raise by comparing drive letters would fire on Windows
+    only: on POSIX a leading `Z:` is an ordinary filename character, so the
+    join lands inside the user directory and nothing raises. Keying on the call
+    instead keeps the guard covered on every platform.
+
+    The earlier `(root_dir, user_root)` comparison in the same function keeps
+    working: both of those paths are derived from the user directory, so a real
+    drive mismatch cannot occur there.
+    """
+    real_commonpath = os.path.commonpath
+    calls = []
+
+    def fake_commonpath(paths):
+        calls.append(paths)
+        if len(calls) == 1:
+            return real_commonpath(paths)
+        raise ValueError("Paths don't have the same drive")
+
+    with patch("os.path.commonpath", side_effect=fake_commonpath):
+        yield calls
+
+
 def test_cross_drive_path_is_rejected_not_raised(user_manager, request_):
     """A drive mismatch must return None, the same as any other escape."""
-    real_commonpath = os.path.commonpath
-
-    def commonpath_raising_on_mismatch(paths):
-        first, second = paths
-        if os.path.splitdrive(first)[0].lower() != os.path.splitdrive(second)[0].lower():
-            raise ValueError("Paths don't have the same drive")
-        return real_commonpath(paths)
-
-    with patch("os.path.commonpath", side_effect=commonpath_raising_on_mismatch):
+    with commonpath_raising_on_the_user_root_check() as calls:
         result = user_manager.get_request_user_filepath(
             request_, "Z:\\Windows\\temp\\test.txt", create_dir=False
         )
 
+    assert len(calls) == 2, "the containment check under test was never reached"
     assert result is None
 
 
 def test_url_encoded_cross_drive_path_is_rejected(user_manager, request_):
     """The reported request shape: the drive letter arrives percent-encoded."""
-    real_commonpath = os.path.commonpath
-
-    def commonpath_raising_on_mismatch(paths):
-        first, second = paths
-        if os.path.splitdrive(first)[0].lower() != os.path.splitdrive(second)[0].lower():
-            raise ValueError("Paths don't have the same drive")
-        return real_commonpath(paths)
-
-    with patch("os.path.commonpath", side_effect=commonpath_raising_on_mismatch):
+    with commonpath_raising_on_the_user_root_check() as calls:
         result = user_manager.get_request_user_filepath(
             request_, "Z:%5CWindows%5Ctemp%5Ctest.txt", create_dir=False
         )
 
+    assert len(calls) == 2, "the containment check under test was never reached"
     assert result is None
 
 

--- a/tests-unit/app_test/user_manager_cross_drive_test.py
+++ b/tests-unit/app_test/user_manager_cross_drive_test.py
@@ -1,0 +1,126 @@
+"""Regression tests for #15820 — a userdata path on another Windows drive.
+
+`get_request_user_filepath()` joins the requested file onto the user root and
+then compares them with `os.path.commonpath()`, which raises
+
+    ValueError: Paths don't have the same drive
+
+when the two paths sit on different Windows drives. Requesting
+`/userdata/C:%5CWindows%5Ctemp%5Ctest.txt` from an install whose user
+directory is on `D:` therefore produced an unhandled 500 rather than the
+intended rejection. Measured on the pre-fix build, user directory on `D:`:
+
+    'C:\\\\Windows\\\\temp\\\\test.txt'      -> ValueError: Paths don't have the same drive
+    'C:%5CWindows%5Ctemp%5Ctest.txt'  -> ValueError: Paths don't have the same drive
+    '../escape.json'                  -> None      (rejected, as it should be)
+    'sub/ok.json'                     -> <path inside the user directory>
+
+The cross-drive case is Windows-only; the tests below simulate the drive
+mismatch on every platform by patching `os.path.commonpath` to raise the same
+ValueError, and additionally run the real thing on Windows when a second drive
+is actually available.
+"""
+
+import os
+import sys
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import folder_paths
+from app.user_manager import UserManager
+
+
+@pytest.fixture
+def user_manager():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        original = folder_paths.get_user_directory()
+        folder_paths.set_user_directory(temp_dir)
+        with patch("app.user_manager.args") as mock_args:
+            mock_args.multi_user = False
+            manager = UserManager()
+            manager.users = {"default": "default"}
+            yield manager
+        folder_paths.set_user_directory(original)
+
+
+@pytest.fixture
+def request_():
+    request = MagicMock()
+    request.headers = {}
+    return request
+
+
+def test_cross_drive_path_is_rejected_not_raised(user_manager, request_):
+    """A drive mismatch must return None, the same as any other escape."""
+    real_commonpath = os.path.commonpath
+
+    def commonpath_raising_on_mismatch(paths):
+        first, second = paths
+        if os.path.splitdrive(first)[0].lower() != os.path.splitdrive(second)[0].lower():
+            raise ValueError("Paths don't have the same drive")
+        return real_commonpath(paths)
+
+    with patch("os.path.commonpath", side_effect=commonpath_raising_on_mismatch):
+        result = user_manager.get_request_user_filepath(
+            request_, "Z:\\Windows\\temp\\test.txt", create_dir=False
+        )
+
+    assert result is None
+
+
+def test_url_encoded_cross_drive_path_is_rejected(user_manager, request_):
+    """The reported request shape: the drive letter arrives percent-encoded."""
+    real_commonpath = os.path.commonpath
+
+    def commonpath_raising_on_mismatch(paths):
+        first, second = paths
+        if os.path.splitdrive(first)[0].lower() != os.path.splitdrive(second)[0].lower():
+            raise ValueError("Paths don't have the same drive")
+        return real_commonpath(paths)
+
+    with patch("os.path.commonpath", side_effect=commonpath_raising_on_mismatch):
+        result = user_manager.get_request_user_filepath(
+            request_, "Z:%5CWindows%5Ctemp%5Ctest.txt", create_dir=False
+        )
+
+    assert result is None
+
+
+def test_ordinary_paths_are_unaffected(user_manager, request_):
+    """The guard must not change the two outcomes that already worked."""
+    inside = user_manager.get_request_user_filepath(
+        request_, "sub/workflow.json", create_dir=False
+    )
+    assert inside is not None
+    assert inside.endswith(os.path.join("sub", "workflow.json"))
+
+    assert (
+        user_manager.get_request_user_filepath(request_, "../escape.json", create_dir=False)
+        is None
+    )
+    assert user_manager.get_request_user_filepath(request_, None, create_dir=False) is not None
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="drive letters are Windows-only")
+def test_real_cross_drive_path_on_windows(user_manager, request_):
+    """Same case again without patching, when a second real drive exists."""
+    user_drive = os.path.splitdrive(folder_paths.get_user_directory())[0].upper()
+    other = next(
+        (
+            f"{letter}:"
+            for letter in "CDEFGH"
+            if f"{letter}:" != user_drive and os.path.exists(f"{letter}:\\")
+        ),
+        None,
+    )
+    if other is None:
+        pytest.skip("no second drive available on this machine")
+
+    assert (
+        user_manager.get_request_user_filepath(
+            request_, f"{other}\\Windows\\temp\\test.txt", create_dir=False
+        )
+        is None
+    )


### PR DESCRIPTION
Fixes #15820.

## Reproduced

ComfyUI installed on `D:`, user directory on `D:`, request for a path on `C:`. Measured on `master` (`b78cec8`), calling the real `get_request_user_filepath()`:

```
'C:\Windows\temp\test.txt'      -> ValueError: Paths don't have the same drive
'C:%5CWindows%5Ctemp%5Ctest.txt'   -> ValueError: Paths don't have the same drive
'../escape.json'                   -> None                     (rejected, as intended)
'sub/ok.json'                      -> D:\...\default\sub\ok.json
```

`os.path.commonpath()` raises when the two paths are on different Windows drives, so the containment check at `app/user_manager.py:95` exited through an exception instead of returning `None`, and aiohttp answered 500 instead of 403/404.

## The fix

A path on another drive is by definition not inside the user directory, so the `ValueError` is treated as "not inside":

```python
try:
    inside_user_root = os.path.commonpath((user_root, path)) == user_root
except ValueError:
    inside_user_root = False
if not inside_user_root:
    return None
```

## Why not `folder_paths.is_within_directory()`

That is what the issue proposes, and it does fix the crash — it already catches this exact `ValueError`. I did not use it here because it also `realpath()`s both operands, which changes behaviour for symlinked user data. Measured with a junction at `user/default/linked` pointing outside the user directory:

```
today:                     'linked/workflow.json' -> D:\...\default\linked\workflow.json   (served)
is_within_directory says:  False                                                           (would 403)
```

Symlinking a subfolder of `user/default` elsewhere is something people do, so switching to the helper would silently start rejecting those installs — a separate decision from fixing a 500. The guard above keeps containment semantics byte-for-byte identical and only stops the crash.

Happy to switch to `is_within_directory()` in this PR if you would rather have the stricter symlink semantics as well — it is a two-line change and the tests below cover both readings except the junction case.

## Tests

`tests-unit/app_test/user_manager_cross_drive_test.py` — 4 tests. The drive mismatch is simulated by making `commonpath` raise the real `ValueError` so the tests run on Linux and macOS too, plus one test that does it for real on Windows when a second drive exists (it did run here, not skip).

Against `master` with only `app/user_manager.py` reverted:

```
FAILED test_cross_drive_path_is_rejected_not_raised
FAILED test_url_encoded_cross_drive_path_is_rejected
FAILED test_real_cross_drive_path_on_windows
3 failed, 1 passed
```

The one that passes on both is `test_ordinary_paths_are_unaffected`, which pins the behaviour that must not change.

With the fix: **4 passed**. Rest of `tests-unit/app_test`: **29 passed** (`frontend_manager_test`, `model_manager_test` and `test_migrations` do not collect in my environment — missing `requests` / `PIL` — unrelated to this change). `ruff check` clean on both files.

## Not fixed here, flagged

The same construction appears at `server.py:414`, `server.py:494`, `server.py:551` and `comfy/sd1_clip.py:426`, where the joined path comes from a request field (`subfolder`, `filename`). I have not exercised those endpoints, so I am flagging rather than claiming they crash — happy to follow up with a separate PR if you want that swept.

The sibling check at `user_manager.py:85` is not affected: `add_user()` reduces a user id to `[a-zA-Z0-9-_]` plus a uuid, so `user_root` can never land on another drive.
