### PR TITLE
Fix MoGe NotImplementedError on Apple Silicon: load on MPS instead of CPU

### DIFF
--- a/comfy/ldm/moge/model.py
+++ b/comfy/ldm/moge/model.py
@@ -270,6 +270,14 @@ class MoGeModel:
     def __init__(self, state_dict: dict):
         self.load_device = comfy.model_management.text_encoder_device()
         offload_device = comfy.model_management.text_encoder_offload_device()
+        if comfy.model_management.is_device_cpu(self.load_device) and comfy.model_management.is_device_mps(comfy.model_management.get_torch_device()):
+            # The text-encoder policy parks models on the CPU on MPS (vram_state
+            # is SHARED) while text_encoder_dtype still selects fp16, and the CPU
+            # has no fp16 antialiased-bilinear kernel, so DINOv2Encoder.forward()
+            # raises NotImplementedError("compute_index_ranges_weights" not
+            # implemented for 'Half'). MoGe is a vision backbone, not a text
+            # encoder: load it on the GPU like the DA3 nodes do.
+            self.load_device = comfy.model_management.get_torch_device()
         self.dtype = comfy.model_management.text_encoder_dtype(self.load_device)
 
         self.model = build_from_state_dict(state_dict, dtype=self.dtype, device=offload_device, operations=comfy.ops.manual_cast).eval()

--- a/comfy/ldm/moge/model.py
+++ b/comfy/ldm/moge/model.py
@@ -270,15 +270,19 @@ class MoGeModel:
     def __init__(self, state_dict: dict):
         self.load_device = comfy.model_management.text_encoder_device()
         offload_device = comfy.model_management.text_encoder_offload_device()
-        if comfy.model_management.is_device_cpu(self.load_device) and comfy.model_management.is_device_mps(comfy.model_management.get_torch_device()):
+        self.dtype = comfy.model_management.text_encoder_dtype(self.load_device)
+        if (self.dtype in (torch.float16, torch.bfloat16)
+                and comfy.model_management.is_device_cpu(self.load_device)
+                and comfy.model_management.is_device_mps(comfy.model_management.get_torch_device())):
             # The text-encoder policy parks models on the CPU on MPS (vram_state
             # is SHARED) while text_encoder_dtype still selects fp16, and the CPU
-            # has no fp16 antialiased-bilinear kernel, so DINOv2Encoder.forward()
-            # raises NotImplementedError("compute_index_ranges_weights" not
-            # implemented for 'Half'). MoGe is a vision backbone, not a text
-            # encoder: load it on the GPU like the DA3 nodes do.
+            # has no fp16/bf16 antialiased-bilinear kernel, so
+            # DINOv2Encoder.forward() raises NotImplementedError
+            # ("compute_index_ranges_weights" not implemented for 'Half').
+            # MoGe is a vision backbone, not a text encoder: load it on the GPU
+            # like the DA3 nodes do. An explicit --fp32-text-enc keeps the CPU
+            # placement, since fp32 works there.
             self.load_device = comfy.model_management.get_torch_device()
-        self.dtype = comfy.model_management.text_encoder_dtype(self.load_device)
 
         self.model = build_from_state_dict(state_dict, dtype=self.dtype, device=offload_device, operations=comfy.ops.manual_cast).eval()
         self.patcher = comfy.model_patcher.CoreModelPatcher(self.model, load_device=self.load_device, offload_device=offload_device)


### PR DESCRIPTION
## Summary

`MoGeModel` borrows the text-encoder device/dtype policy. On Apple Silicon that policy resolves to **CPU + fp16**: MPS machines get `vram_state = SHARED`, which routes text encoders to the CPU, while `text_encoder_dtype()` still returns fp16. The CPU has no fp16 antialiased-bilinear resize kernel, so MoGe's DINOv2 backbone crashes on its very first op, on every Mac, with:

```
NotImplementedError: "compute_index_ranges_weights" not implemented for 'Half'
```

(`compute_index_ranges_weights` is a helper in PyTorch's **CPU** antialiased-resize kernel — the error is often misread as an MPS gap, but MPS runs this exact op fine in fp16, at least since torch 2.13. `PYTORCH_ENABLE_MPS_FALLBACK` never helps because nothing fails on MPS.)

This PR loads MoGe on the GPU when the text-encoder policy says CPU but the machine's torch device is MPS — the same placement the DA3 nodes already use (`mm.get_torch_device()`), which is why Depth Anything 3 never hit this. MoGe is a ViT-L vision backbone, not a text encoder, so GPU placement is also just the right call: besides fixing the crash, inference moves off the CPU.

Fixes #14840

## Relation to #14637

#14637 fixes the same symptom by upcasting fp16/bf16 to fp32 around the antialiased interpolate calls. That's complementary, not competing: it makes the resize robust for any genuinely-CPU/half combination (e.g. `--cpu`), but on Macs it would leave the whole ViT-L running on the CPU with the GPU idle. This PR fixes the placement itself for the MPS case; the two can land together without conflict (different hunks).

## Testing

On an M4 Max (macOS, torch 2.13.0, MPS):
- Before: any MoGe workflow (`LoadMoGeModel` → `MoGeInference` → `MoGeRender`, `moge_2_vitl_normal_fp16.safetensors`) fails with the error above, regardless of `resolution_level` (tried 0 and 9) and with/without `--force-fp16` and `PYTORCH_ENABLE_MPS_FALLBACK=1`.
- After: the same workflow completes — 12-frame batch to 16-bit normal PNGs in ~10 s total on MPS. Standalone check of the full MoGe-2 ViT-L forward on MPS fp16: ~1.7 s per 720p frame, all outputs finite (points/mask/metric_scale/normal).
- CUDA and CPU-only paths are unaffected: the new branch only triggers when `text_encoder_device()` is CPU **and** the torch device is MPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)