### PR TITLE
fix(train): render a constant loss series instead of dividing by zero (#15849)

### DIFF
--- a/comfy_extras/nodes_train.py
+++ b/comfy_extras/nodes_train.py
@@ -1441,7 +1441,18 @@ class LossGraphNode(io.ComfyNode):
         draw = ImageDraw.Draw(img)
 
         min_loss, max_loss = min(loss_values), max(loss_values)
-        scaled_loss = [(l - min_loss) / (max_loss - min_loss) for l in loss_values]
+        loss_range = max_loss - min_loss
+        if loss_range > 0:
+            scaled_loss = [(l - min_loss) / loss_range for l in loss_values]
+        else:
+            # Every recorded loss is identical, so there is no range to
+            # normalize against and the division above would raise. This is not
+            # a degenerate input: a steps=1 run has exactly one value by
+            # definition, and it is the cheapest way to validate a training
+            # config before committing to a long run. Draw the series flat at
+            # mid-height -- 0.0 or 1.0 would pin it to the axis and read as
+            # "lowest"/"highest" when the only true statement is "unchanged".
+            scaled_loss = [0.5 for _ in loss_values]
 
         steps = len(loss_values)
 

--- a/comfy_extras/nodes_train.py
+++ b/comfy_extras/nodes_train.py
@@ -1,4 +1,5 @@
 import logging
+import math
 import os
 
 import numpy as np
@@ -1431,6 +1432,27 @@ class LossGraphNode(io.ComfyNode):
 
     @classmethod
     def execute(cls, loss, filename_prefix, prompt=None, extra_pnginfo=None):
+        """Plot the training loss curve and return it as a preview image.
+
+        The series is normalized to the plot height between its own min and
+        max. Two cases have no meaningful normalization: a series whose values
+        are all identical -- which includes every ``steps=1`` run -- is drawn
+        flat at mid-height, and a series containing NaN or infinity is refused,
+        because normalizing it would render a diverged run as a stable one.
+
+        Args:
+            loss: ``LOSS_MAP`` from a training node; ``loss["loss"]`` is the
+                per-step loss list.
+            filename_prefix: Prefix for the saved graph image.
+            prompt: Hidden prompt metadata, embedded in the saved PNG.
+            extra_pnginfo: Hidden extra PNG metadata.
+
+        Returns:
+            A ``NodeOutput`` carrying the graph as a preview image.
+
+        Raises:
+            ValueError: If any recorded loss is not finite.
+        """
         loss_values = loss["loss"]
         width, height = 800, 480
         margin = 40
@@ -1439,6 +1461,17 @@ class LossGraphNode(io.ComfyNode):
             "RGB", (width + margin, height + margin), "white"
         )  # Extend canvas
         draw = ImageDraw.Draw(img)
+
+        # A diverged run reaches here as NaN/inf. Refuse it by name rather than
+        # normalizing it: NaN fails every comparison, so min, max and the range
+        # are all NaN, the range is not > 0, and the series would take the
+        # constant branch below and be drawn as a healthy flat line. Saying so
+        # is the point -- the operator needs to know training diverged.
+        if not all(math.isfinite(l) for l in loss_values):
+            raise ValueError(
+                "Loss graph cannot be drawn: the loss series contains non-finite "
+                "values (NaN or infinity), which usually means training diverged."
+            )
 
         min_loss, max_loss = min(loss_values), max(loss_values)
         loss_range = max_loss - min_loss
@@ -1457,6 +1490,18 @@ class LossGraphNode(io.ComfyNode):
         steps = len(loss_values)
 
         prev_point = (margin, height - int(scaled_loss[0] * height))
+        if steps == 1:
+            # Nothing to join a single point to, so the loop below never runs
+            # and the canvas would come back empty -- exactly the steps=1 case
+            # this node has to render. Mark the one sample instead.
+            radius = 4
+            draw.ellipse(
+                [
+                    (prev_point[0] - radius, prev_point[1] - radius),
+                    (prev_point[0] + radius, prev_point[1] + radius),
+                ],
+                fill="blue",
+            )
         for i, l in enumerate(scaled_loss[1:], start=1):
             x = margin + int(i / steps * width)  # Scale X properly
             y = height - int(l * height)

--- a/tests-unit/comfy_extras_test/nodes_train_loss_graph_test.py
+++ b/tests-unit/comfy_extras_test/nodes_train_loss_graph_test.py
@@ -46,6 +46,7 @@ def render(tmp_path):
     folder_paths.set_temp_directory(str(tmp_path))
 
     def _render(loss_values):
+        """Render one series and return the rows its blue plot occupies."""
         result = LossGraphNode.execute(
             loss={"loss": loss_values}, filename_prefix="loss_graph"
         )
@@ -54,10 +55,12 @@ def render(tmp_path):
         assert written, "node did not write a preview image"
         image = Image.open(written[0]).convert("RGB")
         width, _ = image.size
+        # tobytes() rather than getdata(), which Pillow 14 removes.
+        raw = image.tobytes()
         rows = {
-            index // width
-            for index, (r, g, b) in enumerate(image.getdata())
-            if b > 200 and r < 100 and g < 100
+            (offset // 3) // width
+            for offset in range(0, len(raw), 3)
+            if raw[offset + 2] > 200 and raw[offset] < 100 and raw[offset + 1] < 100
         }
         return sorted(rows)
 
@@ -99,3 +102,36 @@ def test_varying_series_still_spans_the_plot(render):
     rows = render([3.0, 2.0, 1.0])
     assert min(rows) <= 2, "highest loss should reach the top of the plot"
     assert max(rows) >= HEIGHT - 2, "lowest loss should reach the bottom"
+
+
+def test_single_step_run_draws_a_visible_marker(render):
+    """A one-point series has no segment to draw, so the plot would come back
+    empty -- the node marks the single sample instead.
+
+    Empty output is not much better than a crash for the case this node exists
+    to cover: a steps=1 run is done precisely to look at the result.
+    """
+    rows = render([3.1607])
+    assert rows, "a single-step run must still plot something"
+    assert abs(sum(rows) / len(rows) - HEIGHT / 2) <= 2
+
+
+@pytest.mark.parametrize(
+    "loss_values",
+    [
+        [float("nan"), float("nan")],
+        [float("inf"), float("inf")],
+        [3.0, float("nan"), 1.0],
+        [3.0, float("inf")],
+    ],
+    ids=["all-nan", "all-inf", "one-nan", "one-inf"],
+)
+def test_non_finite_series_is_refused_by_name(render, loss_values):
+    """A diverged run must not be drawn as a healthy flat line.
+
+    NaN fails every comparison, so min, max and the range are all NaN, the
+    range is not > 0, and the series would otherwise fall into the constant
+    branch and render flat -- reporting a diverged run as a stable one.
+    """
+    with pytest.raises(ValueError, match="non-finite"):
+        render(loss_values)

--- a/tests-unit/comfy_extras_test/nodes_train_loss_graph_test.py
+++ b/tests-unit/comfy_extras_test/nodes_train_loss_graph_test.py
@@ -1,0 +1,101 @@
+"""LossGraphNode regression tests for a loss series with no spread.
+
+`LossGraphNode.execute` normalizes the curve with
+
+    (l - min_loss) / (max_loss - min_loss)
+
+which raises `ZeroDivisionError` whenever every recorded loss is identical.
+A `steps=1` run hits that by definition -- it has exactly one value -- and a
+one-step run is the cheap way to validate a training config before committing
+to a long one. Training itself completes and the LoRA is written; only the
+graph node fails, so the run is lost at its last step.
+
+Assertions read the PNG the node actually rendered rather than recomputing the
+scaling here, so a test cannot pass against a reimplementation of the bug.
+"""
+
+import glob
+import os
+
+import pytest
+import torch
+from PIL import Image
+
+from comfy.cli_args import args as cli_args
+
+# comfy.model_management resolves the torch device at import time and asks CUDA
+# for it unless args.cpu is set, so this has to happen before nodes_train is
+# imported. Same guard the SeedVR2 node tests use.
+if not torch.cuda.is_available():
+    cli_args.cpu = True
+
+import folder_paths  # noqa: E402
+from comfy_extras.nodes_train import LossGraphNode  # noqa: E402
+
+HEIGHT = 480  # plot area height inside the rendered canvas
+
+
+@pytest.fixture
+def render(tmp_path):
+    """Render a loss series and hand back the rows its blue line occupies.
+
+    PreviewImage writes the figure to the temp directory, so point that at
+    tmp_path and read the result back from there.
+    """
+    original = folder_paths.get_temp_directory()
+    folder_paths.set_temp_directory(str(tmp_path))
+
+    def _render(loss_values):
+        result = LossGraphNode.execute(
+            loss={"loss": loss_values}, filename_prefix="loss_graph"
+        )
+        assert result is not None
+        written = glob.glob(os.path.join(str(tmp_path), "**", "*.png"), recursive=True)
+        assert written, "node did not write a preview image"
+        image = Image.open(written[0]).convert("RGB")
+        width, _ = image.size
+        rows = {
+            index // width
+            for index, (r, g, b) in enumerate(image.getdata())
+            if b > 200 and r < 100 and g < 100
+        }
+        return sorted(rows)
+
+    yield _render
+    folder_paths.set_temp_directory(original)
+
+
+def test_single_step_run_renders_instead_of_raising(render):
+    """steps=1 gives exactly one loss value, so min == max by definition."""
+    render([3.1607])
+
+
+def test_constant_loss_series_renders_instead_of_raising(render):
+    """Not only steps=1 -- any run whose losses are all equal hit the divide."""
+    render([2.0, 2.0, 2.0])
+
+
+def test_zero_loss_series_renders_instead_of_raising(render):
+    """min == max == 0, so numerator and divisor are both zero."""
+    render([0.0, 0.0])
+
+
+@pytest.mark.parametrize("value", [2.0, 5.0, 0.25])
+def test_constant_series_is_drawn_flat(render, value):
+    """A constant series plots as a flat line at the same height whatever the
+    constant is -- the only true statement about it is that it did not move.
+
+    Mid-height rather than 0.0 or 1.0 deliberately: those pin the line to the
+    bottom or top axis, which reads as "lowest" or "highest" loss.
+    """
+    rows = render([value] * 4)
+    assert rows, "no line was drawn"
+    assert max(rows) - min(rows) <= 2, "a constant series must not slope"
+    assert abs(sum(rows) / len(rows) - HEIGHT / 2) <= 2, "should sit at mid-height"
+
+
+def test_varying_series_still_spans_the_plot(render):
+    """Regression guard: the normal path keeps using the full plot height."""
+    rows = render([3.0, 2.0, 1.0])
+    assert min(rows) <= 2, "highest loss should reach the top of the plot"
+    assert max(rows) >= HEIGHT - 2, "lowest loss should reach the bottom"


### PR DESCRIPTION
## Summary

`LossGraphNode` normalizes the loss curve with

```python
scaled_loss = [(l - min_loss) / (max_loss - min_loss) for l in loss_values]
```

which raises `ZeroDivisionError` whenever every recorded loss is identical. A `steps=1` run hits
it **by definition** — one value, so `min_loss == max_loss` — and a one-step run is the cheap way
to validate a training config before committing to a long one. Training itself completes and the
LoRA is written; only the graph node fails, so the run is lost at its very last step.

It is not only `steps=1`: any run whose recorded losses all land on the same value does the same
thing. Confirmed by running the node directly on `master` (`v0.34.0`):

```
single step (steps=1)    -> ZeroDivisionError: float division by zero
constant series          -> ZeroDivisionError: float division by zero
normal series            -> OK
```

and with this change:

```
single step (steps=1)    -> OK
constant series          -> OK
normal series            -> OK
```

## Related Issues

- Closes #15849

## The choice of mid-height

A constant series is drawn flat at `0.5`. `0.0` or `1.0` would pin the line to the bottom or top
axis, which reads as "lowest loss" / "highest loss" — but the only true statement about a
constant series is that it *did not move*. Mid-height also matches the y-axis labels, which print
the same number at both ends when min == max.

## Tests

`tests-unit/comfy_extras_test/nodes_train_loss_graph_test.py`, 12 cases. They assert against the
PNG the node actually renders — read back out of the temp directory, which the fixture points at
`tmp_path` — rather than recomputing the scaling in the test. That matters: an earlier draft of
this test reimplemented the formula to find the plotted line, and consequently **passed against
the unfixed code**. Reading the real output is what makes it a regression guard.

Verified red on `master`, green with the change:

| case | `master` | this PR |
| --- | :---: | :---: |
| `test_single_step_run_renders_instead_of_raising` | **fail** | pass |
| `test_constant_loss_series_renders_instead_of_raising` | **fail** | pass |
| `test_zero_loss_series_renders_instead_of_raising` | **fail** | pass |
| `test_constant_series_is_drawn_flat[2.0]` | **fail** | pass |
| `test_constant_series_is_drawn_flat[5.0]` | **fail** | pass |
| `test_constant_series_is_drawn_flat[0.25]` | **fail** | pass |
| `test_varying_series_still_spans_the_plot` | pass | pass |
| ...plus the marker and non-finite cases added in review | **fail** | pass |
| | 1 passed, 11 failed | **12 passed** |

The last one passes on both on purpose — it is the regression guard for the path that was never
broken, asserting the normal case still uses the full plot height.

## Notes for review

- **This test cannot be collected alongside the rest of the directory until #15892 lands.**
  Four tests in `tests-unit/comfy_extras_test` stub `sys.modules` with `patch.dict`, which evicts
  numpy and torch on exit and aborts collection for any file importing them afterwards. Mine
  sorts after `nodes_math_test.py`, so it trips that. It passes standalone either way
  (`pytest tests-unit/comfy_extras_test/nodes_train_loss_graph_test.py` → 7 passed), and with
  #15892 applied the whole directory runs 206 passed. I found that bug writing this test and
  split it out rather than bundling it here — but they do need to land in that order.
- **`cli_args.cpu`.** The test sets it when CUDA is unavailable, before importing
  `nodes_train`, because `comfy.model_management` resolves the torch device at import time. This
  is the same guard `test_seedvr2_conditioning.py` already uses, and it is a no-op on a machine
  with CUDA.
- **There is a second copy of this expression**, in `draw_loss_graph()` at
  `comfy_extras/nodes_train.py:408`. I deliberately did not touch it: nothing in the repository
  calls that function (`grep -rn draw_loss_graph` finds only its definition), and it carries a
  second division by zero of its own — `int(i / (steps - 1) * width)`. It looks like dead code
  left over from an earlier version of this node. Happy to fix or delete it in a follow-up, but
  it seemed wrong to quietly edit an unreachable function inside a bug fix.
- **A single-point series** is drawn as a marker at mid-height. It has no segment to join, so
  without that the canvas came back empty — for exactly the `steps=1` case this PR exists to
  support. Added in review (49868c8).
- **A non-finite series is refused by name.** NaN fails every comparison, so an all-NaN run took
  the constant branch and rendered as a healthy flat line — a regression the first commit of this
  PR introduced, caught in review and fixed in 49868c8. `master` raised
  `cannot convert float NaN to integer`; it now says the series is non-finite and that training
  probably diverged. The check is deliberately in the graph node, not in `TrainSampler`: when
  training itself should abort on divergence is a separate decision.
