### PR TITLE
Introduce Comfy Compiler (CORE-389)

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -182,6 +182,7 @@ parser.add_argument("--enable-dynamic-vram", action="store_true", help="Enable d
 parser.add_argument("--fast-disk", action="store_true", help="Prefer disk-backed dynamic loading and offload over unpinned RAM. Can be faster for users with fast NVME disks.")
 parser.add_argument("--disable-cuda-graphs", action="store_true", help="Disable CUDA graphs.")
 parser.add_argument("--disable-comfy-compiler", action="store_true", help="Disable the Comfy model compiler, including its CUDA graph subfeature.")
+parser.add_argument("--assert-graph-breaks", action="store_true", help="Fail on Comfy model compiler graph breaks.")
 
 parser.add_argument("--force-non-blocking", action="store_true", help="Force ComfyUI to use non-blocking operations for all applicable tensors. This may improve performance on some non-Nvidia systems but can cause issues with some workflows.")
 

--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -181,6 +181,7 @@ parser.add_argument("--disable-dynamic-vram", action="store_true", help="Disable
 parser.add_argument("--enable-dynamic-vram", action="store_true", help="Enable dynamic VRAM on systems where it's not enabled by default.")
 parser.add_argument("--fast-disk", action="store_true", help="Prefer disk-backed dynamic loading and offload over unpinned RAM. Can be faster for users with fast NVME disks.")
 parser.add_argument("--disable-cuda-graphs", action="store_true", help="Disable CUDA graphs.")
+parser.add_argument("--disable-comfy-compiler", action="store_true", help="Disable the Comfy model compiler, including its CUDA graph subfeature.")
 
 parser.add_argument("--force-non-blocking", action="store_true", help="Force ComfyUI to use non-blocking operations for all applicable tensors. This may improve performance on some non-Nvidia systems but can cause issues with some workflows.")
 
@@ -290,6 +291,9 @@ if args.windows_standalone_build:
 
 if args.disable_auto_launch:
     args.auto_launch = False
+
+if args.disable_comfy_compiler:
+    args.disable_cuda_graphs = True
 
 if args.force_fp16:
     args.fp16_unet = True

--- a/comfy/ldm/lightricks/av_model.py
+++ b/comfy/ldm/lightricks/av_model.py
@@ -938,8 +938,11 @@ class LTXAVModel(LTXVModel):
         stg_self_attn_blocks = transformer_options.get("stg_self_attn_blocks", ())
 
         # Process transformer blocks
+        comfy.model_prefetch.malloc_graph_begin(self, vx.device)
         for i, block in enumerate(self.transformer_blocks):
-            comfy.model_prefetch.prefetch_queue_pop(prefetch_queue, vx.device, block)
+            comfy.model_prefetch.prefetch_queue_pop(
+                prefetch_queue, vx.device, block, malloc_scope="block"
+            )
             block_transformer_options = transformer_options
             if i in stg_self_attn_blocks:
                 block_transformer_options = {**transformer_options, "stg_skip_self_attn": True}
@@ -1015,7 +1018,10 @@ class LTXAVModel(LTXVModel):
                     a_prompt_timestep=a_prompt_timestep,
                 )
 
-        comfy.model_prefetch.prefetch_queue_pop(prefetch_queue, vx.device, None)
+        comfy.model_prefetch.prefetch_queue_pop(
+            prefetch_queue, vx.device, None, malloc_scope="block"
+        )
+        comfy.model_prefetch.malloc_graph_end()
 
         return [vx, ax]
 

--- a/comfy/ldm/minimax/model.py
+++ b/comfy/ldm/minimax/model.py
@@ -563,12 +563,23 @@ class MiniMaxH3Model(nn.Module):
             carry = (sigma_a / sigma_v).to(audio_src.dtype)
             x = [x[0], audio_src * carry]
 
-        out = comfy.patcher_extension.WrapperExecutor.new_class_executor(
+        compile_allocations = comfy.model_prefetch.malloc_graph_enabled(x[0].device)
+        if compile_allocations:
+            out = [torch.empty_like(x[0]), torch.empty_like(x[1])]
+            comfy.model_prefetch.malloc_graph_begin(self, x[0].device)
+        graph_out = comfy.patcher_extension.WrapperExecutor.new_class_executor(
             self._forward,
             self,
             comfy.patcher_extension.get_all_wrappers(comfy.patcher_extension.WrappersMP.DIFFUSION_MODEL, transformer_options)
         ).execute(x, timestep, context, transformer_options, minimax_payload=minimax_payload,
                   denoise_mask=denoise_mask, audio_denoise_mask=audio_denoise_mask, **kwargs)
+        if compile_allocations:
+            out[0].copy_(graph_out[0])
+            out[1].copy_(graph_out[1])
+            del graph_out
+            comfy.model_prefetch.malloc_graph_end()
+        else:
+            out = graph_out
 
         if scale != 1.0:
             # d/d(sigma_v) of the carried variable
@@ -724,7 +735,7 @@ class MiniMaxH3Model(nn.Module):
         blocks_replace = patches_replace.get("dit", {})
         prefetch_queue = comfy.model_prefetch.make_prefetch_queue(list(self.blocks), device, transformer_options)
         for i, block in enumerate(self.blocks):
-            comfy.model_prefetch.prefetch_queue_pop(prefetch_queue, device, block)
+            comfy.model_prefetch.prefetch_queue_pop(prefetch_queue, device, block, malloc_scope="block")
             if ("double_block", i) in blocks_replace:
                 def block_wrap(args):
                     return {"img": block(args["img"], args["t_emb"], args["mod_segments"], args["rope_freqs"],
@@ -735,8 +746,7 @@ class MiniMaxH3Model(nn.Module):
                     {"original_block": block_wrap})["img"]
             else:
                 h = block(h, t_emb, mod_segments, rope_freqs, transformer_options=transformer_options)
-        if prefetch_queue is not None:
-            comfy.model_prefetch.prefetch_queue_pop(prefetch_queue, device, None)
+        comfy.model_prefetch.prefetch_queue_pop(prefetch_queue, device, None, malloc_scope="block")
 
         # target streams are single contiguous segments (audio then video, last two)
         va, vb, _ = next(s for s in layout.segments if s[2] == "video")

--- a/comfy/ldm/minimax_music/ar.py
+++ b/comfy/ldm/minimax_music/ar.py
@@ -253,6 +253,11 @@ class MiniMaxMusic3AR(nn.Module):
         output = self.model(None, embeds=text_embeds, past_key_values=past, dtype=execution_dtype)
         last_hidden = output[0][:, -1].clone()
         past = output[2]
+        del output
+        vbar = getattr(self, "dynamic_vbars", {}).get(device)
+        if vbar is not None:
+            comfy.model_management.reset_cast_buffers()
+            vbar.set_watermark(vbar.max_size)
 
         generator = torch.Generator(device=device).manual_seed(derive_seed(seed, "ar"))
         decoder = self.model.audio_decoder

--- a/comfy/ldm/minimax_music/ar.py
+++ b/comfy/ldm/minimax_music/ar.py
@@ -268,8 +268,6 @@ class MiniMaxMusic3AR(nn.Module):
             "codes": torch.empty((last_hidden.shape[0], self.num_codebooks), dtype=torch.long, device=device),
             "depth_hidden": torch.empty((1, last_hidden.shape[-1] * (self.num_codebooks - 1)), dtype=execution_dtype, device=device),
         }
-        decoder._comfy_cross_step_state = depth_io
-        comfy.model_management._register_cross_step(decoder)
         hidden_frames = []
         pending_code = None
         stop_token = None

--- a/comfy/ldm/minimax_music/ar.py
+++ b/comfy/ldm/minimax_music/ar.py
@@ -251,7 +251,7 @@ class MiniMaxMusic3AR(nn.Module):
         decode_limit = min(int(max_audio_frames), MAX_AUDIO_FRAMES)
         past = self.model.init_kv_cache(2, prompt_tokens + decode_limit + 1, device, execution_dtype)
         output = self.model(None, embeds=text_embeds, past_key_values=past, dtype=execution_dtype)
-        last_hidden = output[0][:, -1]
+        last_hidden = output[0][:, -1].clone()
         past = output[2]
 
         generator = torch.Generator(device=device).manual_seed(derive_seed(seed, "ar"))
@@ -269,7 +269,8 @@ class MiniMaxMusic3AR(nn.Module):
         pending_code = None
         stop_token = None
         pending_event = None
-        pending_hidden = None
+        pending_hidden = torch.empty(last_hidden.shape[-1] * self.num_codebooks, dtype=execution_dtype, device=device)
+        pending_hidden_valid = False
         progress = comfy.utils.ProgressBar(decode_limit)
         cuda_device = torch.device(device).type == "cuda"
         vocab_mask = None
@@ -284,14 +285,16 @@ class MiniMaxMusic3AR(nn.Module):
                 if pending_event is not None:
                     pending_event.synchronize()
                 if int(pending_code.item()) == stop_token:
-                    pending_hidden = None
+                    pending_hidden_valid = False
                     break
-                if pending_hidden is not None:
-                    hidden_frames.append(pending_hidden)
+                if pending_hidden_valid:
+                    hidden_frames.append(pending_hidden.clone())
                     progress.update_absolute(len(hidden_frames))
                     if len(hidden_frames) >= decode_limit:
                         break
 
+            if frame_index:
+                comfy.model_prefetch.malloc_graph_begin(self, device)
             c0, code_or_stop, stop_token = self._sample_c0(last_hidden, cfg_scale, top_k, generator, vocab_mask)
             if pending_code is None:
                 pending_code = torch.empty_like(code_or_stop, device="cpu", pin_memory=cuda_device)
@@ -318,25 +321,31 @@ class MiniMaxMusic3AR(nn.Module):
                 [[decoder, self.model.audio_extra_embedding]], device, {"prefetch_dynamic_vbars": True}
             )
             comfy.model_prefetch.prefetch_queue_pop(
-                depth_queue, device, decoder, execution_dtype, core=depth_core, enable_graph=True, generator=generator
+                depth_queue, device, decoder, execution_dtype, core=depth_core, enable_graph=True,
+                generator=generator, malloc_scope="depth"
             )
-            comfy.model_prefetch.prefetch_queue_pop(depth_queue, device, None)
+            comfy.model_prefetch.prefetch_queue_pop(
+                depth_queue, device, None, malloc_scope="depth"
+            )
             feedback_codes = depth_io["codes"]
             depth_hidden = depth_io["depth_hidden"]
             frame_hidden = torch.cat((last_hidden[:1].detach(), depth_hidden), dim=-1)
             if frame_index > 0:
-                pending_hidden = frame_hidden[0].clone()
+                pending_hidden.copy_(frame_hidden[0])
+                pending_hidden_valid = True
 
             feedback = self._embed_audio_frame(feedback_codes, execution_dtype)
             output = self.model(None, embeds=feedback, past_key_values=past, dtype=execution_dtype)
-            last_hidden = output[0][:, -1]
+            last_hidden.copy_(output[0][:, -1])
             past = output[2]
+            del output, feedback, frame_hidden, depth_hidden, feedback_codes, c0_embed, c0, code_or_stop
+            comfy.model_prefetch.malloc_graph_end()
 
-        if pending_hidden is not None and len(hidden_frames) < decode_limit:
+        if pending_hidden_valid and len(hidden_frames) < decode_limit:
             if pending_event is not None:
                 pending_event.synchronize()
             if int(pending_code.item()) != stop_token:
-                hidden_frames.append(pending_hidden)
+                hidden_frames.append(pending_hidden.clone())
 
         if not hidden_frames:
             raise ValueError("MiniMax Music3 generated zero audio frames")

--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -1373,6 +1373,7 @@ LARGEST_CASTED_WEIGHT = (None, 0)
 STREAM_AIMDO_CAST_BUFFERS = {}
 LARGEST_AIMDO_CASTED_WEIGHT = (None, 0)
 CROSS_STEP_STATE = weakref.WeakSet()
+MALLOC_GRAPH_MODULES = weakref.WeakSet()
 
 DEFAULT_AIMDO_CAST_BUFFER_RESERVATION_SIZE = 16 * 1024 ** 3
 
@@ -1458,6 +1459,9 @@ def reset_cast_buffers():
 
     STREAM_CAST_BUFFERS.clear()
     STREAM_AIMDO_CAST_BUFFERS.clear()
+    for module in MALLOC_GRAPH_MODULES:
+        del module._comfy_malloc_graph
+    MALLOC_GRAPH_MODULES.clear()
     soft_empty_cache()
 
 def get_offload_stream(device):

--- a/comfy/model_prefetch.py
+++ b/comfy/model_prefetch.py
@@ -1,3 +1,4 @@
+import logging
 import threading
 import warnings
 import weakref
@@ -16,11 +17,19 @@ GRAPH_MODULES = weakref.WeakSet()
 GRAPH_WARMED_MODULES = weakref.WeakSet()
 GRAPH_CAPTURE_STREAMS = {}
 ACTIVE_MALLOC_GRAPHS = {}
+MALLOC_GRAPH_BREAKS = 0
+MALLOC_GRAPH_USED = False
+
+def _malloc_graph_break():
+    global MALLOC_GRAPH_BREAKS
+    MALLOC_GRAPH_BREAKS += 1
+    logging.debug("Comfy model compiler graph break")
 
 def malloc_graph_enabled(device):
     return not args.disable_comfy_compiler and comfy.memory_management.aimdo_enabled and comfy.model_management.is_device_cuda(device)
 
 def malloc_graph_begin(module, device):
+    global MALLOC_GRAPH_USED
     if not malloc_graph_enabled(device):
         return
     graph = getattr(module, "_comfy_malloc_graph", None)
@@ -31,11 +40,12 @@ def malloc_graph_begin(module, device):
     else:
         graph.push()
     ACTIVE_MALLOC_GRAPHS[threading.get_ident()] = graph
+    MALLOC_GRAPH_USED = True
 
 def malloc_graph_end():
     graph = ACTIVE_MALLOC_GRAPHS.pop(threading.get_ident(), None)
-    if graph is not None:
-        graph.pop()
+    if graph is not None and graph.pop():
+        _malloc_graph_break()
 
 def cleanup_prefetched_modules(module, comfy_modules):
     for s in comfy_modules:
@@ -67,6 +77,8 @@ def _drop_graph(module):
 
 def cleanup_prefetch_queues():
     global PREFETCH_QUEUES
+    global MALLOC_GRAPH_BREAKS
+    global MALLOC_GRAPH_USED
 
     ACTIVE_MALLOC_GRAPHS.pop(threading.get_ident(), None)
     for queue in PREFETCH_QUEUES:
@@ -82,13 +94,18 @@ def cleanup_prefetch_queues():
         _drop_graph(module)
     GRAPH_MODULES.clear()
     GRAPH_WARMED_MODULES.clear()
+    if MALLOC_GRAPH_USED:
+        logging.info("Comfy model compiler graph breaks: %d", MALLOC_GRAPH_BREAKS)
+    MALLOC_GRAPH_BREAKS = 0
+    MALLOC_GRAPH_USED = False
 
 def prefetch_queue_pop(queue, device, module, dtype=None, core=None, enable_graph=False, generator=None, malloc_scope=None):
     malloc_graph = ACTIVE_MALLOC_GRAPHS.get(threading.get_ident())
     enable_graph = enable_graph and malloc_graph is not None and not args.disable_cuda_graphs and comfy.model_management.is_device_cuda(device) and getattr(module, "_v_block", None) is not None
     if queue is None:
         if malloc_graph is not None and malloc_scope is not None:
-            malloc_graph.iterate(malloc_scope if module is not None else None)
+            if malloc_graph.iterate(malloc_scope if module is not None else None):
+                _malloc_graph_break()
         if core is not None:
             core()
         return
@@ -117,7 +134,8 @@ def prefetch_queue_pop(queue, device, module, dtype=None, core=None, enable_grap
             graph_hit = comfy_aimdo.model_vbar.vbar_signature_compare(signature, graph["signature"])
 
     if malloc_graph is not None and malloc_scope is not None:
-        malloc_graph.iterate(malloc_scope if module is not None and not graph_hit else None)
+        if malloc_graph.iterate(malloc_scope if module is not None and not graph_hit else None):
+            _malloc_graph_break()
 
     consumed = queue.pop(0)
     if consumed is not None:

--- a/comfy/model_prefetch.py
+++ b/comfy/model_prefetch.py
@@ -193,17 +193,16 @@ def prefetch_queue_pop(queue, device, module, dtype=None, core=None, enable_grap
                 if generator is not None:
                     graph.register_generator_state(generator)
                 malloc_graph.resume()
-                # Aimdo may evict unpinned VBARs without synchronizing during capture.
-                # Complete prior work before a CUDA graph can touch those allocations.
+                # Capture-time VBAR eviction is safe after prior work completes.
                 comfy.model_management.synchronize()
                 capture_stream.wait_stream(comfy.model_management.current_stream(device))
-                malloc_graph.pause()
+                malloc_graph.pause(sync=True)
                 with malloc_graph.use_stream(capture_stream):
                     with torch.cuda.graph(graph, stream=capture_stream, capture_error_mode="thread_local"):
                         malloc_graph.resume()
                         core()
                         malloc_graph.pause()
-                malloc_graph.resume()
+                malloc_graph.resume(sync=True)
                 comfy.model_management.current_stream(device).wait_stream(capture_stream)
                 graph.replay()
                 module._comfy_graph = {"graph": graph, "signature": signature}

--- a/comfy/model_prefetch.py
+++ b/comfy/model_prefetch.py
@@ -34,7 +34,9 @@ def malloc_graph_begin(module, device):
         return
     graph = getattr(module, "_comfy_malloc_graph", None)
     if graph is None:
-        graph = comfy_aimdo.malloc_graph.record(comfy.model_management.current_stream(device))
+        graph = comfy_aimdo.malloc_graph.record(
+            comfy.model_management.current_stream(device), args.assert_graph_breaks
+        )
         module._comfy_malloc_graph = graph
         comfy.model_management.MALLOC_GRAPH_MODULES.add(module)
     else:

--- a/comfy/model_prefetch.py
+++ b/comfy/model_prefetch.py
@@ -45,9 +45,12 @@ def malloc_graph_begin(module, device):
     MALLOC_GRAPH_USED = True
 
 def malloc_graph_end():
-    graph = ACTIVE_MALLOC_GRAPHS.pop(threading.get_ident(), None)
-    if graph is not None and graph.pop():
-        _malloc_graph_break()
+    thread_id = threading.get_ident()
+    graph = ACTIVE_MALLOC_GRAPHS.get(thread_id)
+    if graph is not None:
+        if graph.pop():
+            _malloc_graph_break()
+        ACTIVE_MALLOC_GRAPHS.pop(thread_id)
 
 def cleanup_prefetched_modules(module, comfy_modules):
     for s in comfy_modules:
@@ -82,7 +85,9 @@ def cleanup_prefetch_queues():
     global MALLOC_GRAPH_BREAKS
     global MALLOC_GRAPH_USED
 
-    ACTIVE_MALLOC_GRAPHS.pop(threading.get_ident(), None)
+    graph = ACTIVE_MALLOC_GRAPHS.pop(threading.get_ident(), None)
+    if graph is not None:
+        graph.abort()
     for queue in PREFETCH_QUEUES:
         for entry in queue:
             if entry is None or not isinstance(entry, tuple):

--- a/comfy/model_prefetch.py
+++ b/comfy/model_prefetch.py
@@ -42,7 +42,7 @@ def _drop_graph(module):
     del module._comfy_graph
 
 def cleanup_prefetch_queues():
-    global PREFETCH_QUEUES, GRAPH_CAPTURE_STREAMS
+    global PREFETCH_QUEUES
 
     for queue in PREFETCH_QUEUES:
         for entry in queue:
@@ -57,7 +57,6 @@ def cleanup_prefetch_queues():
         _drop_graph(module)
     GRAPH_MODULES.clear()
     GRAPH_WARMED_MODULES.clear()
-    GRAPH_CAPTURE_STREAMS = {}
 
 def prefetch_queue_pop(queue, device, module, dtype=None, core=None, enable_graph=False, generator=None):
     enable_graph = enable_graph and not args.disable_cuda_graphs and comfy.model_management.is_device_cuda(device) and getattr(module, "_v_block", None) is not None

--- a/comfy/model_prefetch.py
+++ b/comfy/model_prefetch.py
@@ -1,7 +1,10 @@
-import torch
+import threading
 import warnings
 import weakref
 
+import torch
+
+import comfy_aimdo.malloc_graph
 import comfy_aimdo.model_vbar
 from comfy.cli_args import args
 import comfy.memory_management
@@ -12,6 +15,27 @@ PREFETCH_QUEUES = []
 GRAPH_MODULES = weakref.WeakSet()
 GRAPH_WARMED_MODULES = weakref.WeakSet()
 GRAPH_CAPTURE_STREAMS = {}
+ACTIVE_MALLOC_GRAPHS = {}
+
+def malloc_graph_enabled(device):
+    return not args.disable_comfy_compiler and comfy.memory_management.aimdo_enabled and comfy.model_management.is_device_cuda(device)
+
+def malloc_graph_begin(module, device):
+    if not malloc_graph_enabled(device):
+        return
+    graph = getattr(module, "_comfy_malloc_graph", None)
+    if graph is None:
+        graph = comfy_aimdo.malloc_graph.record(comfy.model_management.current_stream(device))
+        module._comfy_malloc_graph = graph
+        comfy.model_management.MALLOC_GRAPH_MODULES.add(module)
+    else:
+        graph.push()
+    ACTIVE_MALLOC_GRAPHS[threading.get_ident()] = graph
+
+def malloc_graph_end():
+    graph = ACTIVE_MALLOC_GRAPHS.pop(threading.get_ident(), None)
+    if graph is not None:
+        graph.pop()
 
 def cleanup_prefetched_modules(module, comfy_modules):
     for s in comfy_modules:
@@ -44,6 +68,7 @@ def _drop_graph(module):
 def cleanup_prefetch_queues():
     global PREFETCH_QUEUES
 
+    ACTIVE_MALLOC_GRAPHS.pop(threading.get_ident(), None)
     for queue in PREFETCH_QUEUES:
         for entry in queue:
             if entry is None or not isinstance(entry, tuple):
@@ -58,9 +83,12 @@ def cleanup_prefetch_queues():
     GRAPH_MODULES.clear()
     GRAPH_WARMED_MODULES.clear()
 
-def prefetch_queue_pop(queue, device, module, dtype=None, core=None, enable_graph=False, generator=None):
-    enable_graph = enable_graph and not args.disable_cuda_graphs and comfy.model_management.is_device_cuda(device) and getattr(module, "_v_block", None) is not None
+def prefetch_queue_pop(queue, device, module, dtype=None, core=None, enable_graph=False, generator=None, malloc_scope=None):
+    malloc_graph = ACTIVE_MALLOC_GRAPHS.get(threading.get_ident())
+    enable_graph = enable_graph and malloc_graph is not None and not args.disable_cuda_graphs and comfy.model_management.is_device_cuda(device) and getattr(module, "_v_block", None) is not None
     if queue is None:
+        if malloc_graph is not None and malloc_scope is not None:
+            malloc_graph.iterate(malloc_scope if module is not None else None)
         if core is not None:
             core()
         return
@@ -70,6 +98,13 @@ def prefetch_queue_pop(queue, device, module, dtype=None, core=None, enable_grap
         capture_stream = GRAPH_CAPTURE_STREAMS.get(device)
         if capture_stream is None:
             capture_stream = torch.cuda.Stream(device=device)
+            # Keep PyTorch's persistent BLAS workspaces outside the allocation graph.
+            malloc_graph.pause()
+            with torch.cuda.stream(capture_stream):
+                torch.cuda.current_blas_handle()
+                one = torch.empty((2, 2), device=device)
+                torch.addmm(one[0], one, one)
+            malloc_graph.resume()
             GRAPH_CAPTURE_STREAMS[device] = capture_stream
 
     signature = None
@@ -80,6 +115,9 @@ def prefetch_queue_pop(queue, device, module, dtype=None, core=None, enable_grap
         if signature is not None:
             module._v_block_faulted = True
             graph_hit = comfy_aimdo.model_vbar.vbar_signature_compare(signature, graph["signature"])
+
+    if malloc_graph is not None and malloc_scope is not None:
+        malloc_graph.iterate(malloc_scope if module is not None and not graph_hit else None)
 
     consumed = queue.pop(0)
     if consumed is not None:
@@ -130,12 +168,22 @@ def prefetch_queue_pop(queue, device, module, dtype=None, core=None, enable_grap
                     module._v_block_faulted = True
             if signature is not None:
                 _drop_graph(module)
+                malloc_graph.pause()
                 graph = torch.cuda.CUDAGraph()
                 if generator is not None:
                     graph.register_generator_state(generator)
+                malloc_graph.resume()
+                # Aimdo may evict unpinned VBARs without synchronizing during capture.
+                # Complete prior work before a CUDA graph can touch those allocations.
+                comfy.model_management.synchronize()
                 capture_stream.wait_stream(comfy.model_management.current_stream(device))
-                with torch.cuda.graph(graph, stream=capture_stream, capture_error_mode="thread_local"):
-                    core()
+                malloc_graph.pause()
+                with malloc_graph.use_stream(capture_stream):
+                    with torch.cuda.graph(graph, stream=capture_stream, capture_error_mode="thread_local"):
+                        malloc_graph.resume()
+                        core()
+                        malloc_graph.pause()
+                malloc_graph.resume()
                 comfy.model_management.current_stream(device).wait_stream(capture_stream)
                 graph.replay()
                 module._comfy_graph = {"graph": graph, "signature": signature}
@@ -145,7 +193,7 @@ def prefetch_queue_pop(queue, device, module, dtype=None, core=None, enable_grap
             core()
         else:
             capture_stream.wait_stream(comfy.model_management.current_stream(device))
-            with torch.cuda.stream(capture_stream):
+            with torch.cuda.stream(capture_stream), malloc_graph.use_stream(capture_stream):
                 core()
             comfy.model_management.current_stream(device).wait_stream(capture_stream)
             GRAPH_WARMED_MODULES.add(module)

--- a/comfy/text_encoders/gemma4.py
+++ b/comfy/text_encoders/gemma4.py
@@ -517,9 +517,10 @@ class Gemma4Transformer(nn.Module):
         fixed_kv = (past_key_values is not None and len(past_key_values) > 0
                     and isinstance(past_key_values[0], FixedKV))
         decode = fixed_kv and past_len > 0 and seq_len == 1
-        # mirror the conditions under which prefetch_queue_pop can actually capture, so
-        # eager fallbacks keep the sliced decode path instead of the full-capacity one
-        enable_graph = (decode and mask is None and self.graph_dynamic_vbar_blocks
+        # Compiled decode needs fixed-capacity attention for a stable allocation trace;
+        # CUDA graph capture has additional prefetch and device requirements.
+        compiled_decode = decode and mask is None and self.graph_dynamic_vbar_blocks
+        enable_graph = (compiled_decode
                         and prefetch_queue is not None
                         and hasattr(self.layers[0], "_v_block")
                         and not comfy.model_management.args.disable_cuda_graphs
@@ -538,7 +539,7 @@ class Gemma4Transformer(nn.Module):
                 for kv in past_key_values:
                     if isinstance(kv, FixedKV) and id(kv.position) not in decode_masks:
                         decode_masks[id(kv.position)] = _fixed_kv_decode_mask(mask, kv, min_val)
-        if enable_graph:
+        if compiled_decode:
             # static buffers + per-capacity attention biases: layer graphs replay against
             # stable storage, refreshed eagerly each step
             capacities = tuple(sorted({kv.key.shape[2] for kv in past_key_values if isinstance(kv, FixedKV)}))
@@ -606,7 +607,7 @@ class Gemma4Transformer(nn.Module):
                     if shared is not None:
                         layer_kwargs['shared_kv'] = shared
 
-            if enable_graph:
+            if compiled_decode:
                 bias_cache = layer_kwargs.get('shared_kv', past_kv)
                 layer_mask = decode_bias[bias_cache.key.shape[2]]
             elif decode:
@@ -619,10 +620,17 @@ class Gemma4Transformer(nn.Module):
 
             def core():
                 nonlocal x
-                x, current_kv, shareable_kv = layer(x=x, attention_mask=layer_mask, freqs_cis=freqs_cis, past_key_value=past_kv, **layer_kwargs)
+                output, current_kv, shareable_kv = layer(x=x, attention_mask=layer_mask, freqs_cis=freqs_cis, past_key_value=past_kv, **layer_kwargs)
+                if compiled_decode:
+                    x.copy_(output)
+                else:
+                    x = output
                 result.append((current_kv, shareable_kv))
 
-            comfy.model_prefetch.prefetch_queue_pop(prefetch_queue, x.device, layer, x.dtype, core=core, enable_graph=enable_graph)
+            comfy.model_prefetch.prefetch_queue_pop(
+                prefetch_queue, x.device, layer, x.dtype, core=core, enable_graph=enable_graph,
+                malloc_scope="block"
+            )
 
             if result:
                 current_kv, shareable_kv = result[0]
@@ -641,8 +649,10 @@ class Gemma4Transformer(nn.Module):
             if i == intermediate_output:
                 intermediate = x.clone()
 
-        if prefetch_queue is not None:
-            comfy.model_prefetch.prefetch_queue_pop(prefetch_queue, x.device, None)
+        comfy.model_prefetch.prefetch_queue_pop(
+            prefetch_queue, x.device, None,
+            malloc_scope="block"
+        )
 
         if fixed_kv:
             for kv in past_key_values:

--- a/comfy/text_encoders/gemma4.py
+++ b/comfy/text_encoders/gemma4.py
@@ -228,9 +228,8 @@ class Gemma4Attention(nn.Module):
             if fixed_cache is not None:
                 if seq_length == 1 and fixed_cache.index > 0:
                     # CUDA-graphable decode: write at the device-side ring/linear position
-                    position = fixed_cache.position.view(batch_size, 1, 1, 1).expand_as(xk)
-                    fixed_cache.key.scatter_(2, position, xk)
-                    fixed_cache.value.scatter_(2, position, xv)
+                    fixed_cache.key.index_copy_(2, fixed_cache.position, xk)
+                    fixed_cache.value.index_copy_(2, fixed_cache.position, xv)
                     output = self._decode_attention(xq, fixed_cache, attention_mask)
                     return self.o_proj(output), fixed_cache, None
 
@@ -516,10 +515,12 @@ class Gemma4Transformer(nn.Module):
 
         fixed_kv = (past_key_values is not None and len(past_key_values) > 0
                     and isinstance(past_key_values[0], FixedKV))
-        decode = fixed_kv and past_len > 0 and seq_len == 1
+        decode = fixed_kv and seq_len == 1
         # Compiled decode needs fixed-capacity attention for a stable allocation trace;
         # CUDA graph capture has additional prefetch and device requirements.
-        compiled_decode = decode and mask is None and self.graph_dynamic_vbar_blocks
+        compiled_decode = decode and past_len > 0 and mask is None and self.graph_dynamic_vbar_blocks
+        if compiled_decode:
+            x = x.clone()
         enable_graph = (compiled_decode
                         and prefetch_queue is not None
                         and hasattr(self.layers[0], "_v_block")
@@ -527,51 +528,23 @@ class Gemma4Transformer(nn.Module):
                         and comfy.model_management.is_device_cuda(x.device))
         decode_bias = None
         decode_masks = None
-        if fixed_kv:
+        if decode:
             prepared = set()
             for kv in past_key_values:
                 if isinstance(kv, FixedKV) and id(kv.position) not in prepared:
                     kv.prepare(seq_len)
                     prepared.add(id(kv.position))
-        if decode:
             if mask is not None:
                 decode_masks = {}
                 for kv in past_key_values:
                     if isinstance(kv, FixedKV) and id(kv.position) not in decode_masks:
                         decode_masks[id(kv.position)] = _fixed_kv_decode_mask(mask, kv, min_val)
         if compiled_decode:
-            # static buffers + per-capacity attention biases: layer graphs replay against
-            # stable storage, refreshed eagerly each step
             capacities = tuple(sorted({kv.key.shape[2] for kv in past_key_values if isinstance(kv, FixedKV)}))
-            state_key = (x.shape, x.dtype, x.device, tuple(t.shape for t in freqs_cis), capacities,
-                         None if per_layer_inputs is None else per_layer_inputs.shape)
-            state = getattr(self, "_comfy_cross_step_state", None)
-            if state is None or state["key"] != state_key:
-                state = {"key": state_key,
-                         "x": torch.empty_like(x),
-                         "freqs_cis": [torch.empty_like(t) for t in freqs_cis],
-                         "bias": {c: torch.empty((1, 1, 1, c), dtype=x.dtype, device=x.device) for c in capacities},
-                         "per_layer": None if per_layer_inputs is None else torch.empty_like(per_layer_inputs),
-                         "bias_valid": -1}
-                self._comfy_cross_step_state = state
-                comfy.model_management._register_cross_step(self)
-            state["x"].copy_(x)
-            for source, target in zip(freqs_cis, state["freqs_cis"]):
-                target.copy_(source)
-            x = state["x"]
-            freqs_cis = state["freqs_cis"]
-            if per_layer_inputs is not None:
-                state["per_layer"].copy_(per_layer_inputs)
-                per_layer_inputs = state["per_layer"]
             valid = past_len + 1
-            for capacity, bias in state["bias"].items():
-                if state["bias_valid"] != past_len:
-                    bias.fill_(min_val)
-                    bias[..., :min(valid, capacity)] = 0
-                elif past_len < capacity:
-                    bias[..., past_len:valid] = 0
-            state["bias_valid"] = valid
-            decode_bias = state["bias"]
+            decode_bias = {capacity: torch.full((1, 1, 1, capacity), min_val, dtype=x.dtype, device=x.device) for capacity in capacities}
+            for capacity, bias in decode_bias.items():
+                bias[..., :min(valid, capacity)] = 0
 
         intermediate = None
         all_intermediate = None
@@ -717,8 +690,8 @@ class Gemma4Base(BaseLlama, BaseGenerate, torch.nn.Module):
             cache_cls = RingKV if sliding else FixedKV
             tracker = trackers.get((cache_cls, length))
             if tracker is None:
-                tracker = (torch.empty((batch,), device=device, dtype=torch.int64),
-                           torch.zeros((batch,), device=device, dtype=torch.int32))
+                tracker = (torch.empty((1,), device=device, dtype=torch.int64),
+                           torch.empty((batch,), device=device, dtype=torch.int32))
                 trackers[(cache_cls, length)] = tracker
             # zero-init: decode attends full capacity with masked tails, 0*0 stays finite
             key = torch.zeros((batch, kv_heads, length, head_dim), device=device, dtype=execution_dtype)

--- a/comfy/text_encoders/gemma4.py
+++ b/comfy/text_encoders/gemma4.py
@@ -691,7 +691,7 @@ class Gemma4Base(BaseLlama, BaseGenerate, torch.nn.Module):
             tracker = trackers.get((cache_cls, length))
             if tracker is None:
                 tracker = (torch.empty((1,), device=device, dtype=torch.int64),
-                           torch.empty((batch,), device=device, dtype=torch.int32))
+                           torch.zeros((batch,), device=device, dtype=torch.int32))
                 trackers[(cache_cls, length)] = tracker
             # zero-init: decode attends full capacity with masked tails, 0*0 stays finite
             key = torch.zeros((batch, kv_heads, length, head_dim), device=device, dtype=execution_dtype)

--- a/comfy/text_encoders/llama.py
+++ b/comfy/text_encoders/llama.py
@@ -858,29 +858,7 @@ class Llama2_(nn.Module):
 
         enable_graph = self.graph_dynamic_vbar_blocks and fixed_kv_decode
         if enable_graph:
-            freqs_cis_groups = freqs_cis if isinstance(freqs_cis, list) else [freqs_cis]
-            cross_step_state_key = [(x.shape, x.stride(), x.dtype, x.device)]
-            for group in freqs_cis_groups:
-                for tensor in group:
-                    cross_step_state_key.append((tensor.shape, tensor.stride(), tensor.dtype, tensor.device))
-            cross_step_state_key = tuple(cross_step_state_key)
-            cross_step_state = getattr(self, "_comfy_cross_step_state", None)
-            if cross_step_state is None or cross_step_state["key"] != cross_step_state_key:
-                static_freqs_cis = []
-                for group in freqs_cis_groups:
-                    static_freqs_cis.append(tuple(torch.empty_like(tensor) for tensor in group))
-                if not isinstance(freqs_cis, list):
-                    static_freqs_cis = static_freqs_cis[0]
-                cross_step_state = {"key": cross_step_state_key, "x": torch.empty_like(x), "freqs_cis": static_freqs_cis}
-                self._comfy_cross_step_state = cross_step_state
-                comfy.model_management._register_cross_step(self)
-            cross_step_state["x"].copy_(x)
-            static_freqs_cis_groups = cross_step_state["freqs_cis"] if isinstance(freqs_cis, list) else [cross_step_state["freqs_cis"]]
-            for source_group, target_group in zip(freqs_cis_groups, static_freqs_cis_groups):
-                for source, target in zip(source_group, target_group):
-                    target.copy_(source)
-            x = cross_step_state["x"]
-            freqs_cis = cross_step_state["freqs_cis"]
+            x = x.clone()
 
         intermediate = None
         all_intermediate = None

--- a/comfy/text_encoders/llama.py
+++ b/comfy/text_encoders/llama.py
@@ -911,17 +911,24 @@ class Llama2_(nn.Module):
 
             def core():
                 nonlocal x
-                x, current_kv = layer(
+                output, current_kv = layer(
                     x=x,
                     attention_mask=mask,
                     freqs_cis=freqs_cis,
                     optimized_attention=optimized_attention,
                     past_key_value=past_kv,
                 )
+                if enable_graph:
+                    x.copy_(output)
+                else:
+                    x = output
                 if next_key_values:
                     next_key_values[i] = current_kv
 
-            comfy.model_prefetch.prefetch_queue_pop(prefetch_queue, x.device, layer, x.dtype, core=core, enable_graph=enable_graph)
+            comfy.model_prefetch.prefetch_queue_pop(
+                prefetch_queue, x.device, layer, x.dtype, core=core, enable_graph=enable_graph,
+                malloc_scope="block"
+            )
             if fixed_kv:
                 next_key_values[i].advance(seq_len)
 
@@ -932,8 +939,10 @@ class Llama2_(nn.Module):
             if i == intermediate_output:
                 intermediate = x.clone()
 
-        if prefetch_queue is not None:
-            comfy.model_prefetch.prefetch_queue_pop(prefetch_queue, x.device, None)
+        comfy.model_prefetch.prefetch_queue_pop(
+            prefetch_queue, x.device, None,
+            malloc_scope="block"
+        )
 
         if self.norm is not None:
             x = self.norm(x)
@@ -1041,9 +1050,19 @@ class BaseGenerate:
         # MRoPE: prefill uses explicit 3D position_ids, decode continues from the last position
         next_pos = int(position_ids[:, -1].max()) + 1 if position_ids is not None else None
 
+        compile_allocations = self.model.graph_dynamic_vbar_blocks and comfy.model_prefetch.malloc_graph_enabled(device)
+        decode_tokens = torch.empty((embeds.shape[0], 1), dtype=torch.long, device=device)
+
         # Generation loop
         current_input_ids = initial_input_ids
         for step in tqdm(range(max_length), desc="Generating tokens"):
+            if step > 0:
+                if compile_allocations:
+                    comfy.model_prefetch.malloc_graph_begin(self, device)
+                embeds = self.model.embed_tokens(decode_tokens).to(execution_dtype)
+                current_input_ids = decode_tokens if initial_input_ids is not None else None
+                position_ids = torch.tensor([[next_pos]], device=device) if next_pos is not None else None
+
             # DeepStack visual features are injected on the prefill only; gemma4's forward lacks these kwargs.
             extra = {}
             if step == 0 and deepstack_embeds is not None:
@@ -1052,13 +1071,16 @@ class BaseGenerate:
             x, _, past_key_values = self.model.forward(None, embeds=embeds, attention_mask=None, past_key_values=past_key_values, input_ids=current_input_ids, position_ids=position_ids, **extra, embeds_info=(embeds_info if step == 0 else None))
             logits = self.logits(x)[:, -1]
             next_token = self.sample_token(logits, temperature, top_k, top_p, min_p, repetition_penalty, initial_tokens + generated_token_ids, generator, do_sample=do_sample, presence_penalty=presence_penalty)
-            token_id = next_token[0].item()
+
+            decode_tokens.copy_(next_token)
+            del next_token, logits, x, embeds, position_ids
+            if step > 0 and compile_allocations:
+                comfy.model_prefetch.malloc_graph_end()
+
+            token_id = decode_tokens[0].item()
             generated_token_ids.append(token_id)
 
-            embeds = self.model.embed_tokens(next_token).to(execution_dtype)
-            current_input_ids = next_token if initial_input_ids is not None else None
-            if next_pos is not None:  # advance MRoPE position for the next (decode) step
-                position_ids = torch.tensor([[next_pos]], device=device)
+            if step > 0 and next_pos is not None:
                 next_pos += 1
             pbar.update(1)
 

--- a/execution.py
+++ b/execution.py
@@ -547,8 +547,8 @@ async def execute(server, dynprompt, caches, current_item, extra_data, executed,
                 if comfy.memory_management.aimdo_enabled:
                     if get_console_log_level(args.verbose) == "DEBUG":
                         comfy_aimdo.control.analyze()
-                    comfy.model_management.reset_cast_buffers()
                     comfy.model_prefetch.cleanup_prefetch_queues()
+                    comfy.model_management.reset_cast_buffers()
                     comfy_aimdo.model_vbar.vbars_reset_watermark_limits()
 
             if has_pending_tasks:

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ SQLAlchemy>=2.0.0
 filelock
 av>=17.0.0
 comfy-kitchen==0.2.31
-comfy-aimdo==0.4.15
+comfy-aimdo==0.5.0
 requests
 simpleeval>=1.0.0
 blake3

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ SQLAlchemy>=2.0.0
 filelock
 av>=17.0.0
 comfy-kitchen==0.2.31
-comfy-aimdo==0.5.0
+comfy-aimdo==0.5.1
 requests
 simpleeval>=1.0.0
 blake3


### PR DESCRIPTION
The comfy compiler is a two layered model compilation process that consists of

- The aimdo memory compiler (in version 0.5.0)
- Existing cuda graphs support

The memory compiler built into aimdo computes an minimize memory allocations to a reduce cuda memory allocation calls to once-only and then keep the memory needed for inference stable and constant.

https://github.com/Comfy-Org/comfy-aimdo/pull/93

The avoids cuda async allocator thrash and any racing between dynamic-vram pressure and cuda reported numbers.

The second big win is this removes VRAM under-utilization due to bad allocation shapes combing with allocator caches. The aimdo compiler uses an aggressive and greedy re-allocation algorithm that guarantees the pyhysical VRAM peak matches the logical allocation peak and no freed allocations are cached.

The cuda graph support is layered on top now as the allocation VBAR now gives the stable VRAM addresses needed for compilation (previously handled by the cross-step-state). Synchronization is added to the cuda graph record process to avoid frees during record causing failures. To compensate, this synchronization is eliminated in the case where the memory subgraph for the transformer block is already compiler (as we are guaranteed to have 0 allocations and nothing to worry about now). So in general only the first block need a sync.

All models that currently use the prefetcher + MiniMax H3 are converted. The AR models remain cuda graphs while the diffusion models are just memory compiler for now.

Minimax AR adds a watermark reset between prefill and AR as this significantly increases step rate on low VRAM cards. This case produced the above described free-on-record bug.

### Future work

- Convert more models. WAN in particular to increase max generation sizes

- Implement graph caching. With the memory compiler we can preserve virtual addresses without needing to hold the physical VRAM for the compiler. This allows us to vacate a models inference VRAM move on to other models but keep the compiled graph. Physical memory is then repopulated into the already known memory compile underneath the cuda graph.


### Example Test Conditions - Diffusion

Windows, RTX5060, 32GB
Minimax H3 720p x158f

<img width="2017" height="618" alt="image" src="https://github.com/user-attachments/assets/0a002b24-d8bf-4043-96e3-ac9149c4f72e" />

Before:

<img width="346" height="577" alt="image" src="https://github.com/user-attachments/assets/499ae7e3-b189-4fd1-a500-f2a4724ba13b" />

<img width="346" height="577" alt="image" src="https://github.com/user-attachments/assets/cffed913-be95-4f78-98bb-09dfa51575d7" />


```
[INFO] Model MiniMaxH3 prepared for dynamic VRAM loading. 19995MB Staged. 0 patches attached. Force pre-loaded 210 weights: 1175 KB.
  0%|          | 0/20 [00:00<?, ?it/s,   Model Initializing ...  ]
  <<No activity after several minutes>>
```

After:

<img width="351" height="570" alt="image" src="https://github.com/user-attachments/assets/d16b673b-59dd-4f42-818e-201b5084dc90" />


```
[INFO] Model MiniMaxH3 prepared for dynamic VRAM loading. 19995MB Staged. 0 patches attached. Force pre-loaded 210 weights: 1175 KB.
 10%|#         | 2/20 [01:26<13:01, 43.43s/it] 
 ```
 
 ### Example Test Conditions - Minimax AR
 
 Windows, RTX5060, 32GB
Minimax Music 3 AR, 3 seconds

<img width="803" height="707" alt="image" src="https://github.com/user-attachments/assets/53f708dc-8de9-4958-b321-e132760fab24" />


before:

```
[INFO] Model MiniMaxMusic3TEModel prepared for dynamic VRAM loading. 8758MB Staged. 0 patches attached. Force pre-loaded 154 weights: 674 KB.
AR sampling: 100%|##########| 76/76 [00:08<00:00,  8.60it/s]                                  
[INFO] Prompt executed in 9.43 seconds
```

After:

```
[INFO] Model MiniMaxMusic3TEModel prepared for dynamic VRAM loading. 8758MB Staged. 0 patches attached. Force pre-loaded 154 weights: 674 KB.
AR sampling: 100%|##########| 76/76 [00:06<00:00, 11.57it/s]                                  
[INFO] Comfy model compiler graph breaks: 1
[INFO] Prompt executed in 8.80 seconds
```
