### PR TITLE
[review-stack 4/4] tests-new — synap5e/feat/asset-record-content-split

### DIFF
--- a/tests-unit/app_test/test_db_init_locking.py
+++ b/tests-unit/app_test/test_db_init_locking.py
@@ -1,0 +1,89 @@
+import os
+import sqlite3
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from filelock import FileLock, Timeout
+
+from app.database import db as db_module
+
+_PRE_HEAD = "0006_add_loader_path"
+
+
+def _make_config(db_path: str) -> Config:
+    root = os.path.join(os.path.dirname(__file__), "../..")
+    cfg = Config(os.path.abspath(os.path.join(root, "alembic.ini")))
+    cfg.set_main_option("script_location", os.path.abspath(os.path.join(root, "alembic_db")))
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    return cfg
+
+
+def _current_revision(db_path: str) -> str:
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
+    assert len(rows) == 1
+    return rows[0][0]
+
+
+@pytest.fixture
+def stale_db(tmp_path, monkeypatch):
+    db_path = str(tmp_path / "comfyui.db")
+    command.upgrade(_make_config(db_path), _PRE_HEAD)
+
+    monkeypatch.setattr(db_module.args, "database_url", f"sqlite:///{db_path}")
+    monkeypatch.setattr(db_module, "Session", None)
+    monkeypatch.setattr(db_module, "_db_lock", None)
+    yield db_path
+    if db_module._db_lock is not None:
+        db_module._db_lock.release(force=True)
+
+
+def test_init_file_db_migrates_when_lock_is_free(stale_db):
+    db_module._init_file_db(db_module.args.database_url)
+
+    assert _current_revision(stale_db) != _PRE_HEAD
+    assert os.path.exists(stale_db + ".bkp")
+
+
+def test_successful_init_keeps_holding_the_lock(stale_db):
+    db_module._init_file_db(db_module.args.database_url)
+
+    contender = FileLock(stale_db + ".lock")
+    with pytest.raises(Timeout):
+        contender.acquire(timeout=0)
+
+
+def test_failed_init_releases_the_lock(stale_db, monkeypatch):
+    def _explode():
+        raise RuntimeError("alembic config exploded")
+
+    monkeypatch.setattr(db_module, "get_alembic_config", _explode)
+
+    with pytest.raises(RuntimeError, match="alembic config exploded"):
+        db_module._init_file_db(db_module.args.database_url)
+
+    contender = FileLock(stale_db + ".lock")
+    try:
+        contender.acquire(timeout=0)
+    except Timeout:
+        pytest.fail(
+            "a failed init stranded the lock; setup_database logs and CONTINUES when assets are "
+            "disabled, so this process would block every other instance for its whole lifetime "
+            "over a database it never opened"
+        )
+    contender.release()
+
+
+def test_held_lock_blocks_before_any_migration_work(stale_db):
+    holder = FileLock(stale_db + ".lock")
+    holder.acquire(timeout=0)
+    try:
+        with pytest.raises(RuntimeError, match="Another ComfyUI process may already be using it"):
+            db_module._init_file_db(db_module.args.database_url)
+
+        assert not os.path.exists(stale_db + ".bkp")
+        assert _current_revision(stale_db) == _PRE_HEAD
+        assert db_module.Session is None
+    finally:
+        holder.release()

--- a/tests-unit/app_test/test_migration_0007.py
+++ b/tests-unit/app_test/test_migration_0007.py
@@ -1,0 +1,215 @@
+import os
+import sqlite3
+
+import pytest
+from alembic import command
+from alembic.config import Config
+
+_BASELINE_0006 = "0006_add_loader_path"
+
+
+def _make_config(db_path: str) -> Config:
+    root = os.path.join(os.path.dirname(__file__), "../..")
+    cfg = Config(os.path.abspath(os.path.join(root, "alembic.ini")))
+    cfg.set_main_option("script_location", os.path.abspath(os.path.join(root, "alembic_db")))
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    return cfg
+
+
+@pytest.fixture
+def db_at_0006(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    cfg = _make_config(db_path)
+    command.upgrade(cfg, _BASELINE_0006)
+    yield cfg, db_path
+
+
+def test_0007_upgrade_from_0006(db_at_0006):
+    cfg, db_path = db_at_0006
+    command.upgrade(cfg, "head")
+    with sqlite3.connect(db_path) as conn:
+        tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert "assets" in tables
+    assert "asset_contents" in tables
+    assert "asset_system_state" in tables
+    assert "asset_references" not in tables
+
+
+def test_0007_schema_has_expected_columns(db_at_0006):
+    cfg, db_path = db_at_0006
+    command.upgrade(cfg, "head")
+    with sqlite3.connect(db_path) as conn:
+        asset_cols = {r[1] for r in conn.execute("PRAGMA table_info(assets)")}
+        content_cols = {r[1] for r in conn.execute("PRAGMA table_info(asset_contents)")}
+    assert {"id", "content_id", "name", "loader_path", "updated_at", "last_access_time"} <= asset_cols
+    assert {"id", "hash", "path", "is_missing", "mtime_ns"} <= content_cols
+
+
+def test_0007_downgrade_restores_0006_schema(db_at_0006):
+    cfg, db_path = db_at_0006
+    command.upgrade(cfg, "head")
+    command.downgrade(cfg, _BASELINE_0006)
+    with sqlite3.connect(db_path) as conn:
+        tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert "asset_references" in tables
+    assert "asset_contents" not in tables
+
+
+def test_0007_invariants_on_migrated_db(db_at_0006):
+    cfg, db_path = db_at_0006
+    command.upgrade(cfg, "head")
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute(
+            "INSERT INTO asset_contents(id, path, is_missing, size_bytes, created_at) "
+            "VALUES ('c1', '/tmp/f1', 0, 0, '2024-01-01')"
+        )
+        conn.execute(
+            "INSERT INTO assets(id, content_id, name, created_at, updated_at) "
+            "VALUES ('a1', 'c1', 'test', '2024-01-01', '2024-01-01')"
+        )
+        conn.commit()
+
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO asset_contents(id, path, is_missing, size_bytes, created_at) "
+                "VALUES ('c2', '/tmp/f1', 0, 0, '2024-01-01')"
+            )
+            conn.commit()
+        conn.rollback()
+
+        conn.execute(
+            "INSERT INTO asset_contents(id, path, is_missing, size_bytes, created_at) "
+            "VALUES ('c3', '/tmp/f1', 1, 0, '2024-01-01')"
+        )
+        conn.commit()
+
+        conn.execute("UPDATE asset_contents SET hash='abc123' WHERE id='c1'")
+        conn.execute(
+            "INSERT INTO asset_contents(id, path, hash, is_missing, size_bytes, created_at) "
+            "VALUES ('c4', '/tmp/f2', 'abc123', 0, 0, '2024-01-01')"
+        )
+        conn.commit()
+
+
+def test_0007_orm_parity(db_at_0006, tmp_path):
+    from sqlalchemy import create_engine, inspect
+
+    import app.assets.database.models as asset_models
+    from app.database.models import Base
+
+    cfg, db_path = db_at_0006
+    command.upgrade(cfg, "head")
+    with sqlite3.connect(db_path) as conn:
+        alembic_tables = {
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name NOT LIKE 'alembic%' AND name NOT LIKE 'sqlite%'"
+            )
+        }
+
+    alembic_engine = create_engine(f"sqlite:///{db_path}")
+    orm_db = str(tmp_path / "orm.db")
+    engine = create_engine(f"sqlite:///{orm_db}")
+    alembic_inspector = inspect(alembic_engine)
+    Base.metadata.create_all(engine)
+    orm_inspector = inspect(engine)
+    orm_tables = set(orm_inspector.get_table_names())
+    assert asset_models.AssetMeta.__tablename__ == "asset_meta"
+
+    alembic_indexes = {
+        (index["name"], tuple(index["column_names"]))
+        for index in alembic_inspector.get_indexes("asset_meta")
+    }
+    orm_indexes = {
+        (index.name, tuple(index.columns.keys()))
+        for index in Base.metadata.tables["asset_meta"].indexes
+    }
+
+    assert alembic_tables == orm_tables, f"Mismatch: alembic={alembic_tables}, orm={orm_tables}"
+    assert alembic_indexes == orm_indexes, f"Mismatch: alembic={alembic_indexes}, orm={orm_indexes}"
+
+
+def test_0007_downgrade_chain_past_0003_succeeds(db_at_0006):
+    cfg, db_path = db_at_0006
+    command.upgrade(cfg, "head")
+    command.downgrade(cfg, "0001_assets")
+    with sqlite3.connect(db_path) as conn:
+        tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert "assets_info" in tables
+    assert "asset_references" not in tables
+    assert "asset_contents" not in tables
+
+
+def test_0007_downgrade_restores_legacy_assets_definition(db_at_0006, tmp_path):
+    from sqlalchemy import create_engine, inspect
+
+    cfg, db_path = db_at_0006
+
+    reference_db = str(tmp_path / "reference_0006.db")
+    reference_cfg = _make_config(reference_db)
+    command.upgrade(reference_cfg, _BASELINE_0006)
+
+    command.upgrade(cfg, "head")
+    command.downgrade(cfg, _BASELINE_0006)
+
+    def _assets_shape(path: str):
+        engine = create_engine(f"sqlite:///{path}")
+        try:
+            inspector = inspect(engine)
+            indexes = {
+                (index["name"], tuple(index["column_names"]), bool(index["unique"]))
+                for index in inspector.get_indexes("assets")
+            }
+            checks = {
+                (check["name"], check["sqltext"])
+                for check in inspector.get_check_constraints("assets")
+            }
+            defaults = {
+                column["name"]: column["default"]
+                for column in inspector.get_columns("assets")
+            }
+            return indexes, checks, defaults
+        finally:
+            engine.dispose()
+
+    restored_indexes, restored_checks, restored_defaults = _assets_shape(db_path)
+    expected_indexes, expected_checks, expected_defaults = _assets_shape(reference_db)
+
+    assert restored_indexes == expected_indexes, (
+        f"index drift: restored={restored_indexes}, expected={expected_indexes}"
+    )
+    assert restored_checks == expected_checks, (
+        f"check drift: restored={restored_checks}, expected={expected_checks}"
+    )
+    assert restored_defaults == expected_defaults, (
+        f"default drift: restored={restored_defaults}, expected={expected_defaults}"
+    )
+
+
+def test_0007_downgrade_restores_0006_asset_references_indexes(db_at_0006, tmp_path):
+    from sqlalchemy import create_engine, inspect
+
+    cfg, db_path = db_at_0006
+
+    reference_db = str(tmp_path / "reference_0006.db")
+    reference_cfg = _make_config(reference_db)
+    command.upgrade(reference_cfg, _BASELINE_0006)
+
+    command.upgrade(cfg, "head")
+    command.downgrade(cfg, _BASELINE_0006)
+
+    def _asset_reference_indexes(path: str) -> set[tuple[str, tuple[str, ...]]]:
+        engine = create_engine(f"sqlite:///{path}")
+        try:
+            return {
+                (index["name"], tuple(index["column_names"]))
+                for index in inspect(engine).get_indexes("asset_references")
+            }
+        finally:
+            engine.dispose()
+
+    restored = _asset_reference_indexes(db_path)
+    expected = _asset_reference_indexes(reference_db)
+    assert restored == expected, f"index drift: restored={restored}, expected={expected}"

--- a/tests-unit/app_test/test_migration_roundtrip.py
+++ b/tests-unit/app_test/test_migration_roundtrip.py
@@ -1,0 +1,56 @@
+
+import os
+import sqlite3
+
+import pytest
+from alembic import command
+from alembic.config import Config
+
+
+def _make_config(db_path: str) -> Config:
+    root = os.path.join(os.path.dirname(__file__), "../..")
+    cfg = Config(os.path.abspath(os.path.join(root, "alembic.ini")))
+    cfg.set_main_option("script_location", os.path.abspath(os.path.join(root, "alembic_db")))
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    return cfg
+
+
+def _user_tables(db_path: str) -> set[str]:
+    conn = sqlite3.connect(db_path)
+    try:
+        return {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name NOT LIKE 'alembic%' AND name NOT LIKE 'sqlite%'"
+            )
+        }
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def db_at_head(tmp_path):
+    db_path = str(tmp_path / "roundtrip.db")
+    cfg = _make_config(db_path)
+    command.upgrade(cfg, "head")
+    yield cfg, db_path
+
+
+def test_downgrade_to_base_empties_the_schema(db_at_head):
+    cfg, db_path = db_at_head
+    assert _user_tables(db_path), "fixture did not build a schema"
+
+    command.downgrade(cfg, "base")
+
+    assert _user_tables(db_path) == set()
+
+
+def test_upgrade_to_head_again_after_downgrade_to_base(db_at_head):
+    cfg, db_path = db_at_head
+    expected = _user_tables(db_path)
+
+    command.downgrade(cfg, "base")
+    command.upgrade(cfg, "head")
+
+    assert _user_tables(db_path) == expected

--- a/tests-unit/assets_test/queries/test_lookup.py
+++ b/tests-unit/assets_test/queries/test_lookup.py
@@ -1,0 +1,159 @@
+import os
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine, update
+from sqlalchemy.orm import Session
+
+import app.assets.mode as mode_module
+from app.assets.database.models import AssetContent
+from app.assets.database.queries.records import create_content
+from app.assets.services.lookup import (
+    claim_qualified_content,
+    is_temp_path as _is_temp_path,
+    lookup_for_from_hash,
+    lookup_for_view,
+    refresh_qualified_content,
+)
+from app.database.models import Base
+
+
+@pytest.fixture
+def session(tmp_path):
+    engine = create_engine(
+        f"sqlite:///{tmp_path}/test.db", connect_args={"check_same_thread": False}
+    )
+    Base.metadata.create_all(engine)
+    with Session(engine) as sess:
+        yield sess
+
+
+@pytest.fixture(autouse=True)
+def enable_hashing():
+    class FakeArgs:
+        enable_asset_hashing = True
+
+    mode_module.init(FakeArgs())
+    yield
+    mode_module.init(None)
+
+
+def _make_file(tmp_path, name: str, content: bytes = b"bytes") -> str:
+    p = tmp_path / name
+    p.write_bytes(content)
+    return str(p)
+
+
+def test_temp_only_match_from_hash_returns_none(session, tmp_path):
+    f = _make_file(tmp_path, "f.png")
+    create_content(session, path=f, hash="abc123")
+    session.commit()
+    with patch("app.assets.services.lookup.is_temp_path", return_value=True):
+        result = lookup_for_from_hash(session, "abc123")
+    assert result is None
+
+
+def test_temp_only_match_view_returns_none(session, tmp_path):
+    f = _make_file(tmp_path, "f2.png")
+    create_content(session, path=f, hash="abc123")
+    session.commit()
+    with patch("app.assets.services.lookup.is_temp_path", return_value=True):
+        result = lookup_for_view(session, "abc123")
+    assert result is None
+
+
+def test_sibling_prefix_not_temp(tmp_path):
+    with patch("folder_paths.get_temp_directory", return_value=str(tmp_path / "temp")):
+        assert not _is_temp_path(str(tmp_path / "temp-other" / "f.png"))
+        assert _is_temp_path(str(tmp_path / "temp" / "f.png"))
+
+
+def test_off_mode_from_hash_returns_none(session, tmp_path):
+    class FakeArgs:
+        enable_asset_hashing = False
+
+    mode_module.init(FakeArgs())
+    f = _make_file(tmp_path, "f3.png")
+    create_content(session, path=f, hash="abc123")
+    session.commit()
+    result = lookup_for_from_hash(session, "abc123")
+    assert result is None
+
+
+def test_upload_content_lookup_not_gated_on_hashing_flag(session, tmp_path):
+    class FakeArgs:
+        enable_asset_hashing = False
+
+    mode_module.init(FakeArgs())
+    f = _make_file(tmp_path, "f4.png")
+    content = create_content(session, path=f, hash="abc123")
+    session.commit()
+    result = lookup_for_view(session, "abc123")
+    assert result is not None
+    assert result.id == content.id
+
+
+def test_stale_older_newer_live_returns_newer(session, tmp_path):
+    f_newer = _make_file(tmp_path, "newer.png")
+    old_time = datetime(2020, 1, 1)
+    new_time = datetime(2024, 1, 1)
+    c_old = create_content(session, path="/nonexistent/old.png", hash="xyz")
+    c_new = create_content(session, path=f_newer, hash="xyz")
+    session.execute(update(AssetContent).where(AssetContent.id == c_old.id).values(created_at=old_time))
+    session.execute(update(AssetContent).where(AssetContent.id == c_new.id).values(created_at=new_time))
+    session.commit()
+
+    result = lookup_for_from_hash(session, "xyz")
+    assert result is not None
+    assert result.id == c_new.id
+
+
+def test_claim_qualified_content_true_for_a_live_matching_row(session, tmp_path):
+    f = _make_file(tmp_path, "revalidate_ok.png")
+    content = create_content(session, path=f, hash="dup")
+    session.commit()
+
+    assert claim_qualified_content(session, content.id, "dup") is True
+
+
+def test_claim_qualified_content_false_once_retired(session, tmp_path):
+    f = _make_file(tmp_path, "revalidate_retired.png")
+    content = create_content(session, path=f, hash="dup")
+    session.commit()
+
+    session.execute(
+        update(AssetContent).where(AssetContent.id == content.id).values(is_missing=True)
+    )
+    session.commit()
+
+    assert claim_qualified_content(session, content.id, "dup") is False, (
+        "a row retired after the lookup must not be reused"
+    )
+
+
+def test_claim_qualified_content_false_once_hash_changed(session, tmp_path):
+    f = _make_file(tmp_path, "revalidate_rehashed.png")
+    content = create_content(session, path=f, hash="dup")
+    session.commit()
+
+    session.execute(
+        update(AssetContent).where(AssetContent.id == content.id).values(hash="different")
+    )
+    session.commit()
+
+    assert claim_qualified_content(session, content.id, "dup") is False, (
+        "a row whose recorded content changed identity must not be reused"
+        " for the hash that used to describe it"
+    )
+
+
+def test_refresh_qualified_content_none_when_file_vanishes(session, tmp_path):
+    f = _make_file(tmp_path, "revalidate_gone.png")
+    content = create_content(session, path=f, hash="dup")
+    session.commit()
+    assert claim_qualified_content(session, content.id, "dup") is True
+
+    os.unlink(f)
+
+    assert refresh_qualified_content(session, content.id) is None

--- a/tests-unit/assets_test/queries/test_records.py
+++ b/tests-unit/assets_test/queries/test_records.py
@@ -1,0 +1,120 @@
+import pytest
+from sqlalchemy import create_engine, select, update
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.assets.database.models import Asset, AssetContent
+from app.assets.database.queries.records import (
+    RecordPageSpec,
+    create_content,
+    create_record,
+    delete_record,
+    get_record_by_id,
+    list_records_page,
+    mark_content_missing,
+)
+from app.database.models import Base
+
+
+@pytest.fixture
+def session():
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(engine)
+    with Session(engine) as sess:
+        yield sess
+
+
+def test_listing_includes_missing_by_default_with_missing_tag(session):
+    content = create_content(session, path="/tmp/f1")
+    record = create_record(session, content_id=content.id, name="test")
+    mark_content_missing(session, content.id)
+    session.commit()
+
+    results, tag_map, total = list_records_page(session, RecordPageSpec())
+
+    assert any(r.id == record.id for r in results)
+    assert total == 1
+    assert "missing" in tag_map.get(record.id, [])
+
+
+def test_listing_excludes_missing_with_filter(session):
+    content = create_content(session, path="/tmp/f2")
+    record = create_record(session, content_id=content.id, name="test2")
+    mark_content_missing(session, content.id)
+    session.commit()
+
+    results, _, total = list_records_page(
+        session,
+        RecordPageSpec(none_tags=("missing",)),
+    )
+
+    assert not any(r.id == record.id for r in results), "Missing record should be excluded"
+    assert total == 0
+
+
+def test_delete_record_never_deletes_referenced_preview(session):
+    preview_content = create_content(session, path="/tmp/preview")
+    preview_record = create_record(session, content_id=preview_content.id, name="preview")
+    content1 = create_content(session, path="/tmp/f3")
+    content2 = create_content(session, path="/tmp/f4")
+    r1 = create_record(session, content_id=content1.id, name="r1")
+    r2 = create_record(session, content_id=content2.id, name="r2")
+
+    session.execute(update(Asset).where(Asset.id == r1.id).values(preview_id=preview_record.id))
+    session.execute(update(Asset).where(Asset.id == r2.id).values(preview_id=preview_record.id))
+    session.commit()
+
+    delete_record(session, r1.id)
+    session.commit()
+    assert get_record_by_id(session, preview_record.id) is not None, "Preview must survive"
+
+    delete_record(session, r2.id)
+    session.commit()
+    assert get_record_by_id(session, preview_record.id) is not None, (
+        "Preview must survive even with no referrers"
+    )
+
+    content_row = session.execute(
+        select(AssetContent).where(AssetContent.id == preview_content.id)
+    ).scalar_one_or_none()
+    assert content_row is not None, "Preview content row should survive (D-3 floor)"
+
+
+def test_concurrent_create_content_same_path(tmp_path):
+    db_path = str(tmp_path / "concurrent.db")
+    engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(engine)
+
+    with Session(engine) as s1, Session(engine) as s2:
+        create_content(s1, path="/tmp/shared")
+        s1.commit()
+        create_content(s2, path="/tmp/shared")
+        s2.commit()
+
+    with Session(engine) as s:
+        live_rows = list(
+            s.execute(
+                select(AssetContent).where(
+                    AssetContent.path == "/tmp/shared",
+                    AssetContent.is_missing.is_(False),
+                )
+            ).scalars()
+        )
+    assert len(live_rows) == 1, f"Expected exactly one live row, got {len(live_rows)}"
+
+
+def test_create_content_check_violation_surfaces_the_constraint_error(session):
+    with pytest.raises(IntegrityError):
+        create_content(session, path="/tmp/negative-size", size_bytes=-1)
+
+
+def test_create_content_check_violation_on_mtime_surfaces(session):
+    with pytest.raises(IntegrityError):
+        create_content(session, path="/tmp/negative-mtime", size_bytes=0, mtime_ns=-1)
+
+
+def test_create_content_uniqueness_race_returns_existing_live_row(session):
+    first = create_content(session, path="/tmp/race")
+    second = create_content(session, path="/tmp/race")
+
+    assert second.id == first.id

--- a/tests-unit/assets_test/queries/test_tags_query.py
+++ b/tests-unit/assets_test/queries/test_tags_query.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Sequence
+
+from sqlalchemy.orm import Session
+
+from app.assets.database.models import Asset, Tag
+from app.assets.database.queries.records import (
+    RecordPageSpec,
+    create_content,
+    create_record,
+    list_records_page,
+    mark_content_missing,
+)
+from app.assets.database.queries.tags import (
+    list_tag_counts_for_filtered_assets,
+    list_tags_with_usage,
+)
+
+
+def _seed_asset(
+    session: Session, path: str, name: str, tags: Sequence[str]
+) -> Asset:
+    content = create_content(session, path=path)
+    return create_record(session, content_id=content.id, name=name, tags=list(tags))
+
+
+def test_usage_counts_match_seeded_asset_tag_rows(session: Session) -> None:
+    _seed_asset(session, "/models/a", "a", ["models", "checkpoint"])
+    _seed_asset(session, "/models/b", "b", ["models"])
+    _seed_asset(session, "/models/c", "c", ["lora"])
+    session.commit()
+
+    rows, total = list_tags_with_usage(session)
+
+    assert dict(rows) == {"models": 2, "checkpoint": 1, "lora": 1}
+    assert total == 3
+
+
+def test_prefix_filters_tags_by_leading_substring(session: Session) -> None:
+    _seed_asset(session, "/m/1", "1", ["model", "mask", "zebra"])
+    session.commit()
+
+    rows, total = list_tags_with_usage(session, prefix="ma")
+
+    assert [name for name, _ in rows] == ["mask"]
+    assert total == 1
+
+
+def test_limit_and_offset_paginate_over_real_total(session: Session) -> None:
+    for index in range(5):
+        _seed_asset(session, f"/p/{index}", str(index), [f"tag{index}"])
+    session.commit()
+
+    rows, total = list_tags_with_usage(session, limit=2, offset=1, order="name_asc")
+
+    assert [name for name, _ in rows] == ["tag1", "tag2"]
+    assert total == 5
+
+
+def test_include_zero_false_drops_unused_tags_and_shrinks_total(session: Session) -> None:
+    _seed_asset(session, "/z/1", "1", ["used"])
+    session.add(Tag(name="unused"))
+    session.commit()
+
+    with_zero, total_with = list_tags_with_usage(session, include_zero=True)
+    without_zero, total_without = list_tags_with_usage(session, include_zero=False)
+
+    assert ("unused", 0) in with_zero
+    assert total_with == 2
+    assert [name for name, _ in without_zero] == ["used"]
+    assert total_without == 1
+
+
+def test_order_is_count_desc_then_name_asc_or_name_asc(session: Session) -> None:
+    _seed_asset(session, "/o/1", "1", ["gamma"])
+    _seed_asset(session, "/o/2", "2", ["gamma", "beta"])
+    _seed_asset(session, "/o/3", "3", ["gamma", "beta", "alpha"])
+    session.commit()
+
+    by_count, _ = list_tags_with_usage(session, order="count_desc")
+    by_name, _ = list_tags_with_usage(session, order="name_asc")
+
+    assert [name for name, _ in by_count] == ["gamma", "beta", "alpha"]
+    assert [name for name, _ in by_name] == ["alpha", "beta", "gamma"]
+
+
+def test_missing_content_counts_all_its_tags_including_missing(
+    session: Session,
+) -> None:
+    _seed_asset(session, "/live", "live", ["foo"])
+    gone = create_content(session, path="/gone")
+    create_record(session, content_id=gone.id, name="gone", tags=["foo"])
+    mark_content_missing(session, gone.id)
+    session.commit()
+
+    counts = dict(list_tags_with_usage(session)[0])
+
+    assert counts["foo"] == 2
+    assert counts["missing"] == 1
+
+
+def test_histogram_counts_every_tag_on_the_filtered_assets(session: Session) -> None:
+    _seed_asset(session, "/h/a", "a", ["models", "checkpoint"])
+    _seed_asset(session, "/h/b", "b", ["models", "lora"])
+    _seed_asset(session, "/h/c", "c", ["other"])
+    session.commit()
+
+    histogram = list_tag_counts_for_filtered_assets(session, include_tags=["models"])
+
+    assert histogram == {"models": 2, "checkpoint": 1, "lora": 1}
+
+
+def test_histogram_includes_missing_content_assets(session: Session) -> None:
+    _seed_asset(session, "/hm/live", "live", ["models"])
+    gone = create_content(session, path="/hm/gone")
+    create_record(session, content_id=gone.id, name="gone", tags=["models"])
+    mark_content_missing(session, gone.id)
+    session.commit()
+
+    histogram = list_tag_counts_for_filtered_assets(session, include_tags=["models"])
+
+    assert histogram == {"models": 2, "missing": 1}
+
+
+def test_refine_and_list_share_the_same_filtered_asset_set(session: Session) -> None:
+    kept = _seed_asset(session, "/s/a", "checkpoint-a", ["models", "checkpoint"])
+    _seed_asset(session, "/s/b", "checkpoint-b", ["models", "archived"])
+    _seed_asset(session, "/s/c", "lora-c", ["models"])
+    gone = create_content(session, path="/s/d")
+    missing_match = create_record(
+        session, content_id=gone.id, name="check-d", tags=["models", "checkpoint"]
+    )
+    mark_content_missing(session, gone.id)
+    session.commit()
+
+    spec = RecordPageSpec(
+        all_tags=("models",),
+        none_tags=("archived",),
+        name_contains="check",
+        limit=100,
+    )
+    records, tag_map, _ = list_records_page(session, spec)
+    expected = Counter(
+        tag for record in records for tag in tag_map.get(record.id, [])
+    )
+    histogram = list_tag_counts_for_filtered_assets(
+        session,
+        include_tags=["models"],
+        exclude_tags=["archived"],
+        name_contains="check",
+        limit=100,
+    )
+
+    assert {record.id for record in records} == {kept.id, missing_match.id}
+    assert histogram == dict(expected)
+    assert histogram == {"models": 2, "checkpoint": 2, "missing": 1}
+
+
+def test_histogram_any_tags_matches_the_list_union(session: Session) -> None:
+    red = _seed_asset(session, "/an/a", "a", ["red"])
+    blue = _seed_asset(session, "/an/b", "b", ["blue"])
+    _seed_asset(session, "/an/c", "c", ["green"])
+    session.commit()
+
+    records, _, _ = list_records_page(
+        session, RecordPageSpec(any_tags=("red", "blue"), limit=100)
+    )
+    histogram = list_tag_counts_for_filtered_assets(session, any_tags=["red", "blue"])
+
+    assert {record.id for record in records} == {red.id, blue.id}
+    assert histogram == {"red": 1, "blue": 1}
+
+
+def test_list_refine_and_tags_agree_on_counts_including_missing(
+    session: Session,
+) -> None:
+    _seed_asset(session, "/agree/live", "live", ["models", "checkpoint"])
+    gone = create_content(session, path="/agree/gone")
+    create_record(session, content_id=gone.id, name="gone", tags=["models", "lora"])
+    mark_content_missing(session, gone.id)
+    session.commit()
+
+    records, tag_map, total = list_records_page(
+        session, RecordPageSpec(all_tags=("models",), limit=100)
+    )
+    list_tally = dict(
+        Counter(tag for record in records for tag in tag_map.get(record.id, []))
+    )
+    refine = list_tag_counts_for_filtered_assets(session, include_tags=["models"])
+    global_usage = dict(list_tags_with_usage(session)[0])
+
+    expected = {"models": 2, "checkpoint": 1, "lora": 1, "missing": 1}
+    assert total == 2
+    assert list_tally == expected
+    assert refine == expected
+    assert global_usage == expected

--- a/tests-unit/assets_test/services/path_prefix_cases.py
+++ b/tests-unit/assets_test/services/path_prefix_cases.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import os
+
+
+def stored_path(path: str) -> str:
+    return os.path.abspath(path)
+
+
+def prefix_case_paths(root: str) -> list[str]:
+    parent = os.path.dirname(root)
+    name = os.path.basename(root)
+    upper = name.upper()
+    assert upper != name, f"root basename {name!r} has no distinct uppercase form"
+
+    return [
+        root,
+        os.path.join(root, "child.png"),
+        os.path.join(root, "sub", "deep.png"),
+        os.path.join(root, "meta%_*?[].png"),
+        os.path.join(parent, upper),
+        os.path.join(parent, upper, "case.png"),
+        root + "-other" + os.sep + "lexical.png",
+        root + "extra",
+        os.path.join(parent, "unrelated.png"),
+        os.path.join(root, os.pardir, "escaped.png"),
+        os.path.join(root, "sub", os.pardir, "in.png"),
+        os.path.join(name, "relative.png"),
+        root + os.sep + os.sep + "doubled.png",
+        os.path.join(root, "trailing.png") + os.sep,
+    ]

--- a/tests-unit/assets_test/services/test_admission_gate.py
+++ b/tests-unit/assets_test/services/test_admission_gate.py
@@ -1,0 +1,165 @@
+import os
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import select
+
+from app.assets import scanner_admission
+from app.assets.database.models import AssetContent
+from app.assets.scanner import (
+    _WATCH_LIST,
+    _WatchEntry,
+    _should_skip_extension,
+    _two_stat_admit,
+    tick_watch_list,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_watch_list() -> Iterator[None]:
+    _WATCH_LIST.clear()
+    yield
+    _WATCH_LIST.clear()
+
+
+def test_part_suffix_never_admitted():
+    assert _should_skip_extension("model.safetensors.part") is True
+
+
+def test_size_drift_watch_listed(temp_dir: Path, monkeypatch):
+    path = temp_dir / "download.bin"
+    path.write_bytes(b"first")
+    first_stat = path.stat()
+
+    def changed_stat(_: float) -> None:
+        path.write_bytes(b"changed")
+
+    monkeypatch.setattr("app.assets.scanner_admission.time.sleep", changed_stat)
+    admitted, watched = _two_stat_admit([(str(path), first_stat)])
+
+    assert admitted == []
+    assert watched == [str(path)]
+
+
+def test_watch_list_is_bounded_when_distinct_paths_keep_changing(temp_dir: Path, monkeypatch):
+    candidates: list[tuple[str, os.stat_result]] = []
+    for index in range(1000):
+        path = temp_dir / f"changing-{index}.bin"
+        path.write_bytes(b"before")
+        candidates.append((str(path), path.stat()))
+        path.write_bytes(b"after-change")
+    monkeypatch.setattr("app.assets.scanner_admission.time.sleep", lambda _: None)
+
+    _two_stat_admit(candidates)
+
+    assert scanner_admission._WATCH_LIST_MAX_SIZE == 256
+    assert len(_WATCH_LIST) <= scanner_admission._WATCH_LIST_MAX_SIZE
+
+
+def test_refreshing_watched_path_preserves_ticks_and_replaces_stat(temp_dir: Path, monkeypatch):
+    path = temp_dir / "changing.bin"
+    path.write_bytes(b"first")
+    first_stat = path.stat()
+    path.write_bytes(b"second-version")
+    monkeypatch.setattr("app.assets.scanner_admission.time.sleep", lambda _: None)
+    _two_stat_admit([(str(path), first_stat)])
+    _WATCH_LIST[0].ticks = 7
+    refresh_first_stat = path.stat()
+    path.write_bytes(b"third-version-is-longer")
+    refreshed_stat = path.stat()
+
+    _two_stat_admit([(str(path), refresh_first_stat)])
+
+    assert len(_WATCH_LIST) == 1
+    assert _WATCH_LIST[0].last_stat == refreshed_stat
+    assert _WATCH_LIST[0].ticks == 7
+
+
+def test_never_stabilizes_dropped_after_cap(session, temp_dir: Path):
+    path = temp_dir / "moving.bin"
+    path.write_bytes(b"0")
+    _WATCH_LIST[:] = [_WatchEntry(str(path), path.stat())]
+    for index in range(scanner_admission._WATCH_SCAN_RETRIES):
+        path.write_bytes(str(index + 1).encode())
+        tick_watch_list(session)
+
+    assert _WATCH_LIST == []
+    assert session.scalars(select(AssetContent)).all() == []
+
+
+def test_stable_scan_admission_removes_watch_entry_before_next_tick(session, temp_dir: Path, monkeypatch):
+    path = temp_dir / "stable.bin"
+    path.write_bytes(b"complete")
+    current_stat = path.stat()
+    _WATCH_LIST[:] = [_WatchEntry(str(path), current_stat, ticks=4)]
+    monkeypatch.setattr("app.assets.scanner_admission.time.sleep", lambda _: None)
+
+    admitted, watched = _two_stat_admit([(str(path), current_stat)])
+    entries_after_admission = len(_WATCH_LIST)
+    with (
+        patch("app.assets.scanner_admission.compute_loader_path", return_value="stable.bin"),
+        patch(
+            "app.assets.scanner_admission.get_name_and_tags_from_asset_path",
+            return_value=("stable.bin", []),
+        ),
+        patch("app.assets.scanner.seed_asset_specs") as seed_asset_specs,
+    ):
+        tick_watch_list(session)
+
+    assert admitted == [str(path)]
+    assert watched == []
+    assert entries_after_admission == 0
+    seed_asset_specs.assert_not_called()
+
+
+def test_evicted_path_is_admitted_by_later_stable_scan(temp_dir: Path, monkeypatch):
+    monkeypatch.setattr(scanner_admission, "_WATCH_LIST_MAX_SIZE", 2, raising=False)
+    monkeypatch.setattr("app.assets.scanner_admission.time.sleep", lambda _: None)
+    paths: list[Path] = []
+    candidates: list[tuple[str, os.stat_result]] = []
+    for index in range(3):
+        path = temp_dir / f"overflow-{index}.bin"
+        path.write_bytes(b"before")
+        candidates.append((str(path), path.stat()))
+        path.write_bytes(b"after-change")
+        paths.append(path)
+    _two_stat_admit(candidates)
+    entries_after_overflow = [entry.path for entry in _WATCH_LIST]
+    stable_stat = paths[0].stat()
+
+    admitted, watched = _two_stat_admit([(str(paths[0]), stable_stat)])
+
+    assert entries_after_overflow == [str(paths[1]), str(paths[2])]
+    assert admitted == [str(paths[0])]
+    assert watched == []
+
+
+def test_empty_candidate_batch_returns_without_paying_stability_gap(monkeypatch):
+    sleeps: list[float] = []
+    monkeypatch.setattr(
+        "app.assets.scanner_admission.time.sleep", lambda seconds: sleeps.append(seconds)
+    )
+
+    admitted, watched = _two_stat_admit([])
+
+    assert admitted == []
+    assert watched == []
+    assert sleeps == []
+
+
+def test_nonempty_candidate_batch_still_pays_stability_gap(temp_dir: Path, monkeypatch):
+    path = temp_dir / "stable.bin"
+    path.write_bytes(b"complete")
+    first_stat = path.stat()
+    sleeps: list[float] = []
+    monkeypatch.setattr(
+        "app.assets.scanner_admission.time.sleep", lambda seconds: sleeps.append(seconds)
+    )
+
+    admitted, watched = _two_stat_admit([(str(path), first_stat)])
+
+    assert sleeps == [0.1]
+    assert admitted == [str(path)]
+    assert watched == []

--- a/tests-unit/assets_test/services/test_admission_integration.py
+++ b/tests-unit/assets_test/services/test_admission_integration.py
@@ -1,0 +1,20 @@
+from unittest.mock import patch
+
+from sqlalchemy import select
+
+from app.assets.database.models import AssetContent
+from app.assets.scanner import build_asset_specs, seed_asset_specs
+
+
+def test_drifting_file_never_reaches_seed(session, temp_dir):
+    path = temp_dir / "drifting.bin"
+    path.write_bytes(b"still downloading")
+
+    with (
+        patch("folder_paths.get_input_directory", return_value=str(temp_dir)),
+        patch("app.assets.scanner._two_stat_admit", return_value=([], [str(path)])),
+    ):
+        specs, _, _ = build_asset_specs([str(path)], set(), enable_metadata_extraction=False)
+        seed_asset_specs(session, specs)
+
+    assert list(session.scalars(select(AssetContent))) == []

--- a/tests-unit/assets_test/services/test_api_routes_b.py
+++ b/tests-unit/assets_test/services/test_api_routes_b.py
@@ -1,0 +1,155 @@
+import json
+from collections.abc import Callable
+from unittest.mock import AsyncMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
+from sqlalchemy.orm import Session
+
+from app.assets import mode
+from app.assets.api import routes
+from app.assets.database.queries.records import (
+    create_content,
+    create_record,
+    mark_content_missing,
+)
+
+
+def _session_factory(engine) -> Callable[[], Session]:
+    return lambda: Session(engine)
+
+
+@pytest.mark.asyncio
+async def test_unfiltered_listing_includes_missing_entity(
+    db_engine, session, temp_dir, monkeypatch
+):
+    content = create_content(session, path=str(temp_dir / "missing.png"))
+    record = create_record(
+        session,
+        content_id=content.id,
+        name="missing.png",
+        mime_type="image/png",
+        tags=["input"],
+    )
+    mark_content_missing(session, content.id)
+    session.commit()
+
+    monkeypatch.setattr(routes, "create_session", _session_factory(db_engine))
+    monkeypatch.setattr(routes, "_ASSETS_ENABLED", True)
+
+    response = await routes.list_assets_route(
+        make_mocked_request("GET", "/api/assets")
+    )
+
+    assert isinstance(response, web.Response)
+    response_body = response.body
+    assert isinstance(response_body, bytes | bytearray)
+    body = json.loads(response_body)
+    assert record.id in {item["id"] for item in body["assets"]}
+    assert body["total"] == 1
+    listed = next(item for item in body["assets"] if item["id"] == record.id)
+    assert "missing" in listed["tags"]
+
+
+@pytest.mark.asyncio
+async def test_exclude_tags_missing_hides_it(db_engine, session, temp_dir, monkeypatch):
+    content = create_content(session, path=str(temp_dir / "missing.png"))
+    record = create_record(
+        session,
+        content_id=content.id,
+        name="missing.png",
+        mime_type="image/png",
+    )
+    mark_content_missing(session, content.id)
+    session.commit()
+
+    monkeypatch.setattr(routes, "create_session", _session_factory(db_engine))
+    monkeypatch.setattr(routes, "_ASSETS_ENABLED", True)
+
+    response = await routes.list_assets_route(
+        make_mocked_request("GET", "/api/assets?exclude_tags=missing")
+    )
+
+    assert isinstance(response, web.Response)
+    response_body = response.body
+    assert isinstance(response_body, bytes | bytearray)
+    body = json.loads(response_body)
+    assert record.id not in {item["id"] for item in body["assets"]}
+
+
+@pytest.mark.asyncio
+async def test_listing_serves_is_immutable_as_false(
+    db_engine, session, temp_dir, monkeypatch
+):
+    content = create_content(session, path=str(temp_dir / "mutable.png"))
+    record = create_record(
+        session,
+        content_id=content.id,
+        name="mutable.png",
+        mime_type="image/png",
+    )
+    session.commit()
+
+    monkeypatch.setattr(routes, "create_session", _session_factory(db_engine))
+    monkeypatch.setattr(routes, "_ASSETS_ENABLED", True)
+
+    response = await routes.list_assets_route(
+        make_mocked_request("GET", "/api/assets")
+    )
+
+    assert isinstance(response, web.Response)
+    response_body = response.body
+    assert isinstance(response_body, bytes | bytearray)
+    listed = next(
+        item
+        for item in json.loads(response_body)["assets"]
+        if item["id"] == record.id
+    )
+    assert listed["is_immutable"] is False, (
+        "the field must be present in the serialized body, not dropped as a default"
+    )
+
+
+@pytest.mark.asyncio
+async def test_detail_serves_is_immutable_as_false(
+    mock_create_session, db_engine, session, temp_dir, monkeypatch
+):
+    content = create_content(session, path=str(temp_dir / "detail.png"))
+    record = create_record(
+        session,
+        content_id=content.id,
+        name="detail.png",
+        mime_type="image/png",
+    )
+    session.commit()
+
+    monkeypatch.setattr(routes, "create_session", _session_factory(db_engine))
+    monkeypatch.setattr(routes, "_ASSETS_ENABLED", True)
+
+    response = await routes.get_asset_route(
+        make_mocked_request(
+            "GET", f"/api/assets/{record.id}", match_info={"id": record.id}
+        )
+    )
+
+    assert isinstance(response, web.Response)
+    response_body = response.body
+    assert isinstance(response_body, bytes | bytearray)
+    assert json.loads(response_body)["is_immutable"] is False
+
+
+@pytest.mark.asyncio
+async def test_from_hash_off_mode_returns_400(monkeypatch):
+    monkeypatch.setattr(mode, "hashing_enabled", lambda: False)
+    monkeypatch.setattr(routes, "_ASSETS_ENABLED", True)
+    request = AsyncMock(spec=web.Request)
+    request.json.return_value = {"hash": f"blake3:{'a' * 64}"}
+
+    response = await routes.create_asset_from_hash_route(request)
+
+    assert isinstance(response, web.Response)
+    assert response.status == 400
+    response_body = response.body
+    assert isinstance(response_body, bytes | bytearray)
+    assert json.loads(response_body)["error"]["code"] == "FEATURE_DISABLED"

--- a/tests-unit/assets_test/services/test_cached_execution_path.py
+++ b/tests-unit/assets_test/services/test_cached_execution_path.py
@@ -1,0 +1,123 @@
+import os
+import sys
+import types
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+from sqlalchemy import event, select
+
+import folder_paths
+from app.assets.database.models import Asset, AssetContent
+from comfy_execution.asset_enrichment import (
+    register_cached_outputs,
+    register_executed_outputs,
+)
+
+
+@contextmanager
+def _assets_enabled(enabled: bool = True):
+    with patch.dict(
+        sys.modules,
+        {"comfy.cli_args": types.SimpleNamespace(args=types.SimpleNamespace(enable_assets=enabled))},
+    ):
+        yield
+
+
+def _write_output_file(name: str) -> Path:
+    path = Path(folder_paths.get_output_directory()) / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"cached output")
+    return path
+
+
+def _output_ui(name: str) -> dict:
+    return {"images": [{"filename": name, "subfolder": "", "type": "output"}]}
+
+
+def _wrapper(name: str, node_id: str = "1") -> dict:
+    return {"meta": {"node_id": node_id}, "output": _output_ui(name)}
+
+
+def test_cached_replay_binds_new_record_to_existing_content(mock_create_session):
+    path = _write_output_file("cached-execution-bind.png")
+    try:
+        with _assets_enabled():
+            executed = register_executed_outputs(_output_ui(path.name), "original-job")
+        original_id = executed["images"][0]["id"]
+        with mock_create_session() as session:
+            original_content_id = session.get(Asset, original_id).content_id
+
+        wrapper = _wrapper(path.name)
+        with _assets_enabled():
+            enriched = register_cached_outputs(wrapper, "cached-job")
+        cached_id = enriched["output"]["images"][0]["id"]
+
+        with mock_create_session() as session:
+            contents = list(
+                session.scalars(
+                    select(AssetContent).where(AssetContent.path == os.path.abspath(path))
+                )
+            )
+            records = list(
+                session.scalars(
+                    select(Asset).where(Asset.content_id == original_content_id)
+                )
+            )
+            assert len(contents) == 1
+            assert len(records) == 2
+            assert original_id in {r.id for r in records}
+            assert cached_id in {r.id for r in records}
+            assert {r.job_id for r in records} == {"original-job", "cached-job"}
+        assert "id" not in wrapper["output"]["images"][0]
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def test_cached_replay_does_not_update_existing_content(mock_create_session, db_engine):
+    path = _write_output_file("cached-execution-no-update.png")
+    update_statements: list[str] = []
+
+    def capture_updates(_, __, statement, ___, ____, _____):
+        if statement.lstrip().upper().startswith("UPDATE"):
+            update_statements.append(statement)
+
+    try:
+        with _assets_enabled():
+            executed = register_executed_outputs(_output_ui(path.name), "original-job")
+        original_id = executed["images"][0]["id"]
+        with mock_create_session() as session:
+            original_content = session.get(
+                AssetContent, session.get(Asset, original_id).content_id
+            )
+            original_state = (
+                original_content.id,
+                original_content.hash,
+                original_content.size_bytes,
+                original_content.path,
+                original_content.mtime_ns,
+                original_content.is_missing,
+                original_content.created_at,
+            )
+
+        event.listen(db_engine, "before_cursor_execute", capture_updates)
+        wrapper = _wrapper(path.name)
+        with _assets_enabled():
+            register_cached_outputs(wrapper, "cached-job")
+
+        with mock_create_session() as session:
+            content = session.get(AssetContent, original_state[0])
+            current_state = (
+                content.id,
+                content.hash,
+                content.size_bytes,
+                content.path,
+                content.mtime_ns,
+                content.is_missing,
+                content.created_at,
+            )
+            assert current_state == original_state
+            assert update_statements == []
+    finally:
+        event.remove(db_engine, "before_cursor_execute", capture_updates)
+        path.unlink(missing_ok=True)

--- a/tests-unit/assets_test/services/test_cached_save.py
+++ b/tests-unit/assets_test/services/test_cached_save.py
@@ -1,0 +1,75 @@
+import os
+
+from sqlalchemy import event, select
+
+import folder_paths
+from app.assets.database.models import Asset, AssetContent
+from app.assets.database.queries.records import mark_content_missing
+from app.assets.services.ingest import register_cached_output, register_executed_output
+
+
+def test_cached_save_creates_delivery_record(mock_create_session, db_engine):
+    output_dir = folder_paths.get_output_directory()
+    os.makedirs(output_dir, exist_ok=True)
+    path = os.path.join(output_dir, "test_cached_save.png")
+    update_count = 0
+
+    def count_updates(_, __, statement, ___, ____, _____):
+        nonlocal update_count
+        if statement.lstrip().upper().startswith("UPDATE"):
+            update_count += 1
+
+    event.listen(db_engine, "before_cursor_execute", count_updates)
+    try:
+        with open(path, "wb") as file:
+            file.write(b"pixels")
+        original = register_executed_output(path, job_id="executed-job")
+        update_count = 0
+
+        cached = register_cached_output(path, job_id="delivery-job")
+
+        with mock_create_session() as session:
+            records = list(
+                session.scalars(select(Asset).where(Asset.content_id == original.content_id))
+            )
+            assert {record.id for record in records} == {original.id, cached.id}
+            assert {record.job_id for record in records} == {"executed-job", "delivery-job"}
+        assert update_count == 0
+    finally:
+        event.remove(db_engine, "before_cursor_execute", count_updates)
+        if os.path.exists(path):
+            os.unlink(path)
+
+
+def test_cached_save_against_missing_content_is_nonevent(mock_create_session):
+    output_dir = folder_paths.get_output_directory()
+    os.makedirs(output_dir, exist_ok=True)
+    path = os.path.join(output_dir, "test_cached_save_missing.png")
+
+    try:
+        with open(path, "wb") as file:
+            file.write(b"pixels")
+        original = register_executed_output(path, job_id="executed-job")
+        with mock_create_session() as session:
+            mark_content_missing(session, original.content_id)
+            session.commit()
+
+        cached = register_cached_output(path, job_id="delivery-job")
+
+        assert cached is None
+        with mock_create_session() as session:
+            contents = list(
+                session.scalars(
+                    select(AssetContent).where(AssetContent.path == os.path.abspath(path))
+                )
+            )
+            assert len(contents) == 1
+            assert contents[0].id == original.content_id
+            assert contents[0].is_missing is True
+            records = list(
+                session.scalars(select(Asset).where(Asset.job_id == "delivery-job"))
+            )
+            assert records == []
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)

--- a/tests-unit/assets_test/services/test_delete_b.py
+++ b/tests-unit/assets_test/services/test_delete_b.py
@@ -1,0 +1,115 @@
+import os
+
+from sqlalchemy import update
+
+import folder_paths
+from app.assets.database.models import Asset, AssetContent
+from app.assets.database.queries.records import (
+    create_content,
+    create_record,
+    delete_record,
+    get_record_by_id,
+    mark_content_missing,
+)
+from app.assets.services.asset_management import delete_asset_reference
+from app.assets.services.ingest import register_executed_output
+
+
+def test_hard_delete_record_content_and_file_remain(mock_create_session, session, temp_dir):
+    content = create_content(session, path=str(temp_dir / "file.bin"), size_bytes=4)
+    record = create_record(session, content_id=content.id, name="file.bin")
+    temp_dir.joinpath("file.bin").write_bytes(b"data")
+    session.commit()
+    record_id = record.id
+    content_id = content.id
+    path = content.path
+
+    assert delete_asset_reference(record_id) is True
+
+    session.expire_all()
+    assert get_record_by_id(session, record_id) is None
+    assert session.get(AssetContent, content_id) is not None
+    assert os.path.isfile(path)
+
+
+def test_two_records_one_content_other_unaffected(mock_create_session, session):
+    content = create_content(session, path="/tmp/shared.bin")
+    r1 = create_record(session, content_id=content.id, name="a")
+    r2 = create_record(session, content_id=content.id, name="b")
+    session.commit()
+    r1_id = r1.id
+    r2_id = r2.id
+
+    assert delete_asset_reference(r1_id) is True
+
+    session.expire_all()
+    assert get_record_by_id(session, r1_id) is None
+    assert get_record_by_id(session, r2_id) is not None
+    assert session.get(AssetContent, content.id) is not None
+
+
+def test_delete_record_never_deletes_pointed_at_preview(mock_create_session, session):
+    b_content = create_content(session, path="/tmp/preview_target.png")
+    b = create_record(session, content_id=b_content.id, name="B")
+    a_content = create_content(session, path="/tmp/owner.png")
+    a = create_record(session, content_id=a_content.id, name="A")
+    session.execute(update(Asset).where(Asset.id == a.id).values(preview_id=b.id))
+    session.commit()
+    a_id = a.id
+    b_id = b.id
+
+    assert delete_asset_reference(a_id) is True
+
+    session.expire_all()
+    assert get_record_by_id(session, a_id) is None
+    assert get_record_by_id(session, b_id) is not None
+
+
+def test_missing_content_record_deletable(mock_create_session, session):
+    content = create_content(session, path="/tmp/missing.bin")
+    record = create_record(session, content_id=content.id, name="missing.bin")
+    mark_content_missing(session, content.id)
+    session.commit()
+    record_id = record.id
+
+    assert delete_asset_reference(record_id) is True
+    session.expire_all()
+    assert get_record_by_id(session, record_id) is None
+
+
+def test_reregister_same_path_fresh_ids(mock_create_session, monkeypatch):
+    output_dir = folder_paths.get_output_directory()
+    os.makedirs(output_dir, exist_ok=True)
+    f = os.path.join(output_dir, "test_delete_reregister.png")
+
+    try:
+        with open(f, "wb") as fh:
+            fh.write(b"v1")
+        first = register_executed_output(f, job_id="job1")
+        first_id = first.id
+        assert delete_asset_reference(first_id) is True
+
+        with open(f, "wb") as fh:
+            fh.write(b"v2")
+        second = register_executed_output(f, job_id="job2")
+        assert second.id != first_id
+    finally:
+        if os.path.exists(f):
+            os.unlink(f)
+
+
+def test_delete_nonexistent_returns_false(mock_create_session):
+    assert delete_asset_reference("00000000-0000-0000-0000-000000000000") is False
+
+
+def test_delete_order_record_before_content(mock_create_session, session):
+    content = create_content(session, path="/tmp/order.bin")
+    record = create_record(session, content_id=content.id, name="order.bin")
+    session.commit()
+    content_id = content.id
+
+    delete_record(session, record.id)
+    session.flush()
+
+    assert session.get(Asset, record.id) is None
+    assert session.get(AssetContent, content_id) is not None

--- a/tests-unit/assets_test/services/test_detection_gate.py
+++ b/tests-unit/assets_test/services/test_detection_gate.py
@@ -1,0 +1,188 @@
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import select
+
+from app.assets.database.models import Asset, AssetContent
+from app.assets.helpers import to_stored_hash
+from app.assets.scanner import (
+    clear_pending_verifications,
+    drain_pending_verifications,
+    sync_prefixes_with_filesystem,
+)
+from app.assets.scanner_changes import queue_pending_verification
+from app.assets.services.snapshot_hash import snapshot_hash
+
+
+@pytest.fixture(autouse=True)
+def _clear_pending_verifications():
+    clear_pending_verifications()
+    yield
+    clear_pending_verifications()
+
+
+def _seed_content(session, path: Path, hash_value: str | None) -> tuple[AssetContent, Asset]:
+    stat = path.stat()
+    content = AssetContent(
+        path=str(path),
+        hash=hash_value,
+        size_bytes=stat.st_size,
+        mtime_ns=stat.st_mtime_ns,
+    )
+    session.add(content)
+    session.flush()
+    record = Asset(content_id=content.id, name=path.name)
+    session.add(record)
+    session.commit()
+    return content, record
+
+
+def _bump_mtime(path: Path) -> None:
+    stat = path.stat()
+    os.utime(path, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000))
+
+
+def _stored_hash(path: Path) -> str:
+    snapshot = snapshot_hash(str(path))
+    assert snapshot is not None
+    digest, _ = snapshot
+    return to_stored_hash(digest)
+
+
+def test_off_mode_same_size_touch_does_not_split(session, temp_dir: Path):
+    input_root = temp_dir / "input"
+    input_root.mkdir()
+    path = input_root / "touched.bin"
+    path.write_bytes(b"same bytes")
+    old_content, _ = _seed_content(session, path, hash_value="historical")
+    _bump_mtime(path)
+
+    with (
+        patch("folder_paths.get_input_directory", return_value=str(input_root)),
+        patch("app.assets.scanner.mode.hashing_enabled", return_value=False),
+    ):
+        sync_prefixes_with_filesystem(session, [str(input_root)])
+    session.commit()
+
+    contents = list(session.scalars(select(AssetContent)))
+    assert len(contents) == 1
+    assert session.get(AssetContent, old_content.id).is_missing is False
+
+
+def test_off_mode_size_change_splits(session, temp_dir: Path):
+    input_root = temp_dir / "input"
+    input_root.mkdir()
+    path = input_root / "grown.bin"
+    path.write_bytes(b"small")
+    old_content, _ = _seed_content(session, path, hash_value="historical")
+    path.write_bytes(b"a decidedly larger set of bytes")
+
+    with (
+        patch("folder_paths.get_input_directory", return_value=str(input_root)),
+        patch("app.assets.scanner.mode.hashing_enabled", return_value=False),
+    ):
+        sync_prefixes_with_filesystem(session, [str(input_root)])
+    session.commit()
+
+    contents = list(session.scalars(select(AssetContent).order_by(AssetContent.created_at)))
+    assert len(contents) == 2
+    assert session.get(AssetContent, old_content.id).is_missing is True
+    assert [content.is_missing for content in contents] == [True, False]
+
+
+def test_hash_mode_touch_refreshes_mtime(session, temp_dir: Path):
+    input_root = temp_dir / "input"
+    input_root.mkdir()
+    path = input_root / "touched.bin"
+    path.write_bytes(b"same bytes")
+    old_content, _ = _seed_content(session, path, _stored_hash(path))
+    _bump_mtime(path)
+
+    with (
+        patch("folder_paths.get_input_directory", return_value=str(input_root)),
+        patch("app.assets.scanner.mode.hashing_enabled", return_value=True),
+    ):
+        sync_prefixes_with_filesystem(session, [str(input_root)])
+        processed = drain_pending_verifications(session)
+    session.commit()
+
+    refreshed = session.get(AssetContent, old_content.id)
+    assert processed == 1
+    assert refreshed.is_missing is False
+    assert refreshed.mtime_ns == path.stat().st_mtime_ns
+    assert len(session.scalars(select(AssetContent)).all()) == 1
+
+
+def test_hash_mode_real_edit_splits(session, temp_dir: Path):
+    input_root = temp_dir / "input"
+    input_root.mkdir()
+    path = input_root / "edited.bin"
+    path.write_bytes(b"old bytes")
+    old_content, _ = _seed_content(session, path, _stored_hash(path))
+    path.write_bytes(b"new bytes with a different length")
+
+    with (
+        patch("folder_paths.get_input_directory", return_value=str(input_root)),
+        patch("app.assets.scanner.mode.hashing_enabled", return_value=True),
+    ):
+        sync_prefixes_with_filesystem(session, [str(input_root)])
+        drain_pending_verifications(session)
+    session.commit()
+
+    contents = list(session.scalars(select(AssetContent).order_by(AssetContent.created_at)))
+    assert len(contents) == 2
+    assert session.get(AssetContent, old_content.id).is_missing is True
+    assert next(content for content in contents if not content.is_missing).hash == _stored_hash(path)
+
+
+def test_old_record_id_resolves_to_missing_content_after_split(session, temp_dir: Path):
+    input_root = temp_dir / "input"
+    input_root.mkdir()
+    path = input_root / "edited.bin"
+    path.write_bytes(b"old bytes")
+    old_content, old_record = _seed_content(session, path, _stored_hash(path))
+    path.write_bytes(b"replacement bytes")
+
+    with (
+        patch("folder_paths.get_input_directory", return_value=str(input_root)),
+        patch("app.assets.scanner.mode.hashing_enabled", return_value=True),
+    ):
+        sync_prefixes_with_filesystem(session, [str(input_root)])
+        drain_pending_verifications(session)
+    session.commit()
+
+    session.expire_all()
+    original_record = session.get(Asset, old_record.id)
+    assert original_record is not None
+    assert original_record.content_id == old_content.id
+    assert original_record.content.is_missing is True
+
+
+def test_hash_mode_split_uses_stat_from_the_verified_snapshot(session, temp_dir: Path, monkeypatch):
+    input_root = temp_dir / "input"
+    input_root.mkdir()
+    path = input_root / "changed.bin"
+    monkeypatch.setattr("folder_paths.get_input_directory", lambda: str(input_root))
+    path.write_bytes(b"old")
+    content, _ = _seed_content(session, path, _stored_hash(path))
+    queue_pending_verification(content.id)
+    new_payload = b"new bytes with a different size"
+    real_snapshot_hash = snapshot_hash
+
+    def mutate_then_hash(candidate_path: str):
+        path.write_bytes(new_payload)
+        return real_snapshot_hash(candidate_path)
+
+    monkeypatch.setattr("app.assets.scanner_changes.snapshot_hash", mutate_then_hash)
+
+    processed = drain_pending_verifications(session)
+
+    live_content = session.scalar(
+        select(AssetContent).where(AssetContent.is_missing.is_(False))
+    )
+    assert processed == 1
+    assert live_content is not None
+    assert live_content.size_bytes == len(new_payload)
+    assert live_content.mtime_ns == path.stat().st_mtime_ns

--- a/tests-unit/assets_test/services/test_enrichment_predicate.py
+++ b/tests-unit/assets_test/services/test_enrichment_predicate.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import patch
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from app.assets.database.queries import create_content, create_record
+from app.assets.scanner import get_unenriched_assets_for_roots
+from app.assets.scanner_changes import is_path_under_prefixes
+
+from .path_prefix_cases import prefix_case_paths
+
+
+@contextmanager
+def _reuse_session(session: Session) -> Iterator[Session]:
+    yield session
+
+
+def _raw_system_metadata(session: Session, record_id: str) -> object:
+    return session.execute(
+        sa.text("SELECT system_metadata FROM assets WHERE id = :id"),
+        {"id": record_id},
+    ).scalar()
+
+
+def test_create_record_stores_none_system_metadata_as_sql_null(
+    session: Session,
+) -> None:
+    content = create_content(session, "/models/no-meta.safetensors", hash=None)
+
+    record = create_record(session, content.id, "no-meta.safetensors")
+    session.commit()
+
+    assert _raw_system_metadata(session, record.id) is None
+
+
+def test_off_mode_returns_metadata_less_seeded_asset(
+    session: Session, temp_dir: Path
+) -> None:
+    path = temp_dir / "fresh.safetensors"
+    content = create_content(session, str(path), hash=None)
+    record = create_record(session, content.id, path.name)
+    session.commit()
+    record_id = record.id
+
+    with (
+        patch("app.assets.scanner.create_session", lambda: _reuse_session(session)),
+        patch(
+            "app.assets.scanner.get_scan_prefixes_for_root",
+            return_value=[str(temp_dir)],
+        ),
+    ):
+        rows = get_unenriched_assets_for_roots(("models",), compute_hashes=False)
+
+    assert record_id in {row.record_id for row in rows}
+
+
+def test_off_mode_excludes_asset_with_system_metadata(
+    session: Session, temp_dir: Path
+) -> None:
+    path = temp_dir / "enriched.safetensors"
+    content = create_content(session, str(path), hash=None)
+    record = create_record(
+        session,
+        content.id,
+        path.name,
+        system_metadata={"architecture": "flux"},
+    )
+    session.commit()
+    record_id = record.id
+
+    with (
+        patch("app.assets.scanner.create_session", lambda: _reuse_session(session)),
+        patch(
+            "app.assets.scanner.get_scan_prefixes_for_root",
+            return_value=[str(temp_dir)],
+        ),
+    ):
+        rows = get_unenriched_assets_for_roots(("models",), compute_hashes=False)
+
+    assert record_id not in {row.record_id for row in rows}
+
+
+def test_query_pushes_limit_into_sql(session: Session, temp_dir: Path) -> None:
+    for index in range(5):
+        path = temp_dir / f"cand-{index}.safetensors"
+        content = create_content(session, str(path), hash=None)
+        create_record(session, content.id, path.name)
+    session.commit()
+
+    statements: list[str] = []
+
+    def _capture(_conn, _cursor, statement, _params, _context, _executemany) -> None:
+        statements.append(statement)
+
+    engine = session.bind
+    sa.event.listen(engine, "before_cursor_execute", _capture)
+    try:
+        with (
+            patch("app.assets.scanner.create_session", lambda: _reuse_session(session)),
+            patch(
+                "app.assets.scanner.get_scan_prefixes_for_root",
+                return_value=[str(temp_dir)],
+            ),
+        ):
+            rows = get_unenriched_assets_for_roots(
+                ("models",), compute_hashes=False, limit=2
+            )
+    finally:
+        sa.event.remove(engine, "before_cursor_execute", _capture)
+
+    assert len(rows) == 2
+    content_selects = [
+        s for s in statements if "asset_contents" in s.lower() and s.lower().lstrip().startswith("select")
+    ]
+    assert content_selects, f"expected a SELECT over asset_contents; got {statements}"
+    assert any("limit" in s.lower() for s in content_selects), (
+        f"enrichment query must push LIMIT into SQL; got: {content_selects}"
+    )
+
+
+def test_prefix_filter_matches_is_path_under_prefixes(
+    session: Session, temp_dir: Path
+) -> None:
+    prefix = str(temp_dir)
+    inside_path = os.path.join(prefix, "sub", "inside.safetensors")
+    sibling_path = prefix + "-sibling" + os.sep + "outside.safetensors"
+
+    inside = create_record(
+        session, create_content(session, inside_path, hash=None).id, "inside.safetensors"
+    )
+    sibling = create_record(
+        session, create_content(session, sibling_path, hash=None).id, "outside.safetensors"
+    )
+    session.commit()
+
+    with (
+        patch("app.assets.scanner.create_session", lambda: _reuse_session(session)),
+        patch(
+            "app.assets.scanner.get_scan_prefixes_for_root",
+            return_value=[prefix],
+        ),
+    ):
+        returned = {
+            row.record_id
+            for row in get_unenriched_assets_for_roots(("models",), compute_hashes=False)
+        }
+
+    assert is_path_under_prefixes(inside_path, [prefix]) is True
+    assert is_path_under_prefixes(sibling_path, [prefix]) is False
+    assert inside.id in returned
+    assert sibling.id not in returned
+
+
+def _seed_paths(session: Session, paths: list[str]) -> dict[str, str]:
+    by_record: dict[str, str] = {}
+    for index, path in enumerate(paths):
+        content = create_content(session, path, hash=None)
+        record = create_record(session, content.id, f"case-{index}.safetensors")
+        by_record[record.id] = content.path
+    session.commit()
+    return by_record
+
+
+def _candidate_paths(session: Session, prefix: str) -> set[str]:
+    with (
+        patch("app.assets.scanner.create_session", lambda: _reuse_session(session)),
+        patch(
+            "app.assets.scanner.get_scan_prefixes_for_root",
+            return_value=[prefix],
+        ),
+    ):
+        rows = get_unenriched_assets_for_roots(("models",), compute_hashes=False)
+    return {row.file_path for row in rows}
+
+
+def test_prefix_filter_result_set_equals_python_predicate(
+    session: Session, temp_dir: Path
+) -> None:
+    root = str(temp_dir / "root")
+    by_record = _seed_paths(session, prefix_case_paths(root))
+    stored = set(by_record.values())
+
+    returned = _candidate_paths(session, root)
+
+    expected = {p for p in stored if is_path_under_prefixes(p, [root])}
+    assert returned == expected
+    assert expected and expected != stored
+
+
+def test_prefix_holding_metacharacters_matches_only_literal_children(
+    session: Session, temp_dir: Path
+) -> None:
+    root = str(temp_dir / "a_b%c*d?e[f")
+    inside_path = os.path.join(root, "inside.safetensors")
+    decoy_path = os.path.join(str(temp_dir), "aXbYcZdWeQf", "decoy.safetensors")
+    _seed_paths(session, [inside_path, decoy_path])
+
+    returned = _candidate_paths(session, root)
+
+    assert is_path_under_prefixes(decoy_path, [root]) is False
+    assert returned == {inside_path}

--- a/tests-unit/assets_test/services/test_enrichment_snapshot.py
+++ b/tests-unit/assets_test/services/test_enrichment_snapshot.py
@@ -1,0 +1,185 @@
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from app.assets.database.models import Asset, AssetContent
+from app.assets.helpers import to_stored_hash
+from app.assets.scanner import enrich_asset
+
+
+def _create_unhashed_record(session, path: Path) -> tuple[AssetContent, Asset]:
+    content = AssetContent(
+        path=str(path),
+        hash=None,
+        size_bytes=path.stat().st_size,
+        mtime_ns=path.stat().st_mtime_ns,
+    )
+    session.add(content)
+    session.flush()
+    record = Asset(content_id=content.id, name=path.name)
+    session.add(record)
+    session.commit()
+    return content, record
+
+
+def test_enrichment_uses_snapshot_hash_not_direct_blake3(session, temp_dir: Path):
+    path = temp_dir / "stable.bin"
+    path.write_bytes(b"stable content")
+    content, record = _create_unhashed_record(session, path)
+
+    with patch(
+        "app.assets.scanner.snapshot_hash", return_value=("snapshot-digest", path.stat())
+    ) as mocked_snapshot_hash:
+        enriched = enrich_asset(
+            session,
+            file_path=str(path),
+            content_id=content.id,
+            record_id=record.id,
+            extract_metadata=False,
+            compute_hash=True,
+        )
+
+    assert enriched is True
+    assert session.get(AssetContent, content.id).hash == to_stored_hash("snapshot-digest")
+    mocked_snapshot_hash.assert_called_once_with(str(path))
+
+
+def test_enrichment_discards_unstable_hash(session, temp_dir: Path):
+    path = temp_dir / "unstable.bin"
+    path.write_bytes(b"unstable content")
+    content, record = _create_unhashed_record(session, path)
+
+    with patch("app.assets.scanner.snapshot_hash", return_value=None):
+        enriched = enrich_asset(
+            session,
+            file_path=str(path),
+            content_id=content.id,
+            record_id=record.id,
+            extract_metadata=False,
+            compute_hash=True,
+        )
+
+    assert enriched is False
+    assert session.get(AssetContent, content.id).hash is None
+
+
+def test_enrichment_discards_metadata_read_from_a_different_file_than_the_hash(
+    session, temp_dir: Path
+):
+    path = temp_dir / "swapped.bin"
+    path.write_bytes(b"original bytes")
+    content, record = _create_unhashed_record(session, path)
+
+    def _replace_file_then_hash(_file_path: str):
+        path.write_bytes(b"replacement bytes, a different length entirely")
+        return "replacement-digest", path.stat()
+
+    with patch("app.assets.scanner.snapshot_hash", side_effect=_replace_file_then_hash):
+        enriched = enrich_asset(
+            session,
+            file_path=str(path),
+            content_id=content.id,
+            record_id=record.id,
+            extract_metadata=True,
+            compute_hash=True,
+        )
+
+    assert enriched is False
+    session.expire_all()
+    assert session.get(AssetContent, content.id).hash is None
+    assert session.get(Asset, record.id).system_metadata is None, (
+        "a mismatched hash observation must discard already-computed metadata too, "
+        "not just the hash"
+    )
+
+
+def test_enrichment_discards_result_when_only_the_hashed_mtime_disagrees(
+    session, temp_dir: Path
+):
+    path = temp_dir / "touched.bin"
+    path.write_bytes(b"same length bytes")
+    content, record = _create_unhashed_record(session, path)
+    later_mtime_ns = path.stat().st_mtime_ns + 5_000_000_000
+
+    def _touch_file_then_hash(_file_path: str):
+        os.utime(path, ns=(later_mtime_ns, later_mtime_ns))
+        return "rewritten-digest", path.stat()
+
+    with patch("app.assets.scanner.snapshot_hash", side_effect=_touch_file_then_hash):
+        enriched = enrich_asset(
+            session,
+            file_path=str(path),
+            content_id=content.id,
+            record_id=record.id,
+            extract_metadata=True,
+            compute_hash=True,
+        )
+
+    assert enriched is False
+    session.expire_all()
+    assert session.get(AssetContent, content.id).hash is None
+    assert session.get(Asset, record.id).system_metadata is None, (
+        "size matching alone is not proof the file is unchanged; an mtime "
+        "disagreement alone must also discard the result"
+    )
+
+
+def test_enrichment_lands_metadata_and_hash_from_one_stable_observation(
+    session, temp_dir: Path
+):
+    path = temp_dir / "stable-both.bin"
+    path.write_bytes(b"stable content for both")
+    content, record = _create_unhashed_record(session, path)
+
+    with patch(
+        "app.assets.scanner.snapshot_hash", return_value=("both-digest", path.stat())
+    ):
+        enriched = enrich_asset(
+            session,
+            file_path=str(path),
+            content_id=content.id,
+            record_id=record.id,
+            extract_metadata=True,
+            compute_hash=True,
+        )
+
+    assert enriched is True
+    session.expire_all()
+    assert session.get(AssetContent, content.id).hash == to_stored_hash("both-digest")
+    assert session.get(Asset, record.id).system_metadata == {
+        "filename": "stable-both.bin",
+        "file_path": str(path),
+        "format": "bin",
+        "content_type": "application/octet-stream",
+        "content_length": path.stat().st_size,
+    }
+
+
+def test_off_mode_enrichment_still_lands_metadata_without_a_hash(
+    session, temp_dir: Path
+):
+    path = temp_dir / "off-mode.bin"
+    path.write_bytes(b"metadata only")
+    content, record = _create_unhashed_record(session, path)
+
+    with patch("app.assets.scanner.snapshot_hash") as never_hashed:
+        enriched = enrich_asset(
+            session,
+            file_path=str(path),
+            content_id=content.id,
+            record_id=record.id,
+            extract_metadata=True,
+            compute_hash=False,
+        )
+
+    never_hashed.assert_not_called()
+    assert enriched is True
+    session.expire_all()
+    assert session.get(AssetContent, content.id).hash is None
+    assert session.get(Asset, record.id).system_metadata == {
+        "filename": "off-mode.bin",
+        "file_path": str(path),
+        "format": "bin",
+        "content_type": "application/octet-stream",
+        "content_length": path.stat().st_size,
+    }

--- a/tests-unit/assets_test/services/test_from_hash.py
+++ b/tests-unit/assets_test/services/test_from_hash.py
@@ -1,0 +1,118 @@
+from unittest.mock import patch
+
+from sqlalchemy import select
+
+from app.assets.database.models import Asset, AssetContent
+from app.assets.database.queries.records import create_content, mark_content_missing
+from app.assets.helpers import to_stored_hash
+from app.assets.services.ingest import create_from_hash
+from app.assets.services.lookup import (
+    claim_qualified_content as _real_claim_qualified_content,
+    refresh_qualified_content as _real_refresh_qualified_content,
+)
+
+
+def test_create_from_hash_with_prefixed_hash_finds_existing_content(
+    mock_create_session, monkeypatch, temp_dir
+):
+    digest = "a" * 64
+    path = temp_dir / "existing.bin"
+    path.write_bytes(b"existing bytes")
+    monkeypatch.setattr("app.assets.mode.hashing_enabled", lambda: True)
+
+    with mock_create_session() as session:
+        content = create_content(session, str(path), to_stored_hash(digest), path.stat().st_size)
+        content_id = content.id
+        session.commit()
+
+    result = create_from_hash(f"blake3:{digest}", "derived.bin")
+
+    assert result is not None
+    with mock_create_session() as session:
+        records = list(session.scalars(select(Asset)))
+        created_record = session.get(Asset, result.ref.id)
+    assert created_record is not None
+    assert created_record.content_id == content_id
+    assert [record.content_id for record in records] == [content_id]
+
+
+def test_create_from_hash_with_bare_hash_also_works(
+    mock_create_session, monkeypatch, temp_dir
+):
+    digest = "b" * 64
+    path = temp_dir / "existing.bin"
+    path.write_bytes(b"existing bytes")
+    monkeypatch.setattr("app.assets.mode.hashing_enabled", lambda: True)
+
+    with mock_create_session() as session:
+        content = create_content(session, str(path), to_stored_hash(digest), path.stat().st_size)
+        content_id = content.id
+        session.commit()
+
+    result = create_from_hash(digest, "derived.bin")
+
+    assert result is not None
+    with mock_create_session() as session:
+        records = list(session.scalars(select(Asset)))
+        created_record = session.get(Asset, result.ref.id)
+    assert created_record is not None
+    assert created_record.content_id == content_id
+    assert [record.content_id for record in records] == [content_id]
+
+
+def _seed_live_content(mock_create_session, path, digest):
+    with mock_create_session() as session:
+        content = create_content(session, str(path), to_stored_hash(digest), path.stat().st_size)
+        content_id = content.id
+        session.commit()
+    return content_id
+
+
+def test_content_retired_between_lookup_and_claim_mints_nothing(
+    mock_create_session, monkeypatch, temp_dir
+):
+    digest = "c" * 64
+    path = temp_dir / "retired.bin"
+    path.write_bytes(b"retired bytes")
+    monkeypatch.setattr("app.assets.mode.hashing_enabled", lambda: True)
+    content_id = _seed_live_content(mock_create_session, path, digest)
+
+    def retire_then_claim(session, claimed_id, hash):
+        mark_content_missing(session, claimed_id)
+        session.commit()
+        return _real_claim_qualified_content(session, claimed_id, hash)
+
+    with patch("app.assets.services.ingest.claim_qualified_content", retire_then_claim):
+        result = create_from_hash(f"blake3:{digest}", "derived.bin")
+
+    assert result is None
+    with mock_create_session() as session:
+        assert list(session.scalars(select(Asset))) == []
+        retired = session.get(AssetContent, content_id)
+        assert retired is not None
+        assert retired.hash == to_stored_hash(digest)
+        assert retired.path == str(path)
+
+
+def test_file_vanishing_between_claim_and_refresh_mints_nothing(
+    mock_create_session, monkeypatch, temp_dir
+):
+    digest = "d" * 64
+    path = temp_dir / "vanishing.bin"
+    path.write_bytes(b"vanishing bytes")
+    monkeypatch.setattr("app.assets.mode.hashing_enabled", lambda: True)
+    content_id = _seed_live_content(mock_create_session, path, digest)
+
+    def delete_file_then_refresh(session, refreshed_id):
+        path.unlink()
+        return _real_refresh_qualified_content(session, refreshed_id)
+
+    with patch(
+        "app.assets.services.ingest.refresh_qualified_content", delete_file_then_refresh
+    ):
+        result = create_from_hash(f"blake3:{digest}", "derived.bin")
+
+    assert result is None
+    with mock_create_session() as session:
+        assert list(session.scalars(select(Asset))) == []
+        assert session.get(AssetContent, content_id) is not None

--- a/tests-unit/assets_test/services/test_hash_mode_state.py
+++ b/tests-unit/assets_test/services/test_hash_mode_state.py
@@ -1,0 +1,58 @@
+from unittest.mock import patch
+
+from app.assets.database.models import AssetContent
+from app.assets.services.hash_mode_state import (
+    clear_transition_queue,
+    drain_transition_queue,
+    enqueue_transition_work,
+    pending_transition_count,
+    read_stored_mode,
+    record_transition_intent,
+    write_stored_mode,
+)
+
+
+def test_absent_row_off_mode_no_transition(session):
+    with patch("app.assets.services.hash_mode_state._mode.hashing_enabled", return_value=False):
+        assert record_transition_intent(session) is None
+    assert read_stored_mode(session) == "off"
+
+
+def test_empty_drain_keeps_off_mode_ready_for_a_later_on_transition(session):
+    write_stored_mode(session, "off")
+
+    drain_transition_queue(session)
+
+    with patch("app.assets.services.hash_mode_state._mode.hashing_enabled", return_value=True):
+        assert record_transition_intent(session) == "off_to_on"
+
+
+def test_off_to_on_enqueues_null_rows(session):
+    session.add(AssetContent(path="/tmp/null", hash=None))
+    session.add(AssetContent(path="/tmp/hashed", hash="abc"))
+    write_stored_mode(session, "off")
+    with patch("app.assets.services.hash_mode_state._mode.hashing_enabled", return_value=True):
+        transition = record_transition_intent(session)
+    enqueue_transition_work(session, transition)
+    assert transition == "off_to_on"
+    assert pending_transition_count() == 2
+    assert read_stored_mode(session) == "off"
+    clear_transition_queue()
+
+
+def test_on_to_off_freezes(session):
+    write_stored_mode(session, "on")
+    with patch("app.assets.services.hash_mode_state._mode.hashing_enabled", return_value=False):
+        transition = record_transition_intent(session)
+    assert transition == "on_to_off"
+    assert read_stored_mode(session) == "off"
+    assert pending_transition_count() == 0
+
+
+def test_mode_stays_off_during_transition(session):
+    session.add(AssetContent(path="/tmp/null", hash=None))
+    write_stored_mode(session, "off")
+    with patch("app.assets.services.hash_mode_state._mode.hashing_enabled", return_value=True):
+        transition = record_transition_intent(session)
+    enqueue_transition_work(session, transition)
+    assert read_stored_mode(session) == "off"

--- a/tests-unit/assets_test/services/test_ingest_b.py
+++ b/tests-unit/assets_test/services/test_ingest_b.py
@@ -1,0 +1,82 @@
+import os
+
+import pytest
+from sqlalchemy import select
+
+import app.assets.mode as mode_module
+import folder_paths
+from app.assets.database.models import Asset, AssetContent
+from app.assets.services.ingest import register_executed_output
+
+
+@pytest.fixture(autouse=True)
+def hashing_off():
+    class FakeArgs:
+        enable_asset_hashing = False
+
+    mode_module.init(FakeArgs())
+    yield
+    mode_module.init(None)
+
+
+def test_new_path_save_off_mode_hash_null(mock_create_session):
+    output_dir = folder_paths.get_output_directory()
+    os.makedirs(output_dir, exist_ok=True)
+    f = os.path.join(output_dir, "test_ingest_b_new.png")
+    with open(f, "wb") as fh:
+        fh.write(b"pixels")
+
+    try:
+        record = register_executed_output(f, job_id="job1")
+        record_id = record.id
+        with mock_create_session() as session:
+            content = session.execute(
+                select(AssetContent).where(AssetContent.path == os.path.abspath(f))
+            ).scalar_one()
+            assert content.hash is None
+            assert content.is_missing is False
+            asset = session.execute(
+                select(Asset).where(Asset.id == record_id)
+            ).scalar_one()
+            assert asset.job_id == "job1"
+    finally:
+        if os.path.exists(f):
+            os.unlink(f)
+
+
+def test_overwrite_at_live_path_marks_old_missing(mock_create_session):
+    output_dir = folder_paths.get_output_directory()
+    os.makedirs(output_dir, exist_ok=True)
+    f = os.path.join(output_dir, "test_ingest_b_overwrite.png")
+
+    try:
+        with open(f, "wb") as fh:
+            fh.write(b"v1")
+        r1 = register_executed_output(f, job_id="job1")
+        old_content_id = r1.content_id
+        old_record_id = r1.id
+
+        with open(f, "wb") as fh:
+            fh.write(b"v2")
+        r2 = register_executed_output(f, job_id="job2")
+        new_record_id = r2.id
+
+        with mock_create_session() as session:
+            old_content = session.execute(
+                select(AssetContent).where(AssetContent.id == old_content_id)
+            ).scalar_one()
+            assert old_content.is_missing is True, "Old content should be marked missing"
+
+            old_record = session.execute(
+                select(Asset).where(Asset.id == old_record_id)
+            ).scalar_one()
+            assert old_record.job_id == "job1", "Old record's job_id must not be mutated"
+
+            new_record = session.execute(
+                select(Asset).where(Asset.id == new_record_id)
+            ).scalar_one()
+            assert new_record.job_id == "job2"
+            assert new_record_id != old_record_id
+    finally:
+        if os.path.exists(f):
+            os.unlink(f)

--- a/tests-unit/assets_test/services/test_ingest_orphan_content.py
+++ b/tests-unit/assets_test/services/test_ingest_orphan_content.py
@@ -1,0 +1,129 @@
+import os
+import uuid
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+import app.assets.mode as mode_module
+import folder_paths
+from app.assets.database.models import Asset, AssetContent
+from app.assets.database.queries import create_record as create_record_query
+from app.assets.scanner import SeedAssetSpec, seed_asset_specs
+from app.assets.services import ingest
+from app.assets.services.ingest import register_file_in_place, upload_from_temp_path
+
+
+@pytest.fixture
+def hashing_off():
+    class FakeArgs:
+        enable_asset_hashing = False
+
+    mode_module.init(FakeArgs())
+    yield
+    mode_module.init(None)
+
+
+def _write_temp(content: bytes) -> str:
+    uploads_root = os.path.join(
+        folder_paths.get_temp_directory(), "uploads", uuid.uuid4().hex
+    )
+    os.makedirs(uploads_root, exist_ok=True)
+    path = os.path.join(uploads_root, ".upload.part")
+    with open(path, "wb") as file:
+        file.write(content)
+    return path
+
+
+def _raise_create_record(*_args, **_kwargs):
+    raise RuntimeError("forced create_record failure")
+
+
+def _live_content_count(session: Session) -> int:
+    return session.scalar(
+        select(func.count())
+        .select_from(AssetContent)
+        .where(AssetContent.is_missing.is_(False))
+    )
+
+
+def test_upload_from_temp_path_discards_content_on_record_failure(
+    mock_create_session, hashing_off, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    content = b"orphan-upload-" + uuid.uuid4().bytes
+    temp_path = _write_temp(content)
+    monkeypatch.setattr(ingest, "create_record", _raise_create_record)
+
+    with pytest.raises(RuntimeError, match="forced create_record failure"):
+        upload_from_temp_path(
+            temp_path=temp_path,
+            name="orphan.bin",
+            tags=["output"],
+            client_filename="orphan.bin",
+        )
+
+    with mock_create_session() as session:
+        assert _live_content_count(session) == 0
+
+
+def test_register_file_in_place_discards_content_on_record_failure(
+    mock_create_session, hashing_off, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output_dir = folder_paths.get_output_directory()
+    os.makedirs(output_dir, exist_ok=True)
+    path = os.path.join(output_dir, f"orphan_inplace_{uuid.uuid4().hex}.png")
+    with open(path, "wb") as file:
+        file.write(b"orphan-inplace-" + uuid.uuid4().bytes)
+    monkeypatch.setattr(ingest, "create_record", _raise_create_record)
+
+    try:
+        with pytest.raises(RuntimeError, match="forced create_record failure"):
+            register_file_in_place(abs_path=path, name="orphan_inplace.png", tags=["output"])
+
+        with mock_create_session() as session:
+            assert _live_content_count(session) == 0
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+
+
+def _seed_spec(path: str, size_bytes: int, mtime_ns: int, name: str) -> SeedAssetSpec:
+    return {
+        "abs_path": path,
+        "size_bytes": size_bytes,
+        "mtime_ns": mtime_ns,
+        "info_name": name,
+        "tags": ["input"],
+        "fname": name,
+        "metadata": None,
+        "mime_type": None,
+        "job_id": None,
+    }
+
+
+def test_seed_asset_specs_discards_content_on_record_failure(
+    session: Session, tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    specs: list[SeedAssetSpec] = []
+    fail_name = "vanished.bin"
+    for name in ("first.bin", fail_name, "last.bin"):
+        file_path = tmp_path / name
+        file_path.write_bytes(name.encode())
+        stat_result = file_path.stat()
+        specs.append(
+            _seed_spec(str(file_path), stat_result.st_size, stat_result.st_mtime_ns, name)
+        )
+
+    def _create_record_or_raise(session_arg, content_id, name, *args, **kwargs):
+        if name == fail_name:
+            raise RuntimeError("forced create_record failure")
+        return create_record_query(session_arg, content_id, name, *args, **kwargs)
+
+    monkeypatch.setattr("app.assets.scanner.create_record", _create_record_or_raise)
+
+    with pytest.raises(RuntimeError, match="forced create_record failure"):
+        seed_asset_specs(session, specs)
+    session.rollback()
+
+    assert _live_content_count(session) == 0
+    assert session.scalar(select(func.count()).select_from(Asset)) == 0

--- a/tests-unit/assets_test/services/test_lifecycle.py
+++ b/tests-unit/assets_test/services/test_lifecycle.py
@@ -1,0 +1,286 @@
+import os
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session as SASession
+
+from app.assets import lifecycle
+from app.assets.database.models import Asset, AssetContent, Base
+from app.assets.database.queries.records import create_content, create_record
+from app.assets.lifecycle import (
+    cleanup_temp_filesystem,
+    get_excluded_scan_roots,
+    run_asset_shutdown_cleanup,
+    run_asset_startup,
+    run_startup,
+    wipe_temp_db_rows,
+)
+from app.assets.scanner import get_temp_prefixes, sync_temp_references_safely
+from app.assets.scanner_changes import is_path_under_prefixes
+from app.assets.seeder import asset_seeder
+
+from .path_prefix_cases import prefix_case_paths
+
+
+@pytest.fixture(autouse=True)
+def autoclean_unit_test_assets():
+    lifecycle._excluded_scan_roots.clear()
+    yield
+    lifecycle._excluded_scan_roots.clear()
+
+
+@pytest.fixture
+def session():
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(engine)
+    with Session(engine) as sess:
+        yield sess
+
+
+@pytest.fixture
+def mock_create_session(session):
+    engine = session.bind
+
+    @contextmanager
+    def _create_session():
+        with SASession(engine) as sess:
+            yield sess
+
+    with patch("app.assets.lifecycle.create_session", _create_session), \
+         patch("app.database.db.create_session", _create_session):
+        yield _create_session
+
+
+@pytest.fixture
+def comfy_dirs():
+    with tempfile.TemporaryDirectory() as base:
+        temp_dir = Path(base) / "temp"
+        temp_dir.mkdir()
+        with patch("folder_paths.get_temp_directory", return_value=str(temp_dir)):
+            yield temp_dir
+
+
+def _seed_temp_rows(session: Session, temp_dir: Path) -> tuple[str, str]:
+    temp_file = temp_dir / "preview.png"
+    temp_file.write_bytes(b"\x00" * 10)
+    content = create_content(session, path=str(temp_file))
+    record = create_record(session, content_id=content.id, name="preview.png")
+    session.commit()
+    return record.id, content.id
+
+
+def test_startup_order_wipe_before_rmtree_before_seeder(mock_create_session):
+    calls: list[str] = []
+
+    def _wipe(session):
+        calls.append("wipe")
+        return 0, 0
+
+    with (
+        patch("app.assets.lifecycle.wipe_temp_db_rows", side_effect=_wipe),
+        patch("app.assets.lifecycle.cleanup_temp_filesystem", side_effect=lambda: calls.append("rmtree") or True),
+        patch("app.assets.lifecycle.enqueue_mode_transition_work", side_effect=lambda: calls.append("enqueue")),
+        patch("app.assets.lifecycle.drain_mode_transition_work", side_effect=lambda: calls.append("drain")),
+        patch("app.assets.lifecycle.start_asset_seeder", side_effect=lambda: calls.append("seeder") or True),
+    ):
+        run_asset_startup()
+
+    assert calls == ["wipe", "rmtree", "enqueue", "drain", "seeder"]
+
+
+def test_db_wipe_failure_skips_rmtree_and_continues(mock_create_session):
+    with (
+        patch("app.assets.lifecycle.wipe_temp_db_rows", side_effect=RuntimeError("db wipe failed")),
+        patch("app.assets.lifecycle.cleanup_temp_filesystem") as cleanup_mock,
+        patch("app.assets.lifecycle.start_asset_seeder", return_value=True) as seeder_mock,
+    ):
+        run_asset_startup()
+
+    cleanup_mock.assert_not_called()
+    seeder_mock.assert_called_once()
+
+
+def test_run_startup_disabled_sweeps_temp_filesystem_without_db_work(comfy_dirs):
+    stale = comfy_dirs / "stale.png"
+    stale.write_bytes(b"\x00" * 10)
+    assert stale.exists()
+
+    with (
+        patch("app.assets.lifecycle.run_asset_startup") as asset_startup_mock,
+        patch("app.assets.lifecycle.wipe_temp_db_rows") as wipe_mock,
+        patch("app.assets.lifecycle.start_asset_seeder") as seeder_mock,
+    ):
+        run_startup(enable_assets=False)
+
+    assert not stale.exists()
+    asset_startup_mock.assert_not_called()
+    wipe_mock.assert_not_called()
+    seeder_mock.assert_not_called()
+
+
+def test_run_startup_enabled_delegates_to_asset_startup_not_bare_sweep():
+    with (
+        patch("app.assets.lifecycle.run_asset_startup") as asset_startup_mock,
+        patch("app.assets.lifecycle.cleanup_temp_filesystem") as cleanup_mock,
+    ):
+        run_startup(enable_assets=True)
+
+    asset_startup_mock.assert_called_once_with()
+    cleanup_mock.assert_not_called()
+
+
+def test_run_startup_logs_and_absorbs_disabled_filesystem_failure(caplog):
+    with patch("app.assets.lifecycle.cleanup_temp_filesystem", side_effect=RuntimeError("filesystem failure")):
+        run_startup(enable_assets=False)
+
+    assert "Asset startup maintenance failed" in caplog.text
+
+
+def test_rmtree_failure_excludes_temp_from_scan(session, comfy_dirs, mock_create_session):
+    record_id, content_id = _seed_temp_rows(session, comfy_dirs)
+
+    wipe_temp_db_rows(session)
+    session.commit()
+    assert session.get(Asset, record_id) is None
+
+    with patch("app.assets.lifecycle.shutil.rmtree", side_effect=OSError("busy")):
+        assert cleanup_temp_filesystem() is False
+
+    assert str(comfy_dirs) in get_excluded_scan_roots()
+    assert get_temp_prefixes() == []
+
+    residual = comfy_dirs / "leftover.png"
+    residual.write_bytes(b"\x00" * 10)
+
+    with patch("app.assets.scanner.create_session", mock_create_session):
+        sync_temp_references_safely()
+
+    assert session.scalars(select(Asset)).all() == []
+
+
+def test_shutdown_skips_cleanup_when_seeder_join_times_out(session, comfy_dirs, mock_create_session, caplog):
+    record_id, _ = _seed_temp_rows(session, comfy_dirs)
+
+    with patch("app.assets.lifecycle.wipe_temp_db_rows") as wipe_mock:
+        with patch.object(asset_seeder, "shutdown", return_value=False):
+            joined = asset_seeder.shutdown()
+            if joined:
+                run_asset_shutdown_cleanup()
+
+    wipe_mock.assert_not_called()
+    assert session.get(Asset, record_id) is not None
+
+
+def test_shutdown_cleanup_wipes_rows_then_rmtree(session, comfy_dirs, mock_create_session):
+    record_id, content_id = _seed_temp_rows(session, comfy_dirs)
+    calls: list[str] = []
+
+    real_wipe = wipe_temp_db_rows
+
+    def tracking_wipe(sess):
+        calls.append("wipe")
+        return real_wipe(sess)
+
+    with (
+        patch("app.assets.lifecycle.wipe_temp_db_rows", side_effect=tracking_wipe),
+        patch("app.assets.lifecycle.cleanup_temp_filesystem", side_effect=lambda: calls.append("rmtree") or True),
+    ):
+        run_asset_shutdown_cleanup()
+
+    assert calls == ["wipe", "rmtree"]
+    assert session.get(Asset, record_id) is None
+    assert session.get(AssetContent, content_id) is None
+
+
+def test_run_shutdown_without_session_sweeps_temp_filesystem(comfy_dirs):
+    stale = comfy_dirs / "stale.png"
+    stale.write_bytes(b"\x00" * 10)
+
+    with (
+        patch("app.assets.lifecycle.can_create_session", return_value=False),
+        patch("app.assets.lifecycle.wipe_temp_db_rows") as wipe_mock,
+    ):
+        lifecycle.run_shutdown()
+
+    assert not stale.exists()
+    wipe_mock.assert_not_called()
+
+
+def test_wipe_temp_db_rows_deletes_records_before_content(session, comfy_dirs):
+    record_id, content_id = _seed_temp_rows(session, comfy_dirs)
+    records_deleted, contents_deleted = wipe_temp_db_rows(session)
+    session.commit()
+
+    assert records_deleted == 1
+    assert contents_deleted == 1
+    assert session.get(Asset, record_id) is None
+    assert session.get(AssetContent, content_id) is None
+
+
+def test_wipe_temp_db_rows_preserves_non_temp_rows(session, comfy_dirs):
+    temp_record_id, temp_content_id = _seed_temp_rows(session, comfy_dirs)
+    keep_path = str(comfy_dirs) + "-sibling" + os.sep + "keep.safetensors"
+    keep_content = create_content(session, path=keep_path)
+    keep_record = create_record(session, content_id=keep_content.id, name="keep.safetensors")
+    session.commit()
+
+    records_deleted, contents_deleted = wipe_temp_db_rows(session)
+    session.commit()
+
+    assert (records_deleted, contents_deleted) == (1, 1)
+    assert session.get(Asset, temp_record_id) is None
+    assert session.get(AssetContent, temp_content_id) is None
+    assert session.get(Asset, keep_record.id) is not None
+    assert session.get(AssetContent, keep_content.id) is not None
+
+
+def _seed_paths(session: Session, paths: list[str]) -> list[str]:
+    stored: list[str] = []
+    for index, path in enumerate(paths):
+        content = create_content(session, path=path)
+        create_record(session, content_id=content.id, name=f"case-{index}.png")
+        stored.append(content.path)
+    session.commit()
+    return stored
+
+
+def _surviving_paths(session: Session) -> set[str]:
+    return set(session.scalars(select(AssetContent.path)).all())
+
+
+def test_wipe_deletes_exactly_what_is_path_under_prefixes_accepts(session, comfy_dirs):
+    temp_root = str(comfy_dirs)
+    stored = _seed_paths(session, prefix_case_paths(temp_root))
+
+    records_deleted, contents_deleted = wipe_temp_db_rows(session)
+    session.commit()
+
+    wiped = {p for p in stored if is_path_under_prefixes(p, [temp_root])}
+    assert _surviving_paths(session) == set(stored) - wiped
+    assert (records_deleted, contents_deleted) == (len(wiped), len(wiped))
+    assert wiped and wiped != set(stored)
+    case_different = os.path.join(
+        os.path.dirname(temp_root), os.path.basename(temp_root).upper(), "case.png"
+    )
+    assert case_different in _surviving_paths(session)
+    assert os.path.join(os.path.dirname(temp_root), "escaped.png") in _surviving_paths(session)
+
+
+def test_wipe_with_metacharacter_temp_root_matches_only_literal_children(session):
+    with tempfile.TemporaryDirectory() as base:
+        temp_root = os.path.join(base, "a_b%c*d?e[f")
+        inside = os.path.join(temp_root, "preview.png")
+        decoy = os.path.join(base, "aXbYcZdWeQf", "keep.safetensors")
+        _seed_paths(session, [inside, decoy])
+
+        with patch("folder_paths.get_temp_directory", return_value=temp_root):
+            wipe_temp_db_rows(session)
+        session.commit()
+
+    assert is_path_under_prefixes(decoy, [temp_root]) is False
+    assert _surviving_paths(session) == {decoy}

--- a/tests-unit/assets_test/services/test_metadata_update_b.py
+++ b/tests-unit/assets_test/services/test_metadata_update_b.py
@@ -1,0 +1,59 @@
+import pytest
+
+from app.assets.database.models import Asset, AssetTag, Tag
+from app.assets.database.queries.records import (
+    create_content,
+    create_record,
+    fetch_record_tags,
+)
+from app.assets.services.asset_management import update_asset_metadata
+from app.assets.services.tagging import apply_tags, remove_tags
+
+
+def _create_record(session, path: str, tags: list[str] | None = None) -> Asset:
+    content = create_content(session, path)
+    record = create_record(session, content.id, "original", tags=tags)
+    session.commit()
+    return record
+
+
+def test_rename_via_update_asset_metadata(session, mock_create_session):
+    record = _create_record(session, "/output/rename.png")
+
+    update_asset_metadata(record.id, name="renamed")
+
+    session.expire_all()
+    assert session.get(Asset, record.id).name == "renamed"
+
+
+def test_apply_tags_adds_tags(session, mock_create_session):
+    record = _create_record(session, "/output/apply-tags.png")
+
+    apply_tags(record.id, ["foo", "bar"])
+
+    session.expire_all()
+    assert fetch_record_tags(session, record.id) == ["bar", "foo"]
+
+
+def test_remove_tags_removes_non_automatic(session, mock_create_session):
+    record = _create_record(session, "/output/remove-tags.png", tags=["foo"])
+    session.add(Tag(name="automatic"))
+    session.add(AssetTag(asset_id=record.id, tag_name="automatic", origin="automatic"))
+    session.commit()
+
+    remove_tags(record.id, ["foo"])
+
+    session.expire_all()
+    assert fetch_record_tags(session, record.id) == ["automatic"]
+
+
+def test_update_asset_metadata_unknown_preview_id_raises(session, mock_create_session):
+    record = _create_record(session, "/output/preview-validate.png")
+
+    with pytest.raises(ValueError):
+        update_asset_metadata(
+            record.id, preview_id="00000000-0000-0000-0000-000000000000"
+        )
+
+    session.expire_all()
+    assert session.get(Asset, record.id).preview_id is None

--- a/tests-unit/assets_test/services/test_null_hash_recovery.py
+++ b/tests-unit/assets_test/services/test_null_hash_recovery.py
@@ -1,0 +1,198 @@
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import select
+
+from app.assets.database.models import Asset, AssetContent, AssetTag
+from app.assets.database.queries.records import create_content, create_record
+from app.assets.helpers import to_stored_hash
+from app.assets.scanner import SeedAssetSpec, clear_pending_verifications, seed_asset_specs
+from app.assets.services import hash_mode_state
+from app.assets.services.hash_mode_state import (
+    clear_transition_queue,
+    drain_transition_queue,
+    enqueue_transition_work,
+    record_transition_intent,
+    write_stored_mode,
+)
+from app.assets.services.snapshot_hash import snapshot_hash
+
+
+@pytest.fixture(autouse=True)
+def _clear_queues():
+    clear_transition_queue()
+    clear_pending_verifications()
+    yield
+    clear_transition_queue()
+    clear_pending_verifications()
+
+
+def _stored_hash(path: Path) -> str:
+    snapshot = snapshot_hash(str(path))
+    assert snapshot is not None
+    digest, _ = snapshot
+    return to_stored_hash(digest)
+
+
+def _spec(path: Path) -> SeedAssetSpec:
+    stat = path.stat()
+    return {
+        "abs_path": str(path),
+        "size_bytes": stat.st_size,
+        "mtime_ns": stat.st_mtime_ns,
+        "info_name": path.name,
+        "tags": ["input"],
+        "fname": path.name,
+        "metadata": None,
+        "mime_type": None,
+        "job_id": None,
+    }
+
+
+def test_deleted_null_hash_row_recovers_via_scanner_after_restore(
+    session, temp_dir, monkeypatch
+):
+    path = temp_dir / "recoverable.bin"
+    monkeypatch.setattr("folder_paths.get_input_directory", lambda: str(temp_dir))
+    original_bytes = b"the exact bytes that come back"
+    path.write_bytes(original_bytes)
+    stat = path.stat()
+    content = create_content(session, str(path), size_bytes=stat.st_size, mtime_ns=stat.st_mtime_ns)
+    content_id = content.id
+    record = create_record(session, content_id, "recoverable.bin", tags=["input"])
+    record_id = record.id
+    session.commit()
+
+    write_stored_mode(session, "off")
+    monkeypatch.setattr(hash_mode_state._mode, "hashing_enabled", lambda: True)
+    path.unlink()
+    transition = record_transition_intent(session)
+    enqueue_transition_work(session, transition)
+    drain_transition_queue(session)
+    session.commit()
+    assert session.get(AssetContent, content_id).is_missing is True, (
+        "precondition: A1's drain marked the row missing on delete"
+    )
+
+    path.write_bytes(original_bytes)
+    os.utime(path, ns=(stat.st_atime_ns, stat.st_mtime_ns))
+    assert path.stat().st_mtime_ns == stat.st_mtime_ns, "setup: mtime must round-trip exactly"
+
+    with patch("app.assets.scanner.mode.hashing_enabled", return_value=True):
+        created = seed_asset_specs(session, [_spec(path)])
+    session.commit()
+
+    assert created == 0, "the original row must recover — no fresh content row minted"
+    recovered = session.get(AssetContent, content_id)
+    assert recovered.is_missing is False
+    assert recovered.hash == _stored_hash(path)
+    assert len(session.scalars(select(AssetContent)).all()) == 1, "no duplicate content row"
+    assert len(session.scalars(select(Asset)).all()) == 1, "no duplicate record"
+    assert session.get(Asset, record_id) is not None, "the original record's identity survives"
+    assert session.get(AssetTag, {"asset_id": record_id, "tag_name": "missing"}) is None
+
+
+def test_different_bytes_restored_at_same_path_does_not_recover_old_row(
+    session, temp_dir, monkeypatch
+):
+    path = temp_dir / "replaced.bin"
+    monkeypatch.setattr("folder_paths.get_input_directory", lambda: str(temp_dir))
+    path.write_bytes(b"original bytes")
+    stat = path.stat()
+    content = create_content(session, str(path), size_bytes=stat.st_size, mtime_ns=stat.st_mtime_ns)
+    content_id = content.id
+    create_record(session, content_id, "replaced.bin")
+    session.commit()
+
+    write_stored_mode(session, "off")
+    monkeypatch.setattr(hash_mode_state._mode, "hashing_enabled", lambda: True)
+    path.unlink()
+    transition = record_transition_intent(session)
+    enqueue_transition_work(session, transition)
+    drain_transition_queue(session)
+    session.commit()
+    assert session.get(AssetContent, content_id).is_missing is True
+
+    path.write_bytes(b"a completely different, much longer payload than the original")
+
+    with patch("app.assets.scanner.mode.hashing_enabled", return_value=True):
+        created = seed_asset_specs(session, [_spec(path)])
+    session.commit()
+
+    assert created == 1, "a genuinely different file must take the normal new-content path"
+    assert session.get(AssetContent, content_id).is_missing is True, (
+        "the old row must stay missing — recovering it here would hand the wrong record's "
+        "identity, tags, and metadata to unrelated bytes"
+    )
+    assert len(session.scalars(select(AssetContent)).all()) == 2
+
+
+def test_same_size_different_mtime_restored_at_same_path_does_not_recover_old_row(
+    session, temp_dir, monkeypatch
+):
+    path = temp_dir / "retimed.bin"
+    monkeypatch.setattr("folder_paths.get_input_directory", lambda: str(temp_dir))
+    original_bytes = b"identical length, different moment in time"
+    path.write_bytes(original_bytes)
+    stat = path.stat()
+    content = create_content(session, str(path), size_bytes=stat.st_size, mtime_ns=stat.st_mtime_ns)
+    content_id = content.id
+    create_record(session, content_id, "retimed.bin")
+    session.commit()
+
+    write_stored_mode(session, "off")
+    monkeypatch.setattr(hash_mode_state._mode, "hashing_enabled", lambda: True)
+    path.unlink()
+    transition = record_transition_intent(session)
+    enqueue_transition_work(session, transition)
+    drain_transition_queue(session)
+    session.commit()
+    assert session.get(AssetContent, content_id).is_missing is True
+
+    path.write_bytes(original_bytes)
+    shifted_ns = stat.st_mtime_ns + 5_000_000_000
+    os.utime(path, ns=(stat.st_atime_ns, shifted_ns))
+    assert path.stat().st_mtime_ns != stat.st_mtime_ns, "setup: mtime must actually differ"
+    assert path.stat().st_size == stat.st_size, "setup: size must match so only mtime disambiguates"
+
+    with patch("app.assets.scanner.mode.hashing_enabled", return_value=True):
+        created = seed_asset_specs(session, [_spec(path)])
+    session.commit()
+
+    assert created == 1, "a same-size-but-different-mtime restore must take the new-content path"
+    assert session.get(AssetContent, content_id).is_missing is True, (
+        "a matching size with a mismatched mtime is not proof the old row's bytes are back — "
+        "recovering here would hand the wrong record's identity to different bytes"
+    )
+    assert len(session.scalars(select(AssetContent)).all()) == 2
+
+
+def test_two_missing_null_hash_candidates_at_same_path_do_not_recover(
+    session, temp_dir, monkeypatch
+):
+    path = temp_dir / "ambiguous_null.bin"
+    monkeypatch.setattr("folder_paths.get_input_directory", lambda: str(temp_dir))
+    path.write_bytes(b"bytes shared by two missing generations")
+    stat = path.stat()
+    first = AssetContent(
+        path=str(path), hash=None, is_missing=True,
+        size_bytes=stat.st_size, mtime_ns=stat.st_mtime_ns,
+    )
+    second = AssetContent(
+        path=str(path), hash=None, is_missing=True,
+        size_bytes=stat.st_size, mtime_ns=stat.st_mtime_ns,
+    )
+    session.add_all([first, second])
+    session.flush()
+    first_id, second_id = first.id, second.id
+    session.commit()
+
+    with patch("app.assets.scanner.mode.hashing_enabled", return_value=True):
+        created = seed_asset_specs(session, [_spec(path)])
+    session.commit()
+
+    assert created == 1, "ambiguous candidates must fall through to the normal new-content path"
+    assert session.get(AssetContent, first_id).is_missing is True
+    assert session.get(AssetContent, second_id).is_missing is True

--- a/tests-unit/assets_test/services/test_output_registration.py
+++ b/tests-unit/assets_test/services/test_output_registration.py
@@ -1,0 +1,147 @@
+import os
+import sys
+import types
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+import folder_paths
+from sqlalchemy import select
+
+from app.assets.database.models import Asset, AssetContent
+from comfy_execution.asset_enrichment import (
+    register_cached_outputs,
+    register_executed_outputs,
+)
+
+
+@contextmanager
+def _assets_enabled(enabled: bool = True):
+    with patch.dict(
+        sys.modules,
+        {"comfy.cli_args": types.SimpleNamespace(args=types.SimpleNamespace(enable_assets=enabled))},
+    ):
+        yield
+
+
+def _write_output_file(name: str, data: bytes) -> Path:
+    path = Path(folder_paths.get_output_directory()) / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+    return path
+
+
+def _output_ui(name: str) -> dict:
+    return {"images": [{"filename": name, "subfolder": "", "type": "output"}]}
+
+
+def _wrapper(name: str, node_id: str = "1") -> dict:
+    return {"meta": {"node_id": node_id}, "output": _output_ui(name)}
+
+
+def test_executed_adapter_registers_new_output(mock_create_session):
+    path = _write_output_file("adapter-executed-new.png", b"exec")
+    try:
+        output_ui = _output_ui(path.name)
+
+        with _assets_enabled():
+            enriched = register_executed_outputs(output_ui, "exec-job")
+
+        new_id = enriched["images"][0]["id"]
+        assert "id" not in output_ui["images"][0]
+        with mock_create_session() as session:
+            record = session.get(Asset, new_id)
+            content = session.get(AssetContent, record.content_id)
+            assert record.job_id == "exec-job"
+            assert content.path == os.path.abspath(path)
+            assert content.is_missing is False
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def test_executed_adapter_over_existing_path_marks_old_missing(mock_create_session):
+    path = _write_output_file("adapter-executed-replace.png", b"original")
+    try:
+        with _assets_enabled():
+            first = register_executed_outputs(_output_ui(path.name), "job-1")
+        old_id = first["images"][0]["id"]
+
+        path.write_bytes(b"replacement")
+        with _assets_enabled():
+            second = register_executed_outputs(_output_ui(path.name), "job-2")
+        new_id = second["images"][0]["id"]
+
+        assert new_id != old_id
+        with mock_create_session() as session:
+            old_content = session.get(AssetContent, session.get(Asset, old_id).content_id)
+            new_content = session.get(AssetContent, session.get(Asset, new_id).content_id)
+            assert old_content.is_missing is True
+            assert new_content.is_missing is False
+            contents = list(
+                session.scalars(
+                    select(AssetContent).where(AssetContent.path == os.path.abspath(path))
+                )
+            )
+            assert len(contents) == 2
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def test_executed_adapter_disabled_registers_nothing(mock_create_session):
+    path = _write_output_file("adapter-executed-disabled.png", b"noop")
+    try:
+        output_ui = _output_ui(path.name)
+
+        with _assets_enabled(False):
+            enriched = register_executed_outputs(output_ui, "job")
+
+        assert "id" not in enriched["images"][0]
+        with mock_create_session() as session:
+            contents = list(
+                session.scalars(
+                    select(AssetContent).where(AssetContent.path == os.path.abspath(path))
+                )
+            )
+            assert contents == []
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def test_executed_adapter_registration_failure_never_raises(mock_create_session):
+    path = _write_output_file("adapter-executed-error.png", b"exec")
+    try:
+        output_ui = _output_ui(path.name)
+
+        with _assets_enabled(), patch(
+            "app.assets.services.ingest.register_executed_output",
+            side_effect=RuntimeError("boom"),
+        ):
+            enriched = register_executed_outputs(output_ui, "job")
+
+        assert "id" not in enriched["images"][0]
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def test_cached_adapter_without_live_content_is_nonevent(mock_create_session):
+    path = _write_output_file("adapter-cached-missing.png", b"new content")
+    try:
+        wrapper = _wrapper(path.name)
+
+        with _assets_enabled():
+            enriched = register_cached_outputs(wrapper, "cached-job")
+
+        assert "id" not in enriched["output"]["images"][0]
+        with mock_create_session() as session:
+            contents = list(
+                session.scalars(
+                    select(AssetContent).where(AssetContent.path == os.path.abspath(path))
+                )
+            )
+            records = list(
+                session.scalars(select(Asset).where(Asset.job_id == "cached-job"))
+            )
+            assert contents == []
+            assert records == []
+    finally:
+        path.unlink(missing_ok=True)

--- a/tests-unit/assets_test/services/test_owner_purge.py
+++ b/tests-unit/assets_test/services/test_owner_purge.py
@@ -1,0 +1,15 @@
+import subprocess
+from pathlib import Path
+
+
+def test_no_owner_id_in_asset_modules():
+    repository = Path(__file__).resolve().parents[3]
+    result = subprocess.run(
+        ["grep", "-rn", "--exclude=*.pyc", "owner_id", "app/assets/"],
+        cwd=repository,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout == ""

--- a/tests-unit/assets_test/services/test_preview_path_resolution.py
+++ b/tests-unit/assets_test/services/test_preview_path_resolution.py
@@ -1,0 +1,64 @@
+from sqlalchemy import event
+
+from app.assets.database.queries.records import (
+    create_content,
+    create_record,
+    mark_content_missing,
+)
+from app.assets.services.asset_management import get_preview_file_paths
+
+
+def test_preview_paths_resolve_preview_record_content(session, mock_create_session) -> None:
+    preview_content = create_content(session, "/output/preview.png")
+    preview = create_record(session, preview_content.id, "preview.png")
+    record_content = create_content(session, "/output/record.png")
+    record = create_record(session, record_content.id, "record.png")
+    record.preview_id = preview.id
+    session.commit()
+
+    paths = get_preview_file_paths([preview.id])
+
+    assert paths == {preview.id: "/output/preview.png"}
+
+
+def test_preview_paths_exclude_missing_preview_content(session, mock_create_session) -> None:
+    preview_content = create_content(session, "/output/missing-preview.png")
+    preview = create_record(session, preview_content.id, "missing-preview.png")
+    record_content = create_content(session, "/output/record.png")
+    record = create_record(session, record_content.id, "record.png")
+    record.preview_id = preview.id
+    mark_content_missing(session, preview_content.id)
+    session.commit()
+
+    paths = get_preview_file_paths([preview.id])
+
+    assert paths == {}
+
+
+def test_preview_paths_resolve_a_page_in_one_query(session, mock_create_session, db_engine) -> None:
+    preview_ids: list[str] = []
+    expected_paths: dict[str, str] = {}
+    for index in range(3):
+        preview_path = f"/output/preview-{index}.png"
+        preview_content = create_content(session, preview_path)
+        preview = create_record(session, preview_content.id, f"preview-{index}.png")
+        record_content = create_content(session, f"/output/record-{index}.png")
+        record = create_record(session, record_content.id, f"record-{index}.png")
+        record.preview_id = preview.id
+        preview_ids.append(preview.id)
+        expected_paths[preview.id] = preview_path
+    session.commit()
+
+    statements: list[str] = []
+
+    def count_statements(_, __, statement, ___, ____, _____) -> None:
+        statements.append(statement)
+
+    event.listen(db_engine, "before_cursor_execute", count_statements)
+    try:
+        paths = get_preview_file_paths(preview_ids)
+    finally:
+        event.remove(db_engine, "before_cursor_execute", count_statements)
+
+    assert paths == expected_paths
+    assert len(statements) == 1

--- a/tests-unit/assets_test/services/test_recovery_gate.py
+++ b/tests-unit/assets_test/services/test_recovery_gate.py
@@ -1,0 +1,137 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import select
+
+from app.assets.database.models import Asset, AssetContent, AssetTag, Tag
+from app.assets.helpers import to_stored_hash
+from app.assets.scanner import (
+    SeedAssetSpec,
+    clear_pending_verifications,
+    pending_recovery_count,
+    seed_asset_specs,
+)
+from app.assets.services.snapshot_hash import snapshot_hash
+
+
+@pytest.fixture(autouse=True)
+def _clear_queues():
+    clear_pending_verifications()
+    yield
+    clear_pending_verifications()
+
+
+def _missing_content(session, path: Path, hash_value: str) -> tuple[AssetContent, Asset]:
+    content = AssetContent(path=str(path), hash=hash_value, is_missing=True)
+    session.add(content)
+    session.flush()
+    record = Asset(content_id=content.id, name=path.name)
+    session.add(record)
+    session.flush()
+    if session.get(Tag, "missing") is None:
+        session.add(Tag(name="missing"))
+    session.add(AssetTag(asset_id=record.id, tag_name="missing", origin="automatic"))
+    session.commit()
+    return content, record
+
+
+def _spec(path: Path) -> SeedAssetSpec:
+    stat = path.stat()
+    return {
+        "abs_path": str(path),
+        "size_bytes": stat.st_size,
+        "mtime_ns": stat.st_mtime_ns,
+        "info_name": path.name,
+        "tags": ["input"],
+        "fname": path.name,
+        "metadata": None,
+        "mime_type": None,
+        "job_id": None,
+    }
+
+
+def _stored_hash(path: Path) -> str:
+    snapshot = snapshot_hash(str(path))
+    assert snapshot is not None
+    digest, _ = snapshot
+    return to_stored_hash(digest)
+
+
+def test_single_hash_match_recovers(session, temp_dir: Path):
+    path = temp_dir / "restored.bin"
+    path.write_bytes(b"restored bytes")
+    content, record = _missing_content(session, path, _stored_hash(path))
+
+    with patch("app.assets.scanner.mode.hashing_enabled", return_value=True):
+        created = seed_asset_specs(session, [_spec(path)])
+    session.commit()
+
+    assert created == 0
+    assert session.get(AssetContent, content.id).is_missing is False
+    assert session.get(AssetTag, {"asset_id": record.id, "tag_name": "missing"}) is None
+
+
+def test_ambiguous_hash_match_recovers_nothing(session, temp_dir: Path):
+    path = temp_dir / "ambiguous.bin"
+    path.write_bytes(b"same bytes")
+    digest = _stored_hash(path)
+    first, _ = _missing_content(session, path, digest)
+    second, _ = _missing_content(session, path, digest)
+
+    with patch("app.assets.scanner.mode.hashing_enabled", return_value=True):
+        created = seed_asset_specs(session, [_spec(path)])
+    session.commit()
+
+    assert created == 1
+    assert session.get(AssetContent, first.id).is_missing is True
+    assert session.get(AssetContent, second.id).is_missing is True
+    assert len(session.scalars(select(AssetContent)).all()) == 3
+
+
+def test_no_hash_match_creates_fresh_rows(session, temp_dir: Path):
+    path = temp_dir / "different.bin"
+    path.write_bytes(b"current bytes")
+    missing, _ = _missing_content(session, path, "old")
+
+    with patch("app.assets.scanner.mode.hashing_enabled", return_value=True):
+        created = seed_asset_specs(session, [_spec(path)])
+    session.commit()
+
+    assert created == 1
+    assert session.get(AssetContent, missing.id).is_missing is True
+    assert len(session.scalars(select(Asset)).all()) == 2
+
+
+def test_off_mode_no_recovery(session, temp_dir: Path):
+    path = temp_dir / "off.bin"
+    path.write_bytes(b"bytes")
+    missing, _ = _missing_content(session, path, _stored_hash(path))
+
+    with (
+        patch("app.assets.scanner.mode.hashing_enabled", return_value=False),
+        patch("app.assets.scanner_changes.snapshot_hash") as hash_mock,
+    ):
+        created = seed_asset_specs(session, [_spec(path)])
+    session.commit()
+
+    hash_mock.assert_not_called()
+    assert created == 1
+    assert session.get(AssetContent, missing.id).is_missing is True
+
+
+def test_unstable_hash_requeues(session, temp_dir: Path):
+    path = temp_dir / "unstable.bin"
+    path.write_bytes(b"bytes")
+    missing, _ = _missing_content(session, path, "old")
+
+    with (
+        patch("app.assets.scanner.mode.hashing_enabled", return_value=True),
+        patch("app.assets.scanner_changes.snapshot_hash", return_value=None),
+    ):
+        created = seed_asset_specs(session, [_spec(path)])
+    session.commit()
+
+    assert created == 0
+    assert pending_recovery_count() == 1
+    assert session.get(AssetContent, missing.id).is_missing is True

--- a/tests-unit/assets_test/services/test_registration_primitives.py
+++ b/tests-unit/assets_test/services/test_registration_primitives.py
@@ -1,0 +1,273 @@
+import os
+from datetime import datetime
+
+import folder_paths
+from sqlalchemy import select
+
+from app.assets.database.models import Asset, AssetContent
+from app.assets.database.queries.records import create_content, create_record
+from app.assets.services.ingest import (
+    register_cached_output,
+    register_executed_output,
+    register_file_in_place,
+)
+
+
+def _output_path(name: str) -> str:
+    output_dir = folder_paths.get_output_directory()
+    os.makedirs(output_dir, exist_ok=True)
+    return os.path.join(output_dir, name)
+
+
+def test_executed_creates_metadata_and_null_hash(mock_create_session):
+    body = b"pixels"
+    path = _output_path("primitives_executed_meta.png")
+    with open(path, "wb") as fh:
+        fh.write(body)
+
+    try:
+        record = register_executed_output(path, job_id="job-exec")
+
+        assert record is not None
+        with mock_create_session() as session:
+            content = session.scalar(
+                select(AssetContent).where(
+                    AssetContent.path == os.path.abspath(path)
+                )
+            )
+            asset = session.get(Asset, record.id)
+
+            assert content.hash is None
+            assert content.is_missing is False
+            assert asset.system_metadata is not None
+            assert asset.system_metadata.get("format") == "png"
+            assert asset.system_metadata.get("content_length") == len(body)
+            assert "filename" in asset.system_metadata
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+
+
+def test_executed_over_live_path_marks_old_missing(mock_create_session):
+    path = _output_path("primitives_executed_overwrite.png")
+
+    try:
+        with open(path, "wb") as fh:
+            fh.write(b"v1")
+        first = register_executed_output(path, job_id="job1")
+
+        with open(path, "wb") as fh:
+            fh.write(b"v2")
+        second = register_executed_output(path, job_id="job2")
+
+        assert first is not None
+        assert second is not None
+        assert second.id != first.id
+        with mock_create_session() as session:
+            old_content = session.get(AssetContent, first.content_id)
+            old_record = session.get(Asset, first.id)
+            new_record = session.get(Asset, second.id)
+
+            assert old_content.is_missing is True
+            assert old_record.job_id == "job1"
+            assert new_record.job_id == "job2"
+            assert new_record.content_id != first.content_id
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+
+
+def test_cached_copies_sibling_metadata(mock_create_session):
+    sibling_metadata = {"provenance": "sibling", "width": 4, "kind": "image"}
+    path = _output_path("primitives_cached_copy.png")
+    with open(path, "wb") as fh:
+        fh.write(b"pixels")
+
+    try:
+        with mock_create_session() as session:
+            content = create_content(session, os.path.abspath(path), None, 6, 0)
+            create_record(
+                session,
+                content.id,
+                "sibling",
+                system_metadata=dict(sibling_metadata),
+            )
+            session.commit()
+            content_id = content.id
+
+        cached = register_cached_output(path, job_id="delivery-job")
+
+        assert cached is not None
+        assert cached.content_id == content_id
+        with mock_create_session() as session:
+            record = session.get(Asset, cached.id)
+            assert record.system_metadata == sibling_metadata
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+
+
+def test_cached_earliest_sibling_wins(mock_create_session):
+    earliest = datetime(2020, 1, 1, 0, 0, 0)
+    later = datetime(2020, 1, 2, 0, 0, 0)
+    winner_metadata = {"winner": "earliest-low-id"}
+    path = _output_path("primitives_cached_earliest.png")
+    with open(path, "wb") as fh:
+        fh.write(b"pixels")
+
+    try:
+        with mock_create_session() as session:
+            content = create_content(session, os.path.abspath(path), None, 6, 0)
+            session.add_all(
+                [
+                    Asset(
+                        id="00000000-0000-0000-0000-000000000001",
+                        content_id=content.id,
+                        name="earliest-low-id",
+                        created_at=earliest,
+                        system_metadata=dict(winner_metadata),
+                    ),
+                    Asset(
+                        id="00000000-0000-0000-0000-000000000002",
+                        content_id=content.id,
+                        name="earliest-high-id",
+                        created_at=earliest,
+                        system_metadata={"winner": "earliest-high-id"},
+                    ),
+                    Asset(
+                        id="00000000-0000-0000-0000-000000000000",
+                        content_id=content.id,
+                        name="later-lowest-id",
+                        created_at=later,
+                        system_metadata={"winner": "later-lowest-id"},
+                    ),
+                ]
+            )
+            session.commit()
+            content_id = content.id
+
+        cached = register_cached_output(path, job_id="delivery-job")
+
+        assert cached is not None
+        assert cached.content_id == content_id
+        with mock_create_session() as session:
+            record = session.get(Asset, cached.id)
+            assert record.system_metadata == winner_metadata
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+
+
+def test_cached_orphan_content_extracts_fresh(mock_create_session):
+    body = b"pixels"
+    path = _output_path("primitives_cached_orphan.png")
+    with open(path, "wb") as fh:
+        fh.write(body)
+
+    try:
+        with mock_create_session() as session:
+            content = create_content(
+                session, os.path.abspath(path), None, len(body), 0
+            )
+            session.commit()
+            content_id = content.id
+
+        cached = register_cached_output(path, job_id="delivery-job")
+
+        assert cached is not None
+        assert cached.content_id == content_id
+        with mock_create_session() as session:
+            record = session.get(Asset, cached.id)
+            assert record.system_metadata is not None
+            assert record.system_metadata.get("format") == "png"
+            assert record.system_metadata.get("content_length") == len(body)
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+
+
+def test_cached_missing_content_is_nonevent(mock_create_session):
+    path = _output_path("primitives_cached_missing.png")
+    with open(path, "wb") as fh:
+        fh.write(b"pixels")
+
+    try:
+        cached = register_cached_output(path, job_id="delivery-job")
+
+        assert cached is None
+        with mock_create_session() as session:
+            contents = list(
+                session.scalars(
+                    select(AssetContent).where(
+                        AssetContent.path == os.path.abspath(path)
+                    )
+                )
+            )
+            records = list(
+                session.scalars(
+                    select(Asset).where(Asset.job_id == "delivery-job")
+                )
+            )
+            assert contents == []
+            assert records == []
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+
+
+def test_registration_failure_never_raises_and_leaves_no_rows(
+    mock_create_session, monkeypatch
+):
+    def _boom(*args, **kwargs):
+        raise RuntimeError("simulated create_record failure")
+
+    monkeypatch.setattr(
+        "app.assets.services.ingest.create_record", _boom
+    )
+
+    path = _output_path("primitives_reg_fail.png")
+    with open(path, "wb") as fh:
+        fh.write(b"pixels")
+
+    try:
+        result = register_executed_output(path, job_id="job-boom")
+
+        assert result is None
+        with mock_create_session() as session:
+            contents = list(
+                session.scalars(
+                    select(AssetContent).where(
+                        AssetContent.path == os.path.abspath(path)
+                    )
+                )
+            )
+            records = list(
+                session.scalars(
+                    select(Asset).where(Asset.job_id == "job-boom")
+                )
+            )
+            assert contents == []
+            assert records == []
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+
+
+def test_upload_record_has_metadata_and_hash(mock_create_session):
+    body = b"pixels-content"
+    path = _output_path("primitives_upload_in_place.png")
+    with open(path, "wb") as fh:
+        fh.write(body)
+
+    try:
+        result = register_file_in_place(
+            path, name="pic.png", tags=["demo"], mime_type="image/png"
+        )
+
+        assert result.asset.hash is not None
+        assert result.ref.system_metadata is not None
+        assert result.ref.system_metadata.get("format") == "png"
+        assert result.ref.system_metadata.get("content_length") == len(body)
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)

--- a/tests-unit/assets_test/services/test_scan_lifecycle.py
+++ b/tests-unit/assets_test/services/test_scan_lifecycle.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from sqlalchemy import select
+
+from app.assets.database.models import AssetContent
+from app.assets.scanner import build_asset_specs, seed_asset_specs, sync_prefixes_with_filesystem
+
+
+def _scan(session, root: Path) -> int:
+    paths = [str(path) for path in root.iterdir()]
+    specs, _, _ = build_asset_specs(paths, set(), enable_metadata_extraction=False)
+    return seed_asset_specs(session, specs)
+
+
+def test_e2e_scan_seed_detect_prune(session, temp_dir: Path):
+    root = temp_dir / "input"
+    root.mkdir()
+    removed = root / "removed.bin"
+    edited = root / "edited.bin"
+    removed.write_bytes(b"removed")
+    edited.write_bytes(b"old")
+    with patch("folder_paths.get_input_directory", return_value=str(root)):
+        assert _scan(session, root) == 2
+        removed.unlink()
+        edited.write_bytes(b"replacement")
+        (root / "partial.part").write_bytes(b"partial")
+        with patch("app.assets.scanner.mode.hashing_enabled", return_value=False):
+            sync_prefixes_with_filesystem(session, [str(root)])
+            _scan(session, root)
+    session.commit()
+    contents = list(session.scalars(select(AssetContent)))
+    assert len(contents) == 3
+    assert len([content for content in contents if content.is_missing]) == 2
+
+
+def test_second_scan_idempotent(session, temp_dir: Path):
+    root = temp_dir / "input"
+    root.mkdir()
+    (root / "stable.bin").write_bytes(b"stable")
+    with patch("folder_paths.get_input_directory", return_value=str(root)):
+        assert _scan(session, root) == 1
+        assert _scan(session, root) == 0

--- a/tests-unit/assets_test/services/test_scanner_b.py
+++ b/tests-unit/assets_test/services/test_scanner_b.py
@@ -1,0 +1,232 @@
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import patch
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.assets.database.models import Asset, AssetContent, AssetTag
+from app.assets.helpers import to_stored_hash
+from app.assets.scanner import (
+    build_asset_specs,
+    enrich_asset,
+    mark_contents_missing_outside_prefixes,
+    seed_asset_specs,
+    sync_prefixes_with_filesystem,
+)
+from app.assets.services.snapshot_hash import snapshot_hash
+
+
+@dataclass(frozen=True, slots=True)
+class _ExtractedMetadata:
+    content_type: str | None
+    system_metadata: Mapping[str, int | str]
+
+    def to_user_metadata(self) -> dict[str, int | str]:
+        return dict(self.system_metadata)
+
+
+def _build_seed_specs(root: Path) -> list:
+    return build_asset_specs(
+        [str(path) for path in sorted(root.iterdir())],
+        existing_paths=set(),
+        enable_metadata_extraction=False,
+    )[0]
+
+
+def _create_enrichment_target(
+    session: Session,
+    path: Path,
+    system_metadata: dict[str, int | str] | None = None,
+) -> tuple[AssetContent, Asset]:
+    content = AssetContent(
+        path=str(path),
+        hash=None,
+        size_bytes=path.stat().st_size,
+        mtime_ns=path.stat().st_mtime_ns,
+    )
+    session.add(content)
+    session.flush()
+    record = Asset(
+        content_id=content.id,
+        name=path.name,
+        system_metadata=system_metadata,
+    )
+    session.add(record)
+    session.commit()
+    return content, record
+
+
+def test_enrichment_retains_absent_system_metadata_keys(session: Session, temp_dir: Path):
+    path = temp_dir / "metadata.bin"
+    path.write_bytes(b"metadata")
+    content, record = _create_enrichment_target(session, path)
+
+    with patch(
+        "app.assets.scanner.extract_file_metadata",
+        side_effect=[
+            _ExtractedMetadata(None, {"a": 1, "b": 2}),
+            _ExtractedMetadata(None, {"b": 3}),
+        ],
+    ):
+        enrich_asset(session, str(path), content.id, record.id)
+        enrich_asset(session, str(path), content.id, record.id)
+
+    assert record.system_metadata == {"a": 1, "b": 3}
+
+
+def test_enrichment_retains_dimensions_when_image_extraction_degrades(
+    session: Session, temp_dir: Path
+):
+    path = temp_dir / "image.png"
+    path.write_bytes(b"not a complete image")
+    content, record = _create_enrichment_target(
+        session,
+        path,
+        {"kind": "image", "width": 64, "height": 64},
+    )
+
+    with (
+        patch(
+            "app.assets.scanner.extract_file_metadata",
+            return_value=_ExtractedMetadata("image/png", {"filename": "image.png"}),
+        ),
+        patch("app.assets.scanner.extract_image_dimensions", return_value=None),
+    ):
+        enrich_asset(session, str(path), content.id, record.id)
+
+    assert record.system_metadata == {
+        "filename": "image.png",
+        "kind": "image",
+        "width": 64,
+        "height": 64,
+    }
+
+
+def test_enrichment_overrides_content_length_with_zero(
+    session: Session, temp_dir: Path
+):
+    path = temp_dir / "empty.bin"
+    path.write_bytes(b"")
+    content, record = _create_enrichment_target(
+        session,
+        path,
+        {"content_length": 1024},
+    )
+
+    with patch(
+        "app.assets.scanner.extract_file_metadata",
+        return_value=_ExtractedMetadata(None, {"content_length": 0}),
+    ):
+        enrich_asset(session, str(path), content.id, record.id)
+
+    assert record.system_metadata == {"content_length": 0}
+
+
+def test_seed_creates_content_and_record(session, temp_dir: Path):
+    input_root = temp_dir / "input"
+    input_root.mkdir()
+    (input_root / "first.png").write_bytes(b"first")
+    (input_root / "second.png").write_bytes(b"second")
+
+    with patch("folder_paths.get_input_directory", return_value=str(input_root)):
+        created = seed_asset_specs(session, _build_seed_specs(input_root))
+    session.commit()
+
+    contents = list(session.scalars(select(AssetContent).order_by(AssetContent.path)))
+    records = list(session.scalars(select(Asset).order_by(Asset.name)))
+
+    assert created == 2
+    assert len(contents) == 2
+    assert len(records) == 2
+    assert [record.loader_path for record in records] == ["first.png", "second.png"]
+    assert [link.tag_name for link in session.scalars(select(AssetTag).order_by(AssetTag.asset_id))] == [
+        "input",
+        "input",
+    ]
+
+
+def test_prune_marks_missing_not_deletes(session, temp_dir: Path):
+    input_root = temp_dir / "input"
+    input_root.mkdir()
+    file_path = input_root / "removed-from-registry.png"
+    file_path.write_bytes(b"content")
+
+    with patch("folder_paths.get_input_directory", return_value=str(input_root)):
+        seed_asset_specs(session, _build_seed_specs(input_root))
+    session.commit()
+
+    marked = mark_contents_missing_outside_prefixes(session, prefixes=[])
+    session.commit()
+
+    content = session.scalar(select(AssetContent))
+    record = session.scalar(select(Asset))
+    missing_tag = session.get(AssetTag, {"asset_id": record.id, "tag_name": "missing"})
+
+    assert marked == 1
+    assert content is not None and content.is_missing is True
+    assert record is not None
+    assert missing_tag is not None and missing_tag.origin == "automatic"
+
+
+def test_unhashed_missing_content_gets_tagged(session, temp_dir: Path):
+    missing_path = os.path.abspath(temp_dir / "missing.bin")
+    content = AssetContent(path=missing_path, hash=None, size_bytes=7, mtime_ns=1)
+    session.add(content)
+    session.flush()
+    record = Asset(content_id=content.id, name="missing.bin")
+    session.add(record)
+    session.commit()
+
+    sync_prefixes_with_filesystem(session, prefixes=[str(temp_dir)])
+    session.commit()
+
+    session.expire_all()
+    content = session.get(AssetContent, content.id)
+    missing_tag = session.get(AssetTag, {"asset_id": record.id, "tag_name": "missing"})
+
+    assert content is not None and content.is_missing is True
+    assert missing_tag is not None and missing_tag.origin == "automatic"
+
+
+def test_enrichment_keeps_equal_hash_contents_distinct(session, temp_dir: Path):
+    path = temp_dir / "new.bin"
+    path.write_bytes(b"same bytes")
+    snapshot = snapshot_hash(str(path))
+    assert snapshot is not None
+    digest, _ = snapshot
+
+    content = AssetContent(
+        path=str(path),
+        hash=None,
+        size_bytes=path.stat().st_size,
+        mtime_ns=path.stat().st_mtime_ns,
+    )
+    existing = AssetContent(
+        path=str(temp_dir / "existing.bin"),
+        hash=to_stored_hash(digest),
+        size_bytes=path.stat().st_size,
+        mtime_ns=path.stat().st_mtime_ns,
+    )
+    session.add_all((content, existing))
+    session.flush()
+    record = Asset(content_id=content.id, name=path.name)
+    existing_record = Asset(content_id=existing.id, name="existing.bin")
+    session.add_all((record, existing_record))
+    session.commit()
+
+    enriched = enrich_asset(
+        session,
+        file_path=str(path),
+        content_id=content.id,
+        record_id=record.id,
+        extract_metadata=False,
+        compute_hash=True,
+    )
+
+    assert enriched is True
+    assert session.get(AssetContent, content.id).hash == to_stored_hash(digest)
+    assert session.get(Asset, record.id).content_id == content.id
+    assert session.get(Asset, existing_record.id).content_id == existing.id

--- a/tests-unit/assets_test/services/test_scanner_seed_resilience.py
+++ b/tests-unit/assets_test/services/test_scanner_seed_resilience.py
@@ -1,0 +1,149 @@
+from collections.abc import Callable
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.assets.database.models import Asset
+from app.assets.database.queries import create_record as create_record_query
+from app.assets.scanner import SeedAssetSpec, seed_asset_specs
+from app.assets.services.snapshot_hash import snapshot_hash
+
+
+def _spec(path: Path) -> SeedAssetSpec:
+    stat_result = path.stat()
+    return {
+        "abs_path": str(path),
+        "size_bytes": stat_result.st_size,
+        "mtime_ns": stat_result.st_mtime_ns,
+        "info_name": path.name,
+        "tags": ["input"],
+        "fname": path.name,
+        "metadata": None,
+        "mime_type": None,
+        "job_id": None,
+    }
+
+
+def _specs_with_vanished_path(root: Path) -> tuple[list[SeedAssetSpec], Path]:
+    paths = [root / name for name in ("first.bin", "vanished.bin", "last.bin")]
+    for path in paths:
+        _ = path.write_bytes(path.name.encode())
+    return [_spec(path) for path in paths], paths[1]
+
+
+def _record_count(session: Session) -> int:
+    return len(session.scalars(select(Asset)).all())
+
+
+def test_seed_persists_remaining_specs_when_path_vanishes_before_restat(
+    session: Session, temp_dir: Path
+) -> None:
+    specs, vanished_path = _specs_with_vanished_path(temp_dir)
+    vanished_path.unlink()
+
+    created = seed_asset_specs(session, specs)
+    session.commit()
+
+    assert created == 2
+    assert _record_count(session) == 2
+
+
+def test_seed_persists_remaining_specs_when_path_vanishes_during_recovery_hash(
+    session: Session, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    specs, vanished_path = _specs_with_vanished_path(temp_dir)
+
+    def _hash_or_raise(path: str) -> str | None:
+        if path == str(vanished_path):
+            vanished_path.unlink()
+            raise OSError("file vanished during recovery")
+        return snapshot_hash(path)
+
+    monkeypatch.setattr("app.assets.scanner_changes.snapshot_hash", _hash_or_raise)
+
+    with patch("app.assets.scanner.mode.hashing_enabled", return_value=True):
+        created = seed_asset_specs(session, specs)
+    session.commit()
+
+    assert created == 2
+    assert _record_count(session) == 2
+
+
+def _delete_before_restat(_monkeypatch: pytest.MonkeyPatch, path: Path) -> None:
+    path.unlink()
+
+
+def _delete_during_recovery(monkeypatch: pytest.MonkeyPatch, path: Path) -> None:
+    def _hash_or_raise(candidate_path: str) -> str | None:
+        if candidate_path == str(path):
+            path.unlink()
+            raise OSError("file vanished during recovery")
+        return snapshot_hash(candidate_path)
+
+    monkeypatch.setattr("app.assets.scanner_changes.snapshot_hash", _hash_or_raise)
+
+
+@pytest.mark.parametrize(
+    "delete_path",
+    [_delete_before_restat, _delete_during_recovery],
+    ids=["before-restat", "during-recovery"],
+)
+def test_seed_logs_once_for_each_vanished_path(
+    session: Session,
+    temp_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    delete_path: Callable[[pytest.MonkeyPatch, Path], None],
+) -> None:
+    specs, vanished_path = _specs_with_vanished_path(temp_dir)
+    delete_path(monkeypatch, vanished_path)
+
+    with patch("app.assets.scanner.mode.hashing_enabled", return_value=True):
+        _ = seed_asset_specs(session, specs)
+    session.commit()
+
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if str(vanished_path) in record.getMessage()
+    ]
+    assert messages == [f"Skipping vanished asset during scan: {vanished_path}"]
+
+
+def test_seed_propagates_integrity_error_and_aborts_batch(
+    session: Session, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    specs, vanished_path = _specs_with_vanished_path(temp_dir)
+
+    def _create_record_or_raise(
+        session: Session,
+        content_id: str,
+        name: str,
+        mime_type: str | None = None,
+        job_id: str | None = None,
+        loader_path: str | None = None,
+        tags: tuple[str, ...] | None = None,
+    ) -> Asset:
+        if name == vanished_path.name:
+            raise IntegrityError("insert asset content", {}, Exception("forced failure"))
+        return create_record_query(
+            session,
+            content_id,
+            name,
+            mime_type,
+            job_id,
+            loader_path,
+            tags,
+        )
+
+    monkeypatch.setattr("app.assets.scanner.create_record", _create_record_or_raise)
+
+    with pytest.raises(IntegrityError):
+        _ = seed_asset_specs(session, specs)
+    session.rollback()
+
+    assert _record_count(session) == 0

--- a/tests-unit/assets_test/services/test_serving_b.py
+++ b/tests-unit/assets_test/services/test_serving_b.py
@@ -1,0 +1,356 @@
+import os
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
+from sqlalchemy import select, update
+
+from app.assets.api import routes
+from app.assets.api.routes import _build_asset_response
+from app.assets.database.models import Asset
+from app.assets.database.queries.records import (
+    RecordPageSpec,
+    create_content,
+    create_record,
+    get_record_by_id,
+    list_records_page,
+    mark_content_missing,
+)
+from app.assets.helpers import to_stored_hash
+from app.assets.services.asset_management import (
+    asset_exists,
+    delete_asset_reference,
+    get_asset_detail,
+    resolve_asset_for_download,
+    resolve_hash_to_path,
+)
+from app.assets.services.lookup import lookup_for_view
+from app.assets.services.schemas import AssetData, AssetDetailResult, ReferenceData
+
+_TS = datetime(2024, 1, 1, 0, 0, 0)
+
+
+def test_missing_content_record_metadata_200_with_tag_content_404(
+    mock_create_session, session, temp_dir
+):
+    content = create_content(session, path=str(temp_dir / "gone.bin"))
+    record = create_record(session, content_id=content.id, name="gone.bin")
+    mark_content_missing(session, content.id)
+    session.commit()
+    record_id = record.id
+
+    detail = get_asset_detail(record_id)
+    assert detail is not None
+    assert "missing" in detail.tags
+
+    with pytest.raises(FileNotFoundError):
+        resolve_asset_for_download(record_id)
+
+
+def test_missing_record_is_listed_but_never_served(
+    mock_create_session, session, temp_dir
+):
+    path = temp_dir / "listed_gone.bin"
+    path.write_bytes(b"x")
+    digest = to_stored_hash("a" * 64)
+    content = create_content(session, path=str(path), hash=digest)
+    record = create_record(session, content_id=content.id, name="listed_gone.bin")
+    mark_content_missing(session, content.id)
+    session.commit()
+    record_id = record.id
+
+    results, tag_map, total = list_records_page(session, RecordPageSpec())
+    assert any(r.id == record_id for r in results)
+    assert total == 1
+    assert "missing" in tag_map.get(record_id, [])
+
+    assert lookup_for_view(session, digest) is None
+    with pytest.raises(FileNotFoundError):
+        resolve_asset_for_download(record_id)
+
+
+def test_deleted_record_metadata_and_content_404(mock_create_session, session):
+    record_id = "00000000-0000-0000-0000-000000000000"
+    assert get_asset_detail(record_id) is None
+    with pytest.raises(ValueError, match="not found"):
+        resolve_asset_for_download(record_id)
+
+
+def test_content_404_when_file_absent_not_marked_missing(
+    mock_create_session, session, temp_dir
+):
+    path = temp_dir / "absent.bin"
+    path.write_bytes(b"x")
+    content = create_content(session, path=str(path))
+    record = create_record(session, content_id=content.id, name="absent.bin")
+    session.commit()
+    record_id = record.id
+    path.unlink()
+
+    detail = get_asset_detail(record_id)
+    assert detail is not None
+    assert "missing" not in detail.tags
+
+    with pytest.raises(FileNotFoundError):
+        resolve_asset_for_download(record_id)
+
+
+def test_content_fail_closed_no_sibling_fallback(mock_create_session, session, temp_dir):
+    digest = "d" * 64
+    missing_path = temp_dir / "missing.bin"
+    live_path = temp_dir / "live.bin"
+    live_path.write_bytes(b"live")
+
+    missing_content = create_content(session, path=str(missing_path), hash=digest)
+    live_content = create_content(session, path=str(live_path), hash=digest)
+    record = create_record(session, content_id=missing_content.id, name="missing.bin")
+    mark_content_missing(session, missing_content.id)
+    session.commit()
+    record_id = record.id
+
+    assert live_content.is_missing is False
+    assert os.path.isfile(live_path)
+
+    with pytest.raises(FileNotFoundError):
+        resolve_asset_for_download(record_id)
+
+
+def test_resolve_hash_to_path_refuses_temp_content(mock_create_session, session, temp_dir):
+    digest = "e" * 64
+    f = temp_dir / "temp_only.bin"
+    f.write_bytes(b"temp")
+    create_content(session, path=str(f), hash=to_stored_hash(digest))
+    session.commit()
+
+    with patch("app.assets.services.lookup.is_temp_path", return_value=True):
+        result = resolve_hash_to_path(f"blake3:{digest}")
+
+    assert result is None
+
+
+def test_resolve_hash_to_path_uses_newest_record_for_name_and_content_type(
+    mock_create_session, session, temp_dir
+):
+    digest = "c" * 64
+    f = temp_dir / "shared.bin"
+    f.write_bytes(b"data")
+    content = create_content(session, path=str(f), hash=to_stored_hash(digest))
+    older = create_record(
+        session,
+        content_id=content.id,
+        name="older.txt",
+        mime_type="text/plain",
+    )
+    newer = create_record(
+        session,
+        content_id=content.id,
+        name="newer.png",
+        mime_type="image/png",
+    )
+    older.created_at = _TS
+    older.updated_at = _TS
+    older.last_access_time = _TS
+    newer.created_at = _TS.replace(microsecond=1)
+    newer.updated_at = _TS.replace(microsecond=1)
+    newer.last_access_time = _TS.replace(microsecond=1)
+    session.commit()
+
+    result = resolve_hash_to_path(f"blake3:{digest}")
+
+    assert result is not None
+    assert result.download_name == "newer.png"
+    assert result.content_type == "image/png"
+
+
+def test_resolve_hash_to_path_serves_content_with_zero_records(
+    mock_create_session, session, temp_dir
+):
+    digest = "d" * 64
+    f = temp_dir / "orphan.png"
+    f.write_bytes(b"data")
+    content = create_content(session, path=str(f), hash=to_stored_hash(digest))
+    record = create_record(
+        session,
+        content_id=content.id,
+        name="renamed.txt",
+        mime_type="text/plain",
+    )
+    session.commit()
+
+    assert delete_asset_reference(record.id) is True
+    session.expire_all()
+    assert lookup_for_view(session, f"blake3:{digest}") is not None
+    assert session.scalars(
+        select(Asset).where(Asset.content_id == content.id)
+    ).all() == []
+
+    result = resolve_hash_to_path(f"blake3:{digest}")
+
+    assert result is not None
+    assert result.download_name == "orphan.png"
+    assert result.content_type == "image/png"
+
+
+def test_resolve_hash_to_path_unknown_hash(mock_create_session):
+    assert resolve_hash_to_path("blake3:" + "f" * 64) is None
+
+
+def test_content_read_updates_last_access_time(
+    mock_create_session, session, temp_dir
+):
+    f = temp_dir / "read.bin"
+    f.write_bytes(b"data")
+    content = create_content(session, path=str(f))
+    record = create_record(session, content_id=content.id, name="read.bin")
+    session.commit()
+    record_id = record.id
+
+    session.execute(
+        update(Asset).where(Asset.id == record_id).values(last_access_time=None)
+    )
+    session.commit()
+
+    before_record = get_record_by_id(session, record_id)
+    assert before_record is not None
+    before = before_record.last_access_time
+    assert before is None
+
+    resolve_asset_for_download(record_id)
+
+    session.expire_all()
+    after_record = get_record_by_id(session, record_id)
+    assert after_record is not None
+    after = after_record.last_access_time
+    assert after is not None
+
+
+def test_view_hash_read_updates_last_access_time(
+    mock_create_session, session, temp_dir
+):
+    digest = "a" * 64
+    f = temp_dir / "view.bin"
+    f.write_bytes(b"view")
+    content = create_content(session, path=str(f), hash=to_stored_hash(digest))
+    record = create_record(session, content_id=content.id, name="view.bin")
+    session.commit()
+    record_id = record.id
+
+    session.execute(
+        update(Asset).where(Asset.id == record_id).values(last_access_time=None)
+    )
+    session.commit()
+
+    result = resolve_hash_to_path(f"blake3:{digest}")
+    assert result is not None
+
+    session.expire_all()
+    record_after = get_record_by_id(session, record_id)
+    assert record_after is not None
+    assert record_after.last_access_time is not None
+
+
+def test_lookup_for_view_returns_none_for_temp_content(session, temp_dir):
+    digest = "b" * 64
+    f = temp_dir / "view_temp.bin"
+    f.write_bytes(b"temp")
+    create_content(session, path=str(f), hash=to_stored_hash(digest))
+    session.commit()
+
+    with patch("app.assets.services.lookup.is_temp_path", return_value=True):
+        assert lookup_for_view(session, to_stored_hash(digest)) is None
+
+
+def test_asset_exists_false_for_temp_content(mock_create_session, session, temp_dir):
+    digest = "c" * 64
+    f = temp_dir / "exists_temp.bin"
+    f.write_bytes(b"temp")
+    create_content(session, path=str(f), hash=to_stored_hash(digest))
+    session.commit()
+
+    with patch("app.assets.services.lookup.is_temp_path", return_value=True):
+        assert asset_exists(f"blake3:{digest}") is False
+
+
+@pytest.mark.asyncio
+async def test_head_hash_route_404_for_temp_content(
+    mock_create_session, session, temp_dir, monkeypatch
+):
+    digest = "d" * 64
+    f = temp_dir / "head_temp.bin"
+    f.write_bytes(b"temp")
+    create_content(session, path=str(f), hash=to_stored_hash(digest))
+    session.commit()
+
+    monkeypatch.setattr(routes, "_ASSETS_ENABLED", True)
+    with patch("app.assets.services.lookup.is_temp_path", return_value=True):
+        response = await routes.head_asset_by_hash(
+            make_mocked_request(
+                "HEAD",
+                f"/api/assets/hash/blake3:{digest}",
+                match_info={"hash": f"blake3:{digest}"},
+            )
+        )
+
+    assert isinstance(response, web.Response)
+    assert response.status == 404
+
+
+def test_resolve_hash_to_path_temp_does_not_bump_last_access_time(
+    mock_create_session, session, temp_dir
+):
+    digest = "f" * 64
+    f = temp_dir / "noaccess_temp.bin"
+    f.write_bytes(b"temp")
+    content = create_content(session, path=str(f), hash=to_stored_hash(digest))
+    record = create_record(session, content_id=content.id, name="noaccess_temp.bin")
+    session.commit()
+    record_id = record.id
+
+    session.execute(
+        update(Asset).where(Asset.id == record_id).values(last_access_time=None)
+    )
+    session.commit()
+
+    with patch("app.assets.services.lookup.is_temp_path", return_value=True):
+        result = resolve_hash_to_path(f"blake3:{digest}")
+
+    assert result is None
+    session.expire_all()
+    record_after = get_record_by_id(session, record_id)
+    assert record_after is not None
+    assert record_after.last_access_time is None
+
+
+@pytest.fixture
+def sandboxed_comfy_roots(tmp_path):
+    with patch("app.assets.services.path_utils.folder_paths") as fp:
+        fp.get_input_directory.return_value = str(tmp_path / "input")
+        fp.get_output_directory.return_value = str(tmp_path / "output")
+        fp.get_temp_directory.return_value = str(tmp_path / "temp")
+        fp.models_dir = str(tmp_path / "models")
+        yield tmp_path
+
+
+def test_temp_asset_preview_url_still_resolves_type_temp(sandboxed_comfy_roots):
+    name = "ComfyUI_temp_abcde_00001_.png"
+    result = AssetDetailResult(
+        ref=ReferenceData(
+            id="ref-temp",
+            name=name,
+            file_path=str(sandboxed_comfy_roots / "temp" / name),
+            loader_path=None,
+            user_metadata=None,
+            preview_id=None,
+            created_at=_TS,
+            updated_at=_TS,
+            last_access_time=_TS,
+        ),
+        asset=AssetData(hash="blake3:abc", size_bytes=1024, mime_type="image/png"),
+        tags=[],
+    )
+
+    resp = _build_asset_response(result, {})
+
+    assert resp.preview_url == f"/api/view?type=temp&filename={name}"

--- a/tests-unit/assets_test/services/test_snapshot_hash.py
+++ b/tests-unit/assets_test/services/test_snapshot_hash.py
@@ -1,0 +1,81 @@
+import builtins
+import os
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from blake3 import blake3
+
+from app.assets.services.snapshot_hash import snapshot_hash
+
+
+class _MutatingReader:
+    def __init__(self, file, mutate: Callable[[], None]) -> None:
+        self._file = file
+        self._mutate = mutate
+        self._did_mutate = False
+
+    def __enter__(self):
+        self._file.__enter__()
+        return self
+
+    def __exit__(self, *args):
+        return self._file.__exit__(*args)
+
+    def fileno(self) -> int:
+        return self._file.fileno()
+
+    def read(self, size: int = -1) -> bytes:
+        result = self._file.read(size)
+        if not self._did_mutate:
+            self._did_mutate = True
+            self._mutate()
+        return result
+
+
+def test_snapshot_hash_returns_digest_for_quiescent_file(tmp_path: Path) -> None:
+    payload = b"quiescent" * 1024
+    path = tmp_path / "asset.bin"
+    path.write_bytes(payload)
+
+    result = snapshot_hash(str(path), chunk_size=64)
+
+    assert result is not None
+    digest, stat_result = result
+    assert digest == blake3(payload).hexdigest()
+    assert isinstance(stat_result, os.stat_result)
+    assert stat_result.st_size == len(payload)
+
+
+@pytest.mark.parametrize("mutation", ["bytes", "replace", "unlink", "truncate", "append"])
+def test_snapshot_hash_returns_none_when_file_drifts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mutation: str
+) -> None:
+    path = tmp_path / "asset.bin"
+    path.write_bytes(b"original" * 1024)
+    original_open = builtins.open
+
+    def mutate() -> None:
+        match mutation:
+            case "bytes":
+                path.write_bytes(b"changed" * 1024)
+            case "replace":
+                replacement = tmp_path / "replacement.bin"
+                replacement.write_bytes(b"replacement")
+                os.replace(replacement, path)
+            case "unlink":
+                path.unlink()
+            case "truncate":
+                path.write_bytes(b"")
+            case "append":
+                with original_open(path, "ab") as output:
+                    output.write(b"more")
+            case unreachable:
+                raise AssertionError(f"unexpected mutation {unreachable}")
+
+    def open_with_mutation(*args, **kwargs):
+        return _MutatingReader(original_open(*args, **kwargs), mutate)
+
+    monkeypatch.setattr(builtins, "open", open_with_mutation)
+
+    assert snapshot_hash(str(path), chunk_size=64) is None

--- a/tests-unit/assets_test/services/test_split_policy.py
+++ b/tests-unit/assets_test/services/test_split_policy.py
@@ -1,0 +1,393 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import patch
+
+import sqlalchemy as sa
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+import pytest
+
+from app.assets.database.models import Asset, AssetContent
+from app.assets.database.queries import create_content, create_record
+from app.assets.database.queries.records import (
+    RecordPageSpec,
+    fetch_record_tags,
+    list_records_page,
+)
+from app.assets.helpers import to_stored_hash
+from app.assets.scanner import get_unenriched_assets_for_roots
+from app.assets.scanner_changes import (
+    clear_pending_verifications,
+    detect_content_change,
+    drain_pending_verifications,
+)
+from app.assets.services.hash_mode_state import (
+    clear_transition_queue,
+    drain_transition_queue,
+    enqueue_transition_work,
+)
+from app.assets.services.lookup import lookup_for_view
+from app.assets.services.snapshot_hash import snapshot_hash
+
+
+@dataclass(frozen=True, slots=True)
+class _FakeStat:
+
+    st_size: int
+    st_mtime_ns: int
+
+
+@contextmanager
+def _reuse_session(session: Session) -> Iterator[Session]:
+    yield session
+
+
+def _raw_system_metadata(session: Session, record_id: str) -> object:
+    return session.execute(
+        sa.text("SELECT system_metadata FROM assets WHERE id = :id"),
+        {"id": record_id},
+    ).scalar()
+
+
+def _candidates_under(session: Session, temp_dir: Path, *, compute_hashes: bool) -> set[str]:
+    with (
+        patch("app.assets.scanner.create_session", lambda: _reuse_session(session)),
+        patch(
+            "app.assets.scanner.get_scan_prefixes_for_root",
+            return_value=[str(temp_dir)],
+        ),
+    ):
+        rows = get_unenriched_assets_for_roots(("models",), compute_hashes=compute_hashes)
+    return {row.record_id for row in rows}
+
+
+@pytest.fixture(autouse=True)
+def _transition_queue_isolation() -> Iterator[None]:
+    clear_transition_queue()
+    yield
+    clear_transition_queue()
+
+
+@pytest.fixture(autouse=True)
+def _input_base_is_temp_dir(temp_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("folder_paths.get_input_directory", lambda: str(temp_dir))
+
+
+@pytest.fixture(autouse=True)
+def _pending_verification_isolation() -> Iterator[None]:
+    clear_pending_verifications()
+    yield
+    clear_pending_verifications()
+
+
+def _seed_hashed_content(session: Session, path: Path, data: bytes) -> AssetContent:
+    path.write_bytes(data)
+    snapshot = snapshot_hash(str(path))
+    assert snapshot is not None
+    digest, verified_stat = snapshot
+    return create_content(
+        session,
+        str(path),
+        to_stored_hash(digest),
+        verified_stat.st_size,
+        verified_stat.st_mtime_ns,
+    )
+
+
+def _bump_mtime(path: Path) -> os.stat_result:
+    before = path.stat()
+    bumped = before.st_mtime_ns + 5_000_000_000
+    os.utime(path, ns=(bumped, bumped))
+    after = path.stat()
+    assert after.st_mtime_ns != before.st_mtime_ns
+    assert after.st_size == before.st_size
+    return after
+
+
+def _rewrite_same_size(path: Path, data: bytes) -> os.stat_result:
+    before = path.stat()
+    assert len(data) == before.st_size
+    assert data != path.read_bytes()
+    path.write_bytes(data)
+    bumped = before.st_mtime_ns + 5_000_000_000
+    os.utime(path, ns=(bumped, bumped))
+    after = path.stat()
+    assert after.st_size == before.st_size
+    assert after.st_mtime_ns != before.st_mtime_ns
+    return after
+
+
+def test_split_record_is_enrich_candidate_in_hash_mode(
+    session: Session, temp_dir: Path
+) -> None:
+    path = temp_dir / "split.safetensors"
+    content = create_content(session, str(path), hash="blake3:deadbeef")
+    record = create_record(session, content.id, path.name)
+    session.commit()
+    record_id = record.id
+
+    candidates = _candidates_under(session, temp_dir, compute_hashes=True)
+
+    assert record_id in candidates
+
+
+def test_enriched_record_is_not_enrich_candidate_in_hash_mode(
+    session: Session, temp_dir: Path
+) -> None:
+    path = temp_dir / "enriched.safetensors"
+    content = create_content(session, str(path), hash="blake3:deadbeef")
+    record = create_record(
+        session, content.id, path.name, system_metadata={"architecture": "flux"}
+    )
+    session.commit()
+    record_id = record.id
+
+    candidates = _candidates_under(session, temp_dir, compute_hashes=True)
+
+    assert record_id not in candidates
+
+
+def test_same_size_mtime_bump_does_not_split(session: Session, temp_dir: Path) -> None:
+    path = temp_dir / "touched.safetensors"
+    content = create_content(session, str(path), hash=None, size_bytes=100, mtime_ns=1000)
+    record = create_record(
+        session, content.id, path.name, tags=["keepme"], system_metadata={"k": "v"}
+    )
+    session.commit()
+    content_id, record_id = content.id, record.id
+
+    detect_content_change(
+        session, content, _FakeStat(st_size=100, st_mtime_ns=2000), hashing_is_enabled=False
+    )
+    session.commit()
+    session.expire_all()
+
+    live = session.get(AssetContent, content_id)
+    assert live is not None and live.is_missing is False
+    rows_at_path = list(
+        session.scalars(select(AssetContent).where(AssetContent.path == str(path)))
+    )
+    assert len(rows_at_path) == 1
+    surviving = session.get(Asset, record_id)
+    assert surviving.system_metadata == {"k": "v"}
+    tags = fetch_record_tags(session, record_id)
+    assert "keepme" in tags
+    assert "missing" not in tags
+
+    assert live.mtime_ns == 2000
+    assert live.size_bytes == 100
+
+
+def test_accepted_mtime_bump_drops_the_unverifiable_hash(
+    session: Session, temp_dir: Path
+) -> None:
+    path = temp_dir / "synced.safetensors"
+    content = _seed_hashed_content(session, path, b"rsynced bytes")
+    record = create_record(
+        session, content.id, path.name, tags=["keepme"], system_metadata={"k": "v"}
+    )
+    session.commit()
+    content_id, record_id, stored_hash = content.id, record.id, content.hash
+    assert lookup_for_view(session, stored_hash) is not None
+
+    observed = _bump_mtime(path)
+    detect_content_change(session, content, observed, hashing_is_enabled=False)
+    session.commit()
+    session.expire_all()
+
+    live = session.get(AssetContent, content_id)
+    assert live.hash is None
+    assert lookup_for_view(session, stored_hash) is None
+
+    assert live.is_missing is False
+    assert live.mtime_ns == observed.st_mtime_ns
+    assert live.size_bytes == observed.st_size
+
+    surviving = session.get(Asset, record_id)
+    assert surviving is not None and surviving.content_id == content_id
+    assert surviving.system_metadata == {"k": "v"}
+    assert "keepme" in fetch_record_tags(session, record_id)
+    listed, _, _ = list_records_page(session, RecordPageSpec(limit=100))
+    assert record_id in {row.id for row in listed}
+
+
+def test_same_size_content_change_is_never_served_under_the_old_hash(
+    session: Session, temp_dir: Path
+) -> None:
+    path = temp_dir / "overwritten.safetensors"
+    content = _seed_hashed_content(session, path, b"AAAA")
+    create_record(session, content.id, path.name, tags=["keepme"])
+    session.commit()
+    old_hash = content.hash
+    assert lookup_for_view(session, old_hash) is not None
+
+    observed = _rewrite_same_size(path, b"BBBB")
+    detect_content_change(session, content, observed, hashing_is_enabled=False)
+    session.commit()
+    session.expire_all()
+
+    assert path.read_bytes() == b"BBBB"
+    assert lookup_for_view(session, old_hash) is None
+
+
+def test_accepted_mtime_bump_is_not_re_detected_by_the_next_scan(
+    session: Session, temp_dir: Path
+) -> None:
+    path = temp_dir / "resynced.safetensors"
+    content = _seed_hashed_content(session, path, b"cloud synced bytes")
+    create_record(session, content.id, path.name, tags=["keepme"])
+    session.commit()
+    content_id = content.id
+    detect_content_change(session, content, _bump_mtime(path), hashing_is_enabled=False)
+    session.commit()
+
+    detect_content_change(session, content, path.stat(), hashing_is_enabled=True)
+
+    assert drain_pending_verifications(session) == 0
+
+    detect_content_change(session, content, path.stat(), hashing_is_enabled=False)
+    session.commit()
+    session.expire_all()
+    rows_at_path = list(
+        session.scalars(select(AssetContent).where(AssetContent.path == str(path)))
+    )
+    assert len(rows_at_path) == 1
+    assert rows_at_path[0].id == content_id
+    assert rows_at_path[0].is_missing is False
+
+
+def test_dropped_hash_is_refilled_in_place_by_a_later_hash_mode_pass(
+    session: Session, temp_dir: Path
+) -> None:
+    path = temp_dir / "refilled.safetensors"
+    content = _seed_hashed_content(session, path, b"cloud synced bytes")
+    record = create_record(
+        session, content.id, path.name, tags=["keepme"], system_metadata={"k": "v"}
+    )
+    session.commit()
+    content_id, record_id = content.id, record.id
+    assert record_id not in _candidates_under(session, temp_dir, compute_hashes=True)
+
+    detect_content_change(session, content, _bump_mtime(path), hashing_is_enabled=False)
+    session.commit()
+    session.expire_all()
+    assert session.get(AssetContent, content_id).hash is None
+    assert record_id in _candidates_under(session, temp_dir, compute_hashes=True)
+
+    enqueue_transition_work(session, "off_to_on")
+    drain_transition_queue(session)
+    session.commit()
+    session.expire_all()
+
+    snapshot = snapshot_hash(str(path))
+    assert snapshot is not None
+    live = session.get(AssetContent, content_id)
+    assert live.is_missing is False
+    assert live.hash == to_stored_hash(snapshot[0])
+    assert lookup_for_view(session, live.hash).id == content_id
+    rows_at_path = list(
+        session.scalars(select(AssetContent).where(AssetContent.path == str(path)))
+    )
+    assert len(rows_at_path) == 1
+    assert "keepme" in fetch_record_tags(session, record_id)
+    assert session.get(Asset, record_id).system_metadata == {"k": "v"}
+    assert record_id not in _candidates_under(session, temp_dir, compute_hashes=True)
+
+
+def test_mtime_and_size_change_splits_with_null_metadata(
+    session: Session, temp_dir: Path
+) -> None:
+    path = temp_dir / "grown.safetensors"
+    content = create_content(session, str(path), hash=None, size_bytes=100, mtime_ns=1000)
+    create_record(
+        session, content.id, path.name, tags=["oldtag"], system_metadata={"k": "v"}
+    )
+    session.commit()
+    old_content_id = content.id
+
+    detect_content_change(
+        session, content, _FakeStat(st_size=200, st_mtime_ns=2000), hashing_is_enabled=False
+    )
+    session.commit()
+    session.expire_all()
+
+    assert session.get(AssetContent, old_content_id).is_missing is True
+    live = session.scalar(
+        select(AssetContent).where(
+            AssetContent.path == str(path), AssetContent.is_missing.is_(False)
+        )
+    )
+    assert live is not None and live.id != old_content_id
+    assert live.size_bytes == 200 and live.mtime_ns == 2000
+    new_record = session.scalar(select(Asset).where(Asset.content_id == live.id))
+    assert new_record is not None
+
+    assert new_record.system_metadata is None
+    assert _raw_system_metadata(session, new_record.id) is None
+    assert "oldtag" not in fetch_record_tags(session, new_record.id)
+    assert new_record.id in _candidates_under(session, temp_dir, compute_hashes=True)
+
+
+def test_mtime_unchanged_size_changed_does_not_split(
+    session: Session, temp_dir: Path
+) -> None:
+    path = temp_dir / "weird.safetensors"
+    content = create_content(session, str(path), hash=None, size_bytes=100, mtime_ns=1000)
+    create_record(session, content.id, path.name, tags=["keepme"])
+    session.commit()
+    content_id = content.id
+
+    detect_content_change(
+        session, content, _FakeStat(st_size=999, st_mtime_ns=1000), hashing_is_enabled=False
+    )
+    session.commit()
+    session.expire_all()
+
+    assert session.get(AssetContent, content_id).is_missing is False
+    rows_at_path = list(
+        session.scalars(select(AssetContent).where(AssetContent.path == str(path)))
+    )
+    assert len(rows_at_path) == 1
+
+
+def test_transition_drain_split_replacement_has_null_metadata(
+    session: Session, temp_dir: Path
+) -> None:
+    path = temp_dir / "changed.bin"
+    path.write_bytes(b"old bytes")
+    old_snapshot = snapshot_hash(str(path))
+    assert old_snapshot is not None
+    old_digest, _ = old_snapshot
+    stat = path.stat()
+    old_content = create_content(
+        session, str(path), to_stored_hash(old_digest), stat.st_size, stat.st_mtime_ns
+    )
+    old_content_id = old_content.id
+    create_record(
+        session, old_content_id, "changed.bin", tags=["oldtag"], system_metadata={"k": "v"}
+    )
+    path.write_bytes(b"different new bytes")
+
+    enqueue_transition_work(session, "off_to_on")
+    drain_transition_queue(session)
+    session.commit()
+    session.expire_all()
+
+    assert session.get(AssetContent, old_content_id).is_missing is True
+    live = session.scalar(
+        select(AssetContent).where(
+            AssetContent.path == str(path), AssetContent.is_missing.is_(False)
+        )
+    )
+    assert live is not None and live.id != old_content_id
+    new_record = session.scalar(select(Asset).where(Asset.content_id == live.id))
+    assert new_record is not None
+    assert new_record.system_metadata is None
+    assert _raw_system_metadata(session, new_record.id) is None
+    assert "oldtag" not in fetch_record_tags(session, new_record.id)

--- a/tests-unit/assets_test/services/test_stored_hash_prefix.py
+++ b/tests-unit/assets_test/services/test_stored_hash_prefix.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from contextlib import contextmanager
+from unittest.mock import AsyncMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session as SASession
+
+from app.assets import mode
+from app.assets.api import routes
+import app.assets.mode as mode_module
+import folder_paths
+from app.assets.database.models import Asset, AssetContent
+from app.assets.database.queries.records import create_record
+from app.assets.scanner import enrich_asset
+from app.assets.scanner_changes import recover_missing_content
+from app.assets.services import asset_management, ingest
+from app.assets.services.asset_management import get_asset_detail
+from app.assets.services.ingest import (
+    HashMismatchError,
+    upload_from_temp_path,
+)
+from app.assets.services.snapshot_hash import snapshot_hash
+
+
+@pytest.fixture
+def hashing_on():
+    class FakeArgs:
+        enable_asset_hashing = True
+
+    class DisabledArgs:
+        enable_asset_hashing = False
+
+    mode_module.init(FakeArgs())
+    yield
+    mode_module.init(DisabledArgs())
+
+
+def _write_temp(content: bytes) -> str:
+    uploads_root = os.path.join(
+        folder_paths.get_temp_directory(), "uploads", uuid.uuid4().hex
+    )
+    os.makedirs(uploads_root, exist_ok=True)
+    path = os.path.join(uploads_root, ".upload.part")
+    with open(path, "wb") as file:
+        file.write(content)
+    return path
+
+
+def test_upload_stores_prefixed_hash_expected_hash_succeeds_and_reuses_content(
+    mock_create_session, hashing_on
+):
+    content_bytes = b"prefixed-stored-upload-bytes"
+    temp1 = _write_temp(content_bytes)
+    snapshot = snapshot_hash(temp1)
+    assert snapshot is not None
+    digest, _ = snapshot
+    expected = f"blake3:{digest}"
+    assert expected.startswith("blake3:")
+
+    temp2 = _write_temp(content_bytes)
+    try:
+        r1 = upload_from_temp_path(
+            temp_path=temp1,
+            name="pref.bin",
+            tags=["output"],
+            client_filename="pref.bin",
+            expected_hash=expected,
+        )
+        assert r1.created_new is True
+
+        with mock_create_session() as session:
+            live = list(
+                session.scalars(
+                    select(AssetContent).where(AssetContent.is_missing.is_(False))
+                )
+            )
+            assert len(live) == 1
+            assert live[0].hash == expected
+            assert live[0].hash.startswith("blake3:")
+
+        assert r1.asset.hash == expected
+
+        r2 = upload_from_temp_path(
+            temp_path=temp2,
+            name="pref.bin",
+            tags=["output"],
+            client_filename="pref.bin",
+            expected_hash=expected,
+        )
+        assert r2.created_new is True
+        assert r2.ref.id != r1.ref.id, "every upload is its own delivery record"
+        with mock_create_session() as session:
+            assert session.scalar(select(func.count()).select_from(AssetContent)) == 1
+            assert session.scalar(select(func.count()).select_from(Asset)) == 2
+    finally:
+        for path in (temp1, temp2):
+            if os.path.exists(path):
+                os.unlink(path)
+
+
+def test_upload_expected_hash_mismatch_still_rejected(mock_create_session, hashing_on):
+    temp = _write_temp(b"mismatch-bytes")
+    try:
+        with pytest.raises(HashMismatchError):
+            upload_from_temp_path(
+                temp_path=temp,
+                name="mismatch.bin",
+                tags=["output"],
+                client_filename="mismatch.bin",
+                expected_hash=f"blake3:{'0' * 64}",
+            )
+        with mock_create_session() as session:
+            assert session.scalar(select(func.count()).select_from(Asset)) == 0
+            assert session.scalar(select(func.count()).select_from(AssetContent)) == 0
+    finally:
+        if os.path.exists(temp):
+            os.unlink(temp)
+
+
+def test_enrich_fills_deferred_hash_prefixed(session, temp_dir):
+    path = temp_dir / "deferred.bin"
+    path.write_bytes(b"deferred output bytes")
+    stat = path.stat()
+
+    content = AssetContent(
+        path=str(path),
+        hash=None,
+        size_bytes=stat.st_size,
+        mtime_ns=stat.st_mtime_ns,
+    )
+    session.add(content)
+    session.flush()
+    record = create_record(session, content.id, path.name)
+    session.commit()
+
+    enriched = enrich_asset(
+        session,
+        file_path=str(path),
+        content_id=content.id,
+        record_id=record.id,
+        extract_metadata=False,
+        compute_hash=True,
+    )
+
+    assert enriched is True
+    stored = session.get(AssetContent, content.id).hash
+    assert stored is not None
+    assert stored.startswith("blake3:")
+    snapshot = snapshot_hash(str(path))
+    assert snapshot is not None
+    digest, _ = snapshot
+    assert stored == f"blake3:{digest}"
+
+
+def test_recovery_matches_prefixed_stored_hash(session, temp_dir):
+    path = temp_dir / "recover.bin"
+    original_bytes = b"recover-me-bytes"
+    path.write_bytes(original_bytes)
+    snapshot = snapshot_hash(str(path))
+    assert snapshot is not None
+    digest, _ = snapshot
+    stored = f"blake3:{digest}"
+    assert stored.startswith("blake3:")
+
+    content = AssetContent(
+        path=str(path),
+        hash=stored,
+        is_missing=True,
+        size_bytes=0,
+        mtime_ns=None,
+    )
+    session.add(content)
+    session.flush()
+    create_record(session, content.id, path.name)
+    session.commit()
+
+    path.unlink()
+    path.write_bytes(original_bytes)
+    stat = os.stat(str(path))
+    result = recover_missing_content(
+        session, str(path), stat, hashing_is_enabled=True
+    )
+
+    assert result == "recovered"
+    recovered = session.get(AssetContent, content.id)
+    assert recovered is not None
+    assert recovered.is_missing is False
+    assert recovered.hash == stored
+
+
+@pytest.mark.asyncio
+async def test_all_read_surfaces_agree_on_prefixed_hash(
+    db_engine, monkeypatch, hashing_on
+):
+    @contextmanager
+    def _factory():
+        with SASession(db_engine) as sess:
+            yield sess
+
+    monkeypatch.setattr(routes, "create_session", lambda: SASession(db_engine))
+    monkeypatch.setattr(routes, "_ASSETS_ENABLED", True)
+    monkeypatch.setattr(mode, "hashing_enabled", lambda: True)
+    monkeypatch.setattr(ingest, "create_session", _factory)
+    monkeypatch.setattr(asset_management, "create_session", _factory)
+
+    content_bytes = b"one-asset-all-surfaces-agree"
+    temp = _write_temp(content_bytes)
+    snapshot = snapshot_hash(temp)
+    assert snapshot is not None
+    digest, _ = snapshot
+    expected = f"blake3:{digest}"
+
+    try:
+        upload_result = ingest.upload_from_temp_path(
+            temp_path=temp,
+            name="surf.bin",
+            tags=["output"],
+            client_filename="surf.bin",
+        )
+        asset_id = upload_result.ref.id
+
+        assert upload_result.asset is not None
+        assert upload_result.asset.hash == expected
+        upload_resp = routes._build_asset_response(upload_result, {})
+        assert upload_resp.hash == expected
+
+        detail = get_asset_detail(asset_id)
+        assert detail is not None
+        assert detail.asset is not None
+        assert detail.asset.hash == expected
+
+        get_resp = await routes.get_asset_route(
+            make_mocked_request(
+                "GET", f"/api/assets/{asset_id}", match_info={"id": asset_id}
+            )
+        )
+        assert isinstance(get_resp, web.Response)
+        assert isinstance(get_resp.body, bytes | bytearray)
+        get_body = json.loads(get_resp.body)
+        assert get_body["hash"] == expected
+
+        list_resp = await routes.list_assets_route(
+            make_mocked_request("GET", "/api/assets")
+        )
+        assert isinstance(list_resp, web.Response)
+        assert isinstance(list_resp.body, bytes | bytearray)
+        list_body = json.loads(list_resp.body)
+        item = next(a for a in list_body["assets"] if a["id"] == asset_id)
+        assert item["hash"] == expected
+
+        head_resp = await routes.head_asset_by_hash(
+            make_mocked_request(
+                "HEAD",
+                f"/api/assets/hash/{expected}",
+                match_info={"hash": expected},
+            )
+        )
+        assert isinstance(head_resp, web.Response)
+        assert head_resp.status == 200
+
+        fh_req = AsyncMock(spec=web.Request)
+        fh_req.json.return_value = {
+            "hash": expected,
+            "name": "fromhash.bin",
+            "tags": ["output"],
+        }
+        fh_resp = await routes.create_asset_from_hash_route(fh_req)
+        assert isinstance(fh_resp, web.Response)
+        assert fh_resp.status == 201
+        assert isinstance(fh_resp.body, bytes | bytearray)
+        fh_body = json.loads(fh_resp.body)
+        assert fh_body["hash"] == expected
+    finally:
+        if os.path.exists(temp):
+            os.unlink(temp)

--- a/tests-unit/assets_test/services/test_tag_protection.py
+++ b/tests-unit/assets_test/services/test_tag_protection.py
@@ -1,0 +1,101 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+from aiohttp import web
+
+from app.assets.api import routes
+
+_RECORD_ID = "00000000-0000-0000-0000-000000000001"
+
+
+class _JsonRequest:
+    def __init__(self, tags: list[str]) -> None:
+        self.match_info = {"id": _RECORD_ID}
+        self._payload = {"tags": tags}
+
+    async def json(self) -> dict[str, list[str]]:
+        return self._payload
+
+
+class _UserManager:
+    def get_request_user_id(self, _request: _JsonRequest) -> str:
+        return "test-user"
+
+
+@pytest.mark.asyncio
+async def test_add_missing_tag_returns_400(monkeypatch):
+    monkeypatch.setattr(routes, "USER_MANAGER", _UserManager())
+    monkeypatch.setattr(
+        routes,
+        "apply_tags",
+        lambda **_kwargs: SimpleNamespace(added=[], already_present=[], total_tags=[]),
+    )
+
+    with pytest.raises(web.HTTPBadRequest) as error:
+        await routes.add_asset_tags.__wrapped__(_JsonRequest(["missing"]))
+
+    assert error.value.status == 400
+
+
+@pytest.mark.asyncio
+async def test_remove_missing_tag_returns_400(monkeypatch):
+    monkeypatch.setattr(routes, "USER_MANAGER", _UserManager())
+    monkeypatch.setattr(
+        routes,
+        "remove_tags",
+        lambda **_kwargs: SimpleNamespace(removed=[], not_present=[], total_tags=[]),
+    )
+
+    with pytest.raises(web.HTTPBadRequest) as error:
+        await routes.delete_asset_tags.__wrapped__(_JsonRequest(["missing"]))
+
+    assert error.value.status == 400
+
+
+@pytest.mark.asyncio
+async def test_other_tags_unaffected(monkeypatch):
+    monkeypatch.setattr(routes, "USER_MANAGER", _UserManager())
+    calls: list[tuple[str, list[str]]] = []
+
+    def apply_tags(**kwargs):
+        calls.append(("add", kwargs["tags"]))
+        return SimpleNamespace(
+            added=kwargs["tags"], already_present=[], total_tags=kwargs["tags"]
+        )
+
+    def remove_tags(**kwargs):
+        calls.append(("remove", kwargs["tags"]))
+        return SimpleNamespace(
+            removed=kwargs["tags"], not_present=[], total_tags=[], protected=[]
+        )
+
+    monkeypatch.setattr(routes, "apply_tags", apply_tags)
+    monkeypatch.setattr(routes, "remove_tags", remove_tags)
+
+    add_response = await routes.add_asset_tags.__wrapped__(_JsonRequest(["manual"]))
+    remove_response = await routes.delete_asset_tags.__wrapped__(
+        _JsonRequest(["manual"])
+    )
+
+    assert add_response.status == 200
+    assert remove_response.status == 200
+    assert calls == [("add", ["manual"]), ("remove", ["manual"])]
+
+
+@pytest.mark.asyncio
+async def test_remove_tags_response_exposes_protected_bucket(monkeypatch):
+    monkeypatch.setattr(routes, "USER_MANAGER", _UserManager())
+    monkeypatch.setattr(
+        routes,
+        "remove_tags",
+        lambda **_kwargs: SimpleNamespace(
+            removed=[], not_present=[], total_tags=["auto"], protected=["auto"]
+        ),
+    )
+
+    response = await routes.delete_asset_tags.__wrapped__(_JsonRequest(["auto"]))
+
+    assert response.status == 200
+    body = json.loads(response.body)
+    assert body["protected"] == ["auto"]

--- a/tests-unit/assets_test/services/test_transition_drain.py
+++ b/tests-unit/assets_test/services/test_transition_drain.py
@@ -1,0 +1,313 @@
+from pathlib import Path
+
+import folder_paths
+import pytest
+from blake3 import blake3
+from sqlalchemy import select
+
+from app.assets.database.models import Asset, AssetContent, AssetTag
+from app.assets.database.queries.records import create_content, create_record
+from app.assets.helpers import to_stored_hash
+from app.assets.services import hash_mode_state
+from app.assets.services.hash_mode_state import (
+    clear_transition_queue,
+    drain_transition_queue,
+    enqueue_transition_work,
+    read_stored_mode,
+    record_transition_intent,
+    write_stored_mode,
+)
+from app.assets.services.lookup import lookup_for_view
+from app.assets.services.path_utils import get_name_and_tags_from_asset_path
+from app.assets.services.snapshot_hash import snapshot_hash
+
+
+@pytest.fixture(autouse=True)
+def transition_queue():
+    clear_transition_queue()
+    yield
+    clear_transition_queue()
+
+
+def _stored_hash(path: Path) -> str:
+    snapshot = snapshot_hash(str(path))
+    assert snapshot is not None
+    digest, _ = snapshot
+    return to_stored_hash(digest)
+
+
+def test_off_to_on_transition_hashes_null_rows_and_persists_mode(session, temp_dir, monkeypatch):
+    paths = [temp_dir / "first.bin", temp_dir / "second.bin"]
+    for index, path in enumerate(paths):
+        path.write_bytes(f"bytes-{index}".encode())
+        stat = path.stat()
+        create_content(session, str(path), size_bytes=stat.st_size, mtime_ns=stat.st_mtime_ns)
+    write_stored_mode(session, "off")
+    monkeypatch.setattr(hash_mode_state._mode, "hashing_enabled", lambda: True)
+
+    transition = record_transition_intent(session)
+    enqueue_transition_work(session, transition)
+    drain_transition_queue(session)
+    session.commit()
+
+    contents = list(session.scalars(select(AssetContent)))
+    assert {content.hash for content in contents} == {_stored_hash(path) for path in paths}
+    assert read_stored_mode(session) == "on"
+
+
+def test_transition_drain_splits_changed_content(session, temp_dir, monkeypatch):
+    path = temp_dir / "changed.bin"
+    monkeypatch.setattr("folder_paths.get_input_directory", lambda: str(temp_dir))
+    path.write_bytes(b"old bytes")
+    old_snapshot = snapshot_hash(str(path))
+    assert old_snapshot is not None
+    old_digest, _ = old_snapshot
+    stat = path.stat()
+    old_content = create_content(
+        session, str(path), to_stored_hash(old_digest), stat.st_size, stat.st_mtime_ns
+    )
+    old_content_id = old_content.id
+    create_record(session, old_content_id, "changed.bin")
+    path.write_bytes(b"new bytes")
+
+    enqueue_transition_work(session, "off_to_on")
+    drain_transition_queue(session)
+    session.commit()
+
+    contents = list(session.scalars(select(AssetContent)))
+    live_content = next(content for content in contents if not content.is_missing)
+    records = list(session.scalars(select(Asset)))
+    assert session.get(AssetContent, old_content_id).is_missing is True
+    assert live_content.hash == _stored_hash(path)
+    assert len(records) == 2
+    assert any(record.content_id == live_content.id for record in records)
+
+
+def test_transition_drain_serves_unchanged_content_whose_stored_stat_went_stale(
+    session, temp_dir, monkeypatch
+):
+    path = temp_dir / "unchanged.bin"
+    path.write_bytes(b"bytes that outlive the mode flip")
+    stat = path.stat()
+    stored_hash = _stored_hash(path)
+    size_before_the_restore = stat.st_size - 1
+    mtime_before_the_restore = stat.st_mtime_ns - 1_000_000_000
+    content = create_content(
+        session, str(path), stored_hash, size_before_the_restore, mtime_before_the_restore
+    )
+    content_id = content.id
+    create_record(session, content_id, "unchanged.bin")
+    monkeypatch.setattr(folder_paths, "get_temp_directory", lambda: str(temp_dir / "never"))
+    write_stored_mode(session, "off")
+    monkeypatch.setattr(hash_mode_state._mode, "hashing_enabled", lambda: True)
+    assert lookup_for_view(session, stored_hash) is None, (
+        "precondition: the stale stat makes the row unservable by hash"
+    )
+
+    transition = record_transition_intent(session)
+    enqueue_transition_work(session, transition)
+    drain_transition_queue(session)
+    session.commit()
+
+    refreshed = session.get(AssetContent, content_id)
+    assert (refreshed.size_bytes, refreshed.mtime_ns) == (stat.st_size, stat.st_mtime_ns)
+    served = lookup_for_view(session, stored_hash)
+    assert served is not None and served.id == content_id, (
+        "the drain verified these bytes but left the row unservable until the next full scan"
+    )
+    assert [row.id for row in session.scalars(select(AssetContent))] == [content_id]
+    assert [row.content_id for row in session.scalars(select(Asset))] == [content_id]
+    assert read_stored_mode(session) == "on"
+
+
+def test_transition_drain_requeues_permission_errors_and_processes_other_paths(
+    session, temp_dir, monkeypatch
+):
+    protected_path = temp_dir / "protected.bin"
+    healthy_path = temp_dir / "healthy.bin"
+    protected_path.write_bytes(b"protected")
+    healthy_payload = b"healthy"
+    healthy_path.write_bytes(healthy_payload)
+    for path in (protected_path, healthy_path):
+        stat = path.stat()
+        create_content(session, str(path), size_bytes=stat.st_size, mtime_ns=stat.st_mtime_ns)
+    write_stored_mode(session, "off")
+    monkeypatch.setattr(hash_mode_state._mode, "hashing_enabled", lambda: True)
+
+    def hash_or_raise(candidate_path: str):
+        if candidate_path == str(protected_path):
+            raise PermissionError("denied")
+        return snapshot_hash(candidate_path)
+
+    monkeypatch.setattr(hash_mode_state, "snapshot_hash", hash_or_raise)
+    transition = record_transition_intent(session)
+    enqueue_transition_work(session, transition)
+
+    drain_transition_queue(session)
+
+    healthy_content = session.scalar(
+        select(AssetContent).where(AssetContent.path == str(healthy_path))
+    )
+    assert healthy_content is not None
+    assert healthy_content.hash == to_stored_hash(blake3(healthy_payload).hexdigest())
+    assert hash_mode_state.pending_transition_count() == 1
+    assert read_stored_mode(session) == "off"
+
+
+def test_transition_drain_marks_deleted_path_missing_and_completes_transition(
+    session, temp_dir, monkeypatch
+):
+    path = temp_dir / "vanished.bin"
+    monkeypatch.setattr("folder_paths.get_input_directory", lambda: str(temp_dir))
+    path.write_bytes(b"bytes that die during the outage")
+    stat = path.stat()
+    content = create_content(session, str(path), size_bytes=stat.st_size, mtime_ns=stat.st_mtime_ns)
+    content_id = content.id
+    record = create_record(session, content_id, "vanished.bin")
+    record_id = record.id
+    write_stored_mode(session, "off")
+    monkeypatch.setattr(hash_mode_state._mode, "hashing_enabled", lambda: True)
+    path.unlink()
+
+    transition = record_transition_intent(session)
+    enqueue_transition_work(session, transition)
+    drain_transition_queue(session)
+    session.commit()
+
+    assert session.get(AssetContent, content_id).is_missing is True, (
+        "a path deleted while every server was down must be marked missing, not requeued forever"
+    )
+    assert session.get(AssetTag, {"asset_id": record_id, "tag_name": "missing"}) is not None
+    assert hash_mode_state.pending_transition_count() == 0, (
+        "the queue never empties while a deleted path is requeued unconditionally"
+    )
+    assert read_stored_mode(session) == "on", (
+        "the completion gate stays wedged at 'off' for the process lifetime when the queue "
+        "cannot drain, so hash-addressed serving never gets its re-verification certificate"
+    )
+
+
+def test_transition_drain_requeues_transient_stat_error_without_marking_it_missing(
+    session, temp_dir, monkeypatch
+):
+    path = temp_dir / "transient-stat-error.bin"
+    path.write_bytes(b"present the whole time")
+    stat = path.stat()
+    content = create_content(session, str(path), size_bytes=stat.st_size, mtime_ns=stat.st_mtime_ns)
+    content_id = content.id
+    write_stored_mode(session, "off")
+    monkeypatch.setattr(hash_mode_state._mode, "hashing_enabled", lambda: True)
+    monkeypatch.setattr(hash_mode_state, "snapshot_hash", lambda candidate_path: None)
+    real_stat = hash_mode_state.os.stat
+
+    def flaky_stat(candidate_path, *args, **kwargs):
+        if candidate_path == str(path):
+            raise NotADirectoryError("stale handle mid-drain")
+        return real_stat(candidate_path, *args, **kwargs)
+
+    monkeypatch.setattr(hash_mode_state.os, "stat", flaky_stat)
+
+    transition = record_transition_intent(session)
+    enqueue_transition_work(session, transition)
+    drain_transition_queue(session)
+    session.commit()
+
+    assert session.get(AssetContent, content_id).is_missing is False, (
+        "a transient stat failure on a file that is still present must not mark its row missing"
+    )
+    assert hash_mode_state.pending_transition_count() == 1
+    assert read_stored_mode(session) == "off"
+
+
+def test_transition_drain_requeues_unstable_present_file_without_marking_it_missing(
+    session, temp_dir, monkeypatch
+):
+    path = temp_dir / "still-being-written.bin"
+    path.write_bytes(b"a partial write in flight")
+    stat = path.stat()
+    content = create_content(session, str(path), size_bytes=stat.st_size, mtime_ns=stat.st_mtime_ns)
+    content_id = content.id
+    create_record(session, content_id, "still-being-written.bin")
+    write_stored_mode(session, "off")
+    monkeypatch.setattr(hash_mode_state._mode, "hashing_enabled", lambda: True)
+    monkeypatch.setattr(hash_mode_state, "snapshot_hash", lambda candidate_path: None)
+
+    transition = record_transition_intent(session)
+    enqueue_transition_work(session, transition)
+    drain_transition_queue(session)
+    session.commit()
+
+    assert session.get(AssetContent, content_id).is_missing is False, (
+        "snapshot_hash returns None for drift too; a file still on disk is unstable, not gone"
+    )
+    assert hash_mode_state.pending_transition_count() == 1
+    assert read_stored_mode(session) == "off"
+
+
+def test_transition_drain_mixes_a_deleted_path_with_a_healthy_one(session, temp_dir, monkeypatch):
+    monkeypatch.setattr("folder_paths.get_input_directory", lambda: str(temp_dir))
+    deleted_path = temp_dir / "deleted.bin"
+    healthy_path = temp_dir / "survivor.bin"
+    deleted_path.write_bytes(b"deleted during the outage")
+    healthy_path.write_bytes(b"survivor")
+    content_ids = {}
+    for path in (deleted_path, healthy_path):
+        stat = path.stat()
+        content = create_content(
+            session, str(path), size_bytes=stat.st_size, mtime_ns=stat.st_mtime_ns
+        )
+        content_ids[path] = content.id
+        create_record(session, content.id, path.name)
+    write_stored_mode(session, "off")
+    monkeypatch.setattr(hash_mode_state._mode, "hashing_enabled", lambda: True)
+    healthy_hash = _stored_hash(healthy_path)
+    deleted_path.unlink()
+
+    transition = record_transition_intent(session)
+    enqueue_transition_work(session, transition)
+    drain_transition_queue(session)
+    session.commit()
+
+    assert session.get(AssetContent, content_ids[deleted_path]).is_missing is True
+    healthy_content = session.get(AssetContent, content_ids[healthy_path])
+    assert (healthy_content.is_missing, healthy_content.hash) == (False, healthy_hash), (
+        "one dead path must not cost the healthy paths behind it their hashes"
+    )
+    assert hash_mode_state.pending_transition_count() == 0
+    assert read_stored_mode(session) == "on"
+
+
+def test_transition_drain_skips_out_of_root_path(session, temp_dir, monkeypatch, caplog):
+    import logging
+
+    outside_path = temp_dir / "orphan.bin"
+    outside_path.write_bytes(b"old bytes")
+    old_snapshot = snapshot_hash(str(outside_path))
+    assert old_snapshot is not None
+    old_digest, _ = old_snapshot
+    stat = outside_path.stat()
+    old_content = create_content(
+        session, str(outside_path), to_stored_hash(old_digest), stat.st_size, stat.st_mtime_ns
+    )
+    old_content_id = old_content.id
+    create_record(session, old_content_id, "orphan.bin")
+    outside_path.write_bytes(b"new bytes")
+
+    with pytest.raises(ValueError):
+        get_name_and_tags_from_asset_path(str(outside_path))
+
+    enqueue_transition_work(session, "off_to_on")
+
+    with caplog.at_level(logging.WARNING):
+        try:
+            drain_transition_queue(session)
+        except ValueError as error:
+            pytest.fail(
+                f"an out-of-root path escaped the drain as {error!r}; setup_database turns that "
+                f"into sys.exit(1) when --enable-assets is set"
+            )
+    session.commit()
+
+    assert session.get(AssetContent, old_content_id).is_missing is False
+    assert hash_mode_state.pending_transition_count() == 0
+    assert any("orphan.bin" in record.getMessage() for record in caplog.records)

--- a/tests-unit/assets_test/services/test_updated_at_semantics.py
+++ b/tests-unit/assets_test/services/test_updated_at_semantics.py
@@ -1,0 +1,285 @@
+
+import os
+from datetime import datetime
+
+import pytest
+from sqlalchemy import update
+from sqlalchemy.orm import Session
+
+from app.assets.database.models import Asset, AssetTag, Tag
+from app.assets.database.queries.records import (
+    create_content,
+    create_record,
+    delete_record,
+    mark_content_missing,
+    unset_content_missing,
+)
+from app.assets.helpers import to_stored_hash
+from app.assets.scanner import enrich_asset
+from app.assets.scanner_changes import split_content
+from app.assets.services.asset_management import (
+    resolve_asset_for_download,
+    resolve_hash_to_path,
+    update_asset_metadata,
+)
+from app.assets.services.tagging import apply_tags, remove_tags
+
+STALE = datetime(2020, 1, 1, 0, 0, 0)
+
+
+def _seed_record(session: Session, path: str, name: str = "fixture", tags=None, hash=None) -> Asset:
+    content = create_content(session, path, hash=hash)
+    record = create_record(session, content.id, name, tags=tags)
+    session.commit()
+    _force_stale(session, record.id)
+    return record
+
+
+def _seed_scannable_record(session: Session, path: str, name: str) -> Asset:
+    stat_result = os.stat(path)
+    content = create_content(
+        session,
+        path,
+        size_bytes=stat_result.st_size,
+        mtime_ns=stat_result.st_mtime_ns,
+    )
+    record = create_record(session, content.id, name)
+    session.commit()
+    _force_stale(session, record.id)
+    return record
+
+
+def _force_stale(session: Session, record_id: str) -> None:
+    session.execute(update(Asset).where(Asset.id == record_id).values(updated_at=STALE))
+    session.commit()
+
+
+def _updated_at(session: Session, record_id: str) -> datetime:
+    session.expire_all()
+    return session.get(Asset, record_id).updated_at
+
+
+def _last_access(session: Session, record_id: str) -> datetime | None:
+    session.expire_all()
+    return session.get(Asset, record_id).last_access_time
+
+
+def _write_file(temp_dir, name: str, payload: bytes = b"payload") -> str:
+    file_path = temp_dir / name
+    file_path.write_bytes(payload)
+    return str(file_path)
+
+
+def test_download_path_moves_last_access_time_but_not_updated_at(
+    session, mock_create_session, temp_dir
+):
+    path = _write_file(temp_dir, "download.bin")
+    record = _seed_record(session, path, name="download.bin")
+
+    resolve_asset_for_download(record.id)
+
+    assert _last_access(session, record.id) is not None, (
+        "serving a download must record the access"
+    )
+    assert _updated_at(session, record.id) == STALE, (
+        "a read moves last_access_time only; it is not an explicit user edit"
+    )
+
+
+def test_hash_serve_path_moves_last_access_time_but_not_updated_at(
+    session, mock_create_session, temp_dir
+):
+    path = _write_file(temp_dir, "served.bin")
+    digest = to_stored_hash("a" * 64)
+    record = _seed_record(session, path, name="served.bin", hash=digest)
+
+    assert resolve_hash_to_path(digest) is not None, "fixture must resolve"
+
+    assert _last_access(session, record.id) is not None, (
+        "serving by hash must record the access"
+    )
+    assert _updated_at(session, record.id) == STALE, (
+        "hash-serving is a read; it is not an explicit user edit"
+    )
+
+
+def test_rename_moves_updated_at(session, mock_create_session, temp_dir):
+    record = _seed_record(session, _write_file(temp_dir, "rename.bin"))
+
+    update_asset_metadata(record.id, name="renamed")
+
+    assert _updated_at(session, record.id) > STALE, "a rename is an explicit user edit"
+
+
+@pytest.mark.parametrize(
+    "field,kwargs",
+    [
+        ("user_metadata", {"user_metadata": {"note": "hello"}}),
+        ("mime_type", {"mime_type": "image/png"}),
+    ],
+)
+def test_user_field_updates_move_updated_at(
+    session, mock_create_session, temp_dir, field, kwargs
+):
+    record = _seed_record(session, _write_file(temp_dir, f"{field}.bin"))
+
+    update_asset_metadata(record.id, **kwargs)
+
+    assert _updated_at(session, record.id) > STALE, (
+        f"setting {field} is an explicit user edit"
+    )
+
+
+def test_preview_id_update_moves_updated_at(session, mock_create_session, temp_dir):
+    record = _seed_record(session, _write_file(temp_dir, "subject.bin"))
+    preview = _seed_record(session, _write_file(temp_dir, "preview.bin"), name="preview")
+
+    update_asset_metadata(record.id, preview_id=preview.id)
+
+    assert _updated_at(session, record.id) > STALE, (
+        "setting preview_id is an explicit user edit"
+    )
+
+
+def test_manual_tag_add_moves_updated_at(session, mock_create_session, temp_dir):
+    record = _seed_record(session, _write_file(temp_dir, "tag-add.bin"))
+
+    apply_tags(record.id, ["favourite"])
+
+    assert _updated_at(session, record.id) > STALE, (
+        "adding a manual tag is an explicit user edit of the record"
+    )
+
+
+def test_manual_tag_remove_moves_updated_at(session, mock_create_session, temp_dir):
+    record = _seed_record(
+        session, _write_file(temp_dir, "tag-remove.bin"), tags=["favourite"]
+    )
+
+    remove_tags(record.id, ["favourite"])
+
+    assert _updated_at(session, record.id) > STALE, (
+        "removing a manual tag is an explicit user edit of the record"
+    )
+
+
+def test_tag_replacement_via_update_asset_metadata_moves_updated_at(
+    session, mock_create_session, temp_dir
+):
+    record = _seed_record(session, _write_file(temp_dir, "tag-replace.bin"), tags=["old"])
+
+    update_asset_metadata(record.id, tags=["new"])
+
+    assert _updated_at(session, record.id) > STALE, (
+        "replacing the manual tag set is an explicit user edit"
+    )
+
+
+def test_noop_tag_calls_do_not_move_updated_at(session, mock_create_session, temp_dir):
+    record = _seed_record(
+        session, _write_file(temp_dir, "tag-noop.bin"), tags=["already"]
+    )
+
+    apply_tags(record.id, ["already"])
+    remove_tags(record.id, ["never-present"])
+
+    assert _updated_at(session, record.id) == STALE, (
+        "a tag call that changes no link is not an edit"
+    )
+
+
+def test_unchanged_tag_replacement_does_not_move_updated_at(
+    session, mock_create_session, temp_dir
+):
+    record = _seed_record(
+        session, _write_file(temp_dir, "tag-same.bin"), tags=["keep"]
+    )
+
+    update_asset_metadata(record.id, tags=["keep"])
+
+    assert _updated_at(session, record.id) == STALE, (
+        "replacing the manual tag set with an identical set changes nothing"
+    )
+
+
+def test_scanner_enrichment_does_not_move_updated_at(session, temp_dir):
+    path = _write_file(temp_dir, "enrich.png", payload=b"\x89PNG\r\n\x1a\n" + b"0" * 64)
+    record = _seed_scannable_record(session, path, name="enrich.png")
+
+    assert enrich_asset(
+        session, path, record.content_id, record.id, extract_metadata=True
+    ), "fixture must actually enrich"
+
+    assert session.get(Asset, record.id).mime_type is not None, (
+        "enrichment must have written a system-derived field"
+    )
+    assert _updated_at(session, record.id) == STALE, (
+        "system-derived facts about unchanged bytes are not a user edit"
+    )
+
+
+def test_automatic_missing_tag_projection_does_not_move_updated_at(session, temp_dir):
+    record = _seed_record(session, _write_file(temp_dir, "missing.bin"))
+
+    mark_content_missing(session, record.content_id)
+    session.commit()
+    assert _updated_at(session, record.id) == STALE, (
+        "the automatic missing tag is a system projection"
+    )
+
+    _force_stale(session, record.id)
+    unset_content_missing(session, record.content_id)
+    session.commit()
+    assert _updated_at(session, record.id) == STALE, (
+        "recovery is a system projection too"
+    )
+
+
+def test_content_split_does_not_move_updated_at_on_retired_record(
+    session, temp_dir, monkeypatch
+):
+    monkeypatch.setattr("folder_paths.get_input_directory", lambda: str(temp_dir))
+    path = _write_file(temp_dir, "split.bin")
+    record = _seed_record(session, path, name="split.bin")
+    content = session.get(Asset, record.id).content
+
+    split_content(session, content, os.stat(path), hash_value=to_stored_hash("b" * 64))
+    session.commit()
+
+    assert _updated_at(session, record.id) == STALE, (
+        "a content split is a system projection over the retired record"
+    )
+
+
+def test_preview_target_delete_cascade_does_not_move_updated_at(db_engine_fk):
+    with Session(db_engine_fk) as session:
+        preview_content = create_content(session, "/output/preview-target.png")
+        preview = create_record(session, preview_content.id, "preview-target")
+        content = create_content(session, "/output/referencing.png")
+        record = create_record(session, content.id, "referencing")
+        session.commit()
+        session.execute(
+            update(Asset)
+            .where(Asset.id == record.id)
+            .values(preview_id=preview.id, updated_at=STALE)
+        )
+        session.commit()
+
+        delete_record(session, preview.id)
+        session.commit()
+
+        session.expire_all()
+        refreshed = session.get(Asset, record.id)
+        assert refreshed.preview_id is None, "the FK cascade must have nulled the link"
+        assert refreshed.updated_at == STALE, (
+            "an FK-level SET NULL is not a user edit of the referencing record"
+        )
+
+
+def test_seed_helper_reports_stale_before_any_edit(session, temp_dir):
+    record = _seed_record(session, _write_file(temp_dir, "seed.bin"))
+
+    assert _updated_at(session, record.id) == STALE, "seeding must set the stale marker"
+    assert isinstance(session.get(Asset, record.id), Asset)
+    assert session.get(Tag, "nonexistent") is None
+    assert session.get(AssetTag, (record.id, "nonexistent")) is None

--- a/tests-unit/assets_test/services/test_upload_b.py
+++ b/tests-unit/assets_test/services/test_upload_b.py
@@ -1,0 +1,1134 @@
+import os
+import uuid
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine, func, select, update
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm import Session as SASession
+
+import app.assets.mode as mode_module
+import app.assets.services.ingest as ingest_module
+import folder_paths
+from app.assets.database.models import Asset, AssetContent, AssetTag
+from app.assets.database.queries.records import (
+    create_content,
+    create_record,
+    mark_content_missing,
+)
+from app.assets.helpers import to_stored_hash
+from app.assets.services.file_utils import get_size_and_mtime_ns
+from app.assets.services.ingest import (
+    UploadUnstableError,
+    register_file_in_place,
+    upload_from_temp_path,
+)
+from app.assets.services.lookup import (
+    claim_qualified_content as _real_claim_qualified_content,
+    is_temp_path,
+    lookup_for_view,
+)
+from app.assets.services.snapshot_hash import snapshot_hash
+from app.database.models import Base
+
+
+def _bump_mtime(path: str) -> int:
+    _, mtime_ns = get_size_and_mtime_ns(path)
+    moved = mtime_ns + 1_000_000_000
+    os.utime(path, ns=(moved, moved))
+    observed = get_size_and_mtime_ns(path)[1]
+    assert observed != mtime_ns
+    return observed
+
+
+@pytest.fixture
+def hashing_on():
+    class FakeArgs:
+        enable_asset_hashing = True
+
+    mode_module.init(FakeArgs())
+    yield
+    mode_module.init(None)
+
+
+@pytest.fixture
+def hashing_off():
+    class FakeArgs:
+        enable_asset_hashing = False
+
+    mode_module.init(FakeArgs())
+    yield
+    mode_module.init(None)
+
+
+def _write_temp(content: bytes) -> str:
+    uploads_root = os.path.join(folder_paths.get_temp_directory(), "uploads", uuid.uuid4().hex)
+    os.makedirs(uploads_root, exist_ok=True)
+    path = os.path.join(uploads_root, ".upload.part")
+    with open(path, "wb") as file:
+        file.write(content)
+    return path
+
+
+def test_hash_mode_multipart_reuses_content_but_in_place_keeps_its_own_path(
+    mock_create_session, hashing_on
+):
+    content = b"duplicate-bytes"
+    temp1 = _write_temp(content)
+    temp2 = _write_temp(content)
+    output_dir = folder_paths.get_output_directory()
+    os.makedirs(output_dir, exist_ok=True)
+    image_path = os.path.join(output_dir, "dup.bin")
+    try:
+        r1 = upload_from_temp_path(
+            temp_path=temp1,
+            name="dup.bin",
+            tags=["output"],
+            client_filename="dup.bin",
+        )
+        r2 = upload_from_temp_path(
+            temp_path=temp2,
+            name="dup.bin",
+            tags=["output"],
+            client_filename="dup.bin",
+        )
+        assert r1.ref.id != r2.ref.id, "every upload is its own delivery record"
+        assert r2.created_new is True
+        with mock_create_session() as session:
+            assert (
+                session.scalar(
+                    select(func.count())
+                    .select_from(AssetContent)
+                    .where(AssetContent.is_missing.is_(False))
+                )
+                == 1
+            ), "same bytes reuse the one content row"
+
+        with open(image_path, "wb") as file:
+            file.write(content)
+        r3 = register_file_in_place(
+            abs_path=image_path, name="dup.bin", tags=["output"]
+        )
+        assert r3.ref.id != r1.ref.id
+        assert r3.created_new is True
+        assert r3.ref.file_path == os.path.abspath(image_path)
+
+        with mock_create_session() as session:
+            assert session.scalar(select(func.count()).select_from(Asset)) == 3
+            live = {
+                row.id: row.path
+                for row in session.scalars(
+                    select(AssetContent).where(AssetContent.is_missing.is_(False))
+                )
+            }
+            assert len(live) == 2
+            in_place = session.get(Asset, r3.ref.id)
+            multipart = session.get(Asset, r1.ref.id)
+            assert in_place is not None
+            assert multipart is not None
+            assert in_place.content_id != multipart.content_id
+            assert live[in_place.content_id] == os.path.abspath(image_path)
+            assert live[multipart.content_id] != os.path.abspath(image_path)
+    finally:
+        for path in (temp1, temp2, image_path):
+            if os.path.exists(path):
+                os.unlink(path)
+
+
+def test_off_mode_api_assets_reuses_content_same_bytes_same_name(
+    mock_create_session, hashing_off
+):
+    content = b"off-mode-bytes"
+    temp1 = _write_temp(content)
+    temp2 = _write_temp(content)
+    try:
+        r1 = upload_from_temp_path(
+            temp_path=temp1,
+            name="off.bin",
+            tags=["output"],
+            client_filename="off.bin",
+        )
+        r2 = upload_from_temp_path(
+            temp_path=temp2,
+            name="off.bin",
+            tags=["output"],
+            client_filename="off.bin",
+        )
+        assert r1.ref.id != r2.ref.id, "every upload is its own delivery record"
+        assert r2.created_new is True
+        with mock_create_session() as session:
+            assert session.scalar(select(func.count()).select_from(Asset)) == 2
+            contents = list(
+                session.scalars(
+                    select(AssetContent).where(AssetContent.is_missing.is_(False))
+                )
+            )
+            assert len(contents) == 1
+    finally:
+        for path in (temp1, temp2):
+            if os.path.exists(path):
+                os.unlink(path)
+
+
+def test_off_mode_register_file_in_place_same_path_reuses_content_row(
+    mock_create_session, hashing_off
+):
+    output_dir = folder_paths.get_output_directory()
+    os.makedirs(output_dir, exist_ok=True)
+    path = os.path.join(output_dir, "image_same.png")
+    with open(path, "wb") as file:
+        file.write(b"img-bytes")
+
+    try:
+        r1 = register_file_in_place(
+            abs_path=path, name="image_same.png", tags=["output"]
+        )
+        r2 = register_file_in_place(
+            abs_path=path, name="image_same.png", tags=["output"]
+        )
+        assert r2.ref.id != r1.ref.id
+        assert r2.created_new is True
+        with mock_create_session() as session:
+            contents = list(
+                session.scalars(
+                    select(AssetContent).where(AssetContent.is_missing.is_(False))
+                )
+            )
+            assert len(contents) == 1
+            assert contents[0].path == os.path.abspath(path)
+            assert open(contents[0].path, "rb").read() == b"img-bytes"
+            records = list(session.scalars(select(Asset)))
+            assert len(records) == 2
+            assert {record.content_id for record in records} == {contents[0].id}
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+
+
+def test_off_mode_register_file_in_place_different_bytes_two_paths(
+    mock_create_session, hashing_off
+):
+    output_dir = folder_paths.get_output_directory()
+    os.makedirs(output_dir, exist_ok=True)
+    path1 = os.path.join(output_dir, "same.png")
+    path2 = os.path.join(output_dir, "same (1).png")
+    with open(path1, "wb") as file:
+        file.write(b"v1")
+    with open(path2, "wb") as file:
+        file.write(b"v2")
+
+    try:
+        r1 = register_file_in_place(abs_path=path1, name="same.png", tags=["output"])
+        r2 = register_file_in_place(abs_path=path2, name="same.png", tags=["output"])
+        assert r1.ref.id != r2.ref.id
+        with mock_create_session() as session:
+            contents = list(
+                session.scalars(
+                    select(AssetContent).where(AssetContent.is_missing.is_(False))
+                )
+            )
+            assert len(contents) == 2
+            assert {content.path for content in contents} == {
+                os.path.abspath(path1),
+                os.path.abspath(path2),
+            }
+    finally:
+        for path in (path1, path2):
+            if os.path.exists(path):
+                os.unlink(path)
+
+
+def test_register_file_in_place_equal_bytes_new_path_is_tracked_separately(
+    mock_create_session, hashing_on
+):
+    output_dir = folder_paths.get_output_directory()
+    os.makedirs(output_dir, exist_ok=True)
+    path_a = os.path.join(output_dir, "crosspath_a.png")
+    path_b = os.path.join(output_dir, "crosspath_b.png")
+    payload = b"cross-path-equal-bytes"
+    try:
+        with open(path_a, "wb") as file:
+            file.write(payload)
+        first = register_file_in_place(
+            abs_path=path_a, name="crosspath_a.png", tags=["output"]
+        )
+
+        with open(path_b, "wb") as file:
+            file.write(payload)
+        second = register_file_in_place(
+            abs_path=path_b, name="crosspath_b.png", tags=["output"]
+        )
+
+        abs_a = os.path.abspath(path_a)
+        abs_b = os.path.abspath(path_b)
+        assert second.ref.id != first.ref.id
+        assert second.created_new is True
+        assert second.ref.file_path == abs_b
+        with mock_create_session() as session:
+            live = {
+                row.path: row
+                for row in session.scalars(
+                    select(AssetContent).where(AssetContent.is_missing.is_(False))
+                )
+            }
+            assert set(live) == {abs_a, abs_b}
+            assert live[abs_a].hash == live[abs_b].hash
+            assert live[abs_a].id != live[abs_b].id
+            record_b = session.get(Asset, second.ref.id)
+            assert record_b is not None
+            assert record_b.content_id == live[abs_b].id
+            record_a = session.get(Asset, first.ref.id)
+            assert record_a is not None
+            assert record_a.content_id == live[abs_a].id
+    finally:
+        for path in (path_a, path_b):
+            if os.path.exists(path):
+                os.unlink(path)
+
+
+def test_register_file_in_place_overwrite_returns_new_file_hash_and_size(
+    mock_create_session, hashing_on
+):
+    output_dir = folder_paths.get_output_directory()
+    os.makedirs(output_dir, exist_ok=True)
+    path = os.path.join(output_dir, "overwrite_hash.png")
+
+    v1 = b"overwrite-version-one"
+    v2 = b"v2"
+    try:
+        with open(path, "wb") as file:
+            file.write(v1)
+        r1 = register_file_in_place(
+            abs_path=path, name="overwrite_hash.png", tags=["output"]
+        )
+
+        with open(path, "wb") as file:
+            file.write(v2)
+        snapshot = snapshot_hash(path)
+        assert snapshot is not None
+        expected_new_hash = to_stored_hash(snapshot[0])
+
+        r2 = register_file_in_place(
+            abs_path=path, name="overwrite_hash.png", tags=["output"]
+        )
+
+        assert r2.asset.hash == expected_new_hash
+        assert r2.asset.hash != r1.asset.hash
+        assert r2.asset.size_bytes == len(v2)
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+
+
+def test_register_file_in_place_overwrite_marks_old_content_missing(
+    mock_create_session, hashing_on
+):
+    output_dir = folder_paths.get_output_directory()
+    os.makedirs(output_dir, exist_ok=True)
+    path = os.path.join(output_dir, "overwrite_missing.png")
+
+    v1 = b"overwrite-version-one"
+    v2 = b"v2"
+    try:
+        with open(path, "wb") as file:
+            file.write(v1)
+        r1 = register_file_in_place(
+            abs_path=path, name="overwrite_missing.png", tags=["output"]
+        )
+
+        with open(path, "wb") as file:
+            file.write(v2)
+        snapshot = snapshot_hash(path)
+        assert snapshot is not None
+        expected_new_hash = to_stored_hash(snapshot[0])
+
+        register_file_in_place(
+            abs_path=path, name="overwrite_missing.png", tags=["output"]
+        )
+
+        with mock_create_session() as session:
+            rows = list(
+                session.scalars(
+                    select(AssetContent).where(
+                        AssetContent.path == os.path.abspath(path)
+                    )
+                )
+            )
+            live = [row for row in rows if not row.is_missing]
+            missing = [row for row in rows if row.is_missing]
+            assert len(live) == 1
+            assert live[0].hash == expected_new_hash
+            assert len(missing) == 1
+            assert missing[0].hash == r1.asset.hash
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+
+
+def _digest_of(path: str) -> str:
+    snapshot = snapshot_hash(path)
+    assert snapshot is not None
+    return snapshot[0]
+
+
+def _seed_live_content(session, path: str, stored_hash: str | None) -> tuple[str, str]:
+    size_bytes, mtime_ns = get_size_and_mtime_ns(path)
+    content = create_content(session, path, stored_hash, size_bytes, mtime_ns)
+    record = create_record(
+        session, content.id, os.path.basename(path), tags=["output"]
+    )
+    session.commit()
+    return content.id, record.id
+
+
+def _is_missing_tagged(session, record_id: str) -> bool:
+    return (
+        session.get(AssetTag, {"asset_id": record_id, "tag_name": "missing"})
+        is not None
+    )
+
+
+def test_register_file_in_place_unhashed_unchanged_file_is_not_retired(
+    mock_create_session, hashing_on
+):
+    output_dir = folder_paths.get_output_directory()
+    os.makedirs(output_dir, exist_ok=True)
+    path = os.path.join(output_dir, "unhashed_noop.png")
+    payload = b"scanner-seeded-bytes"
+    try:
+        with open(path, "wb") as file:
+            file.write(payload)
+        with mock_create_session() as session:
+            content_id, record_id = _seed_live_content(
+                session, os.path.abspath(path), None
+            )
+
+        register_file_in_place(
+            abs_path=path,
+            name="unhashed_noop.png",
+            tags=["output"],
+            content_written=False,
+        )
+
+        with mock_create_session() as session:
+            content = session.get(AssetContent, content_id)
+            assert content is not None
+            assert content.is_missing is False
+            assert _is_missing_tagged(session, record_id) is False
+            live = list(
+                session.scalars(
+                    select(AssetContent).where(
+                        AssetContent.path == os.path.abspath(path),
+                        AssetContent.is_missing.is_(False),
+                    )
+                )
+            )
+            assert [row.id for row in live] == [content_id]
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+
+
+def test_register_file_in_place_unhashed_unchanged_file_adopts_hash(
+    mock_create_session, hashing_on
+):
+    output_dir = folder_paths.get_output_directory()
+    os.makedirs(output_dir, exist_ok=True)
+    path = os.path.join(output_dir, "unhashed_adopt.png")
+    payload = b"scanner-seeded-adopt-bytes"
+    try:
+        with open(path, "wb") as file:
+            file.write(payload)
+        with mock_create_session() as session:
+            content_id, record_id = _seed_live_content(
+                session, os.path.abspath(path), None
+            )
+        expected_hash = to_stored_hash(_digest_of(path))
+
+        result = register_file_in_place(
+            abs_path=path,
+            name="unhashed_adopt.png",
+            tags=["output"],
+            content_written=False,
+        )
+
+        assert result.ref.id != record_id
+        assert result.created_new is True
+        assert result.asset.hash == expected_hash
+        assert result.asset.size_bytes == len(payload)
+        with mock_create_session() as session:
+            content = session.get(AssetContent, content_id)
+            assert content is not None
+            assert content.hash == expected_hash
+            assert content.is_missing is False
+            record = session.get(Asset, result.ref.id)
+            assert record is not None
+            assert record.content_id == content_id
+            live = list(
+                session.scalars(
+                    select(AssetContent).where(
+                        AssetContent.path == os.path.abspath(path),
+                        AssetContent.is_missing.is_(False),
+                    )
+                )
+            )
+            assert [row.id for row in live] == [content_id]
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+
+
+def test_register_file_in_place_unhashed_changed_file_is_retired(
+    mock_create_session, hashing_on
+):
+    output_dir = folder_paths.get_output_directory()
+    os.makedirs(output_dir, exist_ok=True)
+    path = os.path.join(output_dir, "unhashed_changed.png")
+    original = b"scanner-seeded-original-bytes"
+    replacement = b"Z" * len(original)
+    try:
+        with open(path, "wb") as file:
+            file.write(original)
+        with mock_create_session() as session:
+            content_id, record_id = _seed_live_content(
+                session, os.path.abspath(path), None
+            )
+        with open(path, "wb") as file:
+            file.write(replacement)
+        expected_hash = to_stored_hash(_digest_of(path))
+
+        result = register_file_in_place(
+            abs_path=path,
+            name="unhashed_changed.png",
+            tags=["output"],
+            content_written=True,
+        )
+
+        assert result.asset.hash == expected_hash
+        with mock_create_session() as session:
+            stale = session.get(AssetContent, content_id)
+            assert stale is not None
+            assert stale.hash != expected_hash
+            assert stale.is_missing is True
+            assert _is_missing_tagged(session, record_id) is True
+            seeded_record = session.get(Asset, record_id)
+            assert seeded_record is not None
+            assert seeded_record.content_id == content_id
+            assert result.ref.id != record_id
+            live = list(
+                session.scalars(
+                    select(AssetContent).where(
+                        AssetContent.path == os.path.abspath(path),
+                        AssetContent.is_missing.is_(False),
+                    )
+                )
+            )
+            assert len(live) == 1
+            assert live[0].hash == expected_hash
+            assert live[0].id != content_id
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+
+
+def test_register_file_in_place_matching_hash_refreshes_stale_stat(
+    mock_create_session, hashing_on
+):
+    output_dir = folder_paths.get_output_directory()
+    os.makedirs(output_dir, exist_ok=True)
+    path = os.path.join(output_dir, "stale_mtime.png")
+    payload = b"stale-mtime-bytes"
+    try:
+        with open(path, "wb") as file:
+            file.write(payload)
+        stored_hash = to_stored_hash(_digest_of(path))
+        with mock_create_session() as session:
+            content_id, record_id = _seed_live_content(
+                session, os.path.abspath(path), stored_hash
+            )
+        observed_mtime = _bump_mtime(path)
+
+        result = register_file_in_place(
+            abs_path=path, name="stale_mtime.png", tags=["output"]
+        )
+
+        assert result.ref.id != record_id
+        assert result.created_new is True
+        with mock_create_session() as session:
+            content = session.get(AssetContent, content_id)
+            assert content is not None
+            assert content.is_missing is False
+            assert content.mtime_ns == observed_mtime
+            assert content.size_bytes == len(payload)
+            served = lookup_for_view(session, stored_hash)
+            assert served is not None
+            assert served.id == content_id
+            record = session.get(Asset, result.ref.id)
+            assert record is not None
+            assert record.content_id == content_id
+            assert session.scalar(select(func.count()).select_from(Asset)) == 2
+            live = list(
+                session.scalars(
+                    select(AssetContent).where(AssetContent.is_missing.is_(False))
+                )
+            )
+            assert [row.id for row in live] == [content_id]
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+
+
+def test_upload_unhashed_row_at_destination_is_not_retired(
+    mock_create_session, hashing_on
+):
+    payload = b"upload-adopt-destination-bytes"
+    probe = _write_temp(payload)
+    digest = _digest_of(probe)
+    os.unlink(probe)
+    output_dir = folder_paths.get_output_directory()
+    os.makedirs(output_dir, exist_ok=True)
+    dest = os.path.join(output_dir, f"{digest}.bin")
+    temp = _write_temp(payload)
+    try:
+        with open(dest, "wb") as file:
+            file.write(payload)
+        with mock_create_session() as session:
+            content_id, record_id = _seed_live_content(session, dest, None)
+
+        result = upload_from_temp_path(
+            temp_path=temp, name="up.bin", tags=["output"], client_filename="up.bin"
+        )
+
+        assert result.asset.hash == to_stored_hash(digest)
+        assert result.asset.size_bytes == len(payload)
+        with mock_create_session() as session:
+            content = session.get(AssetContent, content_id)
+            assert content is not None
+            assert content.is_missing is False
+            assert _is_missing_tagged(session, record_id) is False
+    finally:
+        for path in (temp, dest):
+            if os.path.exists(path):
+                os.unlink(path)
+
+
+def test_upload_unhashed_destination_holding_other_bytes_is_retired(
+    mock_create_session, hashing_on
+):
+    payload = b"upload-other-bytes-payload"
+    probe = _write_temp(payload)
+    digest = _digest_of(probe)
+    os.unlink(probe)
+    output_dir = folder_paths.get_output_directory()
+    os.makedirs(output_dir, exist_ok=True)
+    dest = os.path.join(output_dir, f"{digest}.bin")
+    decoy = b"X" * len(payload)
+    temp = _write_temp(payload)
+    try:
+        with open(dest, "wb") as file:
+            file.write(decoy)
+        with mock_create_session() as session:
+            content_id, record_id = _seed_live_content(session, dest, None)
+
+        result = upload_from_temp_path(
+            temp_path=temp, name="up.bin", tags=["output"], client_filename="up.bin"
+        )
+
+        assert result.asset.hash == to_stored_hash(digest)
+        assert open(dest, "rb").read() == payload
+        with mock_create_session() as session:
+            stale = session.get(AssetContent, content_id)
+            assert stale is not None
+            assert stale.hash != to_stored_hash(digest)
+            assert stale.is_missing is True
+            assert _is_missing_tagged(session, record_id) is True
+            live = list(
+                session.scalars(
+                    select(AssetContent).where(
+                        AssetContent.path == dest,
+                        AssetContent.is_missing.is_(False),
+                    )
+                )
+            )
+            assert len(live) == 1
+            assert live[0].hash == to_stored_hash(digest)
+            assert live[0].id != content_id
+    finally:
+        for path in (temp, dest):
+            if os.path.exists(path):
+                os.unlink(path)
+
+
+def test_upload_matching_hash_stale_stat_reuses_content_under_a_new_record(
+    mock_create_session, hashing_on
+):
+    payload = b"upload-stale-stat-bytes"
+    probe = _write_temp(payload)
+    digest = _digest_of(probe)
+    os.unlink(probe)
+    stored_hash = to_stored_hash(digest)
+    output_dir = folder_paths.get_output_directory()
+    os.makedirs(output_dir, exist_ok=True)
+    dest = os.path.join(output_dir, f"{digest}.bin")
+    temp = _write_temp(payload)
+    try:
+        with open(dest, "wb") as file:
+            file.write(payload)
+        with mock_create_session() as session:
+            content_id, record_id = _seed_live_content(session, dest, stored_hash)
+        _bump_mtime(dest)
+
+        result = upload_from_temp_path(
+            temp_path=temp,
+            name=os.path.basename(dest),
+            tags=["output"],
+            client_filename="up.bin",
+        )
+
+        assert result.ref.id != record_id, "a re-upload mints its own record"
+        assert result.created_new is True
+        with mock_create_session() as session:
+            minted = session.get(Asset, result.ref.id)
+            assert minted is not None
+            assert minted.content_id == content_id, (
+                "settle refreshes the stale row before lookup, so it qualifies "
+                "and is reused rather than duplicated"
+            )
+            assert (
+                session.scalar(select(func.count()).select_from(AssetContent)) == 1
+            ), "no second content row for bytes already on disk"
+            content = session.get(AssetContent, content_id)
+            assert content is not None
+            assert content.is_missing is False
+            assert content.mtime_ns == get_size_and_mtime_ns(dest)[1]
+            assert content.size_bytes == len(payload)
+            served = lookup_for_view(session, stored_hash)
+            assert served is not None
+            assert served.id == content_id
+    finally:
+        for path in (temp, dest):
+            if os.path.exists(path):
+                os.unlink(path)
+
+
+def test_upload_stale_destination_row_is_retired(mock_create_session, hashing_on):
+    payload = b"upload-retire-destination-bytes"
+    probe = _write_temp(payload)
+    digest = _digest_of(probe)
+    os.unlink(probe)
+    output_dir = folder_paths.get_output_directory()
+    os.makedirs(output_dir, exist_ok=True)
+    dest = os.path.join(output_dir, f"{digest}.bin")
+    temp = _write_temp(payload)
+    foreign_hash = to_stored_hash("f" * 64)
+    try:
+        with open(dest, "wb") as file:
+            file.write(b"externally-replaced")
+        with mock_create_session() as session:
+            content_id, record_id = _seed_live_content(session, dest, foreign_hash)
+
+        result = upload_from_temp_path(
+            temp_path=temp, name="up.bin", tags=["output"], client_filename="up.bin"
+        )
+
+        assert result.asset.hash == to_stored_hash(digest)
+        with mock_create_session() as session:
+            stale = session.get(AssetContent, content_id)
+            assert stale is not None
+            assert stale.is_missing is True
+            assert _is_missing_tagged(session, record_id) is True
+            live = list(
+                session.scalars(
+                    select(AssetContent).where(
+                        AssetContent.path == dest,
+                        AssetContent.is_missing.is_(False),
+                    )
+                )
+            )
+            assert len(live) == 1
+            assert live[0].hash == to_stored_hash(digest)
+            assert live[0].size_bytes == len(payload)
+    finally:
+        for path in (temp, dest):
+            if os.path.exists(path):
+                os.unlink(path)
+
+
+def test_upload_matching_missing_row_stores_bytes(mock_create_session, hashing_on):
+    content_bytes = b"fresh-upload-bytes"
+    temp = _write_temp(content_bytes)
+    snapshot = snapshot_hash(temp)
+    assert snapshot is not None
+    digest, _ = snapshot
+
+    missing_path = os.path.abspath("/nonexistent/missing-upload.bin")
+    with mock_create_session() as session:
+        stale = create_content(session, missing_path, digest, len(content_bytes), 0)
+        mark_content_missing(session, stale.id)
+        session.commit()
+
+    try:
+        result = upload_from_temp_path(
+            temp_path=temp,
+            name="fresh.bin",
+            tags=["output"],
+            client_filename="fresh.bin",
+        )
+        assert result.created_new is True
+        with mock_create_session() as session:
+            live_rows = list(
+                session.scalars(
+                    select(AssetContent).where(AssetContent.is_missing.is_(False))
+                )
+            )
+            assert len(live_rows) == 1
+            assert os.path.isfile(live_rows[0].path)
+            assert open(live_rows[0].path, "rb").read() == content_bytes
+    finally:
+        if os.path.exists(temp):
+            os.unlink(temp)
+
+
+def test_upload_unstable_raises_after_three_attempts_no_rows(
+    mock_create_session, hashing_on
+):
+    temp = _write_temp(b"unstable")
+    try:
+        with patch(
+            "app.assets.services.ingest.snapshot_hash", return_value=None
+        ) as mock_hash:
+            with pytest.raises(UploadUnstableError):
+                upload_from_temp_path(
+                    temp_path=temp,
+                    name="u.bin",
+                    tags=["output"],
+                    client_filename="u.bin",
+                )
+            assert mock_hash.call_count == 3
+        assert not os.path.exists(temp)
+        with mock_create_session() as session:
+            assert session.scalar(select(func.count()).select_from(Asset)) == 0
+            assert session.scalar(select(func.count()).select_from(AssetContent)) == 0
+    finally:
+        if os.path.exists(temp):
+            os.unlink(temp)
+
+
+def test_upload_unknown_preview_id_raises(mock_create_session, hashing_on):
+    temp = _write_temp(b"preview-validate-upload-bytes")
+    try:
+        with pytest.raises(ValueError):
+            upload_from_temp_path(
+                temp_path=temp,
+                name="pv.bin",
+                tags=["output"],
+                client_filename="pv.bin",
+                preview_id="00000000-0000-0000-0000-000000000000",
+            )
+        with mock_create_session() as session:
+            assert session.scalar(select(func.count()).select_from(Asset)) == 0
+    finally:
+        if os.path.exists(temp):
+            os.unlink(temp)
+
+
+def test_reupload_of_known_bytes_carries_this_requests_attributes(
+    mock_create_session, hashing_on
+):
+    payload = b"attribute-carrying-upload-bytes"
+    temp1 = _write_temp(payload)
+    temp2 = _write_temp(payload)
+    try:
+        first = upload_from_temp_path(
+            temp_path=temp1,
+            name="attrs.bin",
+            tags=["output"],
+            client_filename="attrs.bin",
+        )
+        second = upload_from_temp_path(
+            temp_path=temp2,
+            name="attrs.bin",
+            tags=["output"],
+            user_metadata={"note": "second delivery"},
+            client_filename="attrs.bin",
+            preview_id=first.ref.id,
+        )
+
+        assert second.ref.id != first.ref.id
+        assert second.created_new is True
+        assert second.ref.user_metadata == {"note": "second delivery"}, (
+            "the re-upload's own user_metadata must land on its record"
+        )
+        assert second.ref.preview_id == first.ref.id, (
+            "the re-upload's own preview_id must land on its record"
+        )
+        with mock_create_session() as session:
+            assert session.scalar(select(func.count()).select_from(AssetContent)) == 1
+            assert (
+                session.get(Asset, second.ref.id).content_id
+                == session.get(Asset, first.ref.id).content_id
+            )
+    finally:
+        for path in (temp1, temp2):
+            if os.path.exists(path):
+                os.unlink(path)
+
+
+def test_upload_does_not_reuse_temp_backed_content(mock_create_session, hashing_on):
+    payload = b"temp-backed-content-bytes"
+    staged = _write_temp(payload)
+    stored_hash = to_stored_hash(_digest_of(staged))
+    temp = _write_temp(payload)
+    try:
+        with mock_create_session() as session:
+            temp_content_id, _ = _seed_live_content(session, staged, stored_hash)
+
+        result = upload_from_temp_path(
+            temp_path=temp,
+            name="t.bin",
+            tags=["output"],
+            client_filename="t.bin",
+        )
+
+        assert result.created_new is True
+        with mock_create_session() as session:
+            minted = session.get(Asset, result.ref.id)
+            assert minted is not None
+            assert minted.content_id != temp_content_id, (
+                "a temporary location can never become permanent shared content"
+            )
+            content = session.get(AssetContent, minted.content_id)
+            assert content is not None
+            assert not is_temp_path(content.path)
+    finally:
+        for path in (staged, temp):
+            if os.path.exists(path):
+                os.unlink(path)
+
+
+def test_content_retired_after_lookup_falls_back_to_a_new_content_row(
+    mock_create_session, hashing_on
+):
+    payload = b"raced-retirement-upload-bytes"
+    temp1 = _write_temp(payload)
+    temp2 = _write_temp(payload)
+    try:
+        first = upload_from_temp_path(
+            temp_path=temp1,
+            name="raced.bin",
+            tags=["output"],
+            client_filename="raced.bin",
+        )
+        with mock_create_session() as session:
+            reused_content_id = session.get(Asset, first.ref.id).content_id
+
+        def retire_then_claim(session, content_id, hash):
+            mark_content_missing(session, content_id)
+            session.commit()
+            return _real_claim_qualified_content(session, content_id, hash)
+
+        with patch(
+            "app.assets.services.ingest.claim_qualified_content",
+            retire_then_claim,
+        ):
+            second = upload_from_temp_path(
+                temp_path=temp2,
+                name="raced.bin",
+                tags=["output"],
+                client_filename="raced.bin",
+            )
+
+        assert second.created_new is True
+        assert second.ref.id != first.ref.id
+        with mock_create_session() as session:
+            minted = session.get(Asset, second.ref.id)
+            assert minted is not None
+            assert minted.content_id != reused_content_id, (
+                "a record must never be attached to content retired mid-flight"
+            )
+            fresh = session.get(AssetContent, minted.content_id)
+            assert fresh is not None
+            assert fresh.is_missing is False
+            assert os.path.isfile(fresh.path)
+            with open(fresh.path, "rb") as file:
+                assert file.read() == payload, "the uploaded bytes must not be lost"
+    finally:
+        for path in (temp1, temp2):
+            if os.path.exists(path):
+                os.unlink(path)
+
+
+def _file_backed_engine(db_path):
+    engine = create_engine(
+        f"sqlite:///{db_path}",
+        connect_args={"check_same_thread": False, "timeout": 0.2},
+    )
+    Base.metadata.create_all(engine)
+    return engine
+
+
+@contextmanager
+def _session_factory(engine):
+    with SASession(engine) as sess:
+        yield sess
+
+
+def test_two_connections_hash_changed_between_lookup_and_claim_falls_back(
+    tmp_path, hashing_on
+):
+    engine = _file_backed_engine(tmp_path / "race_hash.db")
+    output_dir = folder_paths.get_output_directory()
+    os.makedirs(output_dir, exist_ok=True)
+    seed_path = os.path.join(output_dir, "seed_hash_race.bin")
+    payload = b"two-connection-hash-race-bytes"
+    with open(seed_path, "wb") as file:
+        file.write(payload)
+    stored_hash = to_stored_hash(_digest_of(seed_path))
+    with SASession(engine) as seed_session:
+        content_id, _ = _seed_live_content(seed_session, seed_path, stored_hash)
+
+    temp = _write_temp(payload)
+    real_claim = ingest_module.claim_qualified_content
+
+    def claim_after_a_rehashes(session, content_id_arg, hash_arg):
+        with SASession(engine) as connection_a:
+            connection_a.execute(
+                update(AssetContent)
+                .where(AssetContent.id == content_id_arg)
+                .values(hash="a-different-hash-entirely")
+            )
+            connection_a.commit()
+        return real_claim(session, content_id_arg, hash_arg)
+
+    try:
+        with (
+            patch(
+                "app.assets.services.ingest.create_session",
+                lambda: _session_factory(engine),
+            ),
+            patch(
+                "app.assets.services.ingest.claim_qualified_content",
+                claim_after_a_rehashes,
+            ),
+        ):
+            result = upload_from_temp_path(
+                temp_path=temp,
+                name="race_hash.bin",
+                tags=["output"],
+                client_filename="race_hash.bin",
+            )
+
+        assert result.created_new is True
+        with SASession(engine) as verify:
+            minted = verify.get(Asset, result.ref.id)
+            assert minted is not None
+            assert minted.content_id != content_id, (
+                "the row whose hash changed out from under the claim must "
+                "not be reused"
+            )
+            original = verify.get(AssetContent, content_id)
+            assert original is not None
+            assert original.hash == "a-different-hash-entirely"
+            fresh = verify.get(AssetContent, minted.content_id)
+            assert fresh is not None
+            assert os.path.isfile(fresh.path)
+            with open(fresh.path, "rb") as file:
+                assert file.read() == payload, "the uploaded bytes must not be lost"
+    finally:
+        for path in (seed_path, temp):
+            if os.path.exists(path):
+                os.unlink(path)
+
+
+def test_two_connections_competing_retirement_is_blocked_until_commit(
+    tmp_path, hashing_on
+):
+    engine = _file_backed_engine(tmp_path / "race_toctou.db")
+    output_dir = folder_paths.get_output_directory()
+    os.makedirs(output_dir, exist_ok=True)
+    seed_path = os.path.join(output_dir, "seed_toctou_race.bin")
+    payload = b"two-connection-toctou-race-bytes"
+    with open(seed_path, "wb") as file:
+        file.write(payload)
+    stored_hash = to_stored_hash(_digest_of(seed_path))
+    with SASession(engine) as seed_session:
+        content_id, _ = _seed_live_content(seed_session, seed_path, stored_hash)
+
+    temp = _write_temp(payload)
+    real_create_upload_record = ingest_module._create_upload_record
+    outcome: dict[str, bool] = {}
+
+    def create_record_after_a_retires(session, content_id_arg, *args, **kwargs):
+        with SASession(engine) as connection_a:
+            try:
+                mark_content_missing(connection_a, content_id_arg)
+                connection_a.commit()
+            except OperationalError as exc:
+                assert "lock" in str(exc).lower(), (
+                    "A must fail specifically on SQLite lock contention, not "
+                    f"some other OperationalError: {exc}"
+                )
+                outcome["a_was_blocked"] = True
+                connection_a.rollback()
+            else:
+                outcome["a_was_blocked"] = False
+        return real_create_upload_record(session, content_id_arg, *args, **kwargs)
+
+    try:
+        with (
+            patch(
+                "app.assets.services.ingest.create_session",
+                lambda: _session_factory(engine),
+            ),
+            patch(
+                "app.assets.services.ingest._create_upload_record",
+                create_record_after_a_retires,
+            ),
+        ):
+            result = upload_from_temp_path(
+                temp_path=temp,
+                name="race_toctou.bin",
+                tags=["output"],
+                client_filename="race_toctou.bin",
+            )
+
+        assert outcome["a_was_blocked"] is True, (
+            "connection A's competing retirement must be blocked by the "
+            "claim's write lock, not merely lose a race"
+        )
+        assert result.created_new is True
+        with SASession(engine) as verify:
+            minted = verify.get(Asset, result.ref.id)
+            assert minted is not None
+            assert minted.content_id == content_id, (
+                "the claimed row is still the one reused once A is blocked"
+            )
+            reused = verify.get(AssetContent, content_id)
+            assert reused is not None
+            assert reused.is_missing is False, (
+                "the reused content row must not end up retired"
+            )
+    finally:
+        for path in (seed_path, temp):
+            if os.path.exists(path):
+                os.unlink(path)
+
+
+def test_off_mode_upload_calls_content_lookup(mock_create_session, hashing_off):
+    temp = _write_temp(b"off-mode")
+    try:
+        with patch(
+            "app.assets.services.ingest.lookup_for_view"
+        ) as mock_dedup:
+            mock_dedup.return_value = None
+            upload_from_temp_path(
+                temp_path=temp,
+                name="off.bin",
+                tags=["output"],
+                client_filename="off.bin",
+            )
+            mock_dedup.assert_called_once()
+    finally:
+        if os.path.exists(temp):
+            os.unlink(temp)

--- a/tests-unit/assets_test/test_api_surface.py
+++ b/tests-unit/assets_test/test_api_surface.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from collections.abc import Callable, Collection, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, TypedDict, assert_never
+
+import pytest
+import requests
+from _pytest.mark.structures import ParameterSet
+
+
+RouteKind = Literal[
+    "head_asset_hash",
+    "list_assets",
+    "get_asset",
+    "get_asset_content",
+    "create_from_hash",
+    "upload_asset",
+    "update_asset",
+    "delete_asset",
+    "get_tags",
+    "add_asset_tags",
+    "delete_asset_tags",
+    "get_tags_refine",
+    "seed_assets",
+    "get_seed_status",
+    "cancel_seed",
+    "prune_missing_assets",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class RouteSpec:
+    method: str
+    path: str
+    kind: RouteKind
+    xfail_reason: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SmokeContext:
+    http: requests.Session
+    api_base: str
+    seeded_asset: SmokeAsset
+    make_asset_bytes: Callable[[str, int], bytes]
+
+
+class SmokeAsset(TypedDict):
+    id: str
+    hash: str
+
+
+ROUTES_PY = Path(__file__).resolve().parents[2] / "app/assets/api/routes.py"
+
+ROUTE_DECORATOR_RE = re.compile(
+    r"@ROUTES\.(?P<method>get|post|put|delete|head)\((?:f)?[\"'](?P<path>.*?)[\"']\)",
+    re.DOTALL,
+)
+NESTED_PARAM_RE = re.compile(r"\{(?P<name>[A-Za-z_][A-Za-z0-9_]*)\:\{[^{}]+\}\}")
+PATH_PARAM_RE = re.compile(r"\{(?P<name>[A-Za-z_][A-Za-z0-9_]*)\:[^{}]+\}")
+
+
+ROUTE_SPECS: tuple[RouteSpec, ...] = (
+    RouteSpec("HEAD", "/api/assets/hash/{hash}", "head_asset_hash"),
+    RouteSpec("GET", "/api/assets", "list_assets"),
+    RouteSpec("GET", "/api/assets/{id}", "get_asset"),
+    RouteSpec("GET", "/api/assets/{id}/content", "get_asset_content"),
+    RouteSpec("POST", "/api/assets/from-hash", "create_from_hash"),
+    RouteSpec("POST", "/api/assets", "upload_asset"),
+    RouteSpec("PUT", "/api/assets/{id}", "update_asset"),
+    RouteSpec("DELETE", "/api/assets/{id}", "delete_asset"),
+    RouteSpec("GET", "/api/tags", "get_tags"),
+    RouteSpec("POST", "/api/assets/{id}/tags", "add_asset_tags"),
+    RouteSpec("DELETE", "/api/assets/{id}/tags", "delete_asset_tags"),
+    RouteSpec("GET", "/api/assets/tags/refine", "get_tags_refine"),
+    RouteSpec("POST", "/api/assets/seed", "seed_assets"),
+    RouteSpec("GET", "/api/assets/seed/status", "get_seed_status"),
+    RouteSpec("POST", "/api/assets/seed/cancel", "cancel_seed"),
+    RouteSpec("POST", "/api/assets/prune", "prune_missing_assets"),
+)
+
+EXPECTED_ROUTE_KEYS = {f"{spec.method} {spec.path}" for spec in ROUTE_SPECS}
+
+
+def _normalize_route_path(raw_path: str) -> str:
+    path = raw_path.replace("{{", "{").replace("}}", "}")
+    path = NESTED_PARAM_RE.sub(r"{\g<name>}", path)
+    return PATH_PARAM_RE.sub(r"{\g<name>}", path)
+
+
+def parse_route_keys(source: str) -> set[str]:
+    return {
+        f"{match.group('method').upper()} {_normalize_route_path(match.group('path'))}"
+        for match in ROUTE_DECORATOR_RE.finditer(source)
+    }
+
+
+def assert_routes_covered(route_keys: Collection[str], covered_keys: Collection[str]) -> None:
+    route_set = set(route_keys)
+    covered_set = set(covered_keys)
+    missing = sorted(route_set - covered_set)
+    extra = sorted(covered_set - route_set)
+    if missing or extra:
+        raise AssertionError(f"route coverage mismatch: missing={missing}, extra={extra}")
+
+
+def _route_key(spec: RouteSpec) -> str:
+    return f"{spec.method} {spec.path}"
+
+
+def _make_route_param(spec: RouteSpec) -> ParameterSet:
+    marks = ()
+    if spec.xfail_reason is not None:
+        marks = (pytest.mark.xfail(strict=True, reason=spec.xfail_reason),)
+    return pytest.param(spec, marks=marks, id=_route_key(spec))
+
+
+ROUTE_PARAMS: tuple[ParameterSet, ...] = tuple(_make_route_param(spec) for spec in ROUTE_SPECS)
+
+
+@pytest.fixture
+def smoke_context(
+    http: requests.Session,
+    api_base: str,
+    seeded_asset: SmokeAsset,
+    make_asset_bytes: Callable[[str, int], bytes],
+) -> SmokeContext:
+    return SmokeContext(
+        http=http,
+        api_base=api_base,
+        seeded_asset=seeded_asset,
+        make_asset_bytes=make_asset_bytes,
+    )
+
+
+@pytest.fixture
+def seeded_asset(
+    asset_factory: Callable[[str, Sequence[str], dict[str, object], bytes], dict[str, object]],
+    make_asset_bytes: Callable[[str, int], bytes],
+) -> SmokeAsset:
+    name = f"surface-smoke-{uuid.uuid4().hex}.safetensors"
+    body = asset_factory(
+        name,
+        ["models", "model_type:checkpoints", "unit-tests", "smoke"],
+        {"purpose": "smoke"},
+        make_asset_bytes(name, 512),
+    )
+    return {
+        "id": str(body["id"]),
+        "hash": str(body["hash"]),
+    }
+
+
+def _request_for_spec(spec: RouteSpec, ctx: SmokeContext) -> requests.Response:
+    seeded = ctx.seeded_asset
+    asset_id = str(seeded["id"])
+    asset_hash = str(seeded["hash"])
+
+    match spec.kind:
+        case "head_asset_hash":
+            return ctx.http.head(f"{ctx.api_base}/api/assets/hash/{asset_hash}", timeout=120)
+        case "list_assets":
+            return ctx.http.get(f"{ctx.api_base}/api/assets", params={"limit": "1"}, timeout=120)
+        case "get_asset":
+            return ctx.http.get(f"{ctx.api_base}/api/assets/{asset_id}", timeout=120)
+        case "get_asset_content":
+            return ctx.http.get(f"{ctx.api_base}/api/assets/{asset_id}/content", timeout=120)
+        case "create_from_hash":
+            return ctx.http.post(
+                f"{ctx.api_base}/api/assets/from-hash",
+                json={
+                    "hash": asset_hash,
+                    "name": f"smoke-copy-{uuid.uuid4().hex}.safetensors",
+                    "tags": ["models", "unit-tests", "smoke"],
+                    "user_metadata": {"purpose": "smoke"},
+                },
+                timeout=120,
+            )
+        case "upload_asset":
+            name = f"smoke-upload-{uuid.uuid4().hex}.bin"
+            return ctx.http.post(
+                f"{ctx.api_base}/api/assets",
+                files={"file": (name, ctx.make_asset_bytes(name, 512), "application/octet-stream")},
+                data={
+                    "tags": json.dumps(["input", "unit-tests", "smoke"]),
+                    "name": name,
+                    "user_metadata": json.dumps({"purpose": "smoke"}),
+                },
+                timeout=120,
+            )
+        case "update_asset":
+            return ctx.http.put(
+                f"{ctx.api_base}/api/assets/{asset_id}",
+                json={"name": f"smoke-renamed-{uuid.uuid4().hex}.safetensors"},
+                timeout=120,
+            )
+        case "delete_asset":
+            return ctx.http.delete(f"{ctx.api_base}/api/assets/{asset_id}", timeout=120)
+        case "get_tags":
+            return ctx.http.get(f"{ctx.api_base}/api/tags", params={"limit": "1"}, timeout=120)
+        case "add_asset_tags":
+            return ctx.http.post(
+                f"{ctx.api_base}/api/assets/{asset_id}/tags",
+                json={"tags": ["smoke-tag"]},
+                timeout=120,
+            )
+        case "delete_asset_tags":
+            return ctx.http.delete(
+                f"{ctx.api_base}/api/assets/{asset_id}/tags",
+                json={"tags": ["unit-tests"]},
+                timeout=120,
+            )
+        case "get_tags_refine":
+            return ctx.http.get(
+                f"{ctx.api_base}/api/assets/tags/refine",
+                params={"limit": "1"},
+                timeout=120,
+            )
+        case "seed_assets":
+            return ctx.http.post(
+                f"{ctx.api_base}/api/assets/seed?wait=true",
+                json={"roots": ["models"]},
+                timeout=120,
+            )
+        case "get_seed_status":
+            return ctx.http.get(f"{ctx.api_base}/api/assets/seed/status", timeout=120)
+        case "cancel_seed":
+            return ctx.http.post(f"{ctx.api_base}/api/assets/seed/cancel", timeout=120)
+        case "prune_missing_assets":
+            return ctx.http.post(f"{ctx.api_base}/api/assets/prune", timeout=120)
+        case _:
+            assert_never(spec.kind)
+
+
+def test_route_coverage_guard_rejects_extra_route() -> None:
+    with pytest.raises(AssertionError, match=r"GET /api/extra"):
+        assert_routes_covered(
+            ["GET /api/assets", "POST /api/assets", "GET /api/extra"],
+            ["GET /api/assets", "POST /api/assets"],
+        )
+
+
+def test_route_coverage_matches_routes_py() -> None:
+    assert_routes_covered(
+        parse_route_keys(ROUTES_PY.read_text(encoding="utf-8")),
+        sorted(EXPECTED_ROUTE_KEYS),
+    )
+
+
+@pytest.mark.parametrize("spec", ROUTE_PARAMS)
+def test_api_surface(spec: RouteSpec, smoke_context: SmokeContext) -> None:
+    response = _request_for_spec(spec, smoke_context)
+    assert response.status_code < 500, f"{_route_key(spec)} returned {response.status_code}"

--- a/tests-unit/assets_test/test_intended_behaviour.py
+++ b/tests-unit/assets_test/test_intended_behaviour.py
@@ -1,0 +1,711 @@
+import json
+import os
+import uuid
+from contextlib import contextmanager, nullcontext
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from aiohttp.test_utils import make_mocked_request
+from blake3 import blake3
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+from app.assets import mode
+from app.assets.api import routes
+from app.assets.database.models import Asset, AssetContent, Base
+from app.assets.database.queries import (
+    create_content,
+    create_record,
+    fetch_record_tags,
+    get_record_by_id,
+    mark_content_missing,
+    rename_record,
+)
+from app.assets.database.queries.records import (
+    get_preview_file_paths_by_ids,
+    get_record_by_path_or_none,
+)
+from app.assets.helpers import to_stored_hash
+from app.assets.lifecycle import wipe_temp_db_rows
+from app.assets.scanner import (
+    build_asset_specs,
+    seed_asset_specs,
+    sync_prefixes_with_filesystem,
+)
+from app.assets.scanner_admission import _should_skip_extension
+from app.assets.scanner_changes import (
+    clear_pending_verifications,
+    detect_content_change,
+    drain_pending_verifications,
+    queue_pending_verification,
+)
+from app.assets.services.asset_management import (
+    asset_exists,
+    delete_asset_reference,
+    resolve_hash_to_path,
+)
+from app.assets.services.file_utils import list_files_recursively
+from app.assets.services.ingest import register_cached_output, upload_from_temp_path
+from app.assets.services.lookup import (
+    lookup_for_from_hash,
+    lookup_for_view,
+)
+from app.assets.services.snapshot_hash import snapshot_hash
+
+
+@pytest.fixture
+def session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as database_session:
+        yield database_session
+
+
+def _record(session, path: Path, name: str, hash_value: str | None = None):
+    content = create_content(session, str(path), hash=hash_value, size_bytes=path.stat().st_size if path.exists() else 0)
+    return create_record(session, content.id, name)
+
+
+@contextmanager
+def _sandbox_asset_roots(root: Path, model_category: Path | None = None):
+    with patch("app.assets.services.path_utils.folder_paths") as folder_paths_mock:
+        folder_paths_mock.get_input_directory.return_value = str(root / "input")
+        folder_paths_mock.get_output_directory.return_value = str(root / "output")
+        folder_paths_mock.get_temp_directory.return_value = str(root / "temp")
+        folder_paths_mock.models_dir = str(root / "models")
+        categories = (
+            [("checkpoints", [str(model_category)], {".safetensors"})]
+            if model_category is not None
+            else []
+        )
+        with patch(
+            "app.assets.services.path_utils.get_comfy_models_folders",
+            return_value=categories,
+        ):
+            yield
+
+
+_WRITER_UPDATE_CAP = 16
+
+
+def _differently_sized(payload: bytes, avoid_size: int) -> bytes:
+    return payload if len(payload) != avoid_size else payload + b"!"
+
+
+def _seed_content_row(session, path: Path, hash_value: str | None = None):
+    seed_stat = path.stat()
+    return create_content(
+        session,
+        str(path),
+        hash=hash_value,
+        size_bytes=seed_stat.st_size,
+        mtime_ns=seed_stat.st_mtime_ns,
+    )
+
+
+def _scan_pass(session, root: Path) -> int:
+    survivors = sync_prefixes_with_filesystem(
+        session, [str(root)], collect_existing_paths=True
+    )
+    specs, _tag_pool, _skipped = build_asset_specs(
+        list_files_recursively(str(root)), survivors or set()
+    )
+    return seed_asset_specs(session, specs)
+
+
+@contextmanager
+def _writer_lands_mid_hash(path: Path, replacement: bytes):
+    real_blake3 = blake3
+
+    class _WriterHasher:
+        def __init__(self) -> None:
+            self._inner = real_blake3()
+            self._updates = 0
+
+        def update(self, chunk: bytes) -> None:
+            self._updates += 1
+            assert self._updates <= _WRITER_UPDATE_CAP, (
+                f"simulated writer never converged after {_WRITER_UPDATE_CAP} "
+                "chunks — it is feeding the read loop instead of ending it"
+            )
+            if self._updates == 1:
+                path.write_bytes(_differently_sized(replacement, path.stat().st_size))
+            self._inner.update(chunk)
+
+        def hexdigest(self) -> str:
+            return self._inner.hexdigest()
+
+    with patch("app.assets.services.snapshot_hash.blake3", _WriterHasher):
+        yield _WriterHasher
+
+
+def test_scenario_1_rm_missing_and_strict_recovery(session, tmp_path):
+    """Ruling 1: missing is projected from content to every record."""
+    record = _record(session, tmp_path / "missing.bin", "missing")
+    mark_content_missing(session, record.content_id)
+    assert fetch_record_tags(session, record.id) == ["missing"]
+
+
+def test_scenario_2_edit_split(session, tmp_path):
+    """Ruling 2: edits split content and the old content read is unavailable.
+
+    The split is the production verdict, not the fixture's: an in-place edit is
+    handed to ``detect_content_change`` with hashing off and both halves of a
+    genuine change (size AND mtime moved), which is the one OFF-mode shape that
+    is allowed to retire content.
+    """
+    input_root = tmp_path / "input"
+    input_root.mkdir()
+    path = input_root / "edit.bin"
+    path.write_bytes(b"the-original-bytes")
+    seed_stat = path.stat()
+    old_content = _seed_content_row(session, path)
+    old_record = create_record(session, old_content.id, "edit.bin")
+
+    path.write_bytes(b"a replacement of a decidedly different length")
+    moved_mtime = path.stat().st_mtime_ns + 1_000_000_000
+    os.utime(path, ns=(moved_mtime, moved_mtime))
+    edited_stat = path.stat()
+    assert edited_stat.st_size != seed_stat.st_size
+    assert edited_stat.st_mtime_ns != seed_stat.st_mtime_ns
+
+    with _sandbox_asset_roots(tmp_path):
+        detect_content_change(session, old_content, edited_stat, hashing_is_enabled=False)
+
+    new_record = get_record_by_path_or_none(session, str(path))
+    assert new_record is not None
+    assert new_record.id != old_record.id
+    assert new_record.content_id != old_content.id
+    assert new_record.content.is_missing is False
+    assert new_record.content.size_bytes == edited_stat.st_size
+    assert new_record.content.mtime_ns == edited_stat.st_mtime_ns
+    assert session.get(Asset, old_record.id).content_id == old_content.id
+    assert old_content.is_missing is True
+    assert fetch_record_tags(session, old_record.id) == ["missing"]
+    assert create_content(session, str(path)).id == new_record.content_id
+
+
+def test_scenario_3_path_reuse_convergence(session, tmp_path):
+    """Ruling 3: path reuse converges on missing old content plus a new record."""
+    old = _record(session, tmp_path / "same.bin", "old")
+    mark_content_missing(session, old.content_id)
+    new = _record(session, tmp_path / "same.bin", "new")
+    assert old.content_id != new.content_id
+    assert old.content.is_missing is True
+    assert new.content.is_missing is False
+    assert create_content(session, str(tmp_path / "same.bin")).id == new.content_id
+
+
+def test_scenario_4_delete_no_revival(session, tmp_path):
+    """Ruling 4: delete is hard, spares the content, and cannot be undone."""
+    record = _record(session, tmp_path / "deleted.bin", "deleted")
+    record_id, content_id = record.id, record.content_id
+
+    with patch(
+        "app.assets.services.asset_management.create_session",
+        lambda: nullcontext(session),
+    ):
+        assert delete_asset_reference(record_id) is True
+        assert delete_asset_reference(record_id) is False
+
+    assert get_record_by_id(session, record_id) is None
+    assert session.get(AssetContent, content_id) is not None
+
+
+def test_scenario_5_rename_always(session):
+    """Ruling 5: names are labels and duplicate names are allowed."""
+    first = create_record(session, create_content(session, "/one").id, "same")
+    second = create_record(session, create_content(session, "/two").id, "other")
+    assert rename_record(session, second.id, "same").name == first.name
+
+
+def test_scenario_6_upload_reuses_content_never_the_record(session, tmp_path):
+    """Ruling 6: every upload is a delivery event, so it always mints its own
+    record; dedup is content-level only, and runs in both hashing modes.
+
+    Ratified 2026-08-28, superseding the "same name + same bytes returns the
+    existing record" behavior. Content dedup is unchanged: identical bytes
+    still share one ``AssetContent`` row, in BOTH modes — uploads hash
+    unconditionally (``upload_from_temp_path`` calls
+    ``_snapshot_hash_with_retry`` before it consults anything) and
+    ``lookup_for_view`` never asks ``mode.hashing_enabled``, unlike
+    ``lookup_for_from_hash``. What changed is record identity: a re-upload is a
+    new delivery, so it gets a new record carrying the attributes THAT request
+    supplied, instead of silently handing back an older record that never saw
+    them.
+    """
+    (tmp_path / "output").mkdir(parents=True)
+    payload = b"the-uploaded-bytes"
+    expected_hash = to_stored_hash(blake3(payload).hexdigest())
+
+    def upload(
+        uploaded: bytes,
+        name: str,
+        *,
+        hashing: bool,
+        user_metadata: dict | None = None,
+    ):
+        staging = tmp_path / "temp" / "uploads" / uuid.uuid4().hex
+        staging.mkdir(parents=True)
+        staged = staging / ".upload.part"
+        staged.write_bytes(uploaded)
+        with (
+            _sandbox_asset_roots(tmp_path),
+            patch(
+                "folder_paths.get_temp_directory", return_value=str(tmp_path / "temp")
+            ),
+            patch(
+                "app.assets.services.ingest.create_session",
+                lambda: nullcontext(session),
+            ),
+            patch.object(mode, "hashing_enabled", return_value=hashing),
+        ):
+            return upload_from_temp_path(
+                temp_path=str(staged),
+                name=name,
+                tags=["output"],
+                client_filename=name,
+                user_metadata=user_metadata,
+            )
+
+    first = upload(payload, "upload.bin", hashing=False)
+    again = upload(
+        payload, "upload.bin", hashing=False, user_metadata={"note": "second delivery"}
+    )
+    renamed = upload(payload, "renamed.bin", hashing=False)
+    in_hash_mode = upload(payload, "upload.bin", hashing=True)
+    other = upload(b"a wholly different payload", "upload.bin", hashing=False)
+
+    assert first.created_new is True
+    assert first.asset.hash == expected_hash
+
+    assert again.created_new is True
+    assert again.ref.id != first.ref.id, "a re-upload is its own delivery"
+    assert again.ref.user_metadata == {"note": "second delivery"}, (
+        "the new record carries the attributes THIS request supplied"
+    )
+    assert (
+        session.get(Asset, again.ref.id).content_id
+        == session.get(Asset, first.ref.id).content_id
+    ), "identical bytes still share one content row"
+
+    assert in_hash_mode.created_new is True
+    assert in_hash_mode.ref.id != first.ref.id
+    assert (
+        session.get(Asset, in_hash_mode.ref.id).content_id
+        == session.get(Asset, first.ref.id).content_id
+    ), "content dedup is mode-independent"
+
+    assert renamed.created_new is True
+    assert renamed.ref.id != first.ref.id
+    assert renamed.ref.file_path == first.ref.file_path
+    assert (
+        session.get(Asset, renamed.ref.id).content_id
+        == session.get(Asset, first.ref.id).content_id
+    )
+
+    assert other.created_new is True
+    assert other.asset.hash != expected_hash
+    assert other.ref.file_path != first.ref.file_path
+
+    live = list(
+        session.scalars(select(AssetContent).where(AssetContent.is_missing.is_(False)))
+    )
+    assert {content.hash for content in live} == {expected_hash, other.asset.hash}
+
+
+def test_scenario_7_same_bytes_new_name(session, tmp_path):
+    """Ruling 7: a new name creates a new record."""
+    path = tmp_path / "bytes.bin"
+    path.write_bytes(b"bytes")
+    content = create_content(session, str(path), hash="digest")
+    one = create_record(session, content.id, "one")
+    two = create_record(session, content.id, "two")
+    assert one.id != two.id
+    assert one.content_id == two.content_id == content.id
+    assert {one.name, two.name} == {"one", "two"}
+
+
+def test_scenario_8_diff_bytes_same_name(session, tmp_path):
+    """Ruling 8: different bytes may share a display name."""
+    a = _record(session, tmp_path / "one", "same")
+    b = _record(session, tmp_path / "two", "same")
+    assert a.id != b.id
+    assert a.name == b.name == "same"
+    assert a.content_id != b.content_id
+
+
+def test_scenario_9_equal_hashes_no_merge(session, tmp_path):
+    """Ruling 9: equal hashes never impose content uniqueness."""
+    a = _record(session, tmp_path / "one", "one", "digest")
+    b = _record(session, tmp_path / "two", "two", "digest")
+    assert a.content_id != b.content_id
+    assert a.content.hash == b.content.hash == "digest"
+    assert a.content.is_missing is False
+    assert b.content.is_missing is False
+
+
+def test_scenario_10_cached_delivery_record(session, tmp_path):
+    """Ruling 10: cached delivery creates another record for existing content."""
+    output_root = tmp_path / "output"
+    output_root.mkdir()
+    path = output_root / "cached.png"
+    path.write_bytes(b"pixels")
+    content = _seed_content_row(session, path, hash_value="digest")
+    original = create_record(
+        session,
+        content.id,
+        "cached.png",
+        job_id="executed-job",
+        system_metadata={"inherited": "from-the-earliest-sibling"},
+    )
+    content_before = (
+        content.hash,
+        content.size_bytes,
+        content.mtime_ns,
+        content.is_missing,
+    )
+
+    with (
+        _sandbox_asset_roots(tmp_path),
+        patch(
+            "app.assets.services.ingest.create_session",
+            lambda: nullcontext(session),
+        ),
+    ):
+        delivered = register_cached_output(str(path), job_id="delivery-job")
+
+    assert delivered is not None
+    assert delivered.id != original.id
+    assert delivered.content_id == content.id
+    assert delivered.job_id == "delivery-job"
+    assert session.get(Asset, delivered.id).system_metadata == original.system_metadata
+
+    assert (
+        content.hash,
+        content.size_bytes,
+        content.mtime_ns,
+        content.is_missing,
+    ) == content_before
+    assert (original.job_id, original.name) == ("executed-job", "cached.png")
+    assert [row.id for row in session.scalars(select(AssetContent))] == [content.id]
+    assert {row.id for row in session.scalars(select(Asset))} == {
+        original.id,
+        delivered.id,
+    }
+
+    mark_content_missing(session, content.id)
+    with (
+        _sandbox_asset_roots(tmp_path),
+        patch(
+            "app.assets.services.ingest.create_session",
+            lambda: nullcontext(session),
+        ),
+    ):
+        assert register_cached_output(str(path), job_id="second-delivery") is None
+    assert {row.id for row in session.scalars(select(Asset))} == {
+        original.id,
+        delivered.id,
+    }
+
+
+def test_scenario_11_restart_survival(tmp_path):
+    """Ruling 11: non-temp records survive reopening the database."""
+    database = tmp_path / "assets.sqlite"
+    engine = create_engine(f"sqlite:///{database}")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        record = create_record(session, create_content(session, "/durable").id, "durable")
+        session.commit()
+        record_id = record.id
+    with Session(engine) as session:
+        assert session.get(type(record), record_id) is not None
+
+
+def test_scenario_12_temp_wipe_both_layers(session, tmp_path):
+    """Ruling 12: temp removal deletes records before their content."""
+    temp_root = tmp_path / "temp"
+    temp_root.mkdir()
+    keep_root = tmp_path / "output"
+    keep_root.mkdir()
+    doomed = _record(session, temp_root / "render.png", "render")
+    survivor = _record(session, keep_root / "final.png", "final")
+    doomed_id, doomed_content_id = doomed.id, doomed.content_id
+    survivor_id, survivor_content_id = survivor.id, survivor.content_id
+
+    with patch("folder_paths.get_temp_directory", return_value=str(temp_root)):
+        deleted = wipe_temp_db_rows(session)
+    session.commit()
+
+    assert deleted == (1, 1)
+    assert session.get(Asset, doomed_id) is None
+    assert session.get(AssetContent, doomed_content_id) is None
+    assert session.get(Asset, survivor_id) is not None
+    assert session.get(AssetContent, survivor_content_id) is not None
+
+
+def test_scenario_15_two_locations_hash_relation(session, tmp_path):
+    """Ruling 15: locations retain separate rows even with equal hashes."""
+    a = _record(session, tmp_path / "a", "a", "digest")
+    b = _record(session, tmp_path / "b", "b", "digest")
+    assert a.content_id != b.content_id
+    assert a.content.hash == b.content.hash == "digest"
+    assert a.content.path != b.content.path
+
+
+def test_scenario_17_move_is_missing_plus_new(session, tmp_path):
+    """Ruling 17: a move is missing old content plus a new record.
+
+    Driven as a real ``os.replace`` observed by a real scanner pass: nothing
+    tells the scanner a move happened, it only sees one path gone and another
+    arrived, and the missing-plus-new outcome is entirely its own.
+    """
+    input_root = tmp_path / "input"
+    input_root.mkdir()
+    old_path = input_root / "old.bin"
+    old_path.write_bytes(b"the-bytes-that-move")
+    old_content = _seed_content_row(session, old_path)
+    old_record = create_record(session, old_content.id, "old.bin")
+
+    new_path = input_root / "new.bin"
+    os.replace(old_path, new_path)
+
+    with (
+        _sandbox_asset_roots(tmp_path),
+        patch.object(mode, "hashing_enabled", return_value=False),
+    ):
+        created = _scan_pass(session, input_root)
+
+    assert created == 1
+    new_record = get_record_by_path_or_none(session, str(new_path))
+    assert new_record is not None
+    assert new_record.id != old_record.id
+    assert new_record.content_id != old_content.id
+    assert new_record.content.path == str(new_path)
+    assert new_record.content.is_missing is False
+    assert old_content.is_missing is True
+    assert "missing" in fetch_record_tags(session, old_record.id)
+    assert session.get(Asset, old_record.id).content_id == old_content.id
+    assert get_record_by_path_or_none(session, str(old_path)) is None
+
+
+def test_scenario_18_edit_during_hash_discard(session, tmp_path):
+    """Ruling 18: unstable hashing must not overwrite a content identity."""
+    path = tmp_path / "unstable.bin"
+    committed = b"the-committed-bytes"
+    path.write_bytes(committed)
+    committed_hash = to_stored_hash(blake3(committed).hexdigest())
+    seed_stat = path.stat()
+    content = create_content(
+        session,
+        str(path),
+        hash=committed_hash,
+        size_bytes=seed_stat.st_size,
+        mtime_ns=seed_stat.st_mtime_ns,
+    )
+    record = create_record(session, content.id, "unstable.bin")
+
+    clear_pending_verifications()
+    try:
+        queue_pending_verification(content.id)
+        with _writer_lands_mid_hash(path, b"a-concurrent-writer-was-here"):
+            assert snapshot_hash(str(path)) is None
+            assert drain_pending_verifications(session) == 0
+
+        assert content.hash == committed_hash
+        assert content.is_missing is False
+        assert [row.id for row in session.scalars(select(Asset))] == [record.id]
+        assert [row.id for row in session.scalars(select(AssetContent))] == [content.id]
+
+        path.write_bytes(committed)
+        assert drain_pending_verifications(session) == 1
+    finally:
+        clear_pending_verifications()
+
+    assert content.hash == committed_hash
+    assert content.mtime_ns == path.stat().st_mtime_ns
+
+
+def test_writer_simulation_terminates_and_is_capped(tmp_path):
+    path = tmp_path / "bounded.bin"
+    path.write_bytes(b"0123456789")
+
+    with _writer_lands_mid_hash(path, b"a-replacement-of-another-length") as hasher:
+        assert snapshot_hash(str(path)) is None
+        assert snapshot_hash(str(path)) is None
+        assert path.stat().st_size != 10
+
+        runaway = hasher()
+        with pytest.raises(AssertionError, match="never converged"):
+            for _ in range(_WRITER_UPDATE_CAP + 1):
+                runaway.update(b"chunk")
+
+
+def test_scenario_20_partial_download(tmp_path):
+    """Ruling 20: partial-download admission is separate from content creation."""
+    partial = tmp_path / "model.safetensors.part"
+    partial.write_bytes(b"partial")
+    complete = tmp_path / "model.safetensors"
+    complete.write_bytes(b"complete")
+    assert _should_skip_extension(str(partial)) is True
+    assert _should_skip_extension(str(complete)) is False
+
+
+def test_scenario_21_symlink_two_rows(session, tmp_path):
+    """Ruling 21: lexical locations always retain separate content rows.
+
+    One inode, two names, one real scanner pass. Lexical means the scanner must
+    not resolve the link: if it took the realpath, the second admission would
+    collide on the live-path index and yield a single row.
+    """
+    input_root = tmp_path / "input"
+    input_root.mkdir()
+    real_path = input_root / "real.bin"
+    real_path.write_bytes(b"one-set-of-bytes-answering-to-two-names")
+    link_path = input_root / "link.bin"
+    os.symlink(real_path, link_path)
+    assert link_path.is_symlink()
+    assert os.path.samefile(real_path, link_path)
+
+    with (
+        _sandbox_asset_roots(tmp_path),
+        patch.object(mode, "hashing_enabled", return_value=False),
+    ):
+        created = _scan_pass(session, input_root)
+
+    assert created == 2
+    real_record = get_record_by_path_or_none(session, str(real_path))
+    link_record = get_record_by_path_or_none(session, str(link_path))
+    assert real_record is not None
+    assert link_record is not None
+    assert real_record.content_id != link_record.content_id
+    assert real_record.content.path == str(real_path)
+    assert link_record.content.path == str(link_path)
+    assert real_record.content.is_missing is False
+    assert link_record.content.is_missing is False
+    assert real_record.content.size_bytes == link_record.content.size_bytes
+
+
+def test_scenario_25_registry_birth_fact(session, tmp_path):
+    """Ruling 25: loader classification is stamped at record birth."""
+    category = tmp_path / "models" / "checkpoints"
+    (category / "family").mkdir(parents=True)
+    path = category / "family" / "model.safetensors"
+    path.write_bytes(b"first")
+    seed_stat = path.stat()
+    content = create_content(
+        session, str(path), size_bytes=seed_stat.st_size, mtime_ns=seed_stat.st_mtime_ns
+    )
+    original = create_record(session, content.id, "model.safetensors")
+    assert original.loader_path is None
+
+    path.write_bytes(b"second-bytes-of-a-different-length")
+    with _sandbox_asset_roots(tmp_path, category):
+        detect_content_change(session, content, path.stat(), hashing_is_enabled=False)
+
+    born = get_record_by_path_or_none(session, str(path))
+    assert born.id != original.id
+    assert born.loader_path == "family/model.safetensors"
+    assert original.loader_path is None
+
+
+@pytest.mark.asyncio
+async def test_scenario_26_view_forms(tmp_path):
+    """Ruling 26: record identity is stable for the canonical view form."""
+    nested = tmp_path / "output" / "nested"
+    nested.mkdir(parents=True)
+    file_path = nested / "view.png"
+    file_path.write_bytes(b"pixels")
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as setup:
+        content = create_content(setup, str(file_path))
+        record_id = create_record(
+            setup, content.id, "original-name.png", mime_type="image/png"
+        ).id
+        setup.commit()
+
+    async def view_form() -> tuple[str, str]:
+        response = await routes.list_assets_route(
+            make_mocked_request("GET", "/api/assets")
+        )
+        listed = json.loads(response.body)["assets"]
+        assert len(listed) == 1
+        return listed[0]["id"], listed[0]["preview_url"]
+
+    with (
+        patch.object(routes, "create_session", lambda: Session(engine)),
+        patch.object(routes, "_ASSETS_ENABLED", True),
+        _sandbox_asset_roots(tmp_path),
+    ):
+        before = await view_form()
+        with Session(engine) as renaming:
+            rename_record(renaming, record_id, "renamed-entirely.png")
+            renaming.commit()
+        after = await view_form()
+    engine.dispose()
+
+    assert before == (
+        record_id,
+        "/api/view?type=output&filename=view.png&subfolder=nested",
+    )
+    assert after == before
+
+
+def test_scenario_27_fail_closed_previews_fromhash(session, tmp_path):
+    """Ruling 27: missing content is never a serving candidate."""
+    path = tmp_path / "servable.png"
+    payload = b"pixels"
+    path.write_bytes(payload)
+    seed_stat = path.stat()
+    digest = to_stored_hash(blake3(payload).hexdigest())
+    content = create_content(
+        session,
+        str(path),
+        hash=digest,
+        size_bytes=seed_stat.st_size,
+        mtime_ns=seed_stat.st_mtime_ns,
+    )
+    record_id = create_record(session, content.id, "servable.png").id
+
+    def previews() -> dict[str, str]:
+        return get_preview_file_paths_by_ids(session, [record_id])
+
+    def from_hash():
+        with patch.object(mode, "hashing_enabled", return_value=True):
+            return lookup_for_from_hash(session, digest)
+
+    def serving() -> tuple[bool, object]:
+        with patch(
+            "app.assets.services.asset_management.create_session",
+            lambda: nullcontext(session),
+        ):
+            return asset_exists(digest), resolve_hash_to_path(digest)
+
+    with patch("folder_paths.get_temp_directory", return_value=str(tmp_path / "temp")):
+        assert previews() == {record_id: str(path)}
+        assert from_hash().id == content.id
+        assert lookup_for_view(session, digest).id == content.id
+        exists, resolved = serving()
+        assert exists is True
+        assert resolved is not None
+
+        mark_content_missing(session, content.id)
+
+        assert previews() == {}
+        assert from_hash() is None
+        assert lookup_for_view(session, digest) is None
+        assert serving() == (False, None)
+
+
+def test_scenario_28_temp_exclusion(session, tmp_path):
+    """Ruling 28: a temporary location cannot become permanent shared content."""
+    path = tmp_path / "temp.bin"
+    path.write_bytes(b"bytes")
+    record = _record(session, path, "temp", "digest")
+    with patch("app.assets.services.lookup.is_temp_path", return_value=True):
+        assert lookup_for_view(session, "digest") is None
+    with patch("app.assets.services.lookup.is_temp_path", return_value=False):
+        assert lookup_for_view(session, "digest").id == record.content_id

--- a/tests-unit/assets_test/test_no_assets_regression.py
+++ b/tests-unit/assets_test/test_no_assets_regression.py
@@ -1,0 +1,74 @@
+import contextlib
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+import requests
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server_socket:
+        server_socket.bind(("127.0.0.1", 0))
+        return server_socket.getsockname()[1]
+
+
+@pytest.fixture
+def no_assets_server(tmp_path: Path):
+    for directory in ("models", "custom_nodes", "input", "output", "temp", "user"):
+        (tmp_path / directory).mkdir()
+    port = _free_port()
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "main.py",
+            f"--base-directory={tmp_path}",
+            "--listen",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--cpu",
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    base_url = f"http://127.0.0.1:{port}"
+    for _ in range(120):
+        if process.poll() is not None:
+            raise RuntimeError(f"No-assets server exited with {process.returncode}")
+        try:
+            if requests.get(f"{base_url}/system_stats", timeout=1).status_code == 200:
+                break
+        except requests.ConnectionError:
+            pass
+        time.sleep(0.25)
+    else:
+        raise RuntimeError("No-assets server did not start")
+    yield base_url
+    process.terminate()
+    with contextlib.suppress(subprocess.TimeoutExpired):
+        process.wait(timeout=15)
+
+
+def test_no_assets_keeps_legacy_upload_and_view(no_assets_server: str):
+    assert requests.get(f"{no_assets_server}/api/assets", timeout=10).status_code == 503
+
+    upload = requests.post(
+        f"{no_assets_server}/upload/image",
+        files={"image": ("legacy.png", b"legacy-bytes", "image/png")},
+        data={"type": "output"},
+        timeout=10,
+    )
+
+    assert upload.status_code == 200
+    filename = upload.json()["name"]
+    view = requests.get(
+        f"{no_assets_server}/view",
+        params={"filename": filename, "type": "output"},
+        timeout=10,
+    )
+    assert view.status_code == 200
+    assert view.content == b"legacy-bytes"

--- a/tests-unit/assets_test/test_recovery_same_path.py
+++ b/tests-unit/assets_test/test_recovery_same_path.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import sqlite3
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from .helpers import trigger_sync_seed_assets
+
+
+def _db_path(comfy_tmp_base_dir: Path, request: pytest.FixtureRequest) -> str:
+    url = request.config.getoption("--db-url")
+    if url and url.startswith("sqlite:///"):
+        return url[len("sqlite:///"):]
+    return str(comfy_tmp_base_dir / "assets-test.sqlite3")
+
+
+def _query(db_path: str, sql: str, params: tuple[Any, ...] = ()) -> list[tuple[Any, ...]]:
+    last_err: Exception | None = None
+    for _ in range(20):
+        try:
+            con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5)
+            try:
+                return list(con.execute(sql, params))
+            finally:
+                con.close()
+        except sqlite3.OperationalError as e:
+            last_err = e
+            time.sleep(0.1)
+    raise AssertionError(f"sqlite read failed: {last_err}")
+
+
+def _content_by_id(db_path: str, content_id: str) -> tuple[str | None, int]:
+    rows = _query(
+        db_path,
+        "SELECT hash, is_missing FROM asset_contents WHERE id = ?",
+        (content_id,),
+    )
+    assert rows, f"content {content_id} vanished"
+    return rows[0][0], rows[0][1]
+
+
+def _rows_at_path(db_path: str, path: str) -> list[tuple[Any, ...]]:
+    return _query(
+        db_path,
+        "SELECT id, hash, is_missing FROM asset_contents WHERE path = ? "
+        "ORDER BY created_at",
+        (path,),
+    )
+
+
+def _missing_tag_count(db_path: str, content_id: str) -> int:
+    rows = _query(
+        db_path,
+        "SELECT COUNT(*) FROM asset_tags at "
+        "JOIN assets a ON a.id = at.asset_id "
+        "WHERE a.content_id = ? AND at.tag_name = 'missing'",
+        (content_id,),
+    )
+    return rows[0][0]
+
+
+def _seed_until_row(http, api_base, db_path: str, path: str) -> tuple[str, str | None]:
+    for _ in range(5):
+        trigger_sync_seed_assets(http, api_base)
+        rows = _rows_at_path(db_path, path)
+        if rows:
+            return rows[0][0], rows[0][1]
+    raise AssertionError(f"scanned file never produced a content row: {path}")
+
+
+def _drop_scanned_file(comfy_tmp_base_dir: Path) -> tuple[Path, bytes]:
+    ckpt_dir = comfy_tmp_base_dir / "models" / "checkpoints"
+    ckpt_dir.mkdir(parents=True, exist_ok=True)
+    disk_path = ckpt_dir / f"scanned_{uuid.uuid4().hex}.safetensors"
+    payload = uuid.uuid4().bytes + b"S" * (65536 - 16)
+    disk_path.write_bytes(payload)
+    return disk_path, payload
+
+
+@pytest.mark.hashing_on
+def test_same_path_restore_recovery_characterization(
+    http, api_base, comfy_tmp_base_dir, request
+):
+    db_path = _db_path(comfy_tmp_base_dir, request)
+    disk_path, payload = _drop_scanned_file(comfy_tmp_base_dir)
+
+    content_id, _ = _seed_until_row(http, api_base, db_path, str(disk_path))
+
+    disk_path.unlink()
+    trigger_sync_seed_assets(http, api_base)
+    _, missing_after_delete = _content_by_id(db_path, content_id)
+    assert missing_after_delete == 1
+
+    disk_path.write_bytes(payload)
+    trigger_sync_seed_assets(http, api_base)
+    trigger_sync_seed_assets(http, api_base)
+
+    _, is_missing = _content_by_id(db_path, content_id)
+
+    assert is_missing == 0
+
+
+@pytest.mark.hashing_on
+def test_same_path_restore_recovers_hashed_row(
+    http, api_base, comfy_tmp_base_dir, request
+):
+    db_path = _db_path(comfy_tmp_base_dir, request)
+    disk_path, payload = _drop_scanned_file(comfy_tmp_base_dir)
+
+    content_id, birth_hash = _seed_until_row(http, api_base, db_path, str(disk_path))
+    assert birth_hash is not None, "scanned file was not hashed in hash mode"
+
+    disk_path.unlink()
+    trigger_sync_seed_assets(http, api_base)
+    _, missing_after_delete = _content_by_id(db_path, content_id)
+    assert missing_after_delete == 1
+
+    disk_path.write_bytes(payload)
+    trigger_sync_seed_assets(http, api_base)
+    trigger_sync_seed_assets(http, api_base)
+
+    recovered_hash, is_missing = _content_by_id(db_path, content_id)
+    assert is_missing == 0, "same-path restore did not recover the hashed row"
+    assert recovered_hash == birth_hash
+    assert _missing_tag_count(db_path, content_id) == 0
+
+    live_rows = [r for r in _rows_at_path(db_path, str(disk_path)) if r[2] == 0]
+    assert len(live_rows) == 1
+    assert live_rows[0][0] == content_id

--- a/tests-unit/assets_test/test_upload_hashing_modes.py
+++ b/tests-unit/assets_test/test_upload_hashing_modes.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import os
+import json
+import sqlite3
+import time
+import uuid
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import pytest
+import requests
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session as SASession
+
+import app.assets.mode as mode_module
+import folder_paths
+from app.assets.database.models import AssetContent, Base
+from app.assets.services.ingest import register_executed_output
+
+from .helpers import trigger_sync_seed_assets
+
+
+def _db_path(comfy_tmp_base_dir: Path, request: pytest.FixtureRequest) -> str:
+    url = request.config.getoption("--db-url")
+    if url and url.startswith("sqlite:///"):
+        return url[len("sqlite:///"):]
+    return str(comfy_tmp_base_dir / "assets-test.sqlite3")
+
+
+def _query(db_path: str, sql: str, params: tuple[Any, ...] = ()) -> list[tuple[Any, ...]]:
+    last_err: Exception | None = None
+    for _ in range(20):
+        try:
+            con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5)
+            try:
+                return list(con.execute(sql, params))
+            finally:
+                con.close()
+        except sqlite3.OperationalError as e:
+            last_err = e
+            time.sleep(0.1)
+    raise AssertionError(f"sqlite read failed: {last_err}")
+
+
+def _content_hash_for_asset(db_path: str, asset_id: str) -> str | None:
+    rows = _query(
+        db_path,
+        "SELECT c.hash FROM asset_contents c "
+        "JOIN assets a ON a.content_id = c.id "
+        "WHERE a.id = ?",
+        (asset_id,),
+    )
+    assert rows, f"no content row found for asset {asset_id}"
+    return rows[0][0]
+
+
+def _content_id_for_asset(db_path: str, asset_id: str) -> str:
+    rows = _query(db_path, "SELECT content_id FROM assets WHERE id = ?", (asset_id,))
+    assert rows, f"no asset row found for {asset_id}"
+    return rows[0][0]
+
+
+def _is_stored_blake3_hash(value: str | None) -> bool:
+    if not isinstance(value, str) or not value.startswith("blake3:"):
+        return False
+    digest = value[len("blake3:") :]
+    return len(digest) == 64 and all(c in "0123456789abcdef" for c in digest.lower())
+
+
+def _upload_via_api(
+    http: requests.Session, base: str, *, name: str, tags: list[str], data: bytes
+) -> tuple[int, dict[str, Any]]:
+    files = {"file": (name, data, "application/octet-stream")}
+    form = {"tags": json.dumps(tags), "name": name, "user_metadata": json.dumps({})}
+    r = http.post(base + "/api/assets", files=files, data=form, timeout=120)
+    return r.status_code, r.json()
+
+
+def _upload_via_image(
+    http: requests.Session, base: str, *, name: str, data: bytes, upload_type: str = "input"
+) -> tuple[int, dict[str, Any]]:
+    files = {"image": (name, data, "image/png")}
+    form = {"type": upload_type, "subfolder": ""}
+    r = http.post(base + "/upload/image", files=files, data=form, timeout=120)
+    return r.status_code, r.json()
+
+
+def _unique_bytes(seed: str, size: int = 4096) -> bytes:
+    return uuid.uuid4().bytes + seed.encode("utf-8").ljust(size, b"\0")[: size - 16]
+
+
+@pytest.fixture(scope="session")
+def server_hashing_enabled(request: pytest.FixtureRequest) -> bool:
+    markexpr = request.config.getoption("markexpr") or ""
+    return bool(
+        request.config.getoption("--enable-asset-hashing")
+        or "hashing_on" in markexpr
+        or any(item.get_closest_marker("hashing_on") for item in request.session.items)
+    )
+
+
+def test_upload_via_api_hashes_in_on_mode(http, api_base, comfy_tmp_base_dir, request):
+    db_path = _db_path(comfy_tmp_base_dir, request)
+    data = _unique_bytes("api-hashes")
+    status, body = _upload_via_api(
+        http, api_base, name="api_hashes.bin", tags=["output", "unit-tests"], data=data
+    )
+    assert status in (200, 201), body
+    digest = _content_hash_for_asset(db_path, body["id"])
+    assert _is_stored_blake3_hash(digest), f"expected a stored blake3 hash, got {digest!r}"
+
+
+def test_upload_via_image_hashes_in_on_mode(http, api_base, comfy_tmp_base_dir, request):
+    db_path = _db_path(comfy_tmp_base_dir, request)
+    data = _unique_bytes("image-hashes")
+    status, body = _upload_via_image(http, api_base, name="image_hashes.png", data=data)
+    assert status == 200, body
+    asset = body.get("asset")
+    assert asset and asset.get("id"), f"/upload/image did not register an asset: {body}"
+    digest = _content_hash_for_asset(db_path, asset["id"])
+    assert _is_stored_blake3_hash(digest), f"expected a stored blake3 hash, got {digest!r}"
+
+
+def test_repeat_upload_mints_a_new_record_in_on_mode(
+    http, api_base, comfy_tmp_base_dir, request
+):
+    db_path = _db_path(comfy_tmp_base_dir, request)
+    data = _unique_bytes("dedup-on-mode")
+    status1, first = _upload_via_api(
+        http, api_base, name="dedup_on.bin", tags=["output", "unit-tests"], data=data
+    )
+    status2, second = _upload_via_api(
+        http, api_base, name="dedup_on.bin", tags=["output", "unit-tests"], data=data
+    )
+    assert status1 == 201, first
+    assert status2 == 201, second
+    assert second["id"] != first["id"], "every upload is its own delivery record"
+    assert second.get("created_new") is True
+    assert _content_id_for_asset(db_path, second["id"]) == _content_id_for_asset(
+        db_path, first["id"]
+    ), "same bytes stay one content row (hashes alone can collide across rows)"
+
+
+def test_seeded_file_not_hashed_in_on_mode(
+    http, api_base, comfy_tmp_base_dir, request, server_hashing_enabled
+):
+    if server_hashing_enabled:
+        pytest.skip(
+            "scanner hashing gate only observable with the hashing flag OFF; "
+            "a full-suite run forces the shared server into hash mode"
+        )
+    db_path = _db_path(comfy_tmp_base_dir, request)
+    ckpt_dir = comfy_tmp_base_dir / "models" / "checkpoints"
+    ckpt_dir.mkdir(parents=True, exist_ok=True)
+    disk_path = ckpt_dir / f"seeded_{uuid.uuid4().hex}.safetensors"
+    disk_path.write_bytes(uuid.uuid4().bytes + b"S" * (4096 - 16))
+
+    row_hash: str | None = None
+    for _ in range(5):
+        trigger_sync_seed_assets(http, api_base)
+        rows = _query(
+            db_path,
+            "SELECT hash FROM asset_contents WHERE path = ? AND is_missing = 0",
+            (str(disk_path),),
+        )
+        if rows:
+            row_hash = rows[0][0]
+            break
+    else:
+        raise AssertionError(f"seeded file never produced a content row: {disk_path}")
+
+    assert row_hash is None, "scanner must not hash seeded files while the flag is off"
+
+
+def test_output_not_hashed_in_on_mode(monkeypatch):
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+
+    @contextmanager
+    def _fake_create_session():
+        with SASession(engine) as session:
+            yield session
+
+    monkeypatch.setattr(mode_module, "hashing_enabled", lambda: False)
+    monkeypatch.setattr(
+        "app.assets.services.ingest.create_session", _fake_create_session
+    )
+
+    output_dir = folder_paths.get_output_directory()
+    os.makedirs(output_dir, exist_ok=True)
+    out_path = os.path.join(output_dir, f"render_{uuid.uuid4().hex}.png")
+    with open(out_path, "wb") as fh:
+        fh.write(b"fake-output-bytes")
+
+    try:
+        register_executed_output(out_path, job_id="job-out")
+        with SASession(engine) as session:
+            content = session.execute(
+                select(AssetContent).where(
+                    AssetContent.path == os.path.abspath(out_path)
+                )
+            ).scalar_one()
+            assert content.hash is None, (
+                "workflow output must not be hashed while the hashing flag is off"
+            )
+            assert content.is_missing is False
+    finally:
+        if os.path.exists(out_path):
+            os.unlink(out_path)

--- a/tests-unit/execution_test/test_execute_reentry.py
+++ b/tests-unit/execution_test/test_execute_reentry.py
@@ -1,0 +1,179 @@
+import asyncio
+import os
+import sys
+import tempfile
+import types
+
+import pytest
+
+_BASE = os.path.join(tempfile.gettempdir(), "execute-reentry-test-base")
+
+
+def _find_ids(value) -> list:
+    found: list = []
+    if isinstance(value, dict):
+        for key, sub in value.items():
+            if key == "id":
+                found.append(sub)
+            found.extend(_find_ids(sub))
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            found.extend(_find_ids(item))
+    return found
+
+
+class _Server:
+    def __init__(self, client_id=None) -> None:
+        self.client_id = client_id
+        self.last_node_id = None
+        self.sent: list = []
+
+    def send_sync(self, event, payload, client_id) -> None:
+        self.sent.append((event, payload))
+
+
+class _AsyncDictCache:
+
+    def __init__(self) -> None:
+        self.store: dict = {}
+
+    async def get(self, key):
+        return self.store.get(key)
+
+    async def set(self, key, value) -> None:
+        self.store[key] = value
+
+    async def ensure_subcache_for(self, unique_id, node_ids):
+        return self
+
+
+class _Caches:
+    def __init__(self) -> None:
+        self.outputs = _AsyncDictCache()
+        self.objects = _AsyncDictCache()
+        self.all = [self.outputs, self.objects]
+
+
+class _ExecutionList:
+    def cache_update(self, unique_id, entry) -> None:
+        pass
+
+    def add_external_block(self, unique_id):
+        return lambda: None
+
+    def get_cache(self, a, b):
+        return None
+
+
+class _NoProgress:
+    def start_progress(self, *a, **k) -> None:
+        pass
+
+    def finish_progress(self, *a, **k) -> None:
+        pass
+
+
+class _AsyncUINode:
+
+    RETURN_TYPES = ()
+    FUNCTION = "run"
+    OUTPUT_NODE = True
+    CATEGORY = "test"
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {}}
+
+    async def run(self):
+        await asyncio.sleep(0.02)
+        return {"ui": {"images": [{"filename": "async.png", "subfolder": "", "type": "output"}]}}
+
+
+@pytest.fixture
+def execution_env(monkeypatch):
+    try:
+        from comfy.cli_args import args
+        monkeypatch.setattr(args, "cpu", True, raising=False)
+        import execution
+        import folder_paths
+        import nodes
+    except Exception as exc:  # pragma: no cover - environment dependent
+        pytest.skip(f"execution module could not be imported in CPU mode: {exc!r}")
+
+    monkeypatch.setattr(args, "enable_assets", True, raising=False)
+
+    counter = {"n": 0}
+
+    def _register(abs_path, job_id=None):
+        counter["n"] += 1
+        return types.SimpleNamespace(id=f"asset-{counter['n']}", job_id=job_id)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "app.assets.services.ingest",
+        types.SimpleNamespace(register_executed_output=_register, register_cached_output=_register),
+    )
+    os.makedirs(_BASE, exist_ok=True)
+    monkeypatch.setattr(folder_paths, "get_directory_by_type", lambda t: _BASE)
+    monkeypatch.setattr(execution, "get_progress_state", lambda: _NoProgress())
+    monkeypatch.setitem(nodes.NODE_CLASS_MAPPINGS, "AsyncUINode", _AsyncUINode)
+
+    return execution
+
+
+async def _drive_async_reentry(execution):
+    from comfy_execution.graph import DynamicPrompt
+
+    unique_id = "1"
+    with open(os.path.join(_BASE, "async.png"), "wb") as f:
+        f.write(b"x")
+
+    dynprompt = DynamicPrompt({unique_id: {"class_type": "AsyncUINode", "inputs": {}}})
+    caches = _Caches()
+    server = _Server(client_id=None)
+    exec_list = _ExecutionList()
+    pending_subgraph_results: dict = {}
+    pending_async_nodes: dict = {}
+    ui_outputs: dict = {}
+    executed: set = set()
+
+    common = (server, dynprompt, caches, unique_id, {}, executed, "job-1", exec_list)
+
+    r1, _, _ = await execution.execute(*common, pending_subgraph_results, pending_async_nodes, ui_outputs)
+    ui_outputs_had_uid_after_entry1 = unique_id in ui_outputs
+
+    tasks = [t for t in pending_async_nodes.get(unique_id, []) if isinstance(t, asyncio.Task)]
+    if tasks:
+        await asyncio.gather(*tasks)
+    for _ in range(3):
+        await asyncio.sleep(0)
+
+    r2, _, _ = await execution.execute(*common, pending_subgraph_results, pending_async_nodes, ui_outputs)
+
+    cached = caches.outputs.store.get(unique_id)
+    return {
+        "r1": r1,
+        "r2": r2,
+        "ui_outputs_had_uid_after_entry1": ui_outputs_had_uid_after_entry1,
+        "ui_ids": _find_ids(ui_outputs.get(unique_id)),
+        "cache_entry": cached,
+        "cache_ids": _find_ids(cached.ui) if cached is not None else None,
+    }
+
+
+def test_async_reentry_keeps_cache_id_free(execution_env):
+    execution = execution_env
+    from execution import ExecutionResult
+
+    obs = asyncio.run(_drive_async_reentry(execution))
+
+    assert obs["r1"] == ExecutionResult.PENDING
+    assert obs["r2"] == ExecutionResult.SUCCESS
+    # WHY it is safe: the async branch returns PENDING *before* writing ui_outputs,
+    # so on re-entry ui_outputs.get(unique_id) is None and cannot seed cache_ui_value.
+    assert obs["ui_outputs_had_uid_after_entry1"] is False
+
+    assert obs["ui_ids"] == ["asset-1"]
+
+    assert obs["cache_entry"] is not None
+    assert obs["cache_ids"] == []


### PR DESCRIPTION
Layer 4/4 of the review-and-land stack for `synap5e/feat/asset-record-content-split`, generated by
`review-stack.py`. Full collapse procedure: `~/adocs/review-stack.md`. **Once the
stack starts collapsing, don't rerun `build`/`push` on it** — a rebuild resets every
layer to its original scope from the untouched source branch and discards the collapse.

**Top of the stack.** Once approved, merge this into #15917 (ordinary "Merge" — always a fast-forward; the branches are a linear chain by construction).

**Rule:** test file added  
**Question for this layer:** Is the code layer well covered?  
**Source tip:** `7007d1858257`

**Stack:**
1. #15915 `code` — Is the logic change right?
2. #15916 `tests-removed` — For each dropped assertion: obsolete by a ruling, or covered by a tests-new test?
3. #15917 `tests-changed` — Did the edits weaken an existing check?
4. #15918 `tests-new` — Is the code layer well covered?

**Files (46, +8601/-0):**

| | +/- | path |
|---|---|---|
| A | +89/-0 | `tests-unit/app_test/test_db_init_locking.py` |
| A | +215/-0 | `tests-unit/app_test/test_migration_0007.py` |
| A | +56/-0 | `tests-unit/app_test/test_migration_roundtrip.py` |
| A | +0/-0 | `tests-unit/assets_test/__init__.py` |
| A | +159/-0 | `tests-unit/assets_test/queries/test_lookup.py` |
| A | +120/-0 | `tests-unit/assets_test/queries/test_records.py` |
| A | +198/-0 | `tests-unit/assets_test/queries/test_tags_query.py` |
| A | +31/-0 | `tests-unit/assets_test/services/path_prefix_cases.py` |
| A | +165/-0 | `tests-unit/assets_test/services/test_admission_gate.py` |
| A | +20/-0 | `tests-unit/assets_test/services/test_admission_integration.py` |
| A | +155/-0 | `tests-unit/assets_test/services/test_api_routes_b.py` |
| A | +123/-0 | `tests-unit/assets_test/services/test_cached_execution_path.py` |
| A | +75/-0 | `tests-unit/assets_test/services/test_cached_save.py` |
| A | +115/-0 | `tests-unit/assets_test/services/test_delete_b.py` |
| A | +188/-0 | `tests-unit/assets_test/services/test_detection_gate.py` |
| A | +207/-0 | `tests-unit/assets_test/services/test_enrichment_predicate.py` |
| A | +185/-0 | `tests-unit/assets_test/services/test_enrichment_snapshot.py` |
| A | +118/-0 | `tests-unit/assets_test/services/test_from_hash.py` |
| A | +58/-0 | `tests-unit/assets_test/services/test_hash_mode_state.py` |
| A | +82/-0 | `tests-unit/assets_test/services/test_ingest_b.py` |
| A | +129/-0 | `tests-unit/assets_test/services/test_ingest_orphan_content.py` |
| A | +286/-0 | `tests-unit/assets_test/services/test_lifecycle.py` |
| A | +59/-0 | `tests-unit/assets_test/services/test_metadata_update_b.py` |
| A | +198/-0 | `tests-unit/assets_test/services/test_null_hash_recovery.py` |
| A | +147/-0 | `tests-unit/assets_test/services/test_output_registration.py` |
| A | +15/-0 | `tests-unit/assets_test/services/test_owner_purge.py` |
| A | +64/-0 | `tests-unit/assets_test/services/test_preview_path_resolution.py` |
| A | +137/-0 | `tests-unit/assets_test/services/test_recovery_gate.py` |
| A | +273/-0 | `tests-unit/assets_test/services/test_registration_primitives.py` |
| A | +43/-0 | `tests-unit/assets_test/services/test_scan_lifecycle.py` |
| A | +232/-0 | `tests-unit/assets_test/services/test_scanner_b.py` |
| A | +149/-0 | `tests-unit/assets_test/services/test_scanner_seed_resilience.py` |
| A | +356/-0 | `tests-unit/assets_test/services/test_serving_b.py` |
| A | +81/-0 | `tests-unit/assets_test/services/test_snapshot_hash.py` |
| A | +393/-0 | `tests-unit/assets_test/services/test_split_policy.py` |
| A | +282/-0 | `tests-unit/assets_test/services/test_stored_hash_prefix.py` |
| A | +101/-0 | `tests-unit/assets_test/services/test_tag_protection.py` |
| A | +313/-0 | `tests-unit/assets_test/services/test_transition_drain.py` |
| A | +285/-0 | `tests-unit/assets_test/services/test_updated_at_semantics.py` |
| A | +1134/-0 | `tests-unit/assets_test/services/test_upload_b.py` |
| A | +257/-0 | `tests-unit/assets_test/test_api_surface.py` |
| A | +711/-0 | `tests-unit/assets_test/test_intended_behaviour.py` |
| A | +74/-0 | `tests-unit/assets_test/test_no_assets_regression.py` |
| A | +133/-0 | `tests-unit/assets_test/test_recovery_same_path.py` |
| A | +211/-0 | `tests-unit/assets_test/test_upload_hashing_modes.py` |
| A | +179/-0 | `tests-unit/execution_test/test_execute_reentry.py` |