### PR TITLE
Fix infinite loop in MiniMax H3 VAE split_tiles when tile_size <= tile_overlap_min

### DIFF
--- a/comfy/ldm/minimax/vae.py
+++ b/comfy/ldm/minimax/vae.py
@@ -427,8 +427,13 @@ class MiniMaxH3VideoVAE(nn.Module):
             return [0], [input_len], []
 
         N = math.ceil(input_len / tile_size)
+        # Guard: each tile must advance by at least one latent step past the
+        # previous tile's start, otherwise the constraint below can never be
+        # satisfied and the search hangs forever (reproduced with
+        # tile_size=64, tile_overlap_min=64).
+        tile_overlap = max(0, min(self.tile_overlap_min, tile_size - self.vae_ratio))
         while True:
-            overlaps = [self.tile_overlap_min] * (N - 1)
+            overlaps = [tile_overlap] * (N - 1)
             remaining = tile_size * N - sum(overlaps) - input_len
             if remaining < 0:
                 N += 1


### PR DESCRIPTION
## Problem

`MiniMaxH3VideoVAE.split_tiles()` hangs forever (infinite `while True`) when `tile_size` is configured at or below `tile_overlap_min` (default 64), because the overlap can never be paid down:

```python
N = math.ceil(input_len / tile_size)
while True:
    overlaps = [self.tile_overlap_min] * (N - 1)   # fixed overlap
    remaining = tile_size * N - sum(overlaps) - input_len
    if remaining < 0:
        N += 1        # each step adds (tile_size - tile_overlap_min) <= 0
    else:
        break          # unreachable when tile_overlap_min >= tile_size
```

Reproduced: `model.tile_size = 64; model.encode(...)` on a 96px-tall input — the worker spins at 100% CPU with no error. Device-independent (hits CUDA too).

## Fix

Clamp the per-tile overlap so every tile advances by at least one latent step:

```python
tile_overlap = max(0, min(self.tile_overlap_min, tile_size - self.vae_ratio))
```

## Verification

Exhaustive plan simulation (same method body, upstream vs patched):

| config | upstream | patched |
|---|---|---|
| tile=64, overlap=64, len=96 | hangs | 5 tiles, covers input, monotonic starts |
| tile=40, overlap=64, len=320 | hangs | 36 tiles, covers input, monotonic starts |
| tile=256, overlap=64, len=768 | N=4 | N=4, **plan identical** |
| tile=128, overlap=64, len=768 | N=11 | N=11, **plan identical** |
| tile=200, overlap=64, len=500 | N=4 | N=4, **plan identical** |

Behavior unchanged for any sane tile size; degenerate configs now degrade gracefully instead of hanging.
