### PR TITLE
Accept a YAML list in extra_model_paths.yaml instead of crashing

### DIFF
--- a/tests-unit/utils/extra_config_shapes_test.py
+++ b/tests-unit/utils/extra_config_shapes_test.py
@@ -1,0 +1,123 @@
+"""A YAML list of paths in extra_model_paths.yaml aborted startup.
+
+`load_extra_path_config()` called `.split("\\n")` on every value, so the shape
+people naturally write —
+
+    comfyui:
+      base_path: /models
+      checkpoints:
+        - ckpt_a
+        - ckpt_b
+
+— raised `AttributeError: 'list' object has no attribute 'split'`, a traceback
+naming neither the file nor the key. Measured on master before the change:
+
+    list of paths        -> AttributeError: 'list' object has no attribute 'split'
+    numeric value        -> AttributeError: 'int' object has no attribute 'split'
+    nested mapping       -> AttributeError: 'dict' object has no attribute 'split'
+    section is a string  -> TypeError: string indices must be integers
+    newline string       -> ok  (the documented form, unaffected)
+
+A malformed entry now warns and is skipped, so one bad key no longer takes the
+whole config — and the rest of the search paths still load.
+"""
+
+import os
+import tempfile
+
+import pytest
+from unittest.mock import patch
+
+import folder_paths
+from utils.extra_config import load_extra_path_config
+
+
+@pytest.fixture
+def load_yaml():
+    """Write a config, load it, and return the paths that were registered."""
+
+    def _load(text: str) -> list[tuple]:
+        directory = tempfile.mkdtemp()
+        path = os.path.join(directory, "extra_model_paths.yaml")
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(text)
+
+        added: list[tuple] = []
+        with patch.object(
+            folder_paths, "add_model_folder_path", lambda *args, **kwargs: added.append(args)
+        ):
+            load_extra_path_config(path)
+        return added
+
+    return _load
+
+
+def _basenames(added: list[tuple]) -> list[str]:
+    return [os.path.basename(entry[1]) for entry in added]
+
+
+def test_list_of_paths_is_accepted(load_yaml):
+    added = load_yaml(
+        "comfyui:\n"
+        "  base_path: /models\n"
+        "  checkpoints:\n"
+        "    - ckpt_a\n"
+        "    - ckpt_b\n"
+    )
+
+    assert _basenames(added) == ["ckpt_a", "ckpt_b"]
+    assert [entry[0] for entry in added] == ["checkpoints", "checkpoints"]
+
+
+def test_newline_string_is_unchanged(load_yaml):
+    """The documented form must keep behaving exactly as before."""
+    added = load_yaml(
+        "comfyui:\n"
+        "  base_path: /models\n"
+        "  checkpoints: |\n"
+        "    ckpt_a\n"
+        "    ckpt_b\n"
+    )
+
+    assert _basenames(added) == ["ckpt_a", "ckpt_b"]
+
+
+def test_list_and_string_agree(load_yaml):
+    as_list = load_yaml("comfyui:\n  base_path: /models\n  checkpoints:\n    - a\n    - b\n")
+    as_string = load_yaml("comfyui:\n  base_path: /models\n  checkpoints: |\n    a\n    b\n")
+
+    assert as_list == as_string
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [
+        "  checkpoints: 42\n",
+        "  checkpoints: true\n",
+        "  checkpoints:\n    a: b\n",
+    ],
+)
+def test_a_malformed_value_is_skipped_without_losing_the_rest(load_yaml, bad_value):
+    added = load_yaml("comfyui:\n  base_path: /models\n" + bad_value + "  loras: keep_me\n")
+
+    assert _basenames(added) == ["keep_me"]
+
+
+def test_a_malformed_entry_inside_a_list_is_skipped(load_yaml):
+    added = load_yaml(
+        "comfyui:\n  base_path: /models\n  checkpoints:\n    - ok_a\n    - 7\n"
+    )
+
+    assert _basenames(added) == ["ok_a"]
+
+
+def test_a_section_that_is_not_a_mapping_is_skipped(load_yaml):
+    added = load_yaml("comfyui: /models\nother:\n  base_path: /m2\n  loras: keep_me\n")
+
+    assert _basenames(added) == ["keep_me"]
+
+
+def test_an_empty_section_is_still_tolerated(load_yaml):
+    added = load_yaml("comfyui:\nother:\n  base_path: /m2\n  loras: keep_me\n")
+
+    assert _basenames(added) == ["keep_me"]

--- a/tests-unit/utils/extra_config_shapes_test.py
+++ b/tests-unit/utils/extra_config_shapes_test.py
@@ -22,8 +22,8 @@ A malformed entry now warns and is skipped, so one bad key no longer takes the
 whole config — and the rest of the search paths still load.
 """
 
+import itertools
 import os
-import tempfile
 
 import pytest
 from unittest.mock import patch
@@ -33,14 +33,16 @@ from utils.extra_config import load_extra_path_config
 
 
 @pytest.fixture
-def load_yaml():
+def load_yaml(tmp_path):
     """Write a config, load it, and return the paths that were registered."""
+    counter = itertools.count()
 
     def _load(text: str) -> list[tuple]:
-        directory = tempfile.mkdtemp()
-        path = os.path.join(directory, "extra_model_paths.yaml")
-        with open(path, "w", encoding="utf-8") as handle:
-            handle.write(text)
+        # `tmp_path` is cleaned up by pytest; a fresh name per call keeps two
+        # loads in the same test from overwriting each other.
+        path = tmp_path / f"extra_model_paths_{next(counter)}.yaml"
+        path.write_text(text, encoding="utf-8")
+        path = str(path)
 
         added: list[tuple] = []
         with patch.object(

--- a/utils/extra_config.py
+++ b/utils/extra_config.py
@@ -3,6 +3,38 @@ import yaml
 import folder_paths
 import logging
 
+def _iter_paths(value, folder_name, section, yaml_path):
+    """Yield the configured paths for one folder entry.
+
+    A newline-separated string is the documented form. A YAML list is the shape
+    people reach for anyway, and it used to abort startup with
+    `AttributeError: 'list' object has no attribute 'split'` — a traceback that
+    named neither the file nor the key. Anything else is skipped with a warning
+    rather than crashing the whole config load.
+    """
+    if isinstance(value, str):
+        yield from value.split("\n")
+        return
+
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            if isinstance(item, str):
+                yield from item.split("\n")
+            else:
+                logging.warning(
+                    "Skipping entry in extra search path '%s.%s' in %s: expected a path "
+                    "string, got %s",
+                    section, folder_name, yaml_path, type(item).__name__,
+                )
+        return
+
+    logging.warning(
+        "Skipping extra search path '%s.%s' in %s: expected a path string or a list of "
+        "path strings, got %s",
+        section, folder_name, yaml_path, type(value).__name__,
+    )
+
+
 def load_extra_path_config(yaml_path):
     with open(yaml_path, 'r', encoding='utf-8') as stream:
         config = yaml.safe_load(stream)
@@ -10,6 +42,18 @@ def load_extra_path_config(yaml_path):
     for c in config:
         conf = config[c]
         if conf is None:
+            continue
+        if not isinstance(conf, dict):
+            # A section that is not a mapping used to raise
+            # `TypeError: string indices must be integers` from the
+            # `"base_path" in conf` test, which named neither the file nor the
+            # section. An empty section is already tolerated above; say what is
+            # wrong with this one and keep loading the rest.
+            logging.warning(
+                "Skipping extra search path section '%s' in %s: expected a mapping of "
+                "folder name to path(s), got %s",
+                c, yaml_path, type(conf).__name__,
+            )
             continue
         base_path = None
         if "base_path" in conf:
@@ -21,7 +65,7 @@ def load_extra_path_config(yaml_path):
         if "is_default" in conf:
             is_default = conf.pop("is_default")
         for x in conf:
-            for y in conf[x].split("\n"):
+            for y in _iter_paths(conf[x], x, c, yaml_path):
                 if len(y) == 0:
                     continue
                 full_path = y


### PR DESCRIPTION
## The crash

`load_extra_path_config()` calls `.split("\n")` on every value in the config, so the shape people naturally write aborts startup:

```yaml
comfyui:
  base_path: /models
  checkpoints:
    - ckpt_a
    - ckpt_b
```

```
AttributeError: 'list' object has no attribute 'split'
```

The traceback names neither the file nor the key, so the reader has to know that `extra_model_paths.yaml` wants newline-separated strings. Measured on `master` (`b78cec8`) through the real loader:

```
list of paths        -> AttributeError: 'list' object has no attribute 'split'
numeric value        -> AttributeError: 'int' object has no attribute 'split'
nested mapping       -> AttributeError: 'dict' object has no attribute 'split'
section is a string  -> TypeError: string indices must be integers
newline string       -> ok      (the documented form)
```

## The change

- A **list** of paths is accepted alongside the newline string, and the two produce identical results (there is a test asserting exactly that).
- Anything else is **skipped with a warning naming the file, section and key**, instead of raising. One malformed key no longer stops the other search paths from loading — which matters at startup, where the alternative is a ComfyUI that will not boot until the user decodes an `AttributeError`.

Skipping rather than raising follows what the loader already does one line above: `if conf is None: continue` tolerates an empty section. The difference is that a skip is now visible in the log.

The documented newline form goes through the same code path as before.

## Tests

`tests-unit/utils/extra_config_shapes_test.py` — 9 tests through the real `load_extra_path_config()` with real YAML files on disk.

Against `master` with only `utils/extra_config.py` reverted:

```
FAILED test_list_of_paths_is_accepted
FAILED test_list_and_string_agree
FAILED test_a_malformed_value_is_skipped_without_losing_the_rest[checkpoints: 42]
FAILED test_a_malformed_value_is_skipped_without_losing_the_rest[checkpoints: true]
FAILED test_a_malformed_value_is_skipped_without_losing_the_rest[checkpoints: {a: b}]
FAILED test_a_malformed_entry_inside_a_list_is_skipped
FAILED test_a_section_that_is_not_a_mapping_is_skipped
7 failed, 2 passed
```

The two that pass on both are the ones pinning behaviour that must not change: the documented newline string, and the already-tolerated empty section.

With the change: `tests-unit/utils/` — **24 passed** (15 pre-existing + 9 new). `ruff check` clean on both files.
