### PR TITLE
perf(minimax-h3): reduce reference video conditioning cost

### DIFF
--- a/comfy_extras/nodes_minimax_h3.py
+++ b/comfy_extras/nodes_minimax_h3.py
@@ -61,6 +61,15 @@ def adapt_canvas(width, height):
             max(CANVAS_MULTIPLE, round(nom_h / CANVAS_MULTIPLE) * CANVAS_MULTIPLE))
 
 
+def downscale_to_area(width, height, max_pixels):
+    """Aspect-preserving, down-only sizing on H3's 32px spatial grid."""
+    scale = min(1.0, math.sqrt(max_pixels / (width * height)))
+    return (
+        max(CANVAS_MULTIPLE, round(width * scale / CANVAS_MULTIPLE) * CANVAS_MULTIPLE),
+        max(CANVAS_MULTIPLE, round(height * scale / CANVAS_MULTIPLE) * CANVAS_MULTIPLE),
+    )
+
+
 def _resize(image, width, height, crop):
     # image [B, H, W, C] -> [B, height, width, 3]
     samples = image[..., :3].movedim(-1, 1)
@@ -262,6 +271,8 @@ class MiniMaxH3ReferenceToVideo(io.ComfyNode):
                 io.Int.Input("length", default=124, min=5, max=3600, step=17, tooltip="Frame count at 24 fps, (124 = ~5s, trained range is ~124-362)"),
                 io.Combo.Input("ref_image_size", options=["match", "max"], default="match",
                     tooltip="Reference image sizing. 'match' scales each ref (down only, keeping aspect) to the generation's pixel area; 'max' uses the reference pipeline's 2048px short edge for best identity fidelity. Reference tokens ride through every sampling step, so 'max' can be several times slower."),
+                io.Combo.Input("ref_video_size", options=["official", "match"], default="official", optional=True,
+                    tooltip="Reference video sizing. 'official' keeps MiniMax's 768px short-edge recipe (up to 1344x768); 'match' scales down to the generation's pixel area. The smaller latent reduces reference encoding work and reference tokens processed at every sampling step."),
                 io.Autogrow.Input("ref_images", optional=True,
                     template=io.Autogrow.TemplatePrefix(
                         input=io.Image.Input("ref_image", tooltip="Reference image (downscaled to 2048 short edge if larger, never upscaled)"),
@@ -284,7 +295,8 @@ class MiniMaxH3ReferenceToVideo(io.ComfyNode):
 
     @classmethod
     def execute(cls, clip, vae, audio_vae, prompt, width, height, length, ref_image_size="match",
-                ref_images=None, ref_videos=None, ref_video_audios=None, ref_audios=None) -> io.NodeOutput:
+                ref_video_size="official", ref_images=None, ref_videos=None,
+                ref_video_audios=None, ref_audios=None) -> io.NodeOutput:
         latent, frame_count = _empty_av_latent(width, height, length)
 
         ref_items = []   # for the tokenizer presentation, in request order
@@ -296,11 +308,11 @@ class MiniMaxH3ReferenceToVideo(io.ComfyNode):
             h, w = img.shape[1], img.shape[2]
             if ref_image_size == "match":
                 # aspect-preserving scale (down only) to the generation's pixel area
-                scale = min(1.0, math.sqrt((width * height) / (w * h)))
+                tw, th = downscale_to_area(w, h, width * height)
             else:
                 scale = min(1.0, REF_IMAGE_SHORT_EDGE / min(w, h))
-            tw = max(CANVAS_MULTIPLE, round(w * scale / CANVAS_MULTIPLE) * CANVAS_MULTIPLE)
-            th = max(CANVAS_MULTIPLE, round(h * scale / CANVAS_MULTIPLE) * CANVAS_MULTIPLE)
+                tw = max(CANVAS_MULTIPLE, round(w * scale / CANVAS_MULTIPLE) * CANVAS_MULTIPLE)
+                th = max(CANVAS_MULTIPLE, round(h * scale / CANVAS_MULTIPLE) * CANVAS_MULTIPLE)
             resized = _resize(img[:1], tw, th, "disabled")
             z = vae.encode(resized)
             ref_items.append({"type": "image", "data": resized})
@@ -313,10 +325,13 @@ class MiniMaxH3ReferenceToVideo(io.ComfyNode):
             # index-paired soundtrack: ref_video_audio_N belongs to ref_video_N
             soundtrack = ref_video_audios.get("ref_video_audio_" + name.rsplit("_", 1)[-1])
             vh, vw = video_frames.shape[1], video_frames.shape[2]
-            cw, ch = adapt_canvas(vw, vh)
-            if vw * vh < cw * ch:
-                cw = max(CANVAS_MULTIPLE, round(vw / CANVAS_MULTIPLE) * CANVAS_MULTIPLE)
-                ch = max(CANVAS_MULTIPLE, round(vh / CANVAS_MULTIPLE) * CANVAS_MULTIPLE)
+            if ref_video_size == "match":
+                cw, ch = downscale_to_area(vw, vh, min(width * height, MAX_PIXELS))
+            else:
+                cw, ch = adapt_canvas(vw, vh)
+                if vw * vh < cw * ch:
+                    cw = max(CANVAS_MULTIPLE, round(vw / CANVAS_MULTIPLE) * CANVAS_MULTIPLE)
+                    ch = max(CANVAS_MULTIPLE, round(vh / CANVAS_MULTIPLE) * CANVAS_MULTIPLE)
             frames = _resize(video_frames, cw, ch, "disabled")
             if frames.shape[0] > frame_count:
                 frames = frames[:frame_count]

--- a/comfy_extras/nodes_minimax_h3.py
+++ b/comfy_extras/nodes_minimax_h3.py
@@ -80,6 +80,17 @@ def downscale_to_area(width, height, max_pixels):
         target_width = max(CANVAS_MULTIPLE, math.floor(scaled_width / CANVAS_MULTIPLE) * CANVAS_MULTIPLE)
         target_height = max(CANVAS_MULTIPLE, math.floor(scaled_height / CANVAS_MULTIPLE) * CANVAS_MULTIPLE)
 
+    # If one scaled axis falls below the minimum grid size, clamping it to 32px
+    # can still leave the canvas over budget. Reduce the longer grid axis until
+    # the final area fits.
+    while target_width * target_height > max_pixels:
+        if target_width >= target_height and target_width > CANVAS_MULTIPLE:
+            target_width -= CANVAS_MULTIPLE
+        elif target_height > CANVAS_MULTIPLE:
+            target_height -= CANVAS_MULTIPLE
+        else:
+            break
+
     return target_width, target_height
 
 

--- a/comfy_extras/nodes_minimax_h3.py
+++ b/comfy_extras/nodes_minimax_h3.py
@@ -64,10 +64,23 @@ def adapt_canvas(width, height):
 def downscale_to_area(width, height, max_pixels):
     """Aspect-preserving, down-only sizing on H3's 32px spatial grid."""
     scale = min(1.0, math.sqrt(max_pixels / (width * height)))
-    return (
-        max(CANVAS_MULTIPLE, round(width * scale / CANVAS_MULTIPLE) * CANVAS_MULTIPLE),
-        max(CANVAS_MULTIPLE, round(height * scale / CANVAS_MULTIPLE) * CANVAS_MULTIPLE),
-    )
+    scaled_width = width * scale
+    scaled_height = height * scale
+    target_width = max(CANVAS_MULTIPLE, round(scaled_width / CANVAS_MULTIPLE) * CANVAS_MULTIPLE)
+    target_height = max(CANVAS_MULTIPLE, round(scaled_height / CANVAS_MULTIPLE) * CANVAS_MULTIPLE)
+
+    # Grid alignment must not turn a down-only resize into a slight upscale.
+    target_width = min(target_width, max(CANVAS_MULTIPLE, math.floor(width / CANVAS_MULTIPLE) * CANVAS_MULTIPLE))
+    target_height = min(target_height, max(CANVAS_MULTIPLE, math.floor(height / CANVAS_MULTIPLE) * CANVAS_MULTIPLE))
+
+    # Independent nearest-grid rounding can cross the requested area cap. When
+    # that happens, round both scaled axes down while preserving their ratio as
+    # closely as the 32px grid permits.
+    if target_width * target_height > max_pixels:
+        target_width = max(CANVAS_MULTIPLE, math.floor(scaled_width / CANVAS_MULTIPLE) * CANVAS_MULTIPLE)
+        target_height = max(CANVAS_MULTIPLE, math.floor(scaled_height / CANVAS_MULTIPLE) * CANVAS_MULTIPLE)
+
+    return target_width, target_height
 
 
 def _resize(image, width, height, crop):
@@ -295,8 +308,8 @@ class MiniMaxH3ReferenceToVideo(io.ComfyNode):
 
     @classmethod
     def execute(cls, clip, vae, audio_vae, prompt, width, height, length, ref_image_size="match",
-                ref_video_size="official", ref_images=None, ref_videos=None,
-                ref_video_audios=None, ref_audios=None) -> io.NodeOutput:
+                ref_images=None, ref_videos=None, ref_video_audios=None, ref_audios=None,
+                ref_video_size="official") -> io.NodeOutput:
         latent, frame_count = _empty_av_latent(width, height, length)
 
         ref_items = []   # for the tokenizer presentation, in request order

--- a/tests-unit/comfy_extras_test/test_nodes_minimax_h3.py
+++ b/tests-unit/comfy_extras_test/test_nodes_minimax_h3.py
@@ -1,0 +1,15 @@
+import pytest
+
+from comfy_extras.nodes_minimax_h3 import downscale_to_area
+
+
+@pytest.mark.parametrize(
+    ("width", "height", "max_pixels", "expected"),
+    [
+        (1344, 768, 960 * 544, (960, 544)),
+        (768, 1344, 960 * 544, (544, 960)),
+        (640, 352, 960 * 544, (640, 352)),
+    ],
+)
+def test_downscale_to_area(width, height, max_pixels, expected):
+    assert downscale_to_area(width, height, max_pixels) == expected

--- a/tests-unit/comfy_extras_test/test_nodes_minimax_h3.py
+++ b/tests-unit/comfy_extras_test/test_nodes_minimax_h3.py
@@ -9,7 +9,13 @@ from comfy_extras.nodes_minimax_h3 import downscale_to_area
         (1344, 768, 960 * 544, (960, 544)),
         (768, 1344, 960 * 544, (544, 960)),
         (640, 352, 960 * 544, (640, 352)),
+        (1000, 700, 1000 * 700, (992, 672)),
+        (100, 100, 48 * 48, (32, 32)),
     ],
 )
 def test_downscale_to_area(width, height, max_pixels, expected):
-    assert downscale_to_area(width, height, max_pixels) == expected
+    actual = downscale_to_area(width, height, max_pixels)
+    assert actual == expected
+    assert actual[0] <= width
+    assert actual[1] <= height
+    assert actual[0] * actual[1] <= max_pixels

--- a/tests-unit/comfy_extras_test/test_nodes_minimax_h3.py
+++ b/tests-unit/comfy_extras_test/test_nodes_minimax_h3.py
@@ -11,6 +11,7 @@ from comfy_extras.nodes_minimax_h3 import downscale_to_area
         (640, 352, 960 * 544, (640, 352)),
         (1000, 700, 1000 * 700, (992, 672)),
         (100, 100, 48 * 48, (32, 32)),
+        (1024, 256, 32 * 32, (32, 32)),
     ],
 )
 def test_downscale_to_area(width, height, max_pixels, expected):


### PR DESCRIPTION
## Summary

- add an optional `ref_video_size` setting to `MiniMaxH3ReferenceToVideo`
- keep the existing official 768px-short-edge behavior as the default
- add a `match` mode that downscales reference video to the generated video's pixel area, without upscaling and while preserving aspect ratio on H3's 32px grid
- reuse the same sizing helper for reference images and cover landscape, portrait, and no-upscale cases with unit tests

## Why

H3 reference-video latents are injected at every diffusion step. When a 1344x768 reference conditions a smaller output such as 960x544, the reference contributes almost twice as many spatial rows as the output. Matching the reference area reduces both VAE/Qwen conditioning work and the reference tokens processed throughout sampling.

The option is backward-compatible: `official` remains the default and the new input is optional, so existing API workflows retain current behavior.

## Performance validation

Controlled A/B tests used MiniMax H3 R2V Turbo, the official H3 video VAE, identical input media, prompt, seed, sampler, scheduler, and output settings. Each arm started from a fresh production-shaped CUDA 13 container on an RTX 5090 with VRAM returned to baseline.

| Reference | Output | Official | Match | Change |
| --- | --- | ---: | ---: | ---: |
| 2.33s, 1344x768 | 5.17s, 960x544 | 184.532s | 167.973s | **-9.0%** |
| 5.00s dance clip, 960x544 | 5.17s, 544x960 | 237.747s | 187.639s | **-21.1%** |

For the 1344x768-to-960x544 case, reference spatial rows fall by 49.4%. In the short-reference run, the sampler phase fell from about 101.4s to 88.1s. Native frames and 100% crops covering faces, hands, textures, edges, rain/reflections, and motion showed no obvious regression; the dance A/B had a supplementary whole-video SSIM of 0.971892.

## Testing

- added parameterized unit coverage for landscape, portrait, and already-small inputs
- `git diff --check`
- production-shaped CUDA 13 A/B canaries described above

