### PR TITLE
Retry transient 401 from api.comfy.org in API node client

### DIFF
--- a/comfy_api_nodes/util/client.py
+++ b/comfy_api_nodes/util/client.py
@@ -84,7 +84,7 @@ class _PollUIState:
     active_since: float | None = None  # start time of current active interval (None if queued)
 
 
-_RETRY_STATUS = {408, 500, 502, 503, 504}  # status 429 is handled separately
+_RETRY_STATUS = {401, 408, 500, 502, 503, 504}  # status 429 is handled separately
 _MAX_RETRY_AFTER_WAIT = 150.0  # Cap a server Retry-After at this many seconds so a large hint can't block execution
 
 PRICE_CREDITS_HEADER = "X-Comfy-Credits-Used"

--- a/tests-unit/comfy_api_nodes_test/client_retry_test.py
+++ b/tests-unit/comfy_api_nodes_test/client_retry_test.py
@@ -1,0 +1,93 @@
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from comfy.cli_args import args
+
+if not torch.cuda.is_available():
+    args.cpu = True
+
+from comfy_api_nodes.util import client as client_module  # noqa: E402
+from comfy_api_nodes.util.client import ApiEndpoint, sync_op_raw  # noqa: E402
+
+
+class _FakeResponse:
+    def __init__(self, status, body):
+        self.status = status
+        self._body = body
+        self.headers = {}
+
+    async def json(self):
+        return self._body
+
+    async def text(self):
+        return str(self._body)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+
+class _FakeSession:
+    """A new instance is created per retry attempt (see _request_base), so the
+    response iterator must be shared across instances, not per-instance."""
+
+    def __init__(self, responses_iter):
+        self._responses = responses_iter
+
+    async def request(self, method, url, **kwargs):
+        return next(self._responses)
+
+    async def close(self):
+        pass
+
+
+def _patch_session(monkeypatch, responses):
+    responses_iter = iter(responses)
+    monkeypatch.setattr(
+        client_module.aiohttp, "ClientSession", lambda *a, **kw: _FakeSession(responses_iter)
+    )
+    monkeypatch.setattr(client_module.request_logger, "log_request_response", lambda **kw: None)
+
+
+@pytest.mark.asyncio
+async def test_transient_401_is_retried(monkeypatch):
+    """A transient 401 followed by a 200 should succeed instead of failing the whole request."""
+    responses = [
+        _FakeResponse(401, {"message": "Invalid Comfy API key"}),
+        _FakeResponse(200, {"ok": True}),
+    ]
+    _patch_session(monkeypatch, responses)
+
+    result = await sync_op_raw(
+        MagicMock(),
+        ApiEndpoint("https://example.com/foo", method="GET"),
+        timeout=5,
+        max_retries=3,
+        retry_delay=0.01,
+        retry_backoff=1.0,
+        monitor_progress=False,
+    )
+
+    assert result == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_persistent_401_still_fails(monkeypatch):
+    """A genuinely invalid key must still raise, after exhausting retries."""
+    responses = [_FakeResponse(401, {"message": "Invalid Comfy API key"})] * 10
+    _patch_session(monkeypatch, responses)
+
+    with pytest.raises(Exception, match="Unauthorized"):
+        await sync_op_raw(
+            MagicMock(),
+            ApiEndpoint("https://example.com/foo", method="GET"),
+            timeout=5,
+            max_retries=2,
+            retry_delay=0.01,
+            retry_backoff=1.0,
+            monitor_progress=False,
+        )

--- a/tests-unit/comfy_api_nodes_test/client_retry_test.py
+++ b/tests-unit/comfy_api_nodes_test/client_retry_test.py
@@ -33,12 +33,15 @@ class _FakeResponse:
 
 class _FakeSession:
     """A new instance is created per retry attempt (see _request_base), so the
-    response iterator must be shared across instances, not per-instance."""
+    response iterator and call counter must be shared across instances, not
+    per-instance."""
 
-    def __init__(self, responses_iter):
+    def __init__(self, responses_iter, call_count):
         self._responses = responses_iter
+        self._call_count = call_count
 
     async def request(self, method, url, **kwargs):
+        self._call_count[0] += 1
         return next(self._responses)
 
     async def close(self):
@@ -46,11 +49,14 @@ class _FakeSession:
 
 
 def _patch_session(monkeypatch, responses):
+    """Returns a single-element list holding the number of requests made so far."""
     responses_iter = iter(responses)
+    call_count = [0]
     monkeypatch.setattr(
-        client_module.aiohttp, "ClientSession", lambda *a, **kw: _FakeSession(responses_iter)
+        client_module.aiohttp, "ClientSession", lambda *a, **kw: _FakeSession(responses_iter, call_count)
     )
     monkeypatch.setattr(client_module.request_logger, "log_request_response", lambda **kw: None)
+    return call_count
 
 
 @pytest.mark.asyncio
@@ -79,7 +85,7 @@ async def test_transient_401_is_retried(monkeypatch):
 async def test_persistent_401_still_fails(monkeypatch):
     """A genuinely invalid key must still raise, after exhausting retries."""
     responses = [_FakeResponse(401, {"message": "Invalid Comfy API key"})] * 10
-    _patch_session(monkeypatch, responses)
+    call_count = _patch_session(monkeypatch, responses)
 
     with pytest.raises(Exception, match="Unauthorized"):
         await sync_op_raw(
@@ -91,3 +97,5 @@ async def test_persistent_401_still_fails(monkeypatch):
             retry_backoff=1.0,
             monitor_progress=False,
         )
+
+    assert call_count[0] == 3  # initial attempt + 2 retries, then exhausted


### PR DESCRIPTION
Fixes #15856

## Problem

`api.comfy.org` intermittently returns `HTTP 401 {"message": "Invalid Comfy API key"}` for a valid, unchanged API key. The requests immediately before and after the failing one succeed with the same key, and a follow-up request with the same key also succeeds — so the 401 is transient, not a real auth failure. Today `comfy_api_nodes/util/client.py` treats every 401 as fatal and raises `Unauthorized: Please login first to use this node.`, which aborts the entire workflow.

The issue reporter confirmed that locally adding `401` to `_RETRY_STATUS` let the existing retry mechanism recover from the transient 401 without interrupting the workflow.

## Fix

Add `401` to `_RETRY_STATUS` in `comfy_api_nodes/util/client.py` so a 401 is retried the same way as the other transient statuses already in that set (`408, 500, 502, 503, 504`), using the existing bounded retry/backoff logic (`max_retries`, default 3). A persistent/genuine 401 still raises the same `Unauthorized` error once retries are exhausted.

```diff
-_RETRY_STATUS = {408, 500, 502, 503, 504}  # status 429 is handled separately
+_RETRY_STATUS = {401, 408, 500, 502, 503, 504}  # status 429 is handled separately
```

## Testing

Added `tests-unit/comfy_api_nodes_test/client_retry_test.py` with two cases, mocking `aiohttp.ClientSession` to return canned responses:

- `test_transient_401_is_retried`: a 401 followed by a 200 completes successfully (proves the retry happens).
- `test_persistent_401_still_fails`: a 401 on every attempt still raises `Unauthorized: ...` once retries are exhausted (proves we didn't turn 401 into an infinite/silent retry).

Verified the first test fails without the fix:

```
$ git checkout HEAD~1 -- comfy_api_nodes/util/client.py
$ python -m pytest tests-unit/comfy_api_nodes_test/client_retry_test.py -v
...
tests-unit/comfy_api_nodes_test/client_retry_test.py::test_transient_401_is_retried FAILED
tests-unit/comfy_api_nodes_test/client_retry_test.py::test_persistent_401_still_fails PASSED
E   Exception: Unauthorized: Please login first to use this node.
1 failed, 1 passed
$ git checkout HEAD -- comfy_api_nodes/util/client.py
```

With the fix applied:

```
$ python -m pytest tests-unit/comfy_api_nodes_test/client_retry_test.py -v
tests-unit/comfy_api_nodes_test/client_retry_test.py::test_transient_401_is_retried PASSED
tests-unit/comfy_api_nodes_test/client_retry_test.py::test_persistent_401_still_fails PASSED
2 passed
```

Full unit suite and ruff also pass:

```
$ python -m pytest tests-unit/
1406 passed, 10 skipped
$ ruff check .
All checks passed!
```

## AI-assistance disclosure

This change was prepared with the assistance of an AI coding agent (Claude), based on the issue's own root-cause analysis and reporter-verified hotfix. All changes were reviewed, tested, and verified by re-running the test suite before/after the fix.


<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [ ] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [ ] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [ ] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**

