### PR TITLE
ComfyUI backport release v0.34.1

### DIFF
--- a/comfy_api_nodes/apis/recraft.py
+++ b/comfy_api_nodes/apis/recraft.py
@@ -250,6 +250,26 @@ RECRAFT_V4_PRO_SIZES = [
     "1536x2688",
 ]
 
+RECRAFT_V4_STYLES_MODELS = frozenset(
+    {
+        "recraftv4_styles",
+        "recraftv4_styles_vector",
+        "recraftv4_styles_pro",
+        "recraftv4_styles_pro_vector",
+    }
+)
+
+RECRAFT_V4_VECTOR_MODEL_FOR_STYLE = {
+    "recraftv4": "recraftv4_vector",
+    "recraftv4_pro": "recraftv4_pro_vector",
+}
+
+RECRAFT_STYLE_MATCH_OPTIONS = ["precise", "flexible"]
+
+RECRAFT_STYLE_REFERENCES_MAX = 10
+
+RECRAFT_STYLE_REFERENCES_MAX_BYTES = 10 * 1024 * 1024
+
 
 class RecraftColorObject(BaseModel):
     rgb: list[int] = Field(..., description='An array of 3 integer values in range of 0...255 defining RGB Color Model')
@@ -272,6 +292,8 @@ class RecraftImageGenerationRequest(BaseModel):
     substyle: str | None = Field(None, description='The substyle to apply to the generated image, depending on the style input')
     controls: RecraftControlsObject | None = Field(None, description='A set of custom parameters to tweak generation process')
     style_id: str | None = Field(None, description='Use a previously uploaded style as a reference; UUID')
+    style_match: str | None = Field(None, description='How closely to follow the referenced style: "precise" or "flexible" for V4 models')
+    style_reference_urls: list[str] | None = Field(None, description='URLs or data URLs of style reference images; a private style is created from them and returned as style_id')
     strength: float | None = Field(None, description='Defines the difference with the original image, should lie in [0, 1], where 0 means almost identical, and 1 means miserable similarity')
     random_seed: int | None = Field(None, description="Seed for video generation")
 
@@ -286,10 +308,12 @@ class RecraftImageGenerationResponse(BaseModel):
     credits: int = Field(..., description='Number of credits used for the generation')
     data: list[RecraftReturnedObject] | None = Field(None, description='Array of generated image information')
     image: RecraftReturnedObject | None = Field(None, description='Single generated image')
+    style_id: str | None = Field(None, description='The style applied to the generation, including one auto-created from style references')
 
 
 class RecraftCreateStyleRequest(BaseModel):
-    style: str = Field(..., description="realistic_image, digital_illustration, vector_illustration, or icon")
+    style: str = Field(..., description="any, realistic_image, digital_illustration, vector_illustration, or icon")
+    model: str | None = Field(None, description="The model family the style is created for, e.g. recraftv4_styles")
 
 
 class RecraftCreateStyleResponse(BaseModel):

--- a/comfy_api_nodes/nodes_recraft.py
+++ b/comfy_api_nodes/nodes_recraft.py
@@ -1,3 +1,5 @@
+import base64
+import uuid
 from io import BytesIO
 
 import aiohttp
@@ -8,8 +10,13 @@ from typing_extensions import override
 from comfy.utils import ProgressBar
 from comfy_api.latest import IO, ComfyExtension
 from comfy_api_nodes.apis.recraft import (
+    RECRAFT_STYLE_MATCH_OPTIONS,
+    RECRAFT_STYLE_REFERENCES_MAX,
+    RECRAFT_STYLE_REFERENCES_MAX_BYTES,
     RECRAFT_V4_PRO_SIZES,
     RECRAFT_V4_SIZES,
+    RECRAFT_V4_STYLES_MODELS,
+    RECRAFT_V4_VECTOR_MODEL_FOR_STYLE,
     RecraftColor,
     RecraftColorChain,
     RecraftControls,
@@ -173,6 +180,60 @@ class handle_recraft_image_output:
             )
 
 
+def style_reference_images(images: IO.Autogrow.Type | None) -> list[torch.Tensor]:
+    references = []
+    for batch in (images or {}).values():
+        if batch is None:
+            continue
+        if batch.ndim == 3:
+            batch = batch.unsqueeze(0)
+        references.extend(batch[i] for i in range(batch.shape[0]))
+    return references
+
+
+def encode_style_references(references: list[torch.Tensor]) -> list[bytes]:
+    if not references:
+        raise ValueError("At least one style reference image is required.")
+    if len(references) > RECRAFT_STYLE_REFERENCES_MAX:
+        raise ValueError(
+            f"At most {RECRAFT_STYLE_REFERENCES_MAX} style reference images are allowed; got {len(references)}."
+        )
+    encoded = []
+    total_size = 0
+    for reference in references:
+        data = tensor_to_bytesio(reference, total_pixels=2048 * 2048, mime_type="image/webp").read()
+        total_size += len(data)
+        if total_size > RECRAFT_STYLE_REFERENCES_MAX_BYTES:
+            raise ValueError("Total size of style reference images exceeds the 10 MB limit.")
+        encoded.append(data)
+    return encoded
+
+
+def resolve_v4_style(
+    model: str, style_id: str, style_references: IO.Autogrow.Type | None
+) -> tuple[str | None, list[str] | None]:
+    style_id = style_id.strip()
+    references = style_reference_images(style_references)
+    if style_id and references:
+        raise ValueError("Provide either a style_id or style reference images, not both.")
+    if style_id:
+        try:
+            uuid.UUID(style_id)
+        except ValueError:
+            raise ValueError(f"style_id must be a UUID; got '{style_id}'.") from None
+        return style_id, None
+    if references:
+        return None, [
+            f"data:image/webp;base64,{base64.b64encode(data).decode()}"
+            for data in encode_style_references(references)
+        ]
+    if model in RECRAFT_V4_STYLES_MODELS:
+        raise ValueError(
+            f"Model '{model}' always requires a style: connect style reference images or provide a style_id."
+        )
+    return None, None
+
+
 class RecraftColorRGBNode(IO.ComfyNode):
     @classmethod
     def define_schema(cls):
@@ -272,9 +333,9 @@ class RecraftStyleV3VectorIllustrationNode(RecraftStyleV3RealisticImageNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="RecraftStyleV3VectorIllustrationNode",
-            display_name="Recraft Style - Realistic Image",
+            display_name="Recraft Style - Vector Illustration",
             category="partner/image/Recraft",
-            description="Select realistic_image style and optional substyle.",
+            description="Select vector_illustration style and optional substyle.",
             inputs=[
                 IO.Combo.Input("substyle", options=get_v3_substyles(cls.RECRAFT_STYLE)),
             ],
@@ -293,7 +354,7 @@ class RecraftStyleV3LogoRasterNode(RecraftStyleV3RealisticImageNode):
             node_id="RecraftStyleV3LogoRaster",
             display_name="Recraft Style - Logo Raster",
             category="partner/image/Recraft",
-            description="Select realistic_image style and optional substyle.",
+            description="Select logo_raster style and substyle.",
             inputs=[
                 IO.Combo.Input("substyle", options=get_v3_substyles(cls.RECRAFT_STYLE, include_none=False)),
             ],
@@ -392,6 +453,74 @@ class RecraftCreateStyleNode(IO.ComfyNode):
             max_retries=1,
         )
 
+        return IO.NodeOutput(response.id)
+
+
+class RecraftV4CreateStyleNode(IO.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return IO.Schema(
+            node_id="RecraftV4CreateStyleNode",
+            display_name="Recraft V4 Create Style",
+            category="partner/image/Recraft",
+            description="Create a reusable Recraft V4 style from 1-10 reference images. "
+            "The returned style_id works with every Recraft V4 and V4.1 model of the same output type. "
+            "Total size of all images is limited to 10 MB.",
+            inputs=[
+                IO.Combo.Input(
+                    "model",
+                    options=["recraftv4_styles", "recraftv4_styles_vector"],
+                    tooltip="Output type the style is created for: recraftv4_styles for raster images, "
+                    "recraftv4_styles_vector for SVG.",
+                ),
+                IO.Autogrow.Input(
+                    "images",
+                    template=IO.Autogrow.TemplatePrefix(
+                        IO.Image.Input("image"),
+                        prefix="image",
+                        min=1,
+                        max=RECRAFT_STYLE_REFERENCES_MAX,
+                    ),
+                    tooltip="Reference images defining the style. Similar references sharpen the match, "
+                    "varied references widen it.",
+                ),
+            ],
+            outputs=[
+                IO.String.Output(display_name="style_id"),
+            ],
+            hidden=[
+                IO.Hidden.auth_token_comfy_org,
+                IO.Hidden.api_key_comfy_org,
+                IO.Hidden.unique_id,
+            ],
+            is_api_node=True,
+            price_badge=IO.PriceBadge(
+                expr="""{"type":"usd","usd": 0.005}""",
+            ),
+        )
+
+    @classmethod
+    async def execute(
+        cls,
+        model: str,
+        images: IO.Autogrow.Type,
+    ) -> IO.NodeOutput:
+        files = [
+            (f"file{i + 1}", data)
+            for i, data in enumerate(encode_style_references(style_reference_images(images)))
+        ]
+        response = await sync_op(
+            cls,
+            endpoint=ApiEndpoint(path="/proxy/recraft/styles", method="POST"),
+            response_model=RecraftCreateStyleResponse,
+            files=files,
+            data=RecraftCreateStyleRequest(
+                style="vector_illustration" if model.endswith("_vector") else "any",
+                model=model,
+            ),
+            content_type="multipart/form-data",
+            max_retries=1,
+        )
         return IO.NodeOutput(response.id)
 
 
@@ -1170,8 +1299,31 @@ class RecraftV4TextToImageNode(IO.ComfyNode):
                                 ),
                             ],
                         ),
+                        IO.DynamicCombo.Option(
+                            "recraftv4_styles",
+                            [
+                                IO.Combo.Input(
+                                    "size",
+                                    options=RECRAFT_V4_SIZES,
+                                    default="1024x1024",
+                                    tooltip="The size of the generated image.",
+                                ),
+                            ],
+                        ),
+                        IO.DynamicCombo.Option(
+                            "recraftv4_styles_pro",
+                            [
+                                IO.Combo.Input(
+                                    "size",
+                                    options=RECRAFT_V4_PRO_SIZES,
+                                    default="2048x2048",
+                                    tooltip="The size of the generated image.",
+                                ),
+                            ],
+                        ),
                     ],
-                    tooltip="The model to use for generation.",
+                    tooltip="The model to use for generation. The recraftv4_styles models are built for "
+                    "style-consistent generation and always require a style_id or style_references.",
                 ),
                 IO.Int.Input(
                     "n",
@@ -1194,9 +1346,36 @@ class RecraftV4TextToImageNode(IO.ComfyNode):
                     tooltip="Optional additional controls over the generation via the Recraft Controls node.",
                     optional=True,
                 ),
+                IO.String.Input(
+                    "style_id",
+                    default="",
+                    optional=True,
+                    tooltip="UUID of a Recraft V4 style to apply, e.g. from the Recraft V4 Create Style node "
+                    "or the style_id output of a previous run. Cannot be combined with style_references.",
+                ),
+                IO.Combo.Input(
+                    "style_match",
+                    options=RECRAFT_STYLE_MATCH_OPTIONS,
+                    optional=True,
+                    tooltip="How closely to follow the style: precise reproduces it in detail, "
+                    "flexible matches the general look. Only used when a style is provided.",
+                ),
+                IO.Autogrow.Input(
+                    "style_references",
+                    template=IO.Autogrow.TemplatePrefix(
+                        IO.Image.Input("style_reference"),
+                        prefix="style_reference",
+                        min=0,
+                        max=RECRAFT_STYLE_REFERENCES_MAX,
+                    ),
+                    optional=True,
+                    tooltip="Reference images to create a style from on the fly, billed on top of the generation. "
+                    "The created style is returned as style_id for reuse. Cannot be combined with style_id.",
+                ),
             ],
             outputs=[
                 IO.Image.Output(),
+                IO.String.Output(id="style_id", display_name="style_id"),
             ],
             hidden=[
                 IO.Hidden.auth_token_comfy_org,
@@ -1205,7 +1384,7 @@ class RecraftV4TextToImageNode(IO.ComfyNode):
             ],
             is_api_node=True,
             price_badge=IO.PriceBadge(
-                depends_on=IO.PriceBadgeDepends(widgets=["model", "n"]),
+                depends_on=IO.PriceBadgeDepends(widgets=["model", "n"], input_groups=["style_references"]),
                 expr="""
                 (
                     $prices := {
@@ -1214,9 +1393,13 @@ class RecraftV4TextToImageNode(IO.ComfyNode):
                         "recraftv4_1_pro": 0.21,
                         "recraftv4_1_utility_pro": 0.21,
                         "recraftv4": 0.04,
-                        "recraftv4_pro": 0.25
+                        "recraftv4_pro": 0.25,
+                        "recraftv4_styles": 0.035,
+                        "recraftv4_styles_pro": 0.10
                     };
-                    {"type":"usd","usd": $lookup($prices, widgets.model) * widgets.n}
+                    $references := $lookup(inputGroups, "style_references");
+                    $style := ($references ? $references : 0) > 0 ? 0.005 : 0;
+                    {"type":"usd","usd": $lookup($prices, widgets.model) * widgets.n + $style}
                 )
                 """,
             ),
@@ -1231,8 +1414,12 @@ class RecraftV4TextToImageNode(IO.ComfyNode):
         n: int,
         seed: int,
         recraft_controls: RecraftControls | None = None,
+        style_id: str = "",
+        style_match: str = "precise",
+        style_references: IO.Autogrow.Type | None = None,
     ) -> IO.NodeOutput:
         validate_string(prompt, strip_whitespace=True, min_length=1, max_length=10000)
+        style_id, style_reference_urls = resolve_v4_style(model["model"], style_id, style_references)
         response = await sync_op(
             cls,
             ApiEndpoint(path="/proxy/recraft/image_generation", method="POST"),
@@ -1242,6 +1429,9 @@ class RecraftV4TextToImageNode(IO.ComfyNode):
                 model=model["model"],
                 size=model["size"],
                 n=n,
+                style_id=style_id,
+                style_match=style_match if style_id or style_reference_urls else None,
+                style_reference_urls=style_reference_urls,
                 controls=recraft_controls.create_api_model() if recraft_controls else None,
             ),
             max_retries=1,
@@ -1253,7 +1443,7 @@ class RecraftV4TextToImageNode(IO.ComfyNode):
             if len(image.shape) < 4:
                 image = image.unsqueeze(0)
             images.append(image)
-        return IO.NodeOutput(torch.cat(images, dim=0))
+        return IO.NodeOutput(torch.cat(images, dim=0), response.style_id or "")
 
 
 class RecraftV4TextToVectorNode(IO.ComfyNode):
@@ -1345,8 +1535,31 @@ class RecraftV4TextToVectorNode(IO.ComfyNode):
                                 ),
                             ],
                         ),
+                        IO.DynamicCombo.Option(
+                            "recraftv4_styles_vector",
+                            [
+                                IO.Combo.Input(
+                                    "size",
+                                    options=RECRAFT_V4_SIZES,
+                                    default="1024x1024",
+                                    tooltip="The size of the generated image.",
+                                ),
+                            ],
+                        ),
+                        IO.DynamicCombo.Option(
+                            "recraftv4_styles_pro_vector",
+                            [
+                                IO.Combo.Input(
+                                    "size",
+                                    options=RECRAFT_V4_PRO_SIZES,
+                                    default="2048x2048",
+                                    tooltip="The size of the generated image.",
+                                ),
+                            ],
+                        ),
                     ],
-                    tooltip="The model to use for generation.",
+                    tooltip="The model to use for generation. The recraftv4_styles models are built for "
+                    "style-consistent generation and always require a style_id or style_references.",
                 ),
                 IO.Int.Input(
                     "n",
@@ -1369,9 +1582,36 @@ class RecraftV4TextToVectorNode(IO.ComfyNode):
                     tooltip="Optional additional controls over the generation via the Recraft Controls node.",
                     optional=True,
                 ),
+                IO.String.Input(
+                    "style_id",
+                    default="",
+                    optional=True,
+                    tooltip="UUID of a Recraft V4 vector style to apply, e.g. from the Recraft V4 Create Style node "
+                    "or the style_id output of a previous run. Cannot be combined with style_references.",
+                ),
+                IO.Combo.Input(
+                    "style_match",
+                    options=RECRAFT_STYLE_MATCH_OPTIONS,
+                    optional=True,
+                    tooltip="How closely to follow the style: precise reproduces it in detail, "
+                    "flexible matches the general look. Only used when a style is provided.",
+                ),
+                IO.Autogrow.Input(
+                    "style_references",
+                    template=IO.Autogrow.TemplatePrefix(
+                        IO.Image.Input("style_reference"),
+                        prefix="style_reference",
+                        min=0,
+                        max=RECRAFT_STYLE_REFERENCES_MAX,
+                    ),
+                    optional=True,
+                    tooltip="Reference images to create a vector style from on the fly, billed on top of the generation. "
+                    "The created style is returned as style_id for reuse. Cannot be combined with style_id.",
+                ),
             ],
             outputs=[
                 IO.SVG.Output(),
+                IO.String.Output(id="style_id", display_name="style_id"),
             ],
             hidden=[
                 IO.Hidden.auth_token_comfy_org,
@@ -1380,7 +1620,7 @@ class RecraftV4TextToVectorNode(IO.ComfyNode):
             ],
             is_api_node=True,
             price_badge=IO.PriceBadge(
-                depends_on=IO.PriceBadgeDepends(widgets=["model", "n"]),
+                depends_on=IO.PriceBadgeDepends(widgets=["model", "n"], input_groups=["style_references"]),
                 expr="""
                 (
                     $prices := {
@@ -1389,9 +1629,13 @@ class RecraftV4TextToVectorNode(IO.ComfyNode):
                         "recraftv4_1_pro_vector": 0.30,
                         "recraftv4_1_utility_pro_vector": 0.30,
                         "recraftv4": 0.08,
-                        "recraftv4_pro": 0.30
+                        "recraftv4_pro": 0.30,
+                        "recraftv4_styles_vector": 0.05,
+                        "recraftv4_styles_pro_vector": 0.12
                     };
-                    {"type":"usd","usd": $lookup($prices, widgets.model) * widgets.n}
+                    $references := $lookup(inputGroups, "style_references");
+                    $style := ($references ? $references : 0) > 0 ? 0.005 : 0;
+                    {"type":"usd","usd": $lookup($prices, widgets.model) * widgets.n + $style}
                 )
                 """,
             ),
@@ -1406,19 +1650,30 @@ class RecraftV4TextToVectorNode(IO.ComfyNode):
         n: int,
         seed: int,
         recraft_controls: RecraftControls | None = None,
+        style_id: str = "",
+        style_match: str = "precise",
+        style_references: IO.Autogrow.Type | None = None,
     ) -> IO.NodeOutput:
         validate_string(prompt, strip_whitespace=True, min_length=1, max_length=10000)
+        model_id = model["model"]
+        style_id, style_reference_urls = resolve_v4_style(model_id, style_id, style_references)
+        has_style = bool(style_id or style_reference_urls)
+        if has_style:
+            model_id = RECRAFT_V4_VECTOR_MODEL_FOR_STYLE.get(model_id, model_id)
         response = await sync_op(
             cls,
             ApiEndpoint(path="/proxy/recraft/image_generation", method="POST"),
             response_model=RecraftImageGenerationResponse,
             data=RecraftImageGenerationRequest(
                 prompt=prompt,
-                model=model["model"],
+                model=model_id,
                 size=model["size"],
                 n=n,
-                style=None if model["model"].endswith("_vector") else "vector_illustration",
+                style=None if has_style or model_id.endswith("_vector") else "vector_illustration",
                 substyle=None,
+                style_id=style_id,
+                style_match=style_match if has_style else None,
+                style_reference_urls=style_reference_urls,
                 controls=recraft_controls.create_api_model() if recraft_controls else None,
             ),
             max_retries=1,
@@ -1426,7 +1681,7 @@ class RecraftV4TextToVectorNode(IO.ComfyNode):
         svg_data = []
         for data in response.data:
             svg_data.append(await download_url_as_bytesio(data.url, timeout=1024))
-        return IO.NodeOutput(SVG(svg_data))
+        return IO.NodeOutput(SVG(svg_data), response.style_id or "")
 
 
 class RecraftExtension(ComfyExtension):
@@ -1451,6 +1706,7 @@ class RecraftExtension(ComfyExtension):
             RecraftControlsNode,
             RecraftV4TextToImageNode,
             RecraftV4TextToVectorNode,
+            RecraftV4CreateStyleNode,
         ]
 
 

--- a/comfy_api_nodes/nodes_veo2.py
+++ b/comfy_api_nodes/nodes_veo2.py
@@ -23,229 +23,10 @@ from comfy_api_nodes.util import (
 
 AVERAGE_DURATION_VIDEO_GEN = 32
 MODELS_MAP = {
-    "veo-2.0-generate-001": "veo-2.0-generate-001",
     "veo-3.1-generate": "veo-3.1-generate-001",
     "veo-3.1-fast-generate": "veo-3.1-fast-generate-001",
     "veo-3.1-lite": "veo-3.1-lite-generate-001",
-    "veo-3.0-generate-001": "veo-3.0-generate-001",
-    "veo-3.0-fast-generate-001": "veo-3.0-fast-generate-001",
 }
-
-
-class VeoVideoGenerationNode(IO.ComfyNode):
-    """
-    Generates videos from text prompts using Google's Veo API.
-
-    This node can create videos from text descriptions and optional image inputs,
-    with control over parameters like aspect ratio, duration, and more.
-    """
-
-    @classmethod
-    def define_schema(cls):
-        return IO.Schema(
-            node_id="VeoVideoGenerationNode",
-            display_name="Google Veo 2 Video Generation",
-            category="partner/video/Veo",
-            description="Generates videos from text prompts using Google's Veo 2 API",
-            inputs=[
-                IO.String.Input(
-                    "prompt",
-                    multiline=True,
-                    default="",
-                    tooltip="Text description of the video",
-                ),
-                IO.Combo.Input(
-                    "aspect_ratio",
-                    options=["16:9", "9:16"],
-                    default="16:9",
-                    tooltip="Aspect ratio of the output video",
-                ),
-                IO.String.Input(
-                    "negative_prompt",
-                    multiline=True,
-                    default="",
-                    tooltip="Negative text prompt to guide what to avoid in the video",
-                    optional=True,
-                ),
-                IO.Int.Input(
-                    "duration_seconds",
-                    default=5,
-                    min=5,
-                    max=8,
-                    step=1,
-                    display_mode=IO.NumberDisplay.number,
-                    tooltip="Duration of the output video in seconds",
-                    optional=True,
-                ),
-                IO.Boolean.Input(
-                    "enhance_prompt",
-                    default=True,
-                    tooltip="Whether to enhance the prompt with AI assistance",
-                    optional=True,
-                    advanced=True,
-                ),
-                IO.Combo.Input(
-                    "person_generation",
-                    options=["ALLOW", "BLOCK"],
-                    default="ALLOW",
-                    tooltip="Whether to allow generating people in the video",
-                    optional=True,
-                    advanced=True,
-                ),
-                IO.Int.Input(
-                    "seed",
-                    default=0,
-                    min=0,
-                    max=0xFFFFFFFF,
-                    step=1,
-                    display_mode=IO.NumberDisplay.number,
-                    control_after_generate=True,
-                    tooltip="Seed for video generation (0 for random)",
-                    optional=True,
-                ),
-                IO.Image.Input(
-                    "image",
-                    tooltip="Optional reference image to guide video generation",
-                    optional=True,
-                ),
-                IO.Combo.Input(
-                    "model",
-                    options=["veo-2.0-generate-001"],
-                    default="veo-2.0-generate-001",
-                    tooltip="Veo 2 model to use for video generation",
-                    optional=True,
-                ),
-            ],
-            outputs=[
-                IO.Video.Output(),
-            ],
-            hidden=[
-                IO.Hidden.auth_token_comfy_org,
-                IO.Hidden.api_key_comfy_org,
-                IO.Hidden.unique_id,
-            ],
-            is_api_node=True,
-            price_badge=IO.PriceBadge(
-                depends_on=IO.PriceBadgeDepends(widgets=["duration_seconds"]),
-                expr="""{"type":"usd","usd": 0.5 * widgets.duration_seconds}""",
-            ),
-        )
-
-    @classmethod
-    async def execute(
-        cls,
-        prompt,
-        aspect_ratio="16:9",
-        negative_prompt="",
-        duration_seconds=5,
-        enhance_prompt=True,
-        person_generation="ALLOW",
-        seed=0,
-        image=None,
-        model="veo-2.0-generate-001",
-        generate_audio=False,
-    ):
-        model = MODELS_MAP[model]
-        # Prepare the instances for the request
-        instances = []
-
-        instance = {"prompt": prompt}
-
-        # Add image if provided
-        if image is not None:
-            image_base64 = tensor_to_base64_string(image)
-            if image_base64:
-                instance["image"] = {"bytesBase64Encoded": image_base64, "mimeType": "image/png"}
-
-        instances.append(instance)
-
-        # Create parameters dictionary
-        parameters = {
-            "aspectRatio": aspect_ratio,
-            "personGeneration": person_generation,
-            "durationSeconds": duration_seconds,
-            "enhancePrompt": enhance_prompt,
-        }
-
-        # Add optional parameters if provided
-        if negative_prompt:
-            parameters["negativePrompt"] = negative_prompt
-        if seed > 0:
-            parameters["seed"] = seed
-        # Only add generateAudio for Veo 3 models
-        if model.find("veo-2.0") == -1:
-            parameters["generateAudio"] = generate_audio
-            # force "enhance_prompt" to True for Veo3 models
-            parameters["enhancePrompt"] = True
-
-        initial_response = await sync_op(
-            cls,
-            ApiEndpoint(path=f"/proxy/veo/{model}/generate", method="POST"),
-            response_model=VeoGenVidResponse,
-            data=VeoGenVidRequest(
-                instances=instances,
-                parameters=parameters,
-            ),
-        )
-
-        def status_extractor(response):
-            # Only return "completed" if the operation is done, regardless of success or failure
-            # We'll check for errors after polling completes
-            return "completed" if response.done else "pending"
-
-        poll_response = await poll_op(
-            cls,
-            ApiEndpoint(path=f"/proxy/veo/{model}/poll", method="POST"),
-            response_model=VeoGenVidPollResponse,
-            status_extractor=status_extractor,
-            data=VeoGenVidPollRequest(
-                operationName=initial_response.name,
-            ),
-            poll_interval=5.0,
-            estimated_duration=AVERAGE_DURATION_VIDEO_GEN,
-        )
-
-        # Now check for errors in the final response
-        # Check for error in poll response
-        if poll_response.error:
-            raise Exception(f"Veo API error: {poll_response.error.message} (code: {poll_response.error.code})")
-
-        # Check for RAI filtered content
-        if (
-            hasattr(poll_response.response, "raiMediaFilteredCount")
-            and poll_response.response.raiMediaFilteredCount > 0
-        ):
-
-            # Extract reason message if available
-            if (
-                hasattr(poll_response.response, "raiMediaFilteredReasons")
-                and poll_response.response.raiMediaFilteredReasons
-            ):
-                reason = poll_response.response.raiMediaFilteredReasons[0]
-                error_message = f"Content filtered by Google's Responsible AI practices: {reason} ({poll_response.response.raiMediaFilteredCount} videos filtered.)"
-            else:
-                error_message = f"Content filtered by Google's Responsible AI practices ({poll_response.response.raiMediaFilteredCount} videos filtered.)"
-
-            raise Exception(error_message)
-
-        # Extract video data
-        if (
-            poll_response.response
-            and hasattr(poll_response.response, "videos")
-            and poll_response.response.videos
-            and len(poll_response.response.videos) > 0
-        ):
-            video = poll_response.response.videos[0]
-
-            # Check if video is provided as base64 or URL
-            if hasattr(video, "bytesBase64Encoded") and video.bytesBase64Encoded:
-                return IO.NodeOutput(InputImpl.VideoFromFile(BytesIO(base64.b64decode(video.bytesBase64Encoded))))
-
-            if hasattr(video, "gcsUri") and video.gcsUri:
-                return IO.NodeOutput(await download_url_to_video_output(video.gcsUri))
-
-            raise Exception("Video returned but no data or URL was provided")
-        raise Exception("Video generation completed but no video was returned")
 
 
 class Veo3VideoGenerationNode(IO.ComfyNode):
@@ -275,7 +56,7 @@ class Veo3VideoGenerationNode(IO.ComfyNode):
                     "resolution",
                     options=["720p", "1080p", "4k"],
                     default="720p",
-                    tooltip="Output video resolution. 4K is not available for veo-3.1-lite and veo-3.0 models.",
+                    tooltip="Output video resolution. 4K is not available for the veo-3.1-lite model.",
                     optional=True,
                 ),
                 IO.String.Input(
@@ -328,13 +109,7 @@ class Veo3VideoGenerationNode(IO.ComfyNode):
                 ),
                 IO.Combo.Input(
                     "model",
-                    options=[
-                        "veo-3.1-generate",
-                        "veo-3.1-fast-generate",
-                        "veo-3.1-lite",
-                        "veo-3.0-generate-001",
-                        "veo-3.0-fast-generate-001",
-                    ],
+                    options=["veo-3.1-generate", "veo-3.1-fast-generate", "veo-3.1-lite"],
                     tooltip="Veo 3 model to use for video generation",
                     optional=True,
                 ),
@@ -365,13 +140,9 @@ class Veo3VideoGenerationNode(IO.ComfyNode):
                   $pps :=
                     $contains($m, "lite")
                       ? ($r = "1080p" ? ($a ? 0.08 : 0.05) : ($a ? 0.05 : 0.03))
-                    : $contains($m, "3.1-fast")
+                    : $contains($m, "fast")
                       ? ($r = "4k" ? ($a ? 0.30 : 0.25) : $r = "1080p" ? ($a ? 0.12 : 0.10) : ($a ? 0.10 : 0.08))
-                    : $contains($m, "3.1-generate")
-                      ? ($r = "4k" ? ($a ? 0.60 : 0.40) : ($a ? 0.40 : 0.20))
-                    : $contains($m, "3.0-fast")
-                      ? ($a ? 0.15 : 0.10)
-                    : ($a ? 0.40 : 0.20);
+                    : ($r = "4k" ? ($a ? 0.60 : 0.40) : ($a ? 0.40 : 0.20));
                   {"type":"usd","usd": $pps * $seconds}
                 )
                 """,
@@ -390,11 +161,11 @@ class Veo3VideoGenerationNode(IO.ComfyNode):
         person_generation="ALLOW",
         seed=0,
         image=None,
-        model="veo-3.0-generate-001",
+        model="veo-3.1-generate",
         generate_audio=False,
     ):
-        if resolution == "4k" and ("lite" in model or "3.0" in model):
-            raise Exception("4K resolution is not supported by the veo-3.1-lite or veo-3.0 models.")
+        if resolution == "4k" and "lite" in model:
+            raise Exception("4K resolution is not supported by the veo-3.1-lite model.")
 
         model = MODELS_MAP[model]
 
@@ -410,13 +181,12 @@ class Veo3VideoGenerationNode(IO.ComfyNode):
             "durationSeconds": duration_seconds,
             "enhancePrompt": True,
             "generateAudio": generate_audio,
+            "resolution": resolution,
         }
         if negative_prompt:
             parameters["negativePrompt"] = negative_prompt
         if seed > 0:
             parameters["seed"] = seed
-        if "veo-3.1" in model:
-            parameters["resolution"] = resolution
 
         initial_response = await sync_op(
             cls,
@@ -635,7 +405,6 @@ class VeoExtension(ComfyExtension):
     @override
     async def get_node_list(self) -> list[type[IO.ComfyNode]]:
         return [
-            VeoVideoGenerationNode,
             Veo3VideoGenerationNode,
             Veo3FirstLastFrameNode,
         ]

--- a/comfy_api_nodes/nodes_wan.py
+++ b/comfy_api_nodes/nodes_wan.py
@@ -1721,7 +1721,71 @@ class Wan3ReferenceToVideoApi(IO.ComfyNode):
                                 IO.Combo.Input(
                                     "duration",
                                     options=["auto", *(str(i) for i in range(2, 31))],
-                                    default="5",
+                                    tooltip="Output duration in seconds. With 'auto', the model chooses "
+                                    "a duration that fits the prompt and reference media. The combined "
+                                    "duration of reference videos and output must not exceed 30 seconds.",
+                                ),
+                                IO.Boolean.Input(
+                                    "audio",
+                                    default=True,
+                                    tooltip="Whether the output video contains an audio track.",
+                                ),
+                                IO.Boolean.Input(
+                                    "prompt_extend",
+                                    default=True,
+                                    tooltip="Whether to enhance the prompt with AI assistance.",
+                                    advanced=True,
+                                ),
+                                IO.Autogrow.Input(
+                                    "reference_images",
+                                    template=IO.Autogrow.TemplateNames(
+                                        IO.Image.Input("reference_image"),
+                                        names=[f"image{i}" for i in range(1, 11)],
+                                        min=0,
+                                    ),
+                                ),
+                                IO.Autogrow.Input(
+                                    "reference_videos",
+                                    template=IO.Autogrow.TemplateNames(
+                                        IO.Video.Input("reference_video"),
+                                        names=[f"video{i}" for i in range(1, 6)],
+                                        min=0,
+                                    ),
+                                ),
+                                IO.Autogrow.Input(
+                                    "reference_audios",
+                                    template=IO.Autogrow.TemplateNames(
+                                        IO.Audio.Input("reference_audio"),
+                                        names=[f"audio{i}" for i in range(1, 6)],
+                                        min=0,
+                                    ),
+                                ),
+                            ],
+                        ),
+                        IO.DynamicCombo.Option(
+                            "wan3.0-video-prime",
+                            [
+                                IO.String.Input(
+                                    "prompt",
+                                    multiline=True,
+                                    default="",
+                                    tooltip="Prompt describing the elements and visual features. "
+                                    "Supports English and Chinese. Refer to connected reference media "
+                                    "as @Image1, @Video1, @Audio1, numbered per type in input order.",
+                                ),
+                                IO.Combo.Input(
+                                    "resolution",
+                                    options=["1080P", "720P", "480P"],
+                                ),
+                                IO.Combo.Input(
+                                    "ratio",
+                                    options=["adaptive", "16:9", "9:16", "1:1", "4:3", "3:4"],
+                                    tooltip="Aspect ratio of the output video. With 'adaptive', the output "
+                                    "dimensions are derived from the input media.",
+                                ),
+                                IO.Combo.Input(
+                                    "duration",
+                                    options=["auto", *(str(i) for i in range(2, 31))],
                                     tooltip="Output duration in seconds. With 'auto', the model chooses "
                                     "a duration that fits the prompt and reference media. The combined "
                                     "duration of reference videos and output must not exceed 30 seconds.",
@@ -1795,14 +1859,16 @@ class Wan3ReferenceToVideoApi(IO.ComfyNode):
                 depends_on=IO.PriceBadgeDepends(widgets=["model", "model.resolution", "model.duration"]),
                 expr="""
                 (
-                  $ppsTable := { "480p": 0.0715, "720p": 0.143, "1080p": 0.286 };
+                  $ppsTable := $contains(widgets.model, "prime")
+                    ? { "480p": 0.09724, "720p": 0.2002, "1080p": 0.4004 }
+                    : { "480p": 0.0715, "720p": 0.143, "1080p": 0.286 };
                   $pps := $lookup($ppsTable, $lookup(widgets, "model.resolution"));
                   $dur := $lookup(widgets, "model.duration");
                   $dur = "auto"
                     ? { "type": "usd", "usd": $pps, "format": {"suffix": "/second"} }
                     : (
-                        $minUsd := $round($number($dur) * $pps, 2);
-                        $maxUsd := $round($min([$number($dur) + 15, 30]) * $pps, 2);
+                        $minUsd := $number($dur) * $pps;
+                        $maxUsd := $min([$number($dur) + 15, 30]) * $pps;
                         $minUsd = $maxUsd
                           ? { "type": "usd", "usd": $minUsd }
                           : { "type": "range_usd", "min_usd": $minUsd, "max_usd": $maxUsd }
@@ -1949,7 +2015,45 @@ class Wan3ImageToVideoApi(IO.ComfyNode):
                                 IO.Combo.Input(
                                     "duration",
                                     options=["auto", *(str(i) for i in range(2, 31))],
-                                    default="5",
+                                    tooltip="Output duration in seconds. With 'auto', the model chooses "
+                                    "a duration that fits the prompt.",
+                                ),
+                                IO.Boolean.Input(
+                                    "audio",
+                                    default=True,
+                                    tooltip="Whether the output video contains an audio track.",
+                                ),
+                                IO.Boolean.Input(
+                                    "prompt_extend",
+                                    default=True,
+                                    tooltip="Whether to enhance the prompt with AI assistance.",
+                                    advanced=True,
+                                ),
+                            ],
+                        ),
+                        IO.DynamicCombo.Option(
+                            "wan3.0-video-prime",
+                            [
+                                IO.String.Input(
+                                    "prompt",
+                                    multiline=True,
+                                    default="",
+                                    tooltip="Prompt describing the elements and visual features. "
+                                    "Supports English and Chinese.",
+                                ),
+                                IO.Combo.Input(
+                                    "resolution",
+                                    options=["1080P", "720P", "480P"],
+                                ),
+                                IO.Combo.Input(
+                                    "ratio",
+                                    options=["adaptive", "16:9", "9:16", "1:1", "4:3", "3:4"],
+                                    tooltip="Aspect ratio of the output video. With 'adaptive', the output "
+                                    "dimensions are derived from the first frame.",
+                                ),
+                                IO.Combo.Input(
+                                    "duration",
+                                    options=["auto", *(str(i) for i in range(2, 31))],
                                     tooltip="Output duration in seconds. With 'auto', the model chooses "
                                     "a duration that fits the prompt.",
                                 ),
@@ -2007,12 +2111,14 @@ class Wan3ImageToVideoApi(IO.ComfyNode):
                 depends_on=IO.PriceBadgeDepends(widgets=["model", "model.resolution", "model.duration"]),
                 expr="""
                 (
-                  $ppsTable := { "480p": 0.0715, "720p": 0.143, "1080p": 0.286 };
+                  $ppsTable := $contains(widgets.model, "prime")
+                    ? { "480p": 0.09724, "720p": 0.2002, "1080p": 0.4004 }
+                    : { "480p": 0.0715, "720p": 0.143, "1080p": 0.286 };
                   $pps := $lookup($ppsTable, $lookup(widgets, "model.resolution"));
                   $dur := $lookup(widgets, "model.duration");
                   $dur = "auto"
                     ? { "type": "usd", "usd": $pps, "format": {"suffix": "/second"} }
-                    : { "type": "usd", "usd": $round($number($dur) * $pps, 2) }
+                    : { "type": "usd", "usd": $number($dur) * $pps }
                 )
                 """,
             ),


### PR DESCRIPTION
Backport for v0.34.1.

Cherry-picked from `master` onto `v0.34.0`, oldest first:

- #15883 — [Partner Nodes] chore(Google): drop retiring Veo 2 and Veo 3.0 models
- #15903 — [Partner Nodes] feat(Recraft): add V4 Styles
- #15894 — [Partner Nodes] feat(WAN): add WAN3-Prime model support

These are the only three commits on `master` beyond `v0.34.0`.

Google removes the legacy Veo endpoints on Aug 28, which is what #15883 covers.

<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [ ] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [ ] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [ ] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**

