### PR TITLE
Fix CheckpointError from memory-dependent attention chunking during LoRA training

### DIFF
--- a/comfy/ldm/modules/attention.py
+++ b/comfy/ldm/modules/attention.py
@@ -1,4 +1,5 @@
 import contextlib
+import contextvars
 import math
 import sys
 import inspect
@@ -271,25 +272,25 @@ def attention_basic(q, k, v, heads, mask=None, attn_precision=None, skip_reshape
     return out
 
 _memory_chunk_cache_lock = threading.Lock()
-_memory_chunk_cache = None
+_memory_chunk_cache_var = contextvars.ContextVar("_memory_chunk_cache", default=None)
 
 
 @contextlib.contextmanager
 def deterministic_memory_chunking():
     """Freeze memory-dependent chunk-size decisions so repeated calls with identical
     shapes (e.g. a gradient-checkpoint recomputing the same forward) reuse the first
-    choice instead of picking a different one from the free memory available then."""
-    global _memory_chunk_cache
-    previous = _memory_chunk_cache
-    _memory_chunk_cache = {}
+    choice instead of picking a different one from the free memory available then.
+    The cache lives in a context-local variable so concurrent training contexts
+    (separate threads/tasks) each get their own, instead of sharing one global."""
+    token = _memory_chunk_cache_var.set({})
     try:
         yield
     finally:
-        _memory_chunk_cache = previous
+        _memory_chunk_cache_var.reset(token)
 
 
 def _cached_memory_chunk_choice(key, compute):
-    cache = _memory_chunk_cache
+    cache = _memory_chunk_cache_var.get()
     if cache is None:
         return compute()
     with _memory_chunk_cache_lock:
@@ -299,6 +300,13 @@ def _cached_memory_chunk_choice(key, compute):
     with _memory_chunk_cache_lock:
         cache[key] = value
     return value
+
+
+def _update_cached_memory_chunk_choice(key, value):
+    cache = _memory_chunk_cache_var.get()
+    if cache is not None:
+        with _memory_chunk_cache_lock:
+            cache[key] = value
 
 
 @wrap_attn
@@ -479,6 +487,8 @@ def attention_split(q, k, v, heads, mask=None, attn_precision=None, skip_reshape
                 logging.warning("out of memory error, increasing steps and trying again {}".format(steps))
             else:
                 raise e
+
+    _update_cached_memory_chunk_choice((device, mem_required), steps)
 
     del q, k, v
 

--- a/comfy/ldm/modules/attention.py
+++ b/comfy/ldm/modules/attention.py
@@ -1,6 +1,8 @@
+import contextlib
 import math
 import sys
 import inspect
+import threading
 
 import torch
 import torch.nn.functional as F
@@ -268,6 +270,37 @@ def attention_basic(q, k, v, heads, mask=None, attn_precision=None, skip_reshape
         )
     return out
 
+_memory_chunk_cache_lock = threading.Lock()
+_memory_chunk_cache = None
+
+
+@contextlib.contextmanager
+def deterministic_memory_chunking():
+    """Freeze memory-dependent chunk-size decisions so repeated calls with identical
+    shapes (e.g. a gradient-checkpoint recomputing the same forward) reuse the first
+    choice instead of picking a different one from the free memory available then."""
+    global _memory_chunk_cache
+    previous = _memory_chunk_cache
+    _memory_chunk_cache = {}
+    try:
+        yield
+    finally:
+        _memory_chunk_cache = previous
+
+
+def _cached_memory_chunk_choice(key, compute):
+    cache = _memory_chunk_cache
+    if cache is None:
+        return compute()
+    with _memory_chunk_cache_lock:
+        if key in cache:
+            return cache[key]
+    value = compute()
+    with _memory_chunk_cache_lock:
+        cache[key] = value
+    return value
+
+
 @wrap_attn
 def attention_sub_quad(query, key, value, heads, mask=None, attn_precision=None, skip_reshape=False, skip_output_reshape=False, **kwargs):
     attn_precision = get_attn_precision(attn_precision, query.dtype)
@@ -304,21 +337,18 @@ def attention_sub_quad(query, key, value, heads, mask=None, attn_precision=None,
     batch_x_heads, q_tokens, _ = query.shape
     _, _, k_tokens = key.shape
 
-    mem_free_total, _ = model_management.get_free_memory(query.device, True)
+    def _choose_chunk_sizes():
+        mem_free_total, _ = model_management.get_free_memory(query.device, True)
+        for x in [4096, 2048, 1024, 512, 256]:
+            count = mem_free_total / (batch_x_heads * bytes_per_token * x * 4.0)
+            if count >= k_tokens:
+                return k_tokens, x
+        return None, 512
 
     kv_chunk_size_min = None
-    kv_chunk_size = None
-    query_chunk_size = None
-
-    for x in [4096, 2048, 1024, 512, 256]:
-        count = mem_free_total / (batch_x_heads * bytes_per_token * x * 4.0)
-        if count >= k_tokens:
-            kv_chunk_size = k_tokens
-            query_chunk_size = x
-            break
-
-    if query_chunk_size is None:
-        query_chunk_size = 512
+    kv_chunk_size, query_chunk_size = _cached_memory_chunk_choice(
+        (query.device, batch_x_heads, bytes_per_token, k_tokens), _choose_chunk_sizes
+    )
 
     if mask is not None:
         if len(mask.shape) == 2:
@@ -371,8 +401,6 @@ def attention_split(q, k, v, heads, mask=None, attn_precision=None, skip_reshape
 
     r1 = torch.zeros(q.shape[0], q.shape[1], v.shape[2], device=q.device, dtype=q.dtype)
 
-    mem_free_total = model_management.get_free_memory(q.device)
-
     if attn_precision == torch.float32:
         element_size = 4
         upcast = True
@@ -380,22 +408,25 @@ def attention_split(q, k, v, heads, mask=None, attn_precision=None, skip_reshape
         element_size = q.element_size()
         upcast = False
 
+    device = q.device
     gb = 1024 ** 3
     tensor_size = q.shape[0] * q.shape[1] * k.shape[1] * element_size
     modifier = 3
     mem_required = tensor_size * modifier
-    steps = 1
 
+    def _choose_steps():
+        mem_free_total = model_management.get_free_memory(device)
+        steps = 1
+        if mem_required > mem_free_total:
+            steps = 2**(math.ceil(math.log(mem_required / mem_free_total, 2)))
 
-    if mem_required > mem_free_total:
-        steps = 2**(math.ceil(math.log(mem_required / mem_free_total, 2)))
-        # print(f"Expected tensor size:{tensor_size/gb:0.1f}GB, cuda free:{mem_free_cuda/gb:0.1f}GB "
-        #      f"torch free:{mem_free_torch/gb:0.1f} total:{mem_free_total/gb:0.1f} steps:{steps}")
+        if steps > 64:
+            max_res = math.floor(math.sqrt(math.sqrt(mem_free_total / 2.5)) / 8) * 64
+            raise RuntimeError(f'Not enough memory, use lower resolution (max approx. {max_res}x{max_res}). '
+                                f'Need: {mem_required/64/gb:0.1f}GB free, Have:{mem_free_total/gb:0.1f}GB free')
+        return steps
 
-    if steps > 64:
-        max_res = math.floor(math.sqrt(math.sqrt(mem_free_total / 2.5)) / 8) * 64
-        raise RuntimeError(f'Not enough memory, use lower resolution (max approx. {max_res}x{max_res}). '
-                            f'Need: {mem_required/64/gb:0.1f}GB free, Have:{mem_free_total/gb:0.1f}GB free')
+    steps = _cached_memory_chunk_choice((device, mem_required), _choose_steps)
 
     if mask is not None:
         if len(mask.shape) == 2:

--- a/comfy_extras/nodes_train.py
+++ b/comfy_extras/nodes_train.py
@@ -15,6 +15,7 @@ import comfy.sampler_helpers
 import comfy.sd
 import comfy.utils
 import comfy.model_management
+from comfy.ldm.modules.attention import deterministic_memory_chunking
 from comfy.conds import CONDRegular, CONDList
 from comfy.cli_args import args, PerformanceFeature
 import comfy_extras.nodes_custom_sampler
@@ -356,12 +357,13 @@ class TrainSampler(comfy.samplers.Sampler):
                 self.seed + i * 1000
             )
 
-            if self.bucket_latents is not None:
-                self._train_step_bucket_mode(model_wrap, cond, extra_args, noisegen, latent_image, pbar)
-            elif self.real_dataset is None:
-                self._train_step_standard_mode(model_wrap, cond, extra_args, noisegen, latent_image, dataset_size, pbar)
-            else:
-                self._train_step_multires_mode(model_wrap, cond, extra_args, noisegen, latent_image, dataset_size, pbar)
+            with deterministic_memory_chunking():
+                if self.bucket_latents is not None:
+                    self._train_step_bucket_mode(model_wrap, cond, extra_args, noisegen, latent_image, pbar)
+                elif self.real_dataset is None:
+                    self._train_step_standard_mode(model_wrap, cond, extra_args, noisegen, latent_image, dataset_size, pbar)
+                else:
+                    self._train_step_multires_mode(model_wrap, cond, extra_args, noisegen, latent_image, dataset_size, pbar)
 
             if (i + 1) % self.grad_acc == 0:
                 if self.grad_scaler is not None:

--- a/tests-unit/comfy_test/attention_deterministic_chunking_test.py
+++ b/tests-unit/comfy_test/attention_deterministic_chunking_test.py
@@ -120,3 +120,28 @@ def test_split_oom_retry_updates_cache_with_final_steps(monkeypatch):
         cache = attention._memory_chunk_cache_var.get()
 
     assert list(cache.values()) == [2]
+
+
+def test_memory_chunking_still_reacts_to_free_memory_outside_context_for_split(monkeypatch):
+    """Sanity check for attention_split, mirroring the sub_quad test above: outside
+    deterministic_memory_chunking(), two calls with different free memory can still
+    pick different `steps`, i.e. the fix does not change non-training behavior."""
+    _patch_free_memory(monkeypatch, [SPLIT_FREE_MEMORY, SPLIT_FREE_MEMORY // 2])
+    q, k, v = _make_qkv(*SPLIT_QKV_SHAPE)
+
+    real_einsum = attention.einsum
+    qk_call_counts = []
+
+    def counting_einsum(equation, *operands, **kwargs):
+        if equation == 'b i d, b j d -> b i j':
+            qk_call_counts[-1] += 1
+        return real_einsum(equation, *operands, **kwargs)
+
+    monkeypatch.setattr(attention, "einsum", counting_einsum)
+
+    qk_call_counts.append(0)
+    attention.attention_split(q, k, v, heads=1)
+    qk_call_counts.append(0)
+    attention.attention_split(q, k, v, heads=1)
+
+    assert qk_call_counts[0] != qk_call_counts[1]

--- a/tests-unit/comfy_test/attention_deterministic_chunking_test.py
+++ b/tests-unit/comfy_test/attention_deterministic_chunking_test.py
@@ -68,3 +68,55 @@ def test_memory_chunking_still_reacts_to_free_memory_outside_context(monkeypatch
     attention.attention_sub_quad(q, k, v, heads=1)
 
     assert chosen_query_chunk_sizes[0] != chosen_query_chunk_sizes[1]
+
+
+# batch_x_heads=2, tokens=8, dim=4, bf16 -> mem_required=768 bytes, matching SPLIT_FREE_MEMORY.
+SPLIT_QKV_SHAPE = (2, 8, 4)
+SPLIT_FREE_MEMORY = 768
+
+
+def _patch_free_memory(monkeypatch, free_memory_values):
+    values = iter(free_memory_values)
+
+    def fake_get_free_memory(device, torch_free_too=False):
+        value = next(values)
+        return (value, value) if torch_free_too else value
+
+    monkeypatch.setattr(attention.model_management, "get_free_memory", fake_get_free_memory)
+
+
+def test_deterministic_memory_chunking_reuses_first_choice_for_split(monkeypatch):
+    """Same recomputation scenario as above, for attention_split's `steps` count.
+    Only one free-memory value is queued: a second live query (i.e. a cache miss
+    on the recompute) would raise StopIteration and fail the test."""
+    _patch_free_memory(monkeypatch, [SPLIT_FREE_MEMORY])
+    q, k, v = _make_qkv(*SPLIT_QKV_SHAPE)
+
+    with attention.deterministic_memory_chunking():
+        attention.attention_split(q, k, v, heads=1)
+        attention.attention_split(q, k, v, heads=1)
+        assert len(attention._memory_chunk_cache_var.get()) == 1
+
+
+def test_split_oom_retry_updates_cache_with_final_steps(monkeypatch):
+    """An OOM during the forward pass doubles `steps` past the value cached before
+    the retry; the cache reused by checkpoint recomputation must reflect the final,
+    successful `steps`, not the stale one."""
+    _patch_free_memory(monkeypatch, [SPLIT_FREE_MEMORY])
+    real_einsum = attention.einsum
+    failures_left = [2]
+
+    def flaky_einsum(equation, *operands, **kwargs):
+        if failures_left[0] > 0:
+            failures_left[0] -= 1
+            raise torch.OutOfMemoryError("simulated OOM")
+        return real_einsum(equation, *operands, **kwargs)
+
+    monkeypatch.setattr(attention, "einsum", flaky_einsum)
+    q, k, v = _make_qkv(*SPLIT_QKV_SHAPE)
+
+    with attention.deterministic_memory_chunking():
+        attention.attention_split(q, k, v, heads=1)
+        cache = attention._memory_chunk_cache_var.get()
+
+    assert list(cache.values()) == [2]

--- a/tests-unit/comfy_test/attention_deterministic_chunking_test.py
+++ b/tests-unit/comfy_test/attention_deterministic_chunking_test.py
@@ -1,0 +1,70 @@
+import sys
+
+import torch
+
+sys.argv = ["pytest", "--cpu"]
+from comfy.options import enable_args_parsing  # noqa: E402
+enable_args_parsing()
+
+import comfy.ldm.modules.attention as attention  # noqa: E402
+
+
+# A 2176-token bf16 sequence at this batch_x_heads lands on the 4096 vs. 2048
+# query_chunk_size threshold depending on whether ~2.14GB or ~1.07GB is free.
+BATCH = 30
+TOKENS = 2176
+DIM = 8
+FREE_MEMORY_FORWARD = 2_200_000_000  # picks query_chunk_size=4096
+FREE_MEMORY_RECOMPUTE = 1_500_000_000  # picks query_chunk_size=2048
+
+
+def _make_qkv(batch=BATCH, tokens=TOKENS, dim=DIM, dtype=torch.bfloat16):
+    q = torch.randn(batch, tokens, dim, dtype=dtype)
+    k = torch.randn(batch, tokens, dim, dtype=dtype)
+    v = torch.randn(batch, tokens, dim, dtype=dtype)
+    return q, k, v
+
+
+def _patch_free_memory_and_capture_chunk_sizes(monkeypatch):
+    values = iter([FREE_MEMORY_FORWARD, FREE_MEMORY_RECOMPUTE])
+
+    def fake_get_free_memory(device, torch_free_too=False):
+        value = next(values)
+        return (value, value) if torch_free_too else value
+
+    chosen_query_chunk_sizes = []
+
+    def fake_efficient_dot_product_attention(query, key, value, query_chunk_size=None, **kwargs):
+        chosen_query_chunk_sizes.append(query_chunk_size)
+        return torch.zeros(query.shape[0], query.shape[1], value.shape[-1], dtype=query.dtype)
+
+    monkeypatch.setattr(attention.model_management, "get_free_memory", fake_get_free_memory)
+    monkeypatch.setattr(attention, "efficient_dot_product_attention", fake_efficient_dot_product_attention)
+    return chosen_query_chunk_sizes
+
+
+def test_deterministic_memory_chunking_reuses_first_choice(monkeypatch):
+    """A gradient-checkpoint recomputation calls attention_sub_quad again with the
+    same shapes as the original forward, but free memory can have dropped in the
+    meantime; inside the context both calls must pick the same chunk size."""
+    chosen_query_chunk_sizes = _patch_free_memory_and_capture_chunk_sizes(monkeypatch)
+
+    q, k, v = _make_qkv()
+    with attention.deterministic_memory_chunking():
+        attention.attention_sub_quad(q, k, v, heads=1)
+        attention.attention_sub_quad(q, k, v, heads=1)
+
+    assert len(chosen_query_chunk_sizes) == 2
+    assert chosen_query_chunk_sizes[0] == chosen_query_chunk_sizes[1]
+
+
+def test_memory_chunking_still_reacts_to_free_memory_outside_context(monkeypatch):
+    """Sanity check that normal (non-checkpointed) calls keep querying live free
+    memory, i.e. the fix does not change behavior outside the training path."""
+    chosen_query_chunk_sizes = _patch_free_memory_and_capture_chunk_sizes(monkeypatch)
+
+    q, k, v = _make_qkv()
+    attention.attention_sub_quad(q, k, v, heads=1)
+    attention.attention_sub_quad(q, k, v, heads=1)
+
+    assert chosen_query_chunk_sizes[0] != chosen_query_chunk_sizes[1]


### PR DESCRIPTION
Fixes #15845

## Problem

`attention_sub_quad` and `attention_split` (in `comfy/ldm/modules/attention.py`)
pick their memory-saving chunk size by querying live free memory
(`model_management.get_free_memory`) every time they run. When a `TrainLoraNode`
run uses `gradient_checkpointing=True`, the checkpointed submodule's forward is
executed twice: once during the actual forward pass, and once again during
backward when `torch.utils.checkpoint` recomputes it. Free memory can differ
between those two calls (the recompute happens while other checkpoint segments
are already occupying memory), so the two calls can pick different chunk sizes
for what must be a structurally identical computation. `torch.utils.checkpoint`
detects the mismatch between the original saved tensors and the recomputed ones
and raises `CheckpointError`.

The issue's reporter isolated this precisely: a 2176-token bf16 sequence with
`batch_x_heads=30` needs ~2.14GB free to pick `query_chunk_size=4096` and
~1.07GB to pick `2048`; the forward and recompute landed on opposite sides of
that threshold. A second, similar variant was also isolated for
`--use-split-cross-attention` (`attention_split`'s `steps` calculation).

## Fix

Added `deterministic_memory_chunking()` in `comfy/ldm/modules/attention.py`: a
context manager that activates a small cache (keyed by device + tensor shape)
for the memory-based chunk-size decision. Within the context, the first call
for a given shape queries free memory as before and caches the result;
subsequent calls with the same shape (i.e. a checkpoint recomputing the same
op) reuse that cached decision instead of re-querying memory, so forward and
recompute always agree. Outside the context (normal inference), behavior is
unchanged — free memory is queried on every call as before.

`comfy_extras/nodes_train.py`'s training loop (`TrainSampler.sample`) now wraps
each training step (forward + backward) in `deterministic_memory_chunking()`,
which is the only place gradient checkpointing recomputation for this node can
occur.

## Test plan

Added `tests-unit/comfy_test/attention_deterministic_chunking_test.py`, which
reproduces the exact threshold from the issue (2176 tokens, batch_x_heads=30,
bf16, ~2.2GB vs ~1.5GB free) by monkeypatching `get_free_memory` and the
underlying `efficient_dot_product_attention` call:

- `test_deterministic_memory_chunking_reuses_first_choice`: inside
  `deterministic_memory_chunking()`, two calls with the same shape but
  different simulated free memory pick the *same* `query_chunk_size` — this is
  what prevents the `CheckpointError`.
- `test_memory_chunking_still_reacts_to_free_memory_outside_context`: outside
  the context, the two calls still pick *different* chunk sizes, confirming
  normal (non-training) behavior is untouched.

Verified the first test fails without the fix:
```
$ git checkout HEAD~1 -- comfy/ldm/modules/attention.py comfy_extras/nodes_train.py
$ python -m pytest tests-unit/comfy_test/attention_deterministic_chunking_test.py -v
...
FAILED ...test_deterministic_memory_chunking_reuses_first_choice - AttributeError: module 'comfy.ldm.modules.attention' has no attribute 'deterministic_memory_chunking'
1 failed, 1 passed
$ git checkout HEAD -- comfy/ldm/modules/attention.py comfy_extras/nodes_train.py
```

With the fix:
```
$ python -m pytest tests-unit/comfy_test/attention_deterministic_chunking_test.py -v
tests-unit/comfy_test/attention_deterministic_chunking_test.py::test_deterministic_memory_chunking_reuses_first_choice PASSED
tests-unit/comfy_test/attention_deterministic_chunking_test.py::test_memory_chunking_still_reacts_to_free_memory_outside_context PASSED
2 passed
```

Full unit suite and lint:
```
$ ruff check .
All checks passed!
$ python -m pytest tests-unit -q
1406 passed, 10 skipped
```

## Disclosure

This change was developed with AI assistance (Claude Code), with the diagnosis
independently verified against the issue's reproduction, tested, and reviewed
before submission.
