### PR TITLE
[Partner Nodes] chore(Tripo): remove retired Refine node and v2.0 model version

### DIFF
--- a/comfy_api_nodes/apis/tripo.py
+++ b/comfy_api_nodes/apis/tripo.py
@@ -8,7 +8,6 @@ class TripoModelVersion(str, Enum):
     v3_1_20260211 = "v3.1-20260211"
     v3_0_20250812 = "v3.0-20250812"
     v2_5_20250123 = "v2.5-20250123"
-    v2_0_20240919 = "v2.0-20240919"
     v1_4_20240625 = "v1.4-20240625"
 
 
@@ -39,7 +38,6 @@ class TripoTaskType(str, Enum):
     IMAGE_TO_MODEL = "image_to_model"
     MULTIVIEW_TO_MODEL = "multiview_to_model"
     TEXTURE_MODEL = "texture_model"
-    REFINE_MODEL = "refine_model"
     ANIMATE_PRERIGCHECK = "animate_prerigcheck"
     ANIMATE_RIG = "animate_rig"
     ANIMATE_RETARGET = "animate_retarget"
@@ -228,11 +226,6 @@ class TripoTextureModelRequest(BaseModel):
         description="Optional guidance for texturing. Required in practice for imported models, "
         "which carry no source image to infer texture from.",
     )
-
-
-class TripoRefineModelRequest(BaseModel):
-    type: TripoTaskType = Field(TripoTaskType.REFINE_MODEL, description="Type of task")
-    draft_model_task_id: str = Field(..., description="The task ID of the draft model")
 
 
 class TripoAnimateRigRequest(BaseModel):

--- a/comfy_api_nodes/nodes_tripo.py
+++ b/comfy_api_nodes/nodes_tripo.py
@@ -15,7 +15,6 @@ from comfy_api_nodes.apis.tripo import (
     TripoP1ImageToModelRequest,
     TripoP1MultiviewToModelRequest,
     TripoP1TextToModelRequest,
-    TripoRefineModelRequest,
     TripoStyle,
     TripoTaskResponse,
     TripoTaskStatus,
@@ -598,46 +597,6 @@ class TripoTextureNode(IO.ComfyNode):
             ),
         )
         return await poll_until_finished(cls, response, average_duration=80)
-
-
-class TripoRefineNode(IO.ComfyNode):
-
-    @classmethod
-    def define_schema(cls):
-        return IO.Schema(
-            node_id="TripoRefineNode",
-            display_name="Tripo: Refine Draft model",
-            category="partner/3d/Tripo",
-            description="Refine a draft model created by v1.4 Tripo models only.",
-            inputs=[
-                IO.Custom("MODEL_TASK_ID").Input("model_task_id", tooltip="Must be a v1.4 Tripo model"),
-            ],
-            outputs=[
-                IO.String.Output(display_name="model_file"),  # for backward compatibility only
-                IO.Custom("MODEL_TASK_ID").Output(display_name="model task_id"),
-                IO.File3DGLB.Output(display_name="GLB"),
-            ],
-            hidden=[
-                IO.Hidden.auth_token_comfy_org,
-                IO.Hidden.api_key_comfy_org,
-                IO.Hidden.unique_id,
-            ],
-            is_api_node=True,
-            is_output_node=True,
-            price_badge=IO.PriceBadge(
-                expr="""{"type":"usd","usd":0.3, "format": {"approximate": true}}""",
-            ),
-        )
-
-    @classmethod
-    async def execute(cls, model_task_id) -> IO.NodeOutput:
-        response = await sync_op(
-            cls,
-            endpoint=ApiEndpoint(path="/proxy/tripo/v2/openapi/task", method="POST"),
-            response_model=TripoTaskResponse,
-            data=TripoRefineModelRequest(draft_model_task_id=model_task_id),
-        )
-        return await poll_until_finished(cls, response, average_duration=240)
 
 
 class TripoRigNode(IO.ComfyNode):
@@ -1390,7 +1349,6 @@ class TripoExtension(ComfyExtension):
             TripoP1MultiviewToModelNode,
             TripoImportModelNode,
             TripoTextureNode,
-            TripoRefineNode,
             TripoRigNode,
             TripoRetargetNode,
             TripoConversionNode,


### PR DESCRIPTION
Both are retired upstream and can no longer create a task. Verified live against on 2026-08-24

- `TripoRefineNode` - rejected at submit for both of its possible inputs: a v1.4 draft (its documented input) with 2015 "The version has been deprecated", a v2.5 model+ (the suggested "higher version") with `2006 "The original task type is not supported"`
- `v2.0-20240919` - rejected with 2015 on `text_to_model`, `image_to_model` and `multiview_to_model` alike, so it was a dead option in three model_version combos

<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [x] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [x] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [x] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**

