### PR TITLE
[review-stack 3/4] tests-changed — synap5e/feat/asset-record-content-split

### DIFF
--- a/tests-unit/assets_test/conftest.py
+++ b/tests-unit/assets_test/conftest.py
@@ -13,6 +13,8 @@ from typing import Callable, Iterator, Optional
 import pytest
 import requests
 
+from .helpers import assert_hash_fields_consistent
+
 
 def pytest_addoption(parser: pytest.Parser) -> None:
     """
@@ -27,6 +29,18 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         action="store",
         default=os.environ.get("ASSETS_TEST_DB_URL"),
         help="SQLAlchemy DB URL (e.g. sqlite:///path/to/db.sqlite3)",
+    )
+    parser.addoption(
+        "--enable-asset-hashing",
+        action="store_true",
+        help="Start the assets subprocess with hash-mode behavior enabled.",
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "hashing_on: exercises the subprocess harness with --enable-asset-hashing",
     )
 
 
@@ -103,8 +117,7 @@ def comfy_url_and_proc(comfy_tmp_base_dir: Path, request: pytest.FixtureRequest)
     if not (comfy_root / "main.py").is_file():
         raise FileNotFoundError(f"main.py not found under {comfy_root}")
 
-    proc = subprocess.Popen(
-        args=[
+    command = [
             sys.executable,
             "main.py",
             f"--base-directory={str(comfy_tmp_base_dir)}",
@@ -115,7 +128,19 @@ def comfy_url_and_proc(comfy_tmp_base_dir: Path, request: pytest.FixtureRequest)
             "--port",
             str(port),
             "--cpu",
-        ],
+        ]
+    if (
+        request.config.getoption("--enable-asset-hashing")
+        or "hashing_on" in request.config.getoption("markexpr")
+        or any(
+            item.get_closest_marker("hashing_on")
+            for item in request.session.items
+        )
+    ):
+        command.append("--enable-asset-hashing")
+
+    proc = subprocess.Popen(
+        args=command,
         stdout=out_log,
         stderr=err_log,
         cwd=str(comfy_root),
@@ -190,8 +215,9 @@ def _post_multipart_asset(
 @pytest.fixture
 def make_asset_bytes() -> Callable[[str, int], bytes]:
     # Salt content per test so it never collides with assets left over from
-    # earlier tests. Delete is now always a soft delete (content is preserved),
-    # so the suite can no longer rely on hard-deleting content for isolation.
+    # earlier tests. Delete hard-deletes the record but preserves content
+    # (content rows and files are untouched), so the suite cannot rely on delete
+    # removing content for isolation.
     # Deterministic within a test: the same (name, size) yields the same bytes.
     salt = uuid.uuid4().bytes
 
@@ -236,9 +262,6 @@ def seeded_asset(request: pytest.FixtureRequest, http: requests.Session, api_bas
     if tags is None:
         tags = ["models", "model_type:checkpoints", "unit-tests", "alpha"]
     meta = {"purpose": "test", "epoch": 1, "flags": ["x", "y"], "nullable": None}
-    # Unique content per test so the seed always creates a fresh asset (201).
-    # Delete is now always a soft delete, so content from a prior test survives
-    # and would otherwise dedup this upload into an existing asset (200).
     content = uuid.uuid4().bytes + b"A" * (4096 - 16)
     files = {"file": (name, content, "application/octet-stream")}
     form_data = {
@@ -249,7 +272,6 @@ def seeded_asset(request: pytest.FixtureRequest, http: requests.Session, api_bas
     r = http.post(api_base + "/api/assets", files=files, data=form_data, timeout=120)
     body = r.json()
     assert r.status_code == 201, body
-    from helpers import assert_hash_fields_consistent
     assert_hash_fields_consistent(body)
     return body
 

--- a/tests-unit/assets_test/helpers.py
+++ b/tests-unit/assets_test/helpers.py
@@ -1,7 +1,124 @@
 """Helper functions for assets integration tests."""
-import time
+from __future__ import annotations
 
+import json
+import time
+import uuid
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import NotRequired, TypeAlias, TypedDict
+
+import pytest
 import requests
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
+from sqlalchemy import Engine, create_engine
+from sqlalchemy.orm import Session
+
+from app.assets.api import routes
+from app.assets.database.models import Asset
+from app.assets.database.queries.records import create_content, create_record
+from app.database.models import Base
+
+
+class AssetItem(TypedDict):
+    id: str
+    name: str
+    preview_id: NotRequired[str]
+
+
+class AssetListBody(TypedDict):
+    assets: list[AssetItem]
+    total: int
+    has_more: bool
+    next_cursor: NotRequired[str]
+
+
+class ErrorItem(TypedDict):
+    code: str
+
+
+class ErrorBody(TypedDict):
+    error: ErrorItem
+
+
+@dataclass(frozen=True, slots=True)
+class RecordSeed:
+    name: str
+    tags: tuple[str, ...] = ()
+    size_bytes: int = 0
+
+
+RouteDatabase: TypeAlias = tuple[Engine, Session]
+
+
+@pytest.fixture(autouse=True)
+def autoclean_unit_test_assets() -> Iterator[None]:
+    yield
+
+
+@pytest.fixture
+def route_database(monkeypatch: pytest.MonkeyPatch) -> Iterator[RouteDatabase]:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    monkeypatch.setattr(routes, "create_session", lambda: Session(engine))
+    monkeypatch.setattr(routes, "_ASSETS_ENABLED", True)
+    with Session(engine) as session:
+        yield engine, session
+    engine.dispose()
+
+
+def seed_record(session: Session, seed: RecordSeed) -> Asset:
+    content = create_content(
+        session,
+        path=f"/output/{uuid.uuid4()}-{seed.name}",
+        size_bytes=seed.size_bytes,
+    )
+    return create_record(
+        session,
+        content_id=content.id,
+        name=seed.name,
+        mime_type="image/png",
+        tags=seed.tags,
+    )
+
+
+@pytest.fixture
+def sortable_record_ids(route_database: RouteDatabase) -> tuple[str, str]:
+    _, session = route_database
+    older = seed_record(session, RecordSeed("z.png", ("sort-case",), 100))
+    newer = seed_record(session, RecordSeed("a.png", ("sort-case",), 200))
+    base_time = datetime(2026, 1, 1)
+    older.created_at = base_time
+    newer.created_at = base_time + timedelta(days=1)
+    newer.updated_at = base_time
+    older.updated_at = base_time + timedelta(days=1)
+    older.last_access_time = base_time
+    newer.last_access_time = base_time + timedelta(days=1)
+    session.commit()
+    return newer.id, older.id
+
+
+async def request_assets(query: str = "") -> web.StreamResponse:
+    suffix = f"?{query}" if query else ""
+    return await routes.list_assets_route(
+        make_mocked_request("GET", f"/api/assets{suffix}")
+    )
+
+
+def asset_list_body(response: web.StreamResponse) -> AssetListBody:
+    assert isinstance(response, web.Response)
+    body = response.body
+    assert isinstance(body, bytes | bytearray)
+    return json.loads(body)
+
+
+def error_body(response: web.StreamResponse) -> ErrorBody:
+    assert isinstance(response, web.Response)
+    body = response.body
+    assert isinstance(body, bytes | bytearray)
+    return json.loads(body)
 
 
 def trigger_sync_seed_assets(session: requests.Session, base_url: str) -> None:
@@ -28,7 +145,10 @@ def get_asset_filename(asset_hash: str, extension: str) -> str:
     return asset_hash.removeprefix("blake3:") + extension
 
 
-def assert_hash_fields_consistent(body: dict, expected_hash: str | None = None) -> None:
+def assert_hash_fields_consistent(
+    body: Mapping[str, str | None],
+    expected_hash: str | None = None,
+) -> None:
     """Assert hash and asset_hash invariants on an Asset response.
 
     Both must be present or both absent (so a regression that drops only one

--- a/tests-unit/assets_test/queries/conftest.py
+++ b/tests-unit/assets_test/queries/conftest.py
@@ -5,6 +5,18 @@ from sqlalchemy.orm import Session
 from app.assets.database.models import Base
 
 
+@pytest.fixture(scope="session", autouse=True)
+def assert_asset_metadata_tables():
+    assert set(Base.metadata.tables) == {
+        "assets",
+        "asset_contents",
+        "asset_meta",
+        "asset_tags",
+        "tags",
+        "asset_system_state",
+    }
+
+
 @pytest.fixture
 def session():
     """In-memory SQLite session for fast unit tests."""

--- a/tests-unit/assets_test/queries/test_asset_reference_keyset.py
+++ b/tests-unit/assets_test/queries/test_asset_reference_keyset.py
@@ -1,112 +1,33 @@
-"""Keyset-pagination tiebreaker tests for list_references_page.
-
-When multiple rows share the same primary sort value (e.g. four assets
-created in the same microsecond), the secondary `ORDER BY id` is what keeps
-keyset pagination from losing or repeating rows. This file exercises that
-branch directly against an in-memory SQLite session — engineering identical
-timestamps via HTTP is unreliable enough that we work at the query layer.
-"""
-import uuid
-from datetime import datetime
-
-import pytest
 from sqlalchemy.orm import Session
 
-from app.assets.database.models import Asset, AssetReference
-from app.assets.database.queries.asset_reference import list_references_page
+from app.assets.database.queries import create_content, create_record, list_records_page
+from app.assets.database.queries.records import RecordCursorBoundary, RecordPageSpec
 
 
-def _make_ref(session: Session, created_at: datetime, name: str, owner: str = "") -> AssetReference:
-    asset = Asset(hash=f"blake3:{uuid.uuid4().hex}", size_bytes=1024)
-    session.add(asset)
+def test_record_keyset_cursor_pages_in_creation_order(session: Session) -> None:
+    records = [
+        create_record(session, create_content(session, f"/output/{name}").id, name)
+        for name in ("one.png", "two.png", "three.png")
+    ]
+    for index, record in enumerate(records, start=1):
+        record.id = f"00000000-0000-0000-0000-{index:012d}"
     session.flush()
-    ref = AssetReference(
-        id=str(uuid.uuid4()),
-        asset_id=asset.id,
-        owner_id=owner,
-        name=name,
-        file_path=f"/tmp/{name}",
-        created_at=created_at,
-        updated_at=created_at,
-        last_access_time=created_at,
-        is_missing=False,
+
+    first_page, _, _ = list_records_page(
+        session,
+        RecordPageSpec(limit=2, order="asc"),
     )
-    session.add(ref)
-    return ref
-
-
-@pytest.mark.parametrize("order", ["desc", "asc"])
-def test_tiebreaker_walks_duplicate_sort_values(session: Session, order: str):
-    """Four rows with the SAME created_at must paginate cleanly under cursor
-    mode — no row dropped, no row repeated, despite the primary sort column
-    being non-discriminating.
-    """
-    shared_ts = datetime(2024, 5, 20, 12, 0, 0)  # naive UTC, like the DB stores
-    refs = [_make_ref(session, shared_ts, f"tie_{i}.png") for i in range(4)]
-    session.commit()
-
-    expected_ids = sorted([r.id for r in refs], reverse=(order == "desc"))
-
-    # Walk the cursor by hand: page size 2, take 3 pages (2 + 2 + 0).
-    seen: list[str] = []
-    after_value = None
-    after_id = None
-    for _ in range(4):  # generous loop bound; ought to be 2 iterations
-        page, _tag_map, _total = list_references_page(
-            session,
+    boundary_record = first_page[-1]
+    second_page, _, _ = list_records_page(
+        session,
+        RecordPageSpec(
             limit=2,
-            sort="created_at",
-            order=order,
-            after_cursor_value=after_value,
-            after_cursor_id=after_id,
-        )
-        if not page:
-            break
-        seen.extend(p.id for p in page)
-        # Use the last row's (created_at, id) as the next cursor input.
-        last = page[-1]
-        after_value, after_id = last.created_at, last.id
-        if len(page) < 2:
-            break
-
-    assert seen == expected_ids, (
-        f"keyset tiebreaker failed for order={order}: expected {expected_ids}, got {seen}"
+            order="asc",
+            after=RecordCursorBoundary(
+                value=boundary_record.created_at,
+                id=boundary_record.id,
+            ),
+        ),
     )
 
-
-def test_tiebreaker_no_duplicates_under_mixed_collisions(session: Session):
-    """Some rows share a timestamp, some don't. The cursor must still walk
-    every row exactly once regardless of where ties sit relative to a
-    page boundary."""
-    t1 = datetime(2024, 5, 20, 12, 0, 0)
-    t2 = datetime(2024, 5, 20, 12, 0, 1)
-    layout = [t1, t1, t1, t2, t2]  # three rows at t1, two at t2
-    refs = [_make_ref(session, ts, f"mix_{i}.png") for i, ts in enumerate(layout)]
-    session.commit()
-
-    all_ids = {r.id for r in refs}
-    seen_set: set[str] = set()
-    seen_list: list[str] = []
-    after_value = None
-    after_id = None
-    for _ in range(6):
-        page, _, _ = list_references_page(
-            session,
-            limit=2,
-            sort="created_at",
-            order="desc",
-            after_cursor_value=after_value,
-            after_cursor_id=after_id,
-        )
-        if not page:
-            break
-        for p in page:
-            assert p.id not in seen_set, f"duplicate row {p.id} appeared in cursor walk"
-            seen_set.add(p.id)
-            seen_list.append(p.id)
-        last = page[-1]
-        after_value, after_id = last.created_at, last.id
-        if len(page) < 2:
-            break
-
-    assert seen_set == all_ids, f"missing rows: expected {all_ids}, got {seen_set}"
+    assert [record.id for record in first_page + second_page] == [record.id for record in records]

--- a/tests-unit/assets_test/services/conftest.py
+++ b/tests-unit/assets_test/services/conftest.py
@@ -1,11 +1,13 @@
 import tempfile
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from sqlalchemy import create_engine, event
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, Session as SASession
 
+from app.assets import mode
 from app.assets.database.models import Base
 
 
@@ -13,6 +15,16 @@ from app.assets.database.models import Base
 def autoclean_unit_test_assets():
     """Override parent autouse fixture - service unit tests don't need server cleanup."""
     yield
+
+
+@pytest.fixture(autouse=True)
+def initialised_hash_mode():
+    class _HashingOff:
+        enable_asset_hashing = False
+
+    mode.init(_HashingOff())
+    yield
+    mode.init(None)
 
 
 @pytest.fixture
@@ -48,9 +60,6 @@ def session(db_engine):
 @pytest.fixture
 def mock_create_session(db_engine):
     """Patch create_session to use our in-memory database."""
-    from contextlib import contextmanager
-    from sqlalchemy.orm import Session as SASession
-
     @contextmanager
     def _create_session():
         with SASession(db_engine) as sess:

--- a/tests-unit/assets_test/services/test_asset_response_loader_path.py
+++ b/tests-unit/assets_test/services/test_asset_response_loader_path.py
@@ -81,3 +81,29 @@ def test_all_path_fields_null_without_file_path():
 
     assert resp.loader_path is None
     assert resp.display_name is None
+
+
+def test_display_name_is_serialized_and_file_path_is_not(tmp_path: Path):
+    models = tmp_path / "models"
+    ckpt = models / "checkpoints"
+    ckpt.mkdir(parents=True)
+    f = ckpt / "flux.safetensors"
+    f.touch()
+
+    with patch("app.assets.services.path_utils.folder_paths") as mock_fp, patch(
+        "app.assets.services.path_utils.get_comfy_models_folders",
+        return_value=[("checkpoints", [str(ckpt)], {".safetensors"})],
+    ):
+        mock_fp.get_input_directory.return_value = str(tmp_path / "in")
+        mock_fp.get_output_directory.return_value = str(tmp_path / "out")
+        mock_fp.get_temp_directory.return_value = str(tmp_path / "tmp")
+        mock_fp.models_dir = str(models)
+
+        result = _make_result(file_path=str(f), loader_path=None)
+        resp = _build_asset_response(result, {})
+        dumped = resp.model_dump(mode="json")
+
+    assert dumped["display_name"] == "checkpoints/flux.safetensors"
+    assert "file_path" not in dumped, (
+        "the namespace-rooted storage path must not leak into this public response"
+    )

--- a/tests-unit/assets_test/services/test_asset_response_preview_url.py
+++ b/tests-unit/assets_test/services/test_asset_response_preview_url.py
@@ -4,7 +4,12 @@ from unittest.mock import patch
 
 import pytest
 
-from app.assets.api.routes import _build_asset_response
+from app.assets.api.routes import _build_asset_response, _build_record_response
+from app.assets.database.queries.records import (
+    create_content,
+    create_record,
+    mark_content_missing,
+)
 from app.assets.services.schemas import AssetData, AssetDetailResult, ReferenceData
 
 _TS = datetime(2024, 1, 1, 0, 0, 0)
@@ -30,6 +35,7 @@ def _make_result(
     tags: list[str] | None = None,
     user_metadata: dict | None = None,
     with_asset: bool = True,
+    is_missing: bool = False,
 ) -> AssetDetailResult:
     ref = ReferenceData(
         id=ref_id,
@@ -43,7 +49,12 @@ def _make_result(
         last_access_time=_TS,
     )
     asset = (
-        AssetData(hash="blake3:abc", size_bytes=1024, mime_type=mime_type)
+        AssetData(
+            hash="blake3:abc",
+            size_bytes=1024,
+            mime_type=mime_type,
+            is_missing=is_missing,
+        )
         if with_asset
         else None
     )
@@ -298,3 +309,77 @@ def test_no_preview_url_without_content(sandboxed_comfy_roots: Path):
     )
 
     assert resp.preview_url is None, "no asset row means there is nothing to preview"
+
+
+def test_no_self_preview_url_when_content_is_missing(sandboxed_comfy_roots: Path):
+    resp = _build_asset_response(
+        _make_result(
+            name="gone.png",
+            file_path=str(sandboxed_comfy_roots / "output" / "gone.png"),
+            mime_type="image/png",
+            is_missing=True,
+        ),
+        {},
+    )
+
+    assert resp.preview_url is None, (
+        "a missing-content record must not advertise a preview of its own bytes; "
+        "those bytes are gone, so /api/view would 404"
+    )
+
+
+def test_missing_content_still_shows_a_nominated_preview(sandboxed_comfy_roots: Path):
+    result = _make_result(
+        name="gone.safetensors",
+        file_path=str(sandboxed_comfy_roots / "models" / "checkpoints" / "gone.safetensors"),
+        mime_type="application/safetensors",
+        preview_id="preview-ref",
+        is_missing=True,
+    )
+
+    resp = _build_asset_response(
+        result, {"preview-ref": str(sandboxed_comfy_roots / "output" / "thumb.png")}
+    )
+
+    assert resp.preview_url == "/api/view?type=output&filename=thumb.png", (
+        "suppression targets self-content only; a nominated (live) preview still "
+        "stands in for a missing record"
+    )
+
+
+def test_record_response_shows_self_preview_url_for_live_content(
+    sandboxed_comfy_roots: Path, session
+):
+    content = create_content(
+        session, path=str(sandboxed_comfy_roots / "output" / "live.png")
+    )
+    record = create_record(
+        session, content_id=content.id, name="live.png", mime_type="image/png"
+    )
+    session.commit()
+
+    resp = _build_record_response(record, [], {})
+
+    assert resp.preview_url == "/api/view?type=output&filename=live.png", (
+        "a live record still previews its own bytes — the positive control that "
+        "proves the missing-case suppression is what withholds the URL"
+    )
+
+
+def test_record_response_has_no_self_preview_url_when_content_is_missing(
+    sandboxed_comfy_roots: Path, session
+):
+    content = create_content(
+        session, path=str(sandboxed_comfy_roots / "output" / "gone.png")
+    )
+    record = create_record(
+        session, content_id=content.id, name="gone.png", mime_type="image/png"
+    )
+    mark_content_missing(session, content.id)
+    session.commit()
+
+    resp = _build_record_response(record, ["missing"], {})
+
+    assert resp.preview_url is None, (
+        "the list surface must also withhold a missing record's self-preview URL"
+    )

--- a/tests-unit/assets_test/services/test_tagging.py
+++ b/tests-unit/assets_test/services/test_tagging.py
@@ -1,197 +1,52 @@
-"""Tests for tagging services."""
-import pytest
 from sqlalchemy.orm import Session
 
-from app.assets.database.models import Asset, AssetReference
-from app.assets.database.queries import ensure_tags_exist, add_tags_to_reference
-from app.assets.helpers import get_utc_now
-from app.assets.services import apply_tags, remove_tags, list_tags
+from app.assets.database.models import AssetTag, Tag
+from app.assets.database.queries import create_content, create_record, fetch_record_tags
+from app.assets.services.tagging import remove_tags
 
 
-def _make_asset(session: Session, hash_val: str = "blake3:test") -> Asset:
-    asset = Asset(hash=hash_val, size_bytes=1024)
-    session.add(asset)
-    session.flush()
-    return asset
+def test_tags_are_birth_facts_of_a_record(session: Session) -> None:
+    content = create_content(session, "/models/model.safetensors")
+    record = create_record(session, content.id, "model", tags=["model", "checkpoint"])
+
+    assert fetch_record_tags(session, record.id) == ["checkpoint", "model"]
 
 
-def _make_reference(
-    session: Session,
-    asset: Asset,
-    name: str = "test",
-    owner_id: str = "",
-) -> AssetReference:
-    now = get_utc_now()
-    ref = AssetReference(
-        owner_id=owner_id,
-        name=name,
-        asset_id=asset.id,
-        created_at=now,
-        updated_at=now,
-        last_access_time=now,
+def _attach_automatic_tag(session: Session, record_id: str, tag_name: str) -> None:
+    if session.get(Tag, tag_name) is None:
+        session.add(Tag(name=tag_name))
+        session.flush()
+    session.add(
+        AssetTag(asset_id=record_id, tag_name=tag_name, origin="automatic")
     )
-    session.add(ref)
-    session.flush()
-    return ref
 
 
-class TestApplyTags:
-    def test_adds_new_tags(self, mock_create_session, session: Session):
-        asset = _make_asset(session)
-        ref = _make_reference(session, asset)
-        session.commit()
+def test_removing_present_automatic_tag_reports_it_protected_not_absent(
+    session: Session, mock_create_session
+) -> None:
+    content = create_content(session, "/output/protected.png")
+    record = create_record(session, content.id, "protected-fixture")
+    _attach_automatic_tag(session, record.id, "auto")
+    session.commit()
 
-        result = apply_tags(
-            reference_id=ref.id,
-            tags=["alpha", "beta"],
-        )
+    result = remove_tags(record.id, ["auto"])
 
-        assert set(result.added) == {"alpha", "beta"}
-        assert result.already_present == []
-        assert set(result.total_tags) == {"alpha", "beta"}
-
-    def test_reports_already_present(self, mock_create_session, session: Session):
-        asset = _make_asset(session)
-        ref = _make_reference(session, asset)
-        ensure_tags_exist(session, ["existing"])
-        add_tags_to_reference(session, reference_id=ref.id, tags=["existing"])
-        session.commit()
-
-        result = apply_tags(
-            reference_id=ref.id,
-            tags=["existing", "new"],
-        )
-
-        assert result.added == ["new"]
-        assert result.already_present == ["existing"]
-
-    def test_raises_for_nonexistent_ref(self, mock_create_session):
-        with pytest.raises(ValueError, match="not found"):
-            apply_tags(reference_id="nonexistent", tags=["x"])
-
-    def test_raises_for_wrong_owner(self, mock_create_session, session: Session):
-        asset = _make_asset(session)
-        ref = _make_reference(session, asset, owner_id="user1")
-        session.commit()
-
-        with pytest.raises(PermissionError, match="not owner"):
-            apply_tags(
-                reference_id=ref.id,
-                tags=["new"],
-                owner_id="user2",
-            )
+    assert result.protected == ["auto"]
+    assert result.not_present == []
+    assert result.removed == []
 
 
-class TestRemoveTags:
-    def test_removes_tags(self, mock_create_session, session: Session):
-        asset = _make_asset(session)
-        ref = _make_reference(session, asset)
-        ensure_tags_exist(session, ["a", "b", "c"])
-        add_tags_to_reference(session, reference_id=ref.id, tags=["a", "b", "c"])
-        session.commit()
+def test_remove_tags_separates_removed_protected_and_absent(
+    session: Session, mock_create_session
+) -> None:
+    content = create_content(session, "/output/mixed.png")
+    record = create_record(session, content.id, "mixed-fixture", tags=["keep-me"])
+    _attach_automatic_tag(session, record.id, "auto")
+    session.commit()
 
-        result = remove_tags(
-            reference_id=ref.id,
-            tags=["a", "b"],
-        )
+    result = remove_tags(record.id, ["keep-me", "auto", "ghost"])
 
-        assert set(result.removed) == {"a", "b"}
-        assert result.not_present == []
-        assert result.total_tags == ["c"]
-
-    def test_reports_not_present(self, mock_create_session, session: Session):
-        asset = _make_asset(session)
-        ref = _make_reference(session, asset)
-        ensure_tags_exist(session, ["present"])
-        add_tags_to_reference(session, reference_id=ref.id, tags=["present"])
-        session.commit()
-
-        result = remove_tags(
-            reference_id=ref.id,
-            tags=["present", "absent"],
-        )
-
-        assert result.removed == ["present"]
-        assert result.not_present == ["absent"]
-
-    def test_raises_for_nonexistent_ref(self, mock_create_session):
-        with pytest.raises(ValueError, match="not found"):
-            remove_tags(reference_id="nonexistent", tags=["x"])
-
-    def test_raises_for_wrong_owner(self, mock_create_session, session: Session):
-        asset = _make_asset(session)
-        ref = _make_reference(session, asset, owner_id="user1")
-        session.commit()
-
-        with pytest.raises(PermissionError, match="not owner"):
-            remove_tags(
-                reference_id=ref.id,
-                tags=["x"],
-                owner_id="user2",
-            )
-
-
-class TestListTags:
-    def test_returns_tags_with_counts(self, mock_create_session, session: Session):
-        ensure_tags_exist(session, ["used", "unused"])
-        asset = _make_asset(session)
-        ref = _make_reference(session, asset)
-        add_tags_to_reference(session, reference_id=ref.id, tags=["used"])
-        session.commit()
-
-        rows, total = list_tags()
-
-        tag_dict = {name: count for name, count in rows}
-        assert tag_dict["used"] == 1
-        assert tag_dict["unused"] == 0
-        assert total == 2
-
-    def test_excludes_zero_counts(self, mock_create_session, session: Session):
-        ensure_tags_exist(session, ["used", "unused"])
-        asset = _make_asset(session)
-        ref = _make_reference(session, asset)
-        add_tags_to_reference(session, reference_id=ref.id, tags=["used"])
-        session.commit()
-
-        rows, total = list_tags(include_zero=False)
-
-        tag_names = {name for name, _ in rows}
-        assert "used" in tag_names
-        assert "unused" not in tag_names
-
-    def test_prefix_filter(self, mock_create_session, session: Session):
-        ensure_tags_exist(session, ["alpha", "beta", "alphabet"])
-        session.commit()
-
-        rows, _ = list_tags(prefix="alph")
-
-        tag_names = {name for name, _ in rows}
-        assert tag_names == {"alpha", "alphabet"}
-
-    def test_order_by_name(self, mock_create_session, session: Session):
-        ensure_tags_exist(session, ["zebra", "alpha", "middle"])
-        session.commit()
-
-        rows, _ = list_tags(order="name_asc")
-
-        names = [name for name, _ in rows]
-        assert names == ["alpha", "middle", "zebra"]
-
-    def test_pagination(self, mock_create_session, session: Session):
-        ensure_tags_exist(session, ["a", "b", "c", "d", "e"])
-        session.commit()
-
-        rows, total = list_tags(limit=2, offset=1, order="name_asc")
-
-        assert total == 5
-        assert len(rows) == 2
-        names = [name for name, _ in rows]
-        assert names == ["b", "c"]
-
-    def test_clamps_limit(self, mock_create_session, session: Session):
-        ensure_tags_exist(session, ["a"])
-        session.commit()
-
-        # Service should clamp limit to max 1000
-        rows, _ = list_tags(limit=2000)
-        assert len(rows) <= 1000
+    assert result.removed == ["keep-me"]
+    assert result.protected == ["auto"]
+    assert result.not_present == ["ghost"]
+    assert fetch_record_tags(session, record.id) == ["auto"]

--- a/tests-unit/assets_test/test_list_filter.py
+++ b/tests-unit/assets_test/test_list_filter.py
@@ -1,758 +1,334 @@
-import time
-import uuid
-import warnings
+from __future__ import annotations
+
+import urllib.parse
+from datetime import datetime
 
 import pytest
-import requests
-from helpers import assert_hash_fields_consistent
+from sqlalchemy import event
 
-from app.assets.api import routes as assets_routes
-from app.assets.api import schemas_in
+from . import helpers
+from .helpers import (
+    RouteDatabase,
+    RecordSeed,
+    error_body as _error_body,
+    asset_list_body as _asset_list_body,
+    seed_record as _seed_record,
+    request_assets as _request_assets,
+)
+from app.assets.database.queries.records import (
+    create_content,
+    create_record,
+    mark_content_missing,
+)
+from app.assets.services.cursor import encode_cursor
+
+autoclean_unit_test_assets = helpers.autoclean_unit_test_assets
+route_database = helpers.route_database
+sortable_record_ids = helpers.sortable_record_ids
 
 
-def test_list_assets_paging_and_sort(http: requests.Session, api_base: str, asset_factory, make_asset_bytes):
-    names = ["a1_u.safetensors", "a2_u.safetensors", "a3_u.safetensors"]
-    for n in names:
-        asset_factory(
-            n,
-            ["models", "model_type:checkpoints", "unit-tests", "paging"],
-            {"epoch": 1},
-            make_asset_bytes(n, size=2048),
+def test_record_list_filters_record_tags(http, api_base, asset_factory, make_asset_bytes):
+    record = asset_factory("filtered.png", ["output", "unit-tests", "chosen"], {}, make_asset_bytes("filtered"))
+
+    response = http.get(f"{api_base}/api/assets", params={"include_tags": "chosen"})
+
+    assert response.status_code == 200
+    assert [asset["id"] for asset in response.json()["assets"]] == [record["id"]]
+
+
+def test_record_list_rejects_metadata_filter(http, api_base):
+    response = http.get(
+        f"{api_base}/api/assets", params={"metadata_filter": '{"k":"v"}'}
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "error": {
+            "code": "UNSUPPORTED_PARAM",
+            "message": "metadata_filter is no longer supported",
+            "details": {},
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_tags_any_is_accepted(route_database: RouteDatabase) -> None:
+    _, session = route_database
+    _seed_record(session, RecordSeed("any.png", ("a",)))
+    session.commit()
+
+    response = await _request_assets("tags_any=a")
+
+    assert response.status == 200
+
+
+@pytest.mark.asyncio
+async def test_tags_any_matches_any_requested_tag(route_database: RouteDatabase) -> None:
+    _, session = route_database
+    a_record = _seed_record(session, RecordSeed("a.png", ("a",)))
+    b_record = _seed_record(session, RecordSeed("b.png", ("b",)))
+    _seed_record(session, RecordSeed("neither.png", ("c",)))
+    session.commit()
+
+    response = await _request_assets("tags_any=a,b")
+
+    body = _asset_list_body(response)
+    assert {asset["id"] for asset in body["assets"]} == {a_record.id, b_record.id}
+
+
+@pytest.mark.parametrize(("tag_count", "expected_status"), ((100, 200), (101, 400)))
+@pytest.mark.asyncio
+async def test_tags_any_enforces_the_shared_tag_cap(
+    route_database: RouteDatabase,
+    tag_count: int,
+    expected_status: int,
+) -> None:
+    del route_database
+    tags = ",".join(f"tag-{index}" for index in range(tag_count))
+
+    response = await _request_assets(urllib.parse.urlencode({"tags_any": tags}))
+
+    assert response.status == expected_status
+    if expected_status == 400:
+        assert _error_body(response)["error"]["code"] == "INVALID_TAG_FILTER"
+
+
+@pytest.mark.asyncio
+async def test_name_contains_filters_records(route_database: RouteDatabase) -> None:
+    _, session = route_database
+    match = _seed_record(session, RecordSeed("alpha.png"))
+    _seed_record(session, RecordSeed("beta.png"))
+    session.commit()
+
+    response = await _request_assets("name_contains=lph")
+
+    body = _asset_list_body(response)
+    assert [asset["id"] for asset in body["assets"]] == [match.id]
+
+
+@pytest.mark.asyncio
+async def test_offset_skips_records(route_database: RouteDatabase) -> None:
+    _, session = route_database
+    _seed_record(session, RecordSeed("a.png", ("offset-case",)))
+    second = _seed_record(session, RecordSeed("b.png", ("offset-case",)))
+    session.commit()
+
+    response = await _request_assets(
+        "tags_all=offset-case&sort=name&order=asc&offset=1&limit=1"
+    )
+
+    body = _asset_list_body(response)
+    assert [asset["id"] for asset in body["assets"]] == [second.id]
+
+
+@pytest.mark.asyncio
+async def test_default_order_is_newest_first(route_database: RouteDatabase) -> None:
+    _, session = route_database
+    older = _seed_record(session, RecordSeed("older.png"))
+    newer = _seed_record(session, RecordSeed("newer.png"))
+    older.created_at = datetime(2026, 1, 1)
+    newer.created_at = datetime(2026, 1, 2)
+    session.commit()
+
+    response = await _request_assets()
+
+    body = _asset_list_body(response)
+    assert [asset["id"] for asset in body["assets"]] == [newer.id, older.id]
+
+
+@pytest.mark.parametrize(
+    ("sort", "order"),
+    (
+        ("name", "asc"),
+        ("created_at", "desc"),
+        ("updated_at", "asc"),
+        ("size", "desc"),
+        ("last_access_time", "desc"),
+    ),
+)
+@pytest.mark.asyncio
+async def test_each_sort_field_orders_records(
+    route_database: RouteDatabase,
+    sortable_record_ids: tuple[str, str],
+    sort: str,
+    order: str,
+) -> None:
+    del route_database
+    query = urllib.parse.urlencode(
+        {"tags_all": "sort-case", "sort": sort, "order": order}
+    )
+
+    response = await _request_assets(query)
+
+    body = _asset_list_body(response)
+    assert response.status == 200
+    assert [asset["id"] for asset in body["assets"]] == list(sortable_record_ids)
+
+
+@pytest.mark.asyncio
+async def test_total_counts_all_filtered_records(route_database: RouteDatabase) -> None:
+    _, session = route_database
+    for index in range(5):
+        _seed_record(session, RecordSeed(f"total-{index}.png", ("total-case",)))
+    session.commit()
+
+    response = await _request_assets("tags_all=total-case&limit=2")
+
+    body = _asset_list_body(response)
+    assert len(body["assets"]) == 2
+    assert body["total"] == 5
+
+
+@pytest.mark.parametrize(("offset", "expected"), ((0, True), (4, False)))
+@pytest.mark.asyncio
+async def test_offset_mode_has_more_uses_total(
+    route_database: RouteDatabase,
+    offset: int,
+    expected: bool,
+) -> None:
+    _, session = route_database
+    for index in range(5):
+        _seed_record(session, RecordSeed(f"more-{index}.png", ("more-case",)))
+    session.commit()
+
+    response = await _request_assets(
+        f"tags_all=more-case&sort=name&order=asc&offset={offset}&limit=1"
+    )
+
+    body = _asset_list_body(response)
+    assert body["has_more"] is expected
+
+
+@pytest.mark.asyncio
+async def test_bad_cursor_returns_400(route_database: RouteDatabase) -> None:
+    del route_database
+
+    response = await _request_assets("after=not-a-cursor")
+
+    assert response.status == 400
+    assert _error_body(response)["error"]["code"] == "INVALID_CURSOR"
+
+
+@pytest.mark.asyncio
+async def test_cursor_rejects_last_access_time_sort(route_database: RouteDatabase) -> None:
+    del route_database
+
+    response = await _request_assets("after=not-a-cursor&sort=last_access_time")
+
+    assert response.status == 400
+    assert _error_body(response)["error"]["code"] == "INVALID_CURSOR"
+
+
+@pytest.mark.parametrize(
+    "query",
+    (
+        "sort=created_at&order=asc",
+        "sort=name&order=desc",
+    ),
+)
+@pytest.mark.asyncio
+async def test_cursor_rejects_sort_or_order_mismatch(
+    route_database: RouteDatabase,
+    query: str,
+) -> None:
+    del route_database
+    cursor = encode_cursor("name", "a.png", "cursor-id", order="asc")
+
+    response = await _request_assets(f"{query}&after={cursor}")
+
+    assert response.status == 400
+    assert _error_body(response)["error"]["code"] == "INVALID_CURSOR"
+
+
+@pytest.mark.asyncio
+async def test_terminal_page_has_no_cursor(route_database: RouteDatabase) -> None:
+    _, session = route_database
+    only_record = _seed_record(session, RecordSeed("only.png", ("terminal-case",)))
+    session.commit()
+
+    response = await _request_assets(
+        "tags_all=terminal-case&sort=name&order=asc&limit=1"
+    )
+
+    body = _asset_list_body(response)
+    assert [asset["id"] for asset in body["assets"]] == [only_record.id]
+    assert body["has_more"] is False
+    assert "next_cursor" not in body
+
+
+@pytest.mark.asyncio
+async def test_page_query_budget_is_four_statements(
+    route_database: RouteDatabase,
+) -> None:
+    engine, session = route_database
+    preview = _seed_record(session, RecordSeed("preview.png", ("preview",)))
+    for index in range(3):
+        record = _seed_record(
+            session,
+            RecordSeed(f"page-{index}.png", ("budget-case",)),
         )
+        record.preview_id = preview.id
+    session.commit()
+    statements: list[str] = []
 
-    # name ascending for stable order
-    r1 = http.get(
-        api_base + "/api/assets",
-        params={"include_tags": "unit-tests,paging", "sort": "name", "order": "asc", "limit": "2", "offset": "0"},
-        timeout=120,
+    def count_statements(_, __, statement, ___, ____, _____) -> None:
+        statements.append(statement)
+
+    event.listen(engine, "before_cursor_execute", count_statements)
+    try:
+        response = await _request_assets("tags_all=budget-case&limit=3")
+    finally:
+        event.remove(engine, "before_cursor_execute", count_statements)
+
+    body = _asset_list_body(response)
+    assert len(body["assets"]) == 3
+    assert {asset.get("preview_id") for asset in body["assets"]} == {preview.id}
+    assert len(statements) == 4
+
+
+@pytest.mark.asyncio
+async def test_missing_content_is_listed_with_missing_tag(
+    route_database: RouteDatabase,
+) -> None:
+    _, session = route_database
+    live = _seed_record(session, RecordSeed("live.png", ("live-case",)))
+    missing_content = create_content(session, "/output/missing.png")
+    missing = create_record(
+        session,
+        content_id=missing_content.id,
+        name="missing.png",
+        tags=("live-case",),
     )
-    b1 = r1.json()
-    assert r1.status_code == 200
-    got1 = [a["name"] for a in b1["assets"]]
-    assert got1 == sorted(names)[:2]
-    assert b1["has_more"] is True
-    # Populated assets in list responses must carry both `hash` and `asset_hash` consistently
-    for asset in b1["assets"]:
-        assert_hash_fields_consistent(asset)
-        assert "hash" in asset, "populated asset must emit hash on list endpoint"
+    mark_content_missing(session, missing_content.id)
+    session.commit()
 
-    r2 = http.get(
-        api_base + "/api/assets",
-        params={"include_tags": "unit-tests,paging", "sort": "name", "order": "asc", "limit": "2", "offset": "2"},
-        timeout=120,
+    response = await _request_assets("tags_all=live-case&sort=name&order=asc")
+
+    body = _asset_list_body(response)
+    assert {asset["id"] for asset in body["assets"]} == {live.id, missing.id}
+    assert body["total"] == 2
+    missing_asset = next(a for a in body["assets"] if a["id"] == missing.id)
+    assert "missing" in missing_asset["tags"]
+
+
+@pytest.mark.asyncio
+async def test_missing_content_is_reachable_via_tags_all_missing(
+    route_database: RouteDatabase,
+) -> None:
+    _, session = route_database
+    _seed_record(session, RecordSeed("live.png", ("live-case",)))
+    missing_content = create_content(session, "/output/missing.png")
+    missing = create_record(
+        session,
+        content_id=missing_content.id,
+        name="missing.png",
+        tags=("live-case",),
     )
-    b2 = r2.json()
-    assert r2.status_code == 200
-    got2 = [a["name"] for a in b2["assets"]]
-    assert got2 == sorted(names)[2:]
-    assert b2["has_more"] is False
+    mark_content_missing(session, missing_content.id)
+    session.commit()
 
+    response = await _request_assets("tags_all=missing")
 
-def test_list_assets_include_exclude_and_name_contains(http: requests.Session, api_base: str, asset_factory):
-    a = asset_factory("inc_a.safetensors", ["models", "model_type:checkpoints", "unit-tests", "alpha"], {}, b"X" * 1024)
-    b = asset_factory("inc_b.safetensors", ["models", "model_type:checkpoints", "unit-tests", "beta"], {}, b"Y" * 1024)
-
-    r = http.get(
-        api_base + "/api/assets",
-        params={"include_tags": "unit-tests,alpha", "exclude_tags": "beta", "limit": "50"},
-        timeout=120,
-    )
-    body = r.json()
-    assert r.status_code == 200
-    names = [x["name"] for x in body["assets"]]
-    assert a["name"] in names
-    assert b["name"] not in names
-
-    r2 = http.get(
-        api_base + "/api/assets",
-        params={"include_tags": "unit-tests", "name_contains": "inc_"},
-        timeout=120,
-    )
-    body2 = r2.json()
-    assert r2.status_code == 200
-    names2 = [x["name"] for x in body2["assets"]]
-    assert a["name"] in names2
-    assert b["name"] in names2
-
-    r2 = http.get(
-        api_base + "/api/assets",
-        params={"include_tags": "non-existing-tag"},
-        timeout=120,
-    )
-    body3 = r2.json()
-    assert r2.status_code == 200
-    assert not body3["assets"]
-
-
-def test_list_assets_sort_by_size_both_orders(http, api_base, asset_factory, make_asset_bytes):
-    t = ["models", "model_type:checkpoints", "unit-tests", "lf-size"]
-    n1, n2, n3 = "sz1.safetensors", "sz2.safetensors", "sz3.safetensors"
-    asset_factory(n1, t, {}, make_asset_bytes(n1, 1024))
-    asset_factory(n2, t, {}, make_asset_bytes(n2, 2048))
-    asset_factory(n3, t, {}, make_asset_bytes(n3, 3072))
-
-    r1 = http.get(
-        api_base + "/api/assets",
-        params={"include_tags": "unit-tests,lf-size", "sort": "size", "order": "asc"},
-        timeout=120,
-    )
-    b1 = r1.json()
-    names = [a["name"] for a in b1["assets"]]
-    assert names[:3] == [n1, n2, n3]
-
-    r2 = http.get(
-        api_base + "/api/assets",
-        params={"include_tags": "unit-tests,lf-size", "sort": "size", "order": "desc"},
-        timeout=120,
-    )
-    b2 = r2.json()
-    names2 = [a["name"] for a in b2["assets"]]
-    assert names2[:3] == [n3, n2, n1]
-
-
-
-def test_list_assets_sort_by_updated_at_desc(http, api_base, asset_factory, make_asset_bytes):
-    t = ["models", "model_type:checkpoints", "unit-tests", "lf-upd"]
-    a1 = asset_factory("upd_a.safetensors", t, {}, make_asset_bytes("upd_a", 1200))
-    a2 = asset_factory("upd_b.safetensors", t, {}, make_asset_bytes("upd_b", 1200))
-
-    # Rename the second asset to bump updated_at
-    rp = http.put(f"{api_base}/api/assets/{a2['id']}", json={"name": "upd_b_renamed.safetensors"}, timeout=120)
-    upd = rp.json()
-    assert rp.status_code == 200, upd
-
-    r = http.get(
-        api_base + "/api/assets",
-        params={"include_tags": "unit-tests,lf-upd", "sort": "updated_at", "order": "desc"},
-        timeout=120,
-    )
-    body = r.json()
-    assert r.status_code == 200
-    names = [x["name"] for x in body["assets"]]
-    assert names[0] == "upd_b_renamed.safetensors"
-    assert a1["name"] in names
-
-
-
-def test_list_assets_sort_by_last_access_time_desc(http, api_base, asset_factory, make_asset_bytes):
-    t = ["models", "model_type:checkpoints", "unit-tests", "lf-access"]
-    asset_factory("acc_a.safetensors", t, {}, make_asset_bytes("acc_a", 1100))
-    time.sleep(0.02)
-    a2 = asset_factory("acc_b.safetensors", t, {}, make_asset_bytes("acc_b", 1100))
-
-    # Touch last_access_time of b by downloading its content
-    time.sleep(0.02)
-    dl = http.get(f"{api_base}/api/assets/{a2['id']}/content", timeout=120)
-    assert dl.status_code == 200
-    dl.content
-
-    r = http.get(
-        api_base + "/api/assets",
-        params={"include_tags": "unit-tests,lf-access", "sort": "last_access_time", "order": "desc"},
-        timeout=120,
-    )
-    body = r.json()
-    assert r.status_code == 200
-    names = [x["name"] for x in body["assets"]]
-    assert names[0] == a2["name"]
-
-
-def test_list_assets_include_tags_variants_and_case(http, api_base, asset_factory, make_asset_bytes):
-    t = ["models", "model_type:checkpoints", "unit-tests", "lf-include"]
-    a = asset_factory("incvar_alpha.safetensors", [*t, "alpha"], {}, make_asset_bytes("iva"))
-    asset_factory("incvar_beta.safetensors", [*t, "beta"], {}, make_asset_bytes("ivb"))
-
-    # CSV tag filters are whitespace-trimmed and case-sensitive.
-    r1 = http.get(
-        api_base + "/api/assets",
-        params={"include_tags": "unit-tests,lf-include,alpha"},
-        timeout=120,
-    )
-    b1 = r1.json()
-    assert r1.status_code == 200
-    names1 = [x["name"] for x in b1["assets"]]
-    assert a["name"] in names1
-    assert not any("beta" in x for x in names1)
-
-    # Repeated query params for include_tags
-    params_multi = [
-        ("include_tags", "unit-tests"),
-        ("include_tags", "lf-include"),
-        ("include_tags", "alpha"),
-    ]
-    r2 = http.get(api_base + "/api/assets", params=params_multi, timeout=120)
-    b2 = r2.json()
-    assert r2.status_code == 200
-    names2 = [x["name"] for x in b2["assets"]]
-    assert a["name"] in names2
-    assert not any("beta" in x for x in names2)
-
-    # Duplicates and spaces in CSV
-    r3 = http.get(
-        api_base + "/api/assets",
-        params={"include_tags": " unit-tests , lf-include , alpha , alpha "},
-        timeout=120,
-    )
-    b3 = r3.json()
-    assert r3.status_code == 200
-    names3 = [x["name"] for x in b3["assets"]]
-    assert a["name"] in names3
-
-
-def test_list_assets_exclude_tags_dedup_and_case(http, api_base, asset_factory, make_asset_bytes):
-    t = ["models", "model_type:checkpoints", "unit-tests", "lf-exclude"]
-    a = asset_factory("ex_a_alpha.safetensors", [*t, "alpha"], {}, make_asset_bytes("exa", 900))
-    asset_factory("ex_b_beta.safetensors", [*t, "beta"], {}, make_asset_bytes("exb", 900))
-
-    # Exclude filters are case-sensitive.
-    r1 = http.get(
-        api_base + "/api/assets",
-        params={"include_tags": "unit-tests,lf-exclude", "exclude_tags": "beta"},
-        timeout=120,
-    )
-    b1 = r1.json()
-    assert r1.status_code == 200
-    names1 = [x["name"] for x in b1["assets"]]
-    assert a["name"] in names1
-    # Repeated excludes with duplicates
-    params_multi = [
-        ("include_tags", "unit-tests"),
-        ("include_tags", "lf-exclude"),
-        ("exclude_tags", "beta"),
-        ("exclude_tags", "beta"),
-    ]
-    r2 = http.get(api_base + "/api/assets", params=params_multi, timeout=120)
-    b2 = r2.json()
-    assert r2.status_code == 200
-    names2 = [x["name"] for x in b2["assets"]]
-    assert all("beta" not in x for x in names2)
-
-
-def test_list_assets_name_contains_case_and_specials(http, api_base, asset_factory, make_asset_bytes):
-    t = ["models", "model_type:checkpoints", "unit-tests", "lf-name"]
-    a1 = asset_factory("CaseMix.SAFE", t, {}, make_asset_bytes("cm", 800))
-    a2 = asset_factory("case-other.safetensors", t, {}, make_asset_bytes("co", 800))
-
-    r1 = http.get(
-        api_base + "/api/assets",
-        params={"include_tags": "unit-tests,lf-name", "name_contains": "casemix"},
-        timeout=120,
-    )
-    b1 = r1.json()
-    assert r1.status_code == 200
-    names1 = [x["name"] for x in b1["assets"]]
-    assert a1["name"] in names1
-
-    r2 = http.get(
-        api_base + "/api/assets",
-        params={"include_tags": "unit-tests,lf-name", "name_contains": ".SAFE"},
-        timeout=120,
-    )
-    b2 = r2.json()
-    assert r2.status_code == 200
-    names2 = [x["name"] for x in b2["assets"]]
-    assert a1["name"] in names2
-
-    r3 = http.get(
-        api_base + "/api/assets",
-        params={"include_tags": "unit-tests,lf-name", "name_contains": "case-"},
-        timeout=120,
-    )
-    b3 = r3.json()
-    assert r3.status_code == 200
-    names3 = [x["name"] for x in b3["assets"]]
-    assert a2["name"] in names3
-
-
-def test_list_assets_offset_beyond_total_and_limit_boundary(http, api_base, asset_factory, make_asset_bytes):
-    t = ["models", "model_type:checkpoints", "unit-tests", "lf-pagelimits"]
-    asset_factory("pl1.safetensors", t, {}, make_asset_bytes("pl1", 600))
-    asset_factory("pl2.safetensors", t, {}, make_asset_bytes("pl2", 600))
-    asset_factory("pl3.safetensors", t, {}, make_asset_bytes("pl3", 600))
-
-    # Offset far beyond total
-    r1 = http.get(
-        api_base + "/api/assets",
-        params={"include_tags": "unit-tests,lf-pagelimits", "limit": "2", "offset": "10"},
-        timeout=120,
-    )
-    b1 = r1.json()
-    assert r1.status_code == 200
-    assert not b1["assets"]
-    assert b1["has_more"] is False
-
-    # Boundary large limit (<=500 is valid)
-    r2 = http.get(
-        api_base + "/api/assets",
-        params={"include_tags": "unit-tests,lf-pagelimits", "limit": "500"},
-        timeout=120,
-    )
-    b2 = r2.json()
-    assert r2.status_code == 200
-    assert len(b2["assets"]) == 3
-    assert b2["has_more"] is False
-
-
-@pytest.mark.parametrize(
-    "params,error_code",
-    [
-        ({"offset": "-1"}, "INVALID_QUERY"),
-        ({"limit": "abc"}, "INVALID_QUERY"),
-        ({"limit": "0"}, "INVALID_QUERY"),
-        ({"metadata_filter": "{not json"}, "INVALID_QUERY"),
-    ],
-    ids=["negative_offset", "non_int_limit", "zero_limit", "invalid_metadata_json"],
-)
-def test_list_assets_invalid_query_rejected(http: requests.Session, api_base: str, params, error_code):
-    r = http.get(api_base + "/api/assets", params=params, timeout=120)
-    body = r.json()
-    assert r.status_code == 400
-    assert body["error"]["code"] == error_code
-
-
-def test_list_assets_name_contains_literal_underscore(
-    http,
-    api_base,
-    asset_factory,
-    make_asset_bytes,
-):
-    """'name_contains' must treat '_' literally, not as a SQL wildcard.
-    We create:
-      - foo_bar.safetensors      (should match)
-      - fooxbar.safetensors      (must NOT match if '_' is escaped)
-      - foobar.safetensors       (must NOT match)
-    """
-    scope = f"lf-underscore-{uuid.uuid4().hex[:6]}"
-    tags = ["models", "model_type:checkpoints", "unit-tests", scope]
-
-    a = asset_factory("foo_bar.safetensors", tags, {}, make_asset_bytes("a", 700))
-    b = asset_factory("fooxbar.safetensors", tags, {}, make_asset_bytes("b", 700))
-    c = asset_factory("foobar.safetensors", tags, {}, make_asset_bytes("c", 700))
-
-    r = http.get(
-        api_base + "/api/assets",
-        params={"include_tags": f"unit-tests,{scope}", "name_contains": "foo_bar"},
-        timeout=120,
-    )
-    body = r.json()
-    assert r.status_code == 200, body
-    names = [x["name"] for x in body["assets"]]
-    assert a["name"] in names, f"Expected literal underscore match to include {a['name']}"
-    assert b["name"] not in names, "Underscore must be escaped — should not match 'fooxbar'"
-    assert c["name"] not in names, "Underscore must be escaped — should not match 'foobar'"
+    body = _asset_list_body(response)
+    assert {asset["id"] for asset in body["assets"]} == {missing.id}
     assert body["total"] == 1
-
-
-def test_list_assets_tags_any_alone(http, api_base, asset_factory, make_asset_bytes):
-    scope = f"lf-any-{uuid.uuid4().hex[:6]}"
-    t = ["models", "model_type:checkpoints", "unit-tests", scope]
-    a = asset_factory("any_a.safetensors", [*t, f"{scope}-alpha"], {}, make_asset_bytes("any_a"))
-    b = asset_factory("any_b.safetensors", [*t, f"{scope}-beta"], {}, make_asset_bytes("any_b"))
-    c = asset_factory("any_c.safetensors", [*t, f"{scope}-gamma"], {}, make_asset_bytes("any_c"))
-
-    r = http.get(
-        api_base + "/api/assets",
-        params={"tags_any": f"{scope}-alpha,{scope}-beta", "limit": "50"},
-        timeout=120,
-    )
-    body = r.json()
-    assert r.status_code == 200, body
-    names = [x["name"] for x in body["assets"]]
-    assert a["name"] in names
-    assert b["name"] in names
-    assert c["name"] not in names
-
-
-def test_list_assets_tags_any_with_tags_all(http, api_base, asset_factory, make_asset_bytes):
-    scope = f"lf-anyall-{uuid.uuid4().hex[:6]}"
-    t = ["models", "model_type:checkpoints", "unit-tests", scope]
-    alpha, beta = f"{scope}-alpha", f"{scope}-beta"
-    x = asset_factory("aa_x.safetensors", [*t, alpha], {}, make_asset_bytes("aa_x"))
-    y = asset_factory("aa_y.safetensors", [*t, beta], {}, make_asset_bytes("aa_y"))
-    w = asset_factory("aa_w.safetensors", t, {}, make_asset_bytes("aa_w"))
-    d = asset_factory(
-        "aa_d.safetensors",
-        ["models", "model_type:checkpoints", "unit-tests", f"{scope}-other", alpha],
-        {},
-        make_asset_bytes("aa_d"),
-    )
-
-    r = http.get(
-        api_base + "/api/assets",
-        params={"tags_all": f"unit-tests,{scope}", "tags_any": f"{alpha},{beta}", "limit": "50"},
-        timeout=120,
-    )
-    body = r.json()
-    assert r.status_code == 200, body
-    names = [a["name"] for a in body["assets"]]
-    assert x["name"] in names
-    assert y["name"] in names
-    assert w["name"] not in names, "asset matching tags_all but not tags_any must be excluded"
-    assert d["name"] not in names, "asset matching tags_any but not tags_all must be excluded"
-
-
-def test_list_assets_tags_none_wins_over_tags_any(http, api_base, asset_factory, make_asset_bytes):
-    scope = f"lf-nonewins-{uuid.uuid4().hex[:6]}"
-    t = ["models", "model_type:checkpoints", "unit-tests", scope]
-    alpha, beta = f"{scope}-alpha", f"{scope}-beta"
-    x = asset_factory("nw_x.safetensors", [*t, alpha], {}, make_asset_bytes("nw_x"))
-    y = asset_factory("nw_y.safetensors", [*t, alpha, beta], {}, make_asset_bytes("nw_y"))
-
-    r = http.get(
-        api_base + "/api/assets",
-        params={"tags_any": alpha, "tags_none": beta, "limit": "50"},
-        timeout=120,
-    )
-    body = r.json()
-    assert r.status_code == 200, body
-    names = [a["name"] for a in body["assets"]]
-    assert x["name"] in names
-    assert y["name"] not in names, "tags_none must exclude an asset even when it matches tags_any"
-
-
-def test_list_assets_empty_tag_filter_lists_behave_as_absent(http, api_base, asset_factory, make_asset_bytes):
-    scope = f"lf-empty-{uuid.uuid4().hex[:6]}"
-    t = ["models", "model_type:checkpoints", "unit-tests", scope]
-    a = asset_factory("em_a.safetensors", t, {}, make_asset_bytes("em_a"))
-    b = asset_factory("em_b.safetensors", t, {}, make_asset_bytes("em_b"))
-    expected = {a["name"], b["name"]}
-
-    # Empty new-name lists impose no constraint.
-    r1 = http.get(
-        api_base + "/api/assets",
-        params={"tags_all": f"unit-tests,{scope}", "tags_any": "", "tags_none": ""},
-        timeout=120,
-    )
-    b1 = r1.json()
-    assert r1.status_code == 200, b1
-    assert {x["name"] for x in b1["assets"]} == expected
-
-    # An empty new-name param alongside old names must not trigger validation.
-    r2 = http.get(
-        api_base + "/api/assets",
-        params={"include_tags": f"unit-tests,{scope}", "tags_any": ""},
-        timeout=120,
-    )
-    b2 = r2.json()
-    assert r2.status_code == 200, b2
-    assert {x["name"] for x in b2["assets"]} == expected
-
-    # An empty tags_all next to include_tags is not a mixed-spelling conflict.
-    r3 = http.get(
-        api_base + "/api/assets",
-        params={"include_tags": f"unit-tests,{scope}", "tags_all": ""},
-        timeout=120,
-    )
-    b3 = r3.json()
-    assert r3.status_code == 200, b3
-    assert {x["name"] for x in b3["assets"]} == expected
-
-
-def test_list_assets_old_names_match_new_names(http, api_base, asset_factory, make_asset_bytes):
-    scope = f"lf-alias-{uuid.uuid4().hex[:6]}"
-    t = ["models", "model_type:checkpoints", "unit-tests", scope]
-    alpha, beta = f"{scope}-alpha", f"{scope}-beta"
-    asset_factory("al_a.safetensors", [*t, alpha], {}, make_asset_bytes("al_a"))
-    asset_factory("al_b.safetensors", [*t, beta], {}, make_asset_bytes("al_b"))
-
-    def names_for(params: dict) -> tuple[list, int]:
-        r = http.get(api_base + "/api/assets", params={**params, "sort": "name", "order": "asc"}, timeout=120)
-        body = r.json()
-        assert r.status_code == 200, body
-        return [x["name"] for x in body["assets"]], body["total"]
-
-    # include_tags ≡ tags_all
-    old_names, old_total = names_for({"include_tags": f"unit-tests,{scope}"})
-    new_names, new_total = names_for({"tags_all": f"unit-tests,{scope}"})
-    assert old_names == new_names
-    assert old_total == new_total
-
-    # exclude_tags ≡ tags_none (and old/new spellings mix across slots)
-    old_names, old_total = names_for({"include_tags": f"unit-tests,{scope}", "exclude_tags": alpha})
-    new_names, new_total = names_for({"tags_all": f"unit-tests,{scope}", "tags_none": alpha})
-    mixed_names, mixed_total = names_for({"include_tags": f"unit-tests,{scope}", "tags_none": alpha})
-    assert old_names == new_names == mixed_names == ["al_b.safetensors"]
-    assert old_total == new_total == mixed_total == 1
-
-
-@pytest.mark.parametrize(
-    "params,expected_parameters",
-    [
-        ({"include_tags": "mx-x", "tags_all": "mx-y"}, ["include_tags", "tags_all"]),
-        ({"exclude_tags": "mx-x", "tags_none": "mx-y"}, ["exclude_tags", "tags_none"]),
-    ],
-    ids=["include_tags_with_tags_all", "exclude_tags_with_tags_none"],
-)
-def test_list_assets_mixed_tag_spellings_rejected(http, api_base, params, expected_parameters):
-    r = http.get(api_base + "/api/assets", params=params, timeout=120)
-    body = r.json()
-    assert r.status_code == 400, body
-    assert body["error"]["code"] == "INVALID_TAG_FILTER"
-    assert body["error"]["details"]["parameters"] == expected_parameters
-
-
-@pytest.mark.parametrize(
-    "params,conflicting,parameters",
-    [
-        (
-            {"tags_all": "cf-x", "tags_none": "cf-x"},
-            ["cf-x"],
-            ["tags_all", "tags_none"],
-        ),
-        (
-            {"include_tags": "cf-x", "tags_none": "cf-x"},
-            ["cf-x"],
-            ["include_tags", "tags_none"],
-        ),
-        (
-            {"tags_all": "cf-a,cf-b", "tags_none": "cf-b,cf-c"},
-            ["cf-b"],
-            ["tags_all", "tags_none"],
-        ),
-    ],
-    ids=["new_names", "include_tags_remapped", "partial_overlap"],
-)
-def test_list_assets_all_none_conflict_rejected(http, api_base, params, conflicting, parameters):
-    r = http.get(api_base + "/api/assets", params=params, timeout=120)
-    body = r.json()
-    assert r.status_code == 400, body
-    assert body["error"]["code"] == "INVALID_TAG_FILTER"
-    assert body["error"]["details"]["conflicting_tags"] == conflicting
-    assert body["error"]["details"]["parameters"] == parameters
-
-
-def test_list_assets_any_none_overlap_accepted(http, api_base, asset_factory, make_asset_bytes):
-    scope = f"lf-deadterm-{uuid.uuid4().hex[:6]}"
-    t = ["models", "model_type:checkpoints", "unit-tests", scope]
-    alpha, beta = f"{scope}-alpha", f"{scope}-beta"
-    x = asset_factory("dt_x.safetensors", [*t, alpha], {}, make_asset_bytes("dt_x"))
-    y = asset_factory("dt_y.safetensors", [*t, beta], {}, make_asset_bytes("dt_y"))
-
-    # alpha is a dead term (in both tags_any and tags_none) but the query is valid.
-    r = http.get(
-        api_base + "/api/assets",
-        params={"tags_any": f"{alpha},{beta}", "tags_none": alpha, "limit": "50"},
-        timeout=120,
-    )
-    body = r.json()
-    assert r.status_code == 200, body
-    names = [a["name"] for a in body["assets"]]
-    assert y["name"] in names
-    assert x["name"] not in names
-
-
-def test_list_assets_legacy_include_exclude_conflict_still_200(http, api_base, asset_factory, make_asset_bytes):
-    scope = f"lf-legacy-{uuid.uuid4().hex[:6]}"
-    t = ["models", "model_type:checkpoints", "unit-tests", scope]
-    asset_factory("lg_a.safetensors", t, {}, make_asset_bytes("lg_a"))
-
-    # Old names only: the self-contradictory query stays an empty 200, never a 400.
-    r = http.get(
-        api_base + "/api/assets",
-        params={"include_tags": scope, "exclude_tags": scope},
-        timeout=120,
-    )
-    body = r.json()
-    assert r.status_code == 200, body
-    assert body["assets"] == []
-
-
-def test_tags_refine_new_tag_filters(http, api_base, asset_factory, make_asset_bytes):
-    scope = f"rf-{uuid.uuid4().hex[:6]}"
-    t = ["models", "model_type:checkpoints", "unit-tests", scope]
-    alpha, beta = f"{scope}-alpha", f"{scope}-beta"
-    asset_factory("rf_a.safetensors", [*t, alpha], {}, make_asset_bytes("rf_a"))
-    asset_factory("rf_b.safetensors", [*t, beta], {}, make_asset_bytes("rf_b"))
-
-    r = http.get(
-        api_base + "/api/assets/tags/refine",
-        params={"tags_any": f"{alpha},{beta}", "tags_none": alpha},
-        timeout=120,
-    )
-    body = r.json()
-    assert r.status_code == 200, body
-    counts = body["tag_counts"]
-    assert counts.get(beta) == 1
-    assert alpha not in counts
-
-    r2 = http.get(
-        api_base + "/api/assets/tags/refine",
-        params={"tags_all": "rf-x", "tags_none": "rf-x"},
-        timeout=120,
-    )
-    body2 = r2.json()
-    assert r2.status_code == 400, body2
-    assert body2["error"]["code"] == "INVALID_TAG_FILTER"
-    assert body2["error"]["details"]["conflicting_tags"] == ["rf-x"]
-
-
-def test_list_assets_cross_slot_old_new_combinations(http, api_base, asset_factory, make_asset_bytes):
-    """Old and new spellings of *different* slots combine freely; only
-    same-slot mixing is rejected."""
-    scope = f"lf-cross-{uuid.uuid4().hex[:6]}"
-    t = ["models", "model_type:checkpoints", "unit-tests", scope]
-    alpha, beta = f"{scope}-alpha", f"{scope}-beta"
-    a = asset_factory("cs_a.safetensors", [*t, alpha], {}, make_asset_bytes("cs_a"))
-    b = asset_factory("cs_b.safetensors", [*t, beta], {}, make_asset_bytes("cs_b"))
-
-    def names_for(params: dict) -> set:
-        r = http.get(api_base + "/api/assets", params=params, timeout=120)
-        body = r.json()
-        assert r.status_code == 200, body
-        return {x["name"] for x in body["assets"]}
-
-    assert names_for(
-        {"include_tags": f"unit-tests,{scope}", "tags_any": alpha}
-    ) == {a["name"]}
-    assert names_for(
-        {"tags_all": f"unit-tests,{scope}", "exclude_tags": alpha}
-    ) == {b["name"]}
-    assert names_for(
-        {"tags_any": f"{alpha},{beta}", "exclude_tags": alpha}
-    ) == {b["name"]}
-
-
-def test_list_assets_repeated_query_keys_concatenate(http, api_base, asset_factory, make_asset_bytes):
-    """Repeated occurrences of a tag param concatenate before the CSV split
-    (Core-local behavior, not a cross-platform guarantee)."""
-    scope = f"lf-repeat-{uuid.uuid4().hex[:6]}"
-    t = ["models", "model_type:checkpoints", "unit-tests", scope]
-    alpha, beta = f"{scope}-alpha", f"{scope}-beta"
-    a = asset_factory("rp_a.safetensors", [*t, alpha], {}, make_asset_bytes("rp_a"))
-    b = asset_factory("rp_b.safetensors", [*t, beta], {}, make_asset_bytes("rp_b"))
-
-    # requests encodes a list value as repeated keys: tags_any=<alpha>&tags_any=<beta>
-    r = http.get(
-        api_base + "/api/assets",
-        params={"tags_any": [alpha, beta], "limit": "50"},
-        timeout=120,
-    )
-    body = r.json()
-    assert r.status_code == 200, body
-    names = {x["name"] for x in body["assets"]}
-    assert {a["name"], b["name"]} <= names
-
-
-def test_list_assets_tags_any_cursor_pagination_consistent(http, api_base, asset_factory, make_asset_bytes):
-    scope = f"lf-anypage-{uuid.uuid4().hex[:6]}"
-    t = ["models", "model_type:checkpoints", "unit-tests", scope]
-    alpha = f"{scope}-alpha"
-    expected = set()
-    for i in range(3):
-        made = asset_factory(f"pg_{i}.safetensors", [*t, alpha], {}, make_asset_bytes(f"pg_{i}"))
-        expected.add(made["name"])
-
-    r1 = http.get(
-        api_base + "/api/assets",
-        params={"tags_any": alpha, "limit": "2", "sort": "name", "order": "asc"},
-        timeout=120,
-    )
-    b1 = r1.json()
-    assert r1.status_code == 200, b1
-    assert b1["total"] == 3
-    assert b1["has_more"] is True
-    assert b1.get("next_cursor"), "expected a keyset cursor on the first page"
-
-    r2 = http.get(
-        api_base + "/api/assets",
-        params={
-            "tags_any": alpha,
-            "limit": "2",
-            "sort": "name",
-            "order": "asc",
-            "after": b1["next_cursor"],
-        },
-        timeout=120,
-    )
-    b2 = r2.json()
-    assert r2.status_code == 200, b2
-    assert b2["has_more"] is False
-
-    page1 = {x["name"] for x in b1["assets"]}
-    page2 = {x["name"] for x in b2["assets"]}
-    assert not page1 & page2, "cursor pages must not overlap"
-    assert page1 | page2 == expected
-
-
-def test_tags_refine_mixed_spellings_rejected_and_legacy_conflict_kept(http, api_base):
-    r = http.get(
-        api_base + "/api/assets/tags/refine",
-        params={"include_tags": "rfmx-x", "tags_all": "rfmx-y"},
-        timeout=120,
-    )
-    body = r.json()
-    assert r.status_code == 400, body
-    assert body["error"]["code"] == "INVALID_TAG_FILTER"
-    assert body["error"]["details"]["parameters"] == ["include_tags", "tags_all"]
-
-    # Old names only: the refine route keeps legacy behaviour too.
-    r2 = http.get(
-        api_base + "/api/assets/tags/refine",
-        params={"include_tags": "rfmx-z", "exclude_tags": "rfmx-z"},
-        timeout=120,
-    )
-    body2 = r2.json()
-    assert r2.status_code == 200, body2
-    assert body2["tag_counts"] == {}
-
-
-def test_list_assets_tag_values_case_sensitive(http, api_base, asset_factory, make_asset_bytes):
-    """Case-distinct tags are distinct; the all/none conflict check is byte-exact."""
-    scope = f"lf-case-{uuid.uuid4().hex[:6]}"
-    t = ["models", "model_type:checkpoints", "unit-tests", scope]
-    upper, lower = f"{scope}-ALPHA", f"{scope}-alpha"
-    a = asset_factory("cx_a.safetensors", [*t, upper], {}, make_asset_bytes("cx_a"))
-    b = asset_factory("cx_b.safetensors", [*t, lower], {}, make_asset_bytes("cx_b"))
-
-    def names_for(params: dict) -> set:
-        r = http.get(api_base + "/api/assets", params=params, timeout=120)
-        body = r.json()
-        assert r.status_code == 200, body
-        return {x["name"] for x in body["assets"]}
-
-    assert names_for({"tags_all": f"unit-tests,{scope},{upper}"}) == {a["name"]}
-    assert names_for({"tags_any": lower, "limit": "50"}) == {b["name"]}
-    # Case-distinct all/none pair is NOT a conflict — byte-exact comparison.
-    assert names_for({"tags_all": f"unit-tests,{scope},{upper}", "tags_none": lower}) == {a["name"]}
-
-
-def test_tag_list_cap_applies_to_all_spellings(http, api_base):
-    """The cap covers the legacy spellings too."""
-    big = ",".join(f"cap-{i}" for i in range(101))
-    for param in ("tags_any", "include_tags"):
-        r = http.get(api_base + "/api/assets", params={param: big}, timeout=120)
-        body = r.json()
-        assert r.status_code == 400, body
-        assert body["error"]["code"] == "INVALID_TAG_FILTER"
-        assert body["error"]["details"]["parameter"] == param
-        assert body["error"]["details"]["max"] == 100
-
-    exact = ",".join(f"cap-{i}" for i in range(100))
-    r = http.get(api_base + "/api/assets", params={"tags_any": exact}, timeout=120)
-    assert r.status_code == 200, r.json()
-
-    # The cap counts normalized (deduped) tags, not raw CSV items.
-    dups = ",".join("cap-dup" for _ in range(150))
-    r = http.get(api_base + "/api/assets", params={"tags_any": dups}, timeout=120)
-    assert r.status_code == 200, r.json()
-
-
-def test_resolve_tag_filters_no_deprecation_warning():
-    """The deprecated-field warning is for API clients; the server's own remap
-    shim must not fire it on every request."""
-    for q in (
-        schemas_in.ListAssetsQuery(tags_all="a", tags_none="b"),
-        schemas_in.TagsRefineQuery(tags_any="c"),
-    ):
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", DeprecationWarning)
-            assets_routes._resolve_tag_filters(q)
-
-
-def test_tag_filter_alias_fields_marked_deprecated():
-    for model in (schemas_in.ListAssetsQuery, schemas_in.TagsRefineQuery):
-        props = model.model_json_schema()["properties"]
-        for field in ("include_tags", "exclude_tags"):
-            assert props[field].get("deprecated") is True, (model.__name__, field)
-        for field in ("tags_all", "tags_any", "tags_none"):
-            assert "deprecated" not in props[field], (model.__name__, field)

--- a/tests-unit/execution_test/test_enrich_output.py
+++ b/tests-unit/execution_test/test_enrich_output.py
@@ -1,205 +1,335 @@
-"""Tests for enrich_output_with_assets in comfy_execution/asset_enrichment.py."""
+import copy
 import os
+import sys
+import tempfile
 import types
-import unittest
+from collections import namedtuple
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
+_CacheEntry = namedtuple("_CacheEntry", ["ui", "outputs"])
 
-def _make_args(enable_assets: bool):
-    a = types.SimpleNamespace()
-    a.enable_assets = enable_assets
-    return a
+_BASE = os.path.join(tempfile.gettempdir(), "asset-enrichment-test-base")
 
 
-def _make_register_result(ref_id="ref-id-2"):
-    result = MagicMock()
-    result.ref.id = ref_id
-    return result
+class _FakeAssetDB:
+
+    def __init__(self) -> None:
+        self.live_id_by_path: dict[str, str] = {}
+        self.missing: list[str] = []
+        self.deliveries: list[tuple[str, str, str | None]] = []
+        self._counter = 0
+
+    def _new_id(self) -> str:
+        self._counter += 1
+        return f"asset-{self._counter}"
+
+    def register_executed(self, abs_path: str, job_id: str | None = None):
+        old = self.live_id_by_path.get(abs_path)
+        if old is not None:
+            self.missing.append(old)
+        new_id = self._new_id()
+        self.live_id_by_path[abs_path] = new_id
+        self.deliveries.append((new_id, abs_path, job_id))
+        return types.SimpleNamespace(
+            id=new_id,
+            content_id=f"content-{new_id}",
+            job_id=job_id,
+            name=os.path.basename(abs_path),
+        )
+
+    def register_cached(self, abs_path: str, job_id: str | None = None):
+        if abs_path not in self.live_id_by_path:
+            return None
+        new_id = self._new_id()
+        self.deliveries.append((new_id, abs_path, job_id))
+        return types.SimpleNamespace(
+            id=new_id,
+            content_id=f"content-{self.live_id_by_path[abs_path]}",
+            job_id=job_id,
+            name=os.path.basename(abs_path),
+        )
 
 
-# Platform-appropriate absolute base. tempfile.gettempdir() returns C:\... on
-# Windows and /tmp on POSIX, so containment via commonpath behaves naturally.
-_DEFAULT_BASE = os.path.join(__import__("tempfile").gettempdir(), "asset-enrichment-test-base")
+class _Server:
+    def __init__(self, client_id: str | None = None) -> None:
+        self.client_id = client_id
+        self.sent: list[tuple] = []
+
+    def send_sync(self, event, payload, client_id):
+        self.sent.append((event, payload, client_id))
 
 
-def _mocked_modules(*, enable_assets=True, register_file_in_place=None, directory=_DEFAULT_BASE):
-    return {
-        "comfy.cli_args": MagicMock(args=_make_args(enable_assets)),
-        "folder_paths": MagicMock(get_directory_by_type=MagicMock(return_value=directory)),
-        "app.assets.services.ingest": MagicMock(
-            register_file_in_place=register_file_in_place or MagicMock(return_value=_make_register_result()),
-            DependencyMissingError=type("DependencyMissingError", (Exception,), {}),
+@contextmanager
+def _patched(
+    fake: _FakeAssetDB,
+    *,
+    enable_assets: bool = True,
+    directory: str | None = _BASE,
+    file_exists: bool = True,
+    executed_side_effect=None,
+    cached_side_effect=None,
+):
+    reg_exec = MagicMock(side_effect=executed_side_effect or fake.register_executed)
+    reg_cached = MagicMock(side_effect=cached_side_effect or fake.register_cached)
+    modules = {
+        "comfy.cli_args": MagicMock(
+            args=types.SimpleNamespace(enable_assets=enable_assets)
         ),
+        "folder_paths": MagicMock(
+            get_directory_by_type=MagicMock(return_value=directory)
+        ),
+        "app.assets.services.ingest": MagicMock(
+            register_executed_output=reg_exec,
+            register_cached_output=reg_cached,
+        ),
+    }
+    with patch.dict(sys.modules, modules), patch(
+        "os.path.isfile", return_value=file_exists
+    ):
+        import comfy_execution.asset_enrichment as module
+
+        yield module, reg_exec, reg_cached
+
+
+def _output(filename: str, *, subfolder: str = "", type_: str = "output") -> dict:
+    return {"images": [{"filename": filename, "subfolder": subfolder, "type": type_}]}
+
+
+def _wrapper(filename: str, node_id: str = "1") -> dict:
+    return {
+        "meta": {
+            "node_id": node_id,
+            "display_node": node_id,
+            "parent_node": None,
+            "real_node_id": node_id,
+        },
+        "output": _output(filename),
     }
 
 
-def _call(output_ui, *, enable_assets=True, file_exists=True, register_result=None, directory=_DEFAULT_BASE):
-    register_mock = MagicMock(return_value=register_result or _make_register_result())
-    mocked = _mocked_modules(
-        enable_assets=enable_assets,
-        register_file_in_place=register_mock,
-        directory=directory,
+def _find_ids(value) -> list:
+    found: list = []
+    if isinstance(value, dict):
+        for key, sub in value.items():
+            if key == "id":
+                found.append(sub)
+            found.extend(_find_ids(sub))
+    elif isinstance(value, list):
+        for item in value:
+            found.extend(_find_ids(item))
+    return found
+
+
+# REQUIRED test names (invoked verbatim downstream). Do not rename.
+def test_executed_new_path_gets_fresh_id() -> None:
+    fake = _FakeAssetDB()
+    output_ui = _output("new.png")
+
+    with _patched(fake) as (module, reg_exec, _):
+        enriched = module.register_executed_outputs(output_ui, "job-1")
+
+    assert enriched["images"][0]["id"] == "asset-1"
+    assert "id" not in output_ui["images"][0]
+    reg_exec.assert_called_once()
+    _, kwargs = reg_exec.call_args
+    assert kwargs.get("job_id") == "job-1"
+    assert fake.deliveries == [("asset-1", os.path.join(_BASE, "new.png"), "job-1")]
+
+
+def test_executed_over_existing_path_gets_new_id_and_marks_old_missing() -> None:
+    fake = _FakeAssetDB()
+
+    first_output = _output("same.png")
+    with _patched(fake) as (module, _, _c):
+        first = module.register_executed_outputs(first_output, "job-1")
+    old_id = first["images"][0]["id"]
+
+    second_output = _output("same.png")
+    with _patched(fake) as (module, _, _c):
+        second = module.register_executed_outputs(second_output, "job-2")
+    new_id = second["images"][0]["id"]
+
+    assert new_id != old_id
+    assert old_id in fake.missing
+    assert fake.live_id_by_path[os.path.join(_BASE, "same.png")] == new_id
+
+
+def test_cached_replay_creates_delivery_with_current_job_id() -> None:
+    fake = _FakeAssetDB()
+
+    with _patched(fake) as (module, _, _c):
+        module.register_executed_outputs(_output("replay.png"), "seed-job")
+        enriched = module.register_cached_outputs(_wrapper("replay.png"), "replay-job")
+
+    replay_id = enriched["output"]["images"][0]["id"]
+    assert (replay_id, os.path.join(_BASE, "replay.png"), "replay-job") in fake.deliveries
+    assert replay_id != "asset-1"
+
+
+def test_cached_registration_happens_without_client() -> None:
+    fake = _FakeAssetDB()
+    server = _Server(client_id=None)
+    ui_outputs: dict = {}
+
+    with _patched(fake) as (module, _, _c):
+        module.register_executed_outputs(_output("noclient.png"), "seed-job")
+        module.emit_cached_output(
+            server, "node-1", "node-1", _CacheEntry(ui=_wrapper("noclient.png"), outputs=[]),
+            "job-x", ui_outputs,
+        )
+
+    assert any(job == "job-x" for (_id, _path, job) in fake.deliveries)
+    assert "node-1" in ui_outputs
+    assert ui_outputs["node-1"]["output"]["images"][0]["id"] is not None
+    assert server.sent == []
+
+
+def test_cache_entry_contains_no_asset_ids() -> None:
+    fake = _FakeAssetDB()
+    output_ui = _output("keep.png")
+
+    with _patched(fake) as (module, _, _c):
+        enriched = module.register_executed_outputs(output_ui, "job")
+
+    cache_entry = _CacheEntry(
+        ui={"meta": {"node_id": "1"}, "output": output_ui}, outputs=[]
     )
-
-    # Only os.path.isfile is patched — abspath/join must run natively so the
-    # containment check sees real platform paths.
-    with patch.dict("sys.modules", mocked), \
-         patch("os.path.isfile", return_value=file_exists):
-        import importlib
-        import comfy_execution.asset_enrichment as mod
-        importlib.reload(mod)
-        return mod.enrich_output_with_assets(output_ui)
+    assert _find_ids(cache_entry.ui) == []
+    assert _find_ids(enriched) == ["asset-1"]
 
 
-class TestEnrichOutputWithAssets(unittest.TestCase):
+def test_cached_ui_object_unmodified_after_emission() -> None:
+    fake = _FakeAssetDB()
+    server = _Server(client_id="client-1")
+    cached = _CacheEntry(ui=_wrapper("immut.png"), outputs=[])
+    snapshot = copy.deepcopy(cached.ui)
 
-    def test_disabled_returns_unchanged(self):
-        output = {"images": [{"filename": "a.png", "subfolder": "", "type": "output"}]}
-        result = _call(output, enable_assets=False)
-        self.assertNotIn("id", result["images"][0])
+    with _patched(fake) as (module, _, _c):
+        module.register_executed_outputs(_output("immut.png"), "seed-job")
+        module.emit_cached_output(
+            server, "1", "1", cached, "prompt-1", {}
+        )
 
-    def test_non_list_value_passed_through(self):
-        output = {"text": "hello"}
-        result = _call(output)
-        self.assertEqual(result["text"], "hello")
-
-    def test_entry_without_filename_unchanged(self):
-        output = {"latent": [{"subfolder": "", "type": "output"}]}
-        result = _call(output)
-        self.assertNotIn("id", result["latent"][0])
-
-    def test_entry_without_type_unchanged(self):
-        output = {"data": [{"filename": "a.png", "subfolder": ""}]}
-        result = _call(output)
-        self.assertNotIn("id", result["data"][0])
-
-    def test_file_not_on_disk_unchanged(self):
-        output = {"images": [{"filename": "missing.png", "subfolder": "", "type": "output"}]}
-        result = _call(output, file_exists=False)
-        self.assertNotIn("id", result["images"][0])
-
-    def test_unknown_type_returns_none_directory_unchanged(self):
-        output = {"images": [{"filename": "a.png", "subfolder": "", "type": "unknown"}]}
-        result = _call(output, directory=None)
-        self.assertNotIn("id", result["images"][0])
-
-    def test_register_injects_only_id(self):
-        reg = _make_register_result(ref_id="inline-ref")
-        output = {"images": [{"filename": "new.png", "subfolder": "", "type": "output"}]}
-        result = _call(output, register_result=reg)
-        img = result["images"][0]
-        self.assertEqual(img["id"], "inline-ref")
-        # Only id is injected — no asset_hash, name, preview_url, size
-        self.assertNotIn("asset_hash", img)
-        self.assertNotIn("name", img)
-        self.assertNotIn("preview_url", img)
-        self.assertNotIn("size", img)
-
-    def test_register_called_per_entry(self):
-        register_mock = MagicMock(return_value=_make_register_result())
-        mocked = _mocked_modules(register_file_in_place=register_mock)
-        output = {
-            "images": [
-                {"filename": "a.png", "subfolder": "", "type": "output"},
-                {"filename": "b.png", "subfolder": "", "type": "output"},
-            ]
-        }
-
-        with patch.dict("sys.modules", mocked), \
-             patch("os.path.isfile", return_value=True):
-            import importlib
-            import comfy_execution.asset_enrichment as mod
-            importlib.reload(mod)
-            mod.enrich_output_with_assets(output)
-
-        self.assertEqual(register_mock.call_count, 2)
-
-    def test_original_entry_not_mutated(self):
-        orig = {"filename": "a.png", "subfolder": "", "type": "output"}
-        output = {"images": [orig]}
-        _call(output)
-        self.assertNotIn("id", orig)
-
-    def test_enrichment_error_does_not_block_sibling_entries(self):
-        call_count = [0]
-        good_reg = _make_register_result(ref_id="good-ref")
-
-        def register_side_effect(abs_path, name, tags):
-            call_count[0] += 1
-            if call_count[0] == 1:
-                raise RuntimeError("boom")
-            return good_reg
-
-        mocked = _mocked_modules(register_file_in_place=register_side_effect)
-
-        output = {
-            "images": [
-                {"filename": "bad.png", "subfolder": "", "type": "output"},
-                {"filename": "good.png", "subfolder": "", "type": "output"},
-            ]
-        }
-
-        with patch.dict("sys.modules", mocked), \
-             patch("os.path.isfile", return_value=True):
-            import importlib
-            import comfy_execution.asset_enrichment as mod
-            importlib.reload(mod)
-            result = mod.enrich_output_with_assets(output)
-
-        imgs = result["images"]
-        self.assertNotIn("id", imgs[0])
-        self.assertEqual(imgs[1]["id"], "good-ref")
-
-    def test_multiple_output_keys_all_enriched(self):
-        output = {
-            "images": [{"filename": "a.png", "subfolder": "", "type": "output"}],
-            "videos": [{"filename": "b.mp4", "subfolder": "", "type": "output"}],
-        }
-        result = _call(output)
-        self.assertIn("id", result["images"][0])
-        self.assertIn("id", result["videos"][0])
-
-    def test_none_entry_in_list_unchanged(self):
-        output = {"images": [None, {"filename": "a.png", "subfolder": "", "type": "output"}]}
-        result = _call(output)
-        self.assertIsNone(result["images"][0])
-        self.assertIn("id", result["images"][1])
-
-    def test_path_traversal_subfolder_skipped(self):
-        register_mock = MagicMock(return_value=_make_register_result())
-        mocked = _mocked_modules(register_file_in_place=register_mock)
-
-        output = {"images": [{"filename": "passwd", "subfolder": "../../etc", "type": "output"}]}
-
-        # Do NOT patch os.path.abspath — real resolution is required for the containment check.
-        with patch.dict("sys.modules", mocked), \
-             patch("os.path.isfile", return_value=True):
-            import importlib
-            import comfy_execution.asset_enrichment as mod
-            importlib.reload(mod)
-            result = mod.enrich_output_with_assets(output)
-
-        self.assertNotIn("id", result["images"][0])
-        register_mock.assert_not_called()
-
-    def test_absolute_filename_skipped(self):
-        register_mock = MagicMock(return_value=_make_register_result())
-        mocked = _mocked_modules(register_file_in_place=register_mock)
-
-        # Absolute filename — os.path.join discards earlier components when a later one is absolute.
-        absolute_filename = os.path.abspath(os.sep + "etc" + os.sep + "passwd")
-        output = {"images": [{"filename": absolute_filename, "subfolder": "", "type": "output"}]}
-
-        with patch.dict("sys.modules", mocked), \
-             patch("os.path.isfile", return_value=True):
-            import importlib
-            import comfy_execution.asset_enrichment as mod
-            importlib.reload(mod)
-            result = mod.enrich_output_with_assets(output)
-
-        self.assertNotIn("id", result["images"][0])
-        register_mock.assert_not_called()
+    assert cached.ui == snapshot
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_double_emission_yields_single_delivery() -> None:
+    fake = _FakeAssetDB()
+    server = _Server(client_id="client-1")
+    ui_outputs: dict = {}
+    cached = _CacheEntry(ui=_wrapper("dbl.png"), outputs=[])
+
+    with _patched(fake) as (module, _, _c):
+        module.register_executed_outputs(_output("dbl.png"), "seed-job")
+        module.emit_cached_output(server, "1", "1", cached, "prompt-1", ui_outputs)
+        module.emit_cached_output(server, "1", "1", cached, "prompt-1", ui_outputs)
+
+    cached_deliveries = [d for d in fake.deliveries if d[2] == "prompt-1"]
+    assert len(cached_deliveries) == 1
+
+
+def test_executed_disabled_returns_unenriched_copy() -> None:
+    fake = _FakeAssetDB()
+    output_ui = _output("a.png")
+
+    with _patched(fake, enable_assets=False) as (module, reg_exec, _):
+        enriched = module.register_executed_outputs(output_ui, "job")
+
+    assert enriched is not output_ui
+    assert "id" not in enriched["images"][0]
+    reg_exec.assert_not_called()
+
+
+def test_executed_missing_file_is_skipped() -> None:
+    fake = _FakeAssetDB()
+
+    with _patched(fake, file_exists=False) as (module, reg_exec, _):
+        enriched = module.register_executed_outputs(_output("gone.png"), "job")
+
+    assert "id" not in enriched["images"][0]
+    reg_exec.assert_not_called()
+
+
+def test_executed_path_escape_is_skipped() -> None:
+    fake = _FakeAssetDB()
+    output_ui = {"images": [{"filename": "passwd", "subfolder": "../../etc", "type": "output"}]}
+
+    with _patched(fake) as (module, reg_exec, _):
+        enriched = module.register_executed_outputs(output_ui, "job")
+
+    assert "id" not in enriched["images"][0]
+    reg_exec.assert_not_called()
+
+
+def test_executed_non_list_value_passes_through() -> None:
+    fake = _FakeAssetDB()
+
+    with _patched(fake) as (module, _, _c):
+        enriched = module.register_executed_outputs({"text": "hello"}, "job")
+
+    assert enriched["text"] == "hello"
+
+
+def test_executed_registration_failure_never_raises() -> None:
+    fake = _FakeAssetDB()
+
+    def boom(_abs_path, job_id=None):
+        raise RuntimeError("registration blew up")
+
+    with _patched(fake, executed_side_effect=boom) as (module, _, _c):
+        enriched = module.register_executed_outputs(_output("boom.png"), "job")
+
+    assert "id" not in enriched["images"][0]
+
+
+def test_cached_strips_legacy_ids_before_replay() -> None:
+    fake = _FakeAssetDB()
+    wrapper = _wrapper("legacy.png")
+    wrapper["output"]["images"][0]["id"] = "stale-id"
+
+    with _patched(fake) as (module, _, _c):
+        module.register_executed_outputs(_output("legacy.png"), "seed-job")
+        enriched = module.register_cached_outputs(wrapper, "replay-job")
+
+    assert enriched["output"]["images"][0]["id"] != "stale-id"
+    assert wrapper["output"]["images"][0]["id"] == "stale-id"
+
+
+def test_cached_none_wrapper_returns_none() -> None:
+    fake = _FakeAssetDB()
+
+    with _patched(fake) as (module, _, reg_cached):
+        result = module.register_cached_outputs(None, "job")
+
+    assert result is None
+    reg_cached.assert_not_called()
+
+
+def test_cached_missing_live_content_is_nonevent() -> None:
+    fake = _FakeAssetDB()
+
+    with _patched(fake) as (module, _, _c):
+        enriched = module.register_cached_outputs(_wrapper("orphan.png"), "job")
+
+    assert "id" not in enriched["output"]["images"][0]
+    assert fake.deliveries == []
+
+
+def test_emit_cached_sends_enriched_output_to_client() -> None:
+    fake = _FakeAssetDB()
+    server = _Server(client_id="client-1")
+    ui_outputs: dict = {}
+
+    with _patched(fake) as (module, _, _c):
+        module.register_executed_outputs(_output("send.png"), "seed-job")
+        module.emit_cached_output(
+            server, "1", "1", _CacheEntry(ui=_wrapper("send.png"), outputs=[]),
+            "prompt-1", ui_outputs,
+        )
+
+    assert len(server.sent) == 1
+    event, payload, client_id = server.sent[0]
+    assert event == "executed"
+    assert client_id == "client-1"
+    assert payload["output"]["images"][0]["id"] is not None

--- a/tests-unit/folder_paths_test/filter_by_content_types_test.py
+++ b/tests-unit/folder_paths_test/filter_by_content_types_test.py
@@ -5,12 +5,14 @@ from folder_paths import filter_files_content_types, extension_mimetypes_cache
 from unittest.mock import patch
 
 
+
+
 @pytest.fixture(scope="module")
 def file_extensions():
     return {
         'image': ['gif', 'heif', 'ico', 'jpeg', 'jpg', 'png', 'pnm', 'ppm', 'svg', 'tiff', 'webp', 'xbm', 'xpm'],
         'audio': ['aif', 'aifc', 'aiff', 'au', 'flac', 'm4a', 'mp2', 'mp3', 'ogg', 'snd', 'wav'],
-        'video': ['avi', 'm2v', 'm4v', 'mkv', 'mov', 'mp4', 'mpeg', 'mpg', 'ogv', 'qt', 'webm', 'wmv'],
+        'video': ['avi', 'm4v', 'mkv', 'mov', 'mp4', 'mpeg', 'mpg', 'ogv', 'qt', 'webm', 'wmv'],
         'model': ['gltf', 'glb', 'obj', 'fbx', 'stl']
     }
 

--- a/tests-unit/security_test/test_ghsa_779p_06_inline_svg_image_dest.py
+++ b/tests-unit/security_test/test_ghsa_779p_06_inline_svg_image_dest.py
@@ -119,7 +119,7 @@ def asset_app(monkeypatch, tmp_path):
         monkeypatch.setattr(
             asset_routes,
             "resolve_asset_for_download",
-            lambda reference_id, owner_id: DownloadResolutionResult(
+            lambda reference_id: DownloadResolutionResult(
                 abs_path=str(svg),
                 content_type=stored_mime_type,
                 download_name="thumb.svg",

--- a/tests/execution/testing_nodes/testing-pack/specific_tests.py
+++ b/tests/execution/testing_nodes/testing-pack/specific_tests.py
@@ -482,6 +482,67 @@ class TestOutputNodeWithSocketOutput:
         result = image * value
         return (result,)
 
+
+class TestExecutedNodeIdsChild:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "value": ("STRING", {"default": "expanded-child"}),
+            },
+        }
+
+    RETURN_TYPES = ()
+    FUNCTION = "emit"
+    CATEGORY = "Testing/Nodes"
+    OUTPUT_NODE = True
+
+    def emit(self, value):
+        return {"ui": {"values": [value]}}
+
+
+class TestExecutedNodeIdsExpander:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "value": ("STRING", {"default": "expanded-child"}),
+            },
+        }
+
+    RETURN_TYPES = ()
+    FUNCTION = "expand"
+    CATEGORY = "Testing/Nodes"
+    OUTPUT_NODE = True
+
+    @classmethod
+    def IS_CHANGED(cls, **kwargs):
+        return float("NaN")
+
+    def expand(self, value):
+        graph = GraphBuilder()
+        graph.node("TestExecutedNodeIdsChild", value=value)
+        return {"result": (), "expand": graph.finalize()}
+
+
+class TestExecutedNodeIdsBlocking:
+    started_event = None
+    release_event = None
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {}}
+
+    RETURN_TYPES = ()
+    FUNCTION = "block"
+    CATEGORY = "Testing/Nodes"
+    OUTPUT_NODE = True
+
+    async def block(self):
+        self.started_event.set()
+        await self.release_event.wait()
+        return {"ui": {"completed": [True]}}
+
 TEST_NODE_CLASS_MAPPINGS = {
     "TestLazyMixImages": TestLazyMixImages,
     "TestVariadicAverage": TestVariadicAverage,
@@ -498,6 +559,9 @@ TEST_NODE_CLASS_MAPPINGS = {
     "TestSleep": TestSleep,
     "TestParallelSleep": TestParallelSleep,
     "TestOutputNodeWithSocketOutput": TestOutputNodeWithSocketOutput,
+    "TestExecutedNodeIdsChild": TestExecutedNodeIdsChild,
+    "TestExecutedNodeIdsExpander": TestExecutedNodeIdsExpander,
+    "TestExecutedNodeIdsBlocking": TestExecutedNodeIdsBlocking,
 }
 
 TEST_NODE_DISPLAY_NAME_MAPPINGS = {
@@ -516,4 +580,7 @@ TEST_NODE_DISPLAY_NAME_MAPPINGS = {
     "TestSleep": "Test Sleep",
     "TestParallelSleep": "Test Parallel Sleep",
     "TestOutputNodeWithSocketOutput": "Test Output Node With Socket Output",
+    "TestExecutedNodeIdsChild": "Executed Node IDs Child",
+    "TestExecutedNodeIdsExpander": "Executed Node IDs Expander",
+    "TestExecutedNodeIdsBlocking": "Executed Node IDs Blocking",
 }


### PR DESCRIPTION
Layer 3/4 of the review-and-land stack for `synap5e/feat/asset-record-content-split`, generated by
`review-stack.py`. Full collapse procedure: `~/adocs/review-stack.md`. **Once the
stack starts collapsing, don't rerun `build`/`push` on it** — a rebuild resets every
layer to its original scope from the untouched source branch and discards the collapse.

Once approved, merge this into #15916 (ordinary "Merge" — fast-forward). Once everything above has merged down into this one and it's approved, continue the collapse toward layer 1.

**Rule:** remaining modified test files (incl. conftest.py / helpers)  
**Question for this layer:** Did the edits weaken an existing check?  
**Source tip:** `7007d1858257`

**Stack:**
1. #15915 `code` — Is the logic change right?
2. #15916 `tests-removed` — For each dropped assertion: obsolete by a ruling, or covered by a tests-new test?
3. #15917 `tests-changed` — Did the edits weaken an existing check?
4. #15918 `tests-new` — Is the code layer well covered?

**Files (13, +1043/-1218):**

| | +/- | path |
|---|---|---|
| M | +31/-9 | `tests-unit/assets_test/conftest.py` |
| M | +121/-1 | `tests-unit/assets_test/helpers.py` |
| M | +12/-0 | `tests-unit/assets_test/queries/conftest.py` |
| M | +24/-103 | `tests-unit/assets_test/queries/test_asset_reference_keyset.py` |
| M | +13/-4 | `tests-unit/assets_test/services/conftest.py` |
| M | +26/-0 | `tests-unit/assets_test/services/test_asset_response_loader_path.py` |
| M | +87/-2 | `tests-unit/assets_test/services/test_asset_response_preview_url.py` |
| M | +37/-182 | `tests-unit/assets_test/services/test_tagging.py` |
| M | +301/-725 | `tests-unit/assets_test/test_list_filter.py` |
| M | +320/-190 | `tests-unit/execution_test/test_enrich_output.py` |
| M | +3/-1 | `tests-unit/folder_paths_test/filter_by_content_types_test.py` |
| M | +1/-1 | `tests-unit/security_test/test_ghsa_779p_06_inline_svg_image_dest.py` |
| M | +67/-0 | `tests/execution/testing_nodes/testing-pack/specific_tests.py` |