### PR TITLE
comfy-aimdo 0.4.15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ SQLAlchemy>=2.0.0
 filelock
 av>=17.0.0
 comfy-kitchen==0.2.31
-comfy-aimdo==0.4.13
+comfy-aimdo==0.4.15
 requests
 simpleeval>=1.0.0
 blake3


### PR DESCRIPTION
Comfy-aimdo 0.4.15 fixes the headroom on the NVML pressure mechanism. Some system have only NVML as the pressure out and this could cause shared VRAM spills. This bumps the headroom to 512MB.

I never reproduced this issue.

Regression Tests:

(All windows)

```
System                         Workflow         Time 0.4.13 -> 0.4.15   Free VRAM 0.4.13 -> 0.4.15   Delta      Residency 0.4.13 -> 0.4.15
RTX3060, 48GB RAM, PCIE4x16    LTX 2.3          45.4s -> 46.5s          1.127 -> 1.252 GiB            +128 MiB   9.094 -> 8.969 GiB
RTX3060, 48GB RAM, PCIE4x16    MiniMax Music    25.7s -> 25.8s          2.260 -> 2.260 GiB               0 MiB   8.562 -> 8.562 GiB
RTX3060, 48GB RAM, PCIE4x16    Z-Image          25.2s -> 24.6s          2.572 -> 2.979 GiB            +416 MiB   8.250 -> 7.844 GiB
RTX3060, 48GB RAM, PCIE4x16    Qwen3 8B          3.80s -> 3.78s         2.729 -> 2.729 GiB               0 MiB   8.094 -> 8.094 GiB

RTX5060, 32GB RAM, PCIE5x8     MiniMax H3      602.8s -> 603.8s         6.751 -> 6.751 GiB               0 MiB   fully unloaded
RTX5060, 32GB RAM, PCIE5x8     LTX 2.3          90.0s -> 90.0s          6.749 -> 6.749 GiB               0 MiB   fully unloaded
RTX5060, 32GB RAM, PCIE5x8     Z-Image          21.3s -> 21.2s          2.593 -> 3.093 GiB            +512 MiB   4.156 -> 3.656 GiB
RTX5060, 32GB RAM, PCIE5x8     Gemma4 E2B       28.2s -> 28.5s          5.466 -> 5.466 GiB               0 MiB   1.219 -> 1.219 GiB

RTX5080, 32GB RAM, PCIE4x8     MiniMax H3      185.5s -> 185.1s        12.782 -> 13.157 GiB           +384 MiB   1.688 -> 1.312 GiB
RTX5080, 32GB RAM, PCIE4x8     LTX 2.3          71.7s -> 70.2s         14.437 -> 14.437 GiB              0 MiB   fully unloaded
RTX5080, 32GB RAM, PCIE4x8     Z-Image          15.5s -> 15.4s          2.374 -> 2.687 GiB            +320 MiB   12.094 -> 11.782 GiB
RTX5080, 32GB RAM, PCIE4x8     Gemma4 E2B        5.40s -> 5.40s         5.745 -> 5.745 GiB               0 MiB   8.656 -> 8.656 GiB
```