### PR TITLE
fix(tests): stop sys.modules stubs from evicting freshly-imported modules

### DIFF
--- a/tests-unit/comfy_extras_test/image_stitch_test.py
+++ b/tests-unit/comfy_extras_test/image_stitch_test.py
@@ -9,19 +9,25 @@ mock_nodes.MAX_RESOLUTION = 16384
 # Mock server module for PromptServer
 mock_server = MagicMock()
 
-previous_nodes = sys.modules.get("nodes")
-previous_server = sys.modules.get("server")
-sys.modules["nodes"] = mock_nodes
-sys.modules["server"] = mock_server
-from comfy_extras.nodes_images import ImageStitch
-if previous_nodes is None:
-    sys.modules.pop("nodes")
-else:
-    sys.modules["nodes"] = previous_nodes
-if previous_server is None:
-    sys.modules.pop("server")
-else:
-    sys.modules["server"] = previous_server
+# Stub only `nodes` and `server`, and put back only those two keys.
+#
+# `patch.dict("sys.modules", ...)` restores the mapping to its state on entry,
+# which also *evicts* every module this import pulled in for the first time. A
+# later import of one of those re-initialises an already-loaded C extension --
+# numpy raises "cannot load module more than once per process" -- aborting the
+# whole pytest run rather than failing one test.
+_MISSING = object()
+_stubs = {"nodes": mock_nodes, "server": mock_server}
+_originals = {name: sys.modules.get(name, _MISSING) for name in _stubs}
+sys.modules.update(_stubs)
+try:
+    from comfy_extras.nodes_images import ImageStitch
+finally:
+    for _name, _original in _originals.items():
+        if _original is _MISSING:
+            sys.modules.pop(_name, None)
+        else:
+            sys.modules[_name] = _original
 
 
 class TestImageStitch:
@@ -252,3 +258,4 @@ class TestImageStitch:
         expected_image2_width = int(64 * (32/32))  # Resized to height 64
         expected_total_width = 48 + 8 + expected_image2_width
         assert result[0].shape[2] == expected_total_width
+

--- a/tests-unit/comfy_extras_test/nodes_math_test.py
+++ b/tests-unit/comfy_extras_test/nodes_math_test.py
@@ -1,15 +1,33 @@
+import sys
 import math
 
 import pytest
 from collections import OrderedDict
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock
 
 mock_nodes = MagicMock()
 mock_nodes.MAX_RESOLUTION = 16384
 mock_server = MagicMock()
 
-with patch.dict("sys.modules", {"nodes": mock_nodes, "server": mock_server}):
+# Stub only `nodes` and `server`, and put back only those two keys.
+#
+# `patch.dict("sys.modules", ...)` restores the mapping to its state on entry,
+# which also *evicts* every module this import pulled in for the first time. A
+# later import of one of those re-initialises an already-loaded C extension --
+# numpy raises "cannot load module more than once per process" -- aborting the
+# whole pytest run rather than failing one test.
+_MISSING = object()
+_stubs = {"nodes": mock_nodes, "server": mock_server}
+_originals = {name: sys.modules.get(name, _MISSING) for name in _stubs}
+sys.modules.update(_stubs)
+try:
     from comfy_extras.nodes_math import MathExpressionNode
+finally:
+    for _name, _original in _originals.items():
+        if _original is _MISSING:
+            sys.modules.pop(_name, None)
+        else:
+            sys.modules[_name] = _original
 
 
 class TestMathExpressionExecute:

--- a/tests-unit/comfy_extras_test/nodes_number_convert_test.py
+++ b/tests-unit/comfy_extras_test/nodes_number_convert_test.py
@@ -1,12 +1,30 @@
+import sys
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock
 
 mock_nodes = MagicMock()
 mock_nodes.MAX_RESOLUTION = 16384
 mock_server = MagicMock()
 
-with patch.dict("sys.modules", {"nodes": mock_nodes, "server": mock_server}):
+# Stub only `nodes` and `server`, and put back only those two keys.
+#
+# `patch.dict("sys.modules", ...)` restores the mapping to its state on entry,
+# which also *evicts* every module this import pulled in for the first time. A
+# later import of one of those re-initialises an already-loaded C extension --
+# numpy raises "cannot load module more than once per process" -- aborting the
+# whole pytest run rather than failing one test.
+_MISSING = object()
+_stubs = {"nodes": mock_nodes, "server": mock_server}
+_originals = {name: sys.modules.get(name, _MISSING) for name in _stubs}
+sys.modules.update(_stubs)
+try:
     from comfy_extras.nodes_number_convert import NumberConvertNode
+finally:
+    for _name, _original in _originals.items():
+        if _original is _MISSING:
+            sys.modules.pop(_name, None)
+        else:
+            sys.modules[_name] = _original
 
 
 class TestNumberConvertExecute:

--- a/tests-unit/comfy_extras_test/nodes_preview_any_test.py
+++ b/tests-unit/comfy_extras_test/nodes_preview_any_test.py
@@ -1,11 +1,29 @@
-from unittest.mock import patch, MagicMock
+import sys
+from unittest.mock import MagicMock
 
 mock_nodes = MagicMock()
 mock_nodes.MAX_RESOLUTION = 16384
 mock_server = MagicMock()
 
-with patch.dict("sys.modules", {"nodes": mock_nodes, "server": mock_server}):
+# Stub only `nodes` and `server`, and put back only those two keys.
+#
+# `patch.dict("sys.modules", ...)` restores the mapping to its state on entry,
+# which also *evicts* every module this import pulled in for the first time. A
+# later import of one of those re-initialises an already-loaded C extension --
+# numpy raises "cannot load module more than once per process" -- aborting the
+# whole pytest run rather than failing one test.
+_MISSING = object()
+_stubs = {"nodes": mock_nodes, "server": mock_server}
+_originals = {name: sys.modules.get(name, _MISSING) for name in _stubs}
+sys.modules.update(_stubs)
+try:
     from comfy_extras.nodes_preview_any import PreviewAny
+finally:
+    for _name, _original in _originals.items():
+        if _original is _MISSING:
+            sys.modules.pop(_name, None)
+        else:
+            sys.modules[_name] = _original
 
 
 class TestPreviewAnyMain:


### PR DESCRIPTION
## Summary

Four tests in `tests-unit/comfy_extras_test` stub `nodes` and `server` like this:

```python
with patch.dict("sys.modules", {"nodes": mock_nodes, "server": mock_server}):
    from comfy_extras.nodes_x import ...
```

`patch.dict` restores the mapping to its **exact** state on entry, so on exit it also *evicts*
every module the import inside the block pulled in for the first time — `numpy`, `torch` and
friends, by way of `comfy_api`. Those modules are gone from `sys.modules` but their C extensions
are still loaded in the process, so the next import of one re-initialises it:

- `numpy` → `ImportError: cannot load module more than once per process`
- `torch` → re-registers `torch._inductor.test_operators`, raising
  `RuntimeError: Only a single TORCH_LIBRARY can be used to register the namespace _inductor_test`

Both abort **collection for the entire run** rather than failing one test, which quietly makes
the order these files are collected in load-bearing.

## Repro — this is already biting on master

```console
$ python -m pytest tests-unit/comfy_extras_test/ --ignore=tests-unit/comfy_extras_test/compositor_node_test.py
ERROR tests-unit/comfy_extras_test/test_seedvr2_post_processing.py - RuntimeError: ...
ERROR tests-unit/comfy_extras_test/test_seedvr2_temporal_chunk.py - RuntimeError: ...
!!!!! Interrupted: 2 errors during collection !!!!!
2 errors in 5.64s
```

(`compositor_node_test.py` is excluded only because it needs CUDA and this machine has none —
it is unrelated to this change.)

Forcing two **existing** files into an order the alphabet does not currently produce crashes the
interpreter outright — no new file of mine involved:

```console
$ python -m pytest tests-unit/comfy_extras_test/nodes_math_test.py \
                   tests-unit/comfy_extras_test/image_stitch_test.py
Fatal Python error: ...
```

Today that ordering does not arise by accident, because every numpy-importing test in the
directory happens to sort *before* `nodes_math_test.py`. It is luck, not design: adding one new
test file whose name sorts after it takes the suite down. I hit exactly that writing a
regression test for #15849, which is what sent me here.

## After

```console
$ python -m pytest tests-unit/comfy_extras_test/ --ignore=tests-unit/comfy_extras_test/compositor_node_test.py
206 passed in 4.09s
```

Note that this also clears the two `test_seedvr2_*` collection errors **and** a
`test_seedvr2_conditioning` failure that were present before — they were downstream of the same
eviction, not separate problems.

## The change

Each file now stubs the two keys it means to stub and restores **only those two**, leaving
anything imported during the block in `sys.modules` where it belongs:

```python
_stubbed = {"nodes": mock_nodes, "server": mock_server}
_original_modules = {name: sys.modules.get(name) for name in _stubbed}
sys.modules.update(_stubbed)
try:
    from comfy_extras.nodes_x import ...
finally:
    for _name, _original in _original_modules.items():
        if _original is None:
            sys.modules.pop(_name, None)
        else:
            sys.modules[_name] = _original
```

No test logic or assertions changed — only how the stubs are installed and removed.

## Notes for review

- **Why not just pre-import numpy at the top of each file?** That fixes the symptom for numpy
  and leaves the mechanism in place; the `torch._inductor` variant would still be waiting for
  whichever module gets evicted next. Restoring only the keys we set removes the cause.
- **Duplication.** The same eight lines now appear in four files. I kept them inline rather than
  adding a shared helper because `tests-unit` is not an importable package name (the hyphen), so
  a shared module there would need either a relative import or a conftest fixture, and both are
  more machinery than this deserves. Happy to switch to a `conftest.py` fixture if you'd prefer
  it in one place.
- `patch` is no longer used in three of the four files, so the import was narrowed to
  `MagicMock`. `ruff check tests-unit/comfy_extras_test/` passes.
- `tests-unit/execution_test/test_enrich_output.py` uses `patch.dict("sys.modules", ...)` too,
  but inside test functions rather than at import time, where the blast radius is different.
  I left it alone rather than widen this PR — happy to follow up if you want it converted.
