### PR TITLE
Sort image dataset folder listings (os.listdir order is filesystem-dependent)

### DIFF
--- a/comfy_extras/nodes_dataset.py
+++ b/comfy_extras/nodes_dataset.py
@@ -197,11 +197,14 @@ class LoadImageDataSetFromFolderNode(io.ComfyNode):
     def execute(cls, folder):
         sub_input_dir = secure_subfolder_path(folder_paths.get_input_directory(), folder)
         valid_extensions = [".png", ".jpg", ".jpeg", ".webp"]
-        image_files = [
+        # Sort explicitly: os.listdir() order is filesystem-dependent (e.g.
+        # APFS returns filename-hash order), which silently scrambles frame
+        # sequences.
+        image_files = sorted(
             f
             for f in os.listdir(sub_input_dir)
             if any(f.lower().endswith(ext) for ext in valid_extensions)
-        ]
+        )
         output_tensor = load_and_process_images(image_files, sub_input_dir)
         return io.NodeOutput(output_tensor)
 
@@ -245,7 +248,10 @@ class LoadImageTextDataSetFromFolderNode(io.ComfyNode):
         valid_extensions = [".png", ".jpg", ".jpeg", ".webp"]
 
         image_files = []
-        for item in os.listdir(sub_input_dir):
+        # Sort explicitly: os.listdir() order is filesystem-dependent (e.g.
+        # APFS returns filename-hash order), which silently scrambles frame
+        # sequences.
+        for item in sorted(os.listdir(sub_input_dir)):
             path = os.path.join(sub_input_dir, item)
             if any(item.lower().endswith(ext) for ext in valid_extensions):
                 image_files.append(path)
@@ -255,11 +261,11 @@ class LoadImageTextDataSetFromFolderNode(io.ComfyNode):
                 if item.split("_")[0].isdigit():
                     repeat = int(item.split("_")[0])
                 image_files.extend(
-                    [
+                    sorted(
                         os.path.join(path, f)
                         for f in os.listdir(path)
                         if any(f.lower().endswith(ext) for ext in valid_extensions)
-                    ]
+                    )
                     * repeat
                 )
 


### PR DESCRIPTION
Fixes #15925.

`LoadImageDataSetFromFolder` and `LoadImageTextDataSetFromFolder` build their file lists straight from `os.listdir()`, whose order is explicitly undefined and filesystem-dependent. On APFS (macOS) it returns filename-hash order, so a frame sequence `frame_000001.png ... frame_000145.png` loads effectively scrambled (e.g. `117, 103, 88, 63, 77, ...`).

Consequences (details and repro in the issue):
- Per-frame outputs are written under counters that don't correspond to input frame numbers.
- Temporally-aware downstream nodes silently compute garbage — video tracking runs across a shuffled sequence, optical flow runs between unrelated frame pairs. No error is raised anywhere.
- Invisible on filesystems that happen to return sorted/insertion order, so graphs that work on one machine break silently on another.

This PR sorts the listings in both nodes, including `LoadImageTextDataSetFromFolder`'s kohya-style subfolder branch — where sorting also makes the image/caption pairing deterministic. Matches the existing `return sorted(found)` convention already used by the subfolder-scanning helper at the top of the same file.

Verified on a 145-frame sequence on macOS/APFS: before the change, batch output index 31 was pixel-identical to input frame 70 (matching `os.listdir()` order exactly); after the change, isolated single-frame ground-truth runs match batch outputs at the same index with r = 1.0000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)