### PR TITLE
MiniMax H3 VAE: replace temporal F.pad(constant) with torch.cat — fixes silent encode corruption on MPS

### DIFF
--- a/comfy/ldm/minimax/vae.py
+++ b/comfy/ldm/minimax/vae.py
@@ -52,7 +52,17 @@ class CausalConv3d(ops.Conv3d):
         if x.shape[2] == 1:
             # single frame: the causal front padding is all zeros truncate the temporal taps instead of convolving zero frames
             return super().forward(x, autopad="causal_zero")
-        x = F.pad(x, (0, 0, 0, 0, self.causal_padding[0] * 2, 0), mode="constant")
+        # On MPS, F.pad(mode="constant") along the temporal axis of a 5D
+        # tensor is corrupted for padded spatial extents above ~2^16
+        # elements/frame: it silently writes wrong values into ~80% of the
+        # tensor (NaNs in fp16) with no error raised. This destroyed H3 VAE
+        # encodes above ~224x480 on Apple Silicon; see pytorch/pytorch#194922
+        # for the upstream kernel bug and characterization. torch.cat with a
+        # zero slab is equivalent and correct on every backend (bit-exact vs
+        # CPU at 256x544).
+        pad_t = self.causal_padding[0] * 2
+        zeros = x.new_zeros(*x.shape[:2], pad_t, *x.shape[3:])
+        x = torch.cat([zeros, x], dim=2)
         return super().forward(x)
 
 


### PR DESCRIPTION
## Problem

On Apple MPS, `F.pad(mode="constant")` applied along the **temporal axis of 5D tensors** silently writes wrong values for padded spatial extents above ~2^16 elements/frame — ~80% of elements corrupted, NaNs in fp16, no error raised. Full characterization and minimal repro: pytorch/pytorch#194922.

`CausalConv3d` uses exactly this padding (`(0,0,0,0,pad*2,0)`), so the H3 VAE encoder silently corrupts latents for inputs above ~224x480 on any Apple-Silicon machine. The corrupted latents look plausible but are wrong, and decode to flat/washed video. This is not theoretical — it produced uniform "tan" output videos in production:

- 224x480 and below: correct (encode tiles stay under the kernel bug's threshold)
- 256x544: latent std inflated, spatial detail destroyed (silent garbage)
- 288x608+: latent zero-filled + Metal command-buffer faults

Because the trigger is size-dependent and code-pattern-dependent, users experience this as "the model is broken at high res on Mac," not as a framework bug.

## Fix

Replace only the temporal constant-pad with a `torch.cat` of a zero slab:

```python
pad_t = self.causal_padding[0] * 2
zeros = x.new_zeros(*x.shape[:2], pad_t, *x.shape[3:])
x = torch.cat([zeros, x], dim=2)
```

Spatial reflect padding is unaffected by the kernel bug and stays as-is. `torch.cat` is numerically identical on every backend; no behavior change on CUDA/CPU. Diff is 4 lines inside `CausalConv3d.forward`.

## Validation

- Single-shot encode 256x544 on MPS: latent correlation vs CPU = 1.0000 (was 0.02)
- Full encoder bit-exact vs CPU at previously-corrupting sizes
- End-to-end through ComfyUI worker (MPS): 22f 352x768 -> 3x upscale -> 1056x2304: output luminance std 49.6 vs source 50.3, SSIM 0.998, zero Metal faults (previously: flat tan, std ~0)
- Longer clip with audio (39f): SSIM 0.996 vs native

Companion upstream report: pytorch/pytorch#194922
