### PR TITLE
Update workflow templates to v0.11.46

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 comfyui-frontend-package==1.49.6
-comfyui-workflow-templates==0.11.44
+comfyui-workflow-templates==0.11.46
 comfyui-embedded-docs==0.5.10
 torch
 torchsde


### PR DESCRIPTION
## Update workflow templates to v0.11.46
New template 
- Wan3.0
- Meshy 7
- vCude 

Updated Meshy 6 templates
<img width="2560" height="1800" alt="image" src="https://github.com/user-attachments/assets/e8fbea58-ef52-47fc-9ff0-bec9739a5911" />

### 📦 Package Information
- **PyPI**: https://pypi.org/project/comfyui-workflow-templates/0.11.46/
- **Release**: https://github.com/Comfy-Org/workflow_templates/releases/tag/v0.11.46
<img width="1300" height="746" alt="image" src="https://github.com/user-attachments/assets/3a5d5c0d-b22f-47bf-b6d9-eb98c8c1ef75" />

### 📝 Changes
Updated dependency version in `requirements.txt`:
```diff
- comfyui-workflow-templates==0.11.44
+ comfyui-workflow-templates==0.11.46
```

---
*This is an automated draft PR created by the auto-pr-script*