### PR TITLE
Mark Compare Image node as not experimental anymore

### DIFF
--- a/comfy_extras/nodes_image_compare.py
+++ b/comfy_extras/nodes_image_compare.py
@@ -15,7 +15,6 @@ class ImageCompare(IO.ComfyNode):
             description="Compares two images side by side with a slider.",
             category="image",
             essentials_category="Image Tools",
-            is_experimental=True,
             is_output_node=True,
             inputs=[
                 IO.Image.Input("image_a", optional=True),


### PR DESCRIPTION
Remove `is_experimental` from Compare Image node to promote it to stable node.