### PR TITLE
Feat: support launching auto-launch in a custom browser

### DIFF
--- a/comfy/browser.py
+++ b/comfy/browser.py
@@ -14,6 +14,7 @@ def open_browser(url: str, browser_path: str = None, browser_profile: str = None
         cmd.append(url)
 
         try:
+            logging.info(f"Launching custom browser: {browser_path}")
             subprocess.Popen(cmd)
             return
         except Exception as e:

--- a/comfy/browser.py
+++ b/comfy/browser.py
@@ -1,0 +1,28 @@
+import logging
+import subprocess
+import webbrowser
+
+def open_browser(url: str, browser_path: str = None, browser_profile: str = None) -> None:
+    """
+    Launches a custom browser if specified via CLI args, 
+    otherwise falls back to the system default browser.
+    """
+    if browser_path:
+        cmd = [browser_path]
+        if browser_profile:
+            cmd.append(f"--profile-directory={browser_profile}")
+        cmd.append(url)
+
+        try:
+            subprocess.Popen(cmd)
+            return
+        except Exception as e:
+            logging.warning(
+                f"Failed to launch custom browser '{browser_path}': {e}. "
+                f"Falling back to default browser."
+            )
+
+    try:
+        webbrowser.open(url)
+    except Exception as e:
+        logging.error(f"Failed to open web browser: {e}")

--- a/comfy/browser.py
+++ b/comfy/browser.py
@@ -17,13 +17,14 @@ def open_browser(url: str, browser_path: str = None, browser_profile: str = None
             logging.info(f"Launching custom browser: {browser_path}")
             subprocess.Popen(cmd)
             return
-        except Exception as e:
+        except OSError as e:
             logging.warning(
                 f"Failed to launch custom browser '{browser_path}': {e}. "
                 f"Falling back to default browser."
             )
 
     try:
-        webbrowser.open(url)
-    except Exception as e:
+        if not webbrowser.open(url):
+            logging.warning(f"Failed to open default web browser for URL: {url}")
+    except webbrowser.Error as e:
         logging.error(f"Failed to open web browser: {e}")

--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -74,6 +74,8 @@ parser.add_argument("--temp-directory", type=str, default=None, help="Set the Co
 parser.add_argument("--input-directory", type=str, default=None, help="Set the ComfyUI input directory. Overrides --base-directory.")
 parser.add_argument("--auto-launch", action="store_true", help="Automatically launch ComfyUI in the default browser.")
 parser.add_argument("--disable-auto-launch", action="store_true", help="Disable auto launching the browser.")
+parser.add_argument("--browser-path", type=str, default=None, help="Path to custom browser executable.")
+parser.add_argument("--browser-profile", type=str, default=None, help="Browser profile directory (for Chromium-based browsers).")
 parser.add_argument("--cuda-device", type=str, default=None, metavar="DEVICE_ID", help="Set the ids of cuda devices this instance will use, as a comma-separated list (e.g. '0' or '0,1'), or 'all' to leave all currently visible devices available. All other devices will not be visible.")
 parser.add_argument("--default-device", type=int, default=None, metavar="DEFAULT_DEVICE_ID", help="Set the id of the default device, all other devices will stay visible.")
 cm_group = parser.add_mutually_exclusive_group()

--- a/main.py
+++ b/main.py
@@ -565,12 +565,20 @@ def start_comfyui(asyncio_loop=None):
     call_on_start = None
     if args.auto_launch:
         def startup_server(scheme, address, port):
-            import webbrowser
             if os.name == 'nt' and address == '0.0.0.0':
                 address = '127.0.0.1'
             if ':' in address:
                 address = "[{}]".format(address)
-            webbrowser.open(f"{scheme}://{address}:{port}")
+
+            url = f"{scheme}://{address}:{port}"
+            
+            import comfy.browser
+            comfy.browser.open_browser(
+                url,
+                browser_path=args.browser_path,
+                browser_profile=args.browser_profile,
+            )
+
         call_on_start = startup_server
 
     async def start_all():

--- a/main.py
+++ b/main.py
@@ -31,6 +31,7 @@ import faulthandler
 import logging
 import signal
 import sys
+import comfy.browser
 from comfy_execution.progress import get_progress_state
 from comfy_execution.utils import get_executing_context
 from comfy_api import feature_flags
@@ -572,7 +573,6 @@ def start_comfyui(asyncio_loop=None):
 
             url = f"{scheme}://{address}:{port}"
             
-            import comfy.browser
             comfy.browser.open_browser(
                 url,
                 browser_path=args.browser_path,


### PR DESCRIPTION
Fixes #11709
**UPDATE: Tested and working on v0.37.0**

### Issue
`--auto-launch` always opens the default system browser, requiring users wanting custom browsers or profiles to edit core server files directly.

### Behavioral change
- Adds `--browser-path` CLI flag for custom browser executables.
- Adds `--browser-profile` CLI flag for Chromium profile directories[].
- Adds `comfy/browser.py` helper module to handle launching and graceful fallback.
- Logs launcher status cleanly in the console.

### Tests run and behavior
- Browser path is 👍 OK-> Custom browser opens on the set profile (or assuming "Default" if blank).
A log entry is made.
Tested valid paths on Windows 11 across Opera, Ungoogled Chrome, and Brave; all opened properly on the set profile.

- Browser path is 👎 NOT OK -> Falls back to default system browser.
A log entry is made.
Tested invalid paths; confirmed a clear warning is logged and execution falls back to default without breaking startup.  Invalid path include typo errors and incorrectly set quotes.

- Socket is ⛔BUSY  -> ComfyUI aborts loading process, nothing happens.
NO log entry is made.
Since `open_browser()` is attached to the `call_on_start` callback it aborts execution before `call_on_start `ever gets invoked. 

- Switch is 😶 NOT INVOKED -> It opens default system browser.
NO log entry is made.
Verified `--auto-launch` without flags maintains standard browser launch.
