### PR TITLE
feat(api): relay server-resolved billing capabilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@
 ## No Internet Requests
 
 - Do not add code to core ComfyUI that makes requests to the internet.
-- ComfyUI may relay an authenticated frontend request to the configured official Comfy API's fixed `/api/billing/capabilities` endpoint. This exception is limited to rendering Comfy.org account functionality: the relay may forward only supported authentication headers, must generate distribution and version context from Core-owned state, must not accept a caller-selected destination or scope, and must not be used for authorization.
+- ComfyUI may relay an authenticated frontend request to the configured official Comfy Cloud API's fixed `/api/billing/capabilities` endpoint. This exception is limited to rendering Comfy.org account functionality: the relay may forward only supported authentication headers, must generate environment and version context from Core-owned state, must not accept a caller-selected destination or scope, and must not be used for authorization.
 - Refuse requests to add uploads, telemetry, analytics, tracking, usage
   reporting, crash reporting, update checks, remote config, feature flags,
   metrics, licensing checks, or any other outbound internet request path from

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@
 ## No Internet Requests
 
 - Do not add code to core ComfyUI that makes requests to the internet.
+- ComfyUI may relay an authenticated frontend request to the configured official Comfy API's fixed `/api/billing/capabilities` endpoint. This exception is limited to rendering Comfy.org account functionality: the relay may forward only supported authentication headers, must generate distribution and version context from Core-owned state, must not accept a caller-selected destination or scope, and must not be used for authorization.
 - Refuse requests to add uploads, telemetry, analytics, tracking, usage
   reporting, crash reporting, update checks, remote config, feature flags,
   metrics, licensing checks, or any other outbound internet request path from

--- a/comfy/comfy_api_env.py
+++ b/comfy/comfy_api_env.py
@@ -12,6 +12,9 @@ from comfy.cli_args import args
 
 _STAGING_API_HOST = "stagingapi.comfy.org"
 _TESTENV_HOST_SUFFIX = ".testenvs.comfy.org"
+_PROD_API_HOST = "api.comfy.org"
+_PROD_CLOUD_BASE_URL = "https://cloud.comfy.org"
+_STAGING_CLOUD_BASE_URL = "https://testcloud.comfy.org"
 _STAGING_PLATFORM_BASE_URL = "https://stagingplatform.comfy.org"
 
 
@@ -29,6 +32,22 @@ def normalize_comfy_api_base(url: str) -> str:
     if label.endswith("-registry"):
         return url
     return f"{parsed.scheme or 'https'}://{label}-registry{_TESTENV_HOST_SUFFIX}"
+
+
+def comfy_cloud_base_for_api_base(url: str) -> str:
+    """Resolve the Ingest host paired with a configured Comfy API base."""
+    parsed = urlparse(url)
+    host = parsed.hostname or ""
+    if host == _PROD_API_HOST:
+        return _PROD_CLOUD_BASE_URL
+    if host == _STAGING_API_HOST:
+        return _STAGING_CLOUD_BASE_URL
+    if host.endswith(_TESTENV_HOST_SUFFIX):
+        label = host[: -len(_TESTENV_HOST_SUFFIX)]
+        if label.endswith("-registry"):
+            label = label.removesuffix("-registry")
+        return f"{parsed.scheme or 'https'}://{label}{_TESTENV_HOST_SUFFIX}"
+    return url
 
 
 def environment_overrides_for_base(base_url: str) -> dict[str, Any] | None:

--- a/comfy/comfy_api_env.py
+++ b/comfy/comfy_api_env.py
@@ -12,10 +12,12 @@ from comfy.cli_args import args
 
 _STAGING_API_HOST = "stagingapi.comfy.org"
 _TESTENV_HOST_SUFFIX = ".testenvs.comfy.org"
-_PROD_API_HOST = "api.comfy.org"
-_PROD_CLOUD_BASE_URL = "https://cloud.comfy.org"
-_STAGING_CLOUD_BASE_URL = "https://testcloud.comfy.org"
 _STAGING_PLATFORM_BASE_URL = "https://stagingplatform.comfy.org"
+_CLOUD_BASE_BY_API_HOST = {
+    "api.comfy.org": "https://cloud.comfy.org",
+    "stagingapi.comfy.org": "https://stagingcloud.comfy.org",
+    "testapi.comfy.org": "https://testcloud.comfy.org",
+}
 
 
 def _is_staging_tier(host: str) -> bool:
@@ -38,10 +40,8 @@ def comfy_cloud_base_for_api_base(url: str) -> str:
     """Resolve the Ingest host paired with a configured Comfy API base."""
     parsed = urlparse(url)
     host = parsed.hostname or ""
-    if host == _PROD_API_HOST:
-        return _PROD_CLOUD_BASE_URL
-    if host == _STAGING_API_HOST:
-        return _STAGING_CLOUD_BASE_URL
+    if cloud_base := _CLOUD_BASE_BY_API_HOST.get(host):
+        return cloud_base
     if host.endswith(_TESTENV_HOST_SUFFIX):
         label = host[: -len(_TESTENV_HOST_SUFFIX)]
         if label.endswith("-registry"):

--- a/comfy_api/billing_capabilities.py
+++ b/comfy_api/billing_capabilities.py
@@ -1,0 +1,44 @@
+import asyncio
+import json
+
+import aiohttp
+from aiohttp import web
+
+from comfy.cli_args import args
+from comfy.comfy_api_env import normalize_comfy_api_base
+from comfy.deploy_environment import get_deploy_environment
+from comfyui_version import __version__ as comfyui_version
+
+
+_UPSTREAM_PATH = "/api/billing/capabilities"
+_EXPECTED_STATUSES = {200, 401, 403, 404, 502}
+_RESPONSE_HEADERS = ("Cache-Control", "Vary", "X-Capability-Revision", "Content-Type")
+_TIMEOUT = aiohttp.ClientTimeout(total=10)
+
+
+def _unavailable_response() -> web.Response:
+    return web.json_response({"error": "Billing capabilities unavailable"}, status=502)
+
+
+async def relay_billing_capabilities(request: web.Request, client_session: aiohttp.ClientSession) -> web.Response:
+    headers = {
+        "Accept": "application/json",
+        "Comfy-Env": get_deploy_environment(),
+        "Comfy-Core-Version": comfyui_version,
+    }
+    for name in ("Authorization", "X-API-Key"):
+        if value := request.headers.get(name):
+            headers[name] = value
+
+    base_url = normalize_comfy_api_base(args.comfy_api_base).rstrip("/")
+    try:
+        async with client_session.get(f"{base_url}{_UPSTREAM_PATH}", headers=headers, timeout=_TIMEOUT) as upstream:
+            if upstream.status not in _EXPECTED_STATUSES:
+                return _unavailable_response()
+
+            body = await upstream.read()
+            json.loads(body)
+            response_headers = {name: upstream.headers[name] for name in _RESPONSE_HEADERS if name in upstream.headers}
+            return web.Response(body=body, status=upstream.status, headers=response_headers)
+    except (aiohttp.ClientError, asyncio.TimeoutError, json.JSONDecodeError, UnicodeDecodeError):
+        return _unavailable_response()

--- a/comfy_api/billing_capabilities.py
+++ b/comfy_api/billing_capabilities.py
@@ -37,7 +37,8 @@ async def relay_billing_capabilities(request: web.Request, client_session: aioht
                 return _unavailable_response()
 
             body = await upstream.read()
-            json.loads(body)
+            if upstream.content_type != "application/json" or not isinstance(json.loads(body), dict):
+                return _unavailable_response()
             response_headers = {name: upstream.headers[name] for name in _RESPONSE_HEADERS if name in upstream.headers}
             return web.Response(body=body, status=upstream.status, headers=response_headers)
     except (aiohttp.ClientError, asyncio.TimeoutError, json.JSONDecodeError, UnicodeDecodeError):

--- a/comfy_api/billing_capabilities.py
+++ b/comfy_api/billing_capabilities.py
@@ -32,7 +32,9 @@ async def relay_billing_capabilities(request: web.Request, client_session: aioht
 
     base_url = normalize_comfy_api_base(args.comfy_api_base).rstrip("/")
     try:
-        async with client_session.get(f"{base_url}{_UPSTREAM_PATH}", headers=headers, timeout=_TIMEOUT) as upstream:
+        async with client_session.get(
+            f"{base_url}{_UPSTREAM_PATH}", headers=headers, timeout=_TIMEOUT, allow_redirects=False
+        ) as upstream:
             if upstream.status not in _EXPECTED_STATUSES:
                 return _unavailable_response()
 

--- a/comfy_api/billing_capabilities.py
+++ b/comfy_api/billing_capabilities.py
@@ -5,14 +5,20 @@ import aiohttp
 from aiohttp import web
 
 from comfy.cli_args import args
-from comfy.comfy_api_env import normalize_comfy_api_base
+from comfy.comfy_api_env import comfy_cloud_base_for_api_base
 from comfy.deploy_environment import get_deploy_environment
 from comfyui_version import __version__ as comfyui_version
 
 
 _UPSTREAM_PATH = "/api/billing/capabilities"
-_EXPECTED_STATUSES = {200, 401, 403, 404, 502}
-_RESPONSE_HEADERS = ("Cache-Control", "Vary", "X-Capability-Revision", "Content-Type")
+_EXPECTED_STATUSES = {200, 401, 403, 404, 429, 502, 503}
+_RESPONSE_HEADERS = (
+    "Cache-Control",
+    "X-Capability-Revision",
+    "Content-Type",
+    "Retry-After",
+)
+_AUTH_HEADERS = ("Authorization", "X-API-Key")
 _TIMEOUT = aiohttp.ClientTimeout(total=10)
 
 
@@ -20,28 +26,78 @@ def _unavailable_response() -> web.Response:
     return web.json_response({"error": "Billing capabilities unavailable"}, status=502)
 
 
-async def relay_billing_capabilities(request: web.Request, client_session: aiohttp.ClientSession) -> web.Response:
+def _authentication_required_response() -> web.Response:
+    return web.json_response(
+        {"error": "Authentication required"},
+        status=401,
+        headers={
+            "Cache-Control": "private, no-store",
+            "Vary": ", ".join(_AUTH_HEADERS),
+        },
+    )
+
+
+def _response_headers(upstream: aiohttp.ClientResponse) -> dict[str, str]:
+    headers = {
+        name: upstream.headers[name]
+        for name in _RESPONSE_HEADERS
+        if name in upstream.headers
+    }
+    vary = [
+        name.strip()
+        for name in upstream.headers.get("Vary", "").split(",")
+        if name.strip()
+    ]
+    varied_names = {name.lower() for name in vary}
+    vary.extend(name for name in _AUTH_HEADERS if name.lower() not in varied_names)
+    headers["Vary"] = ", ".join(vary)
+    return headers
+
+
+async def relay_billing_capabilities(
+    request: web.Request, client_session: aiohttp.ClientSession
+) -> web.Response:
+    if not isinstance(client_session.cookie_jar, aiohttp.DummyCookieJar):
+        raise RuntimeError(
+            "Billing capabilities relay requires a non-persistent cookie jar"
+        )
+
     headers = {
         "Accept": "application/json",
         "Comfy-Env": get_deploy_environment(),
         "Comfy-Core-Version": comfyui_version,
     }
-    for name in ("Authorization", "X-API-Key"):
+    for name in _AUTH_HEADERS:
         if value := request.headers.get(name):
             headers[name] = value
+    if not any(name in headers for name in _AUTH_HEADERS):
+        return _authentication_required_response()
 
-    base_url = normalize_comfy_api_base(args.comfy_api_base).rstrip("/")
     try:
+        base_url = comfy_cloud_base_for_api_base(args.comfy_api_base).rstrip("/")
         async with client_session.get(
-            f"{base_url}{_UPSTREAM_PATH}", headers=headers, timeout=_TIMEOUT, allow_redirects=False
+            f"{base_url}{_UPSTREAM_PATH}",
+            headers=headers,
+            timeout=_TIMEOUT,
+            allow_redirects=False,
         ) as upstream:
             if upstream.status not in _EXPECTED_STATUSES:
                 return _unavailable_response()
 
             body = await upstream.read()
-            if upstream.content_type != "application/json" or not isinstance(json.loads(body), dict):
+            if upstream.status == 200 and (
+                upstream.content_type != "application/json"
+                or not isinstance(json.loads(body), dict)
+            ):
                 return _unavailable_response()
-            response_headers = {name: upstream.headers[name] for name in _RESPONSE_HEADERS if name in upstream.headers}
-            return web.Response(body=body, status=upstream.status, headers=response_headers)
-    except (aiohttp.ClientError, asyncio.TimeoutError, json.JSONDecodeError, UnicodeDecodeError):
+            return web.Response(
+                body=body, status=upstream.status, headers=_response_headers(upstream)
+            )
+    except (
+        aiohttp.ClientError,
+        asyncio.TimeoutError,
+        json.JSONDecodeError,
+        UnicodeDecodeError,
+        ValueError,
+    ):
         return _unavailable_response()

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2758,7 +2758,7 @@ paths:
                 - node
     /api/billing/capabilities:
         get:
-            description: Relays the authenticated request to the configured Comfy API billing capabilities endpoint
+            description: Relays the authenticated request to the configured Comfy Cloud API billing capabilities endpoint
             operationId: getBillingCapabilities
             responses:
                 "200":
@@ -2789,6 +2789,8 @@ paths:
                                 additionalProperties: true
                                 type: object
                     description: Workspace not found
+                "429":
+                    description: Upstream rate limit reached
                 "502":
                     content:
                         application/json:
@@ -2796,10 +2798,11 @@ paths:
                                 additionalProperties: true
                                 type: object
                     description: Upstream capability resolution failed
+                "503":
+                    description: Upstream capability service unavailable
             security:
                 - ApiKeyAuth: []
                 - BearerAuth: []
-                - {}
             summary: Get server-resolved billing capabilities
             tags:
                 - billing

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2756,6 +2756,53 @@ paths:
             summary: List custom node JS extensions
             tags:
                 - node
+    /api/billing/capabilities:
+        get:
+            description: Relays the authenticated request to the configured Comfy API billing capabilities endpoint
+            operationId: getBillingCapabilities
+            responses:
+                "200":
+                    content:
+                        application/json:
+                            schema:
+                                additionalProperties: true
+                                type: object
+                    description: Server-resolved billing capabilities
+                "401":
+                    content:
+                        application/json:
+                            schema:
+                                additionalProperties: true
+                                type: object
+                    description: Missing or invalid credentials
+                "403":
+                    content:
+                        application/json:
+                            schema:
+                                additionalProperties: true
+                                type: object
+                    description: Workspace access denied
+                "404":
+                    content:
+                        application/json:
+                            schema:
+                                additionalProperties: true
+                                type: object
+                    description: Workspace not found
+                "502":
+                    content:
+                        application/json:
+                            schema:
+                                additionalProperties: true
+                                type: object
+                    description: Upstream capability resolution failed
+            security:
+                - ApiKeyAuth: []
+                - BearerAuth: []
+                - {}
+            summary: Get server-resolved billing capabilities
+            tags:
+                - billing
     /api/features:
         get:
             description: Returns the server's feature capabilities

--- a/server.py
+++ b/server.py
@@ -39,6 +39,7 @@ from comfy.deploy_environment import get_deploy_environment
 import comfy.utils
 import comfy.model_management
 from comfy_api import feature_flags
+from comfy_api.billing_capabilities import relay_billing_capabilities
 from comfy.comfy_api_env import get_environment_overrides
 import node_helpers
 from comfyui_version import __version__
@@ -743,6 +744,11 @@ class PromptServer():
             if overrides:
                 features.update(overrides)
             return web.json_response(features)
+
+        if not args.disable_api_nodes:
+            @routes.get("/billing/capabilities")
+            async def get_billing_capabilities(request):
+                return await relay_billing_capabilities(request, self.client_session)
 
         @routes.get("/prompt")
         async def get_prompt(request):

--- a/server.py
+++ b/server.py
@@ -1221,7 +1221,10 @@ class PromptServer():
 
     async def setup(self):
         timeout = aiohttp.ClientTimeout(total=None) # no timeout
-        self.client_session = aiohttp.ClientSession(timeout=timeout)
+        self.client_session = aiohttp.ClientSession(
+            timeout=timeout,
+            cookie_jar=aiohttp.DummyCookieJar(),
+        )
 
     def add_routes(self):
         self.user_manager.add_routes(self.routes)

--- a/server.py
+++ b/server.py
@@ -1223,6 +1223,8 @@ class PromptServer():
         timeout = aiohttp.ClientTimeout(total=None) # no timeout
         self.client_session = aiohttp.ClientSession(
             timeout=timeout,
+            # The billing capabilities relay shares this process-wide session
+            # across users, so upstream cookies must never persist between calls.
             cookie_jar=aiohttp.DummyCookieJar(),
         )
 

--- a/server.py
+++ b/server.py
@@ -124,7 +124,7 @@ def create_cors_middleware(allowed_origin: str):
 
         response.headers['Access-Control-Allow-Origin'] = allowed_origin
         response.headers['Access-Control-Allow-Methods'] = 'POST, GET, DELETE, PUT, OPTIONS, PATCH'
-        response.headers['Access-Control-Allow-Headers'] = 'Content-Type, Authorization'
+        response.headers['Access-Control-Allow-Headers'] = 'Content-Type, Authorization, X-API-Key'
         response.headers['Access-Control-Allow-Credentials'] = 'true'
         return response
 

--- a/tests-unit/billing_capabilities_test.py
+++ b/tests-unit/billing_capabilities_test.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 
 import aiohttp
 import pytest
@@ -9,10 +10,33 @@ from comfy_api.billing_capabilities import relay_billing_capabilities
 
 pytestmark = pytest.mark.asyncio
 
+AUTH_HEADERS = {"Authorization": "Bearer test-token"}
+CAPABILITY_BODY = {
+    "resolved_for": {"user_id": "user-1", "workspace_id": "workspace-1"},
+    "capabilities": {
+        "can_subscribe_self_serve": True,
+        "can_top_up": True,
+        "can_cancel": False,
+        "can_reactivate": False,
+        "can_change_seats": False,
+        "can_invite_members": True,
+        "can_downgrade_to_personal": False,
+    },
+    "rollout_defaults_applied": {
+        "can_downgrade_to_personal": False,
+        "can_subscribe_self_serve": False,
+        "can_top_up": False,
+    },
+    "revision": 42,
+    "expires_at": "2026-09-08T00:00:00Z",
+}
+
 
 async def _relay_client(aiohttp_client, monkeypatch, upstream_url):
-    monkeypatch.setattr("comfy_api.billing_capabilities.args.comfy_api_base", upstream_url)
-    session = aiohttp.ClientSession()
+    monkeypatch.setattr(
+        "comfy_api.billing_capabilities.args.comfy_api_base", upstream_url
+    )
+    session = aiohttp.ClientSession(cookie_jar=aiohttp.DummyCookieJar())
     app = web.Application()
 
     async def cleanup(_app):
@@ -26,20 +50,26 @@ async def _relay_client(aiohttp_client, monkeypatch, upstream_url):
     return await aiohttp_client(app)
 
 
-async def test_relay_uses_fixed_endpoint_and_header_allowlist(aiohttp_client, aiohttp_server, monkeypatch):
+async def test_relay_uses_fixed_endpoint_and_header_allowlist(
+    aiohttp_client, aiohttp_server, monkeypatch
+):
     received = {}
 
     async def upstream_handler(request):
         received["path"] = request.path
         received["headers"] = request.headers
-        return web.json_response({"can_manage_subscription": True})
+        return web.json_response(CAPABILITY_BODY)
 
     upstream_app = web.Application()
     upstream_app.router.add_get("/api/billing/capabilities", upstream_handler)
     upstream = await aiohttp_server(upstream_app)
-    monkeypatch.setattr("comfy_api.billing_capabilities.get_deploy_environment", lambda: "local-test")
+    monkeypatch.setattr(
+        "comfy_api.billing_capabilities.get_deploy_environment", lambda: "local-test"
+    )
     monkeypatch.setattr("comfy_api.billing_capabilities.comfyui_version", "1.2.3")
-    client = await _relay_client(aiohttp_client, monkeypatch, str(upstream.make_url("/")))
+    client = await _relay_client(
+        aiohttp_client, monkeypatch, str(upstream.make_url("/"))
+    )
 
     response = await client.get(
         "/api/billing/capabilities",
@@ -65,30 +95,40 @@ async def test_relay_uses_fixed_endpoint_and_header_allowlist(aiohttp_client, ai
 
 
 @pytest.mark.parametrize("status", [200, 401, 403, 404, 502])
-async def test_relay_preserves_expected_responses(aiohttp_client, aiohttp_server, monkeypatch, status):
+async def test_relay_preserves_expected_responses(
+    aiohttp_client, aiohttp_server, monkeypatch, status
+):
+    body = (
+        CAPABILITY_BODY
+        if status == 200
+        else {"code": "UPSTREAM_ERROR", "message": f"status {status}"}
+    )
+
     async def upstream_handler(_request):
         return web.json_response(
-            {"status": status},
+            body,
             status=status,
             headers={
                 "Cache-Control": "private, max-age=30",
                 "Vary": "Authorization",
-                "X-Capability-Revision": "revision-1",
+                "X-Capability-Revision": "42",
             },
         )
 
     upstream_app = web.Application()
     upstream_app.router.add_get("/api/billing/capabilities", upstream_handler)
     upstream = await aiohttp_server(upstream_app)
-    client = await _relay_client(aiohttp_client, monkeypatch, str(upstream.make_url("/")))
+    client = await _relay_client(
+        aiohttp_client, monkeypatch, str(upstream.make_url("/"))
+    )
 
-    response = await client.get("/api/billing/capabilities")
+    response = await client.get("/api/billing/capabilities", headers=AUTH_HEADERS)
 
     assert response.status == status
-    assert await response.json() == {"status": status}
+    assert await response.json() == body
     assert response.headers["Cache-Control"] == "private, max-age=30"
-    assert response.headers["Vary"] == "Authorization"
-    assert response.headers["X-Capability-Revision"] == "revision-1"
+    assert response.headers["Vary"] == "Authorization, X-API-Key"
+    assert response.headers["X-Capability-Revision"] == "42"
     assert response.headers["Content-Type"] == "application/json; charset=utf-8"
 
 
@@ -97,10 +137,10 @@ async def test_relay_preserves_expected_responses(aiohttp_client, aiohttp_server
     [
         (500, b'{"internal": "detail"}', "application/json"),
         (200, b"not json", "text/plain"),
-        (200, b'{"can_manage_subscription": true}', "text/plain"),
+        (200, json.dumps(CAPABILITY_BODY).encode(), "text/plain"),
         (200, b"[]", "application/json"),
         (200, b"null", "application/json"),
-        (200, b'\xff\xfe{"can_manage_subscription": true}', "application/json"),
+        (200, b'\xff\xfe{"resolved_for": {}}', "application/json"),
     ],
 )
 async def test_relay_converts_invalid_upstream_responses_to_502(
@@ -112,20 +152,24 @@ async def test_relay_converts_invalid_upstream_responses_to_502(
     upstream_app = web.Application()
     upstream_app.router.add_get("/api/billing/capabilities", upstream_handler)
     upstream = await aiohttp_server(upstream_app)
-    client = await _relay_client(aiohttp_client, monkeypatch, str(upstream.make_url("/")))
+    client = await _relay_client(
+        aiohttp_client, monkeypatch, str(upstream.make_url("/"))
+    )
 
-    response = await client.get("/api/billing/capabilities")
+    response = await client.get("/api/billing/capabilities", headers=AUTH_HEADERS)
 
     assert response.status == 502
     assert await response.json() == {"error": "Billing capabilities unavailable"}
 
 
-async def test_relay_refuses_to_follow_upstream_redirects(aiohttp_client, aiohttp_server, monkeypatch):
+async def test_relay_refuses_to_follow_upstream_redirects(
+    aiohttp_client, aiohttp_server, monkeypatch
+):
     redirect_target_requests = []
 
     async def redirect_target_handler(request):
         redirect_target_requests.append(request.headers)
-        return web.json_response({"can_manage_subscription": True})
+        return web.json_response(CAPABILITY_BODY)
 
     target_app = web.Application()
     target_app.router.add_get("/api/billing/capabilities", redirect_target_handler)
@@ -137,7 +181,9 @@ async def test_relay_refuses_to_follow_upstream_redirects(aiohttp_client, aiohtt
     upstream_app = web.Application()
     upstream_app.router.add_get("/api/billing/capabilities", upstream_handler)
     upstream = await aiohttp_server(upstream_app)
-    client = await _relay_client(aiohttp_client, monkeypatch, str(upstream.make_url("/")))
+    client = await _relay_client(
+        aiohttp_client, monkeypatch, str(upstream.make_url("/"))
+    )
 
     response = await client.get(
         "/api/billing/capabilities",
@@ -149,36 +195,48 @@ async def test_relay_refuses_to_follow_upstream_redirects(aiohttp_client, aiohtt
     assert redirect_target_requests == []
 
 
-async def test_relay_converts_connection_failure_to_502(aiohttp_client, monkeypatch, unused_tcp_port):
-    client = await _relay_client(aiohttp_client, monkeypatch, f"http://127.0.0.1:{unused_tcp_port}")
+async def test_relay_converts_connection_failure_to_502(
+    aiohttp_client, monkeypatch, unused_tcp_port
+):
+    client = await _relay_client(
+        aiohttp_client, monkeypatch, f"http://127.0.0.1:{unused_tcp_port}"
+    )
 
-    response = await client.get("/api/billing/capabilities")
+    response = await client.get("/api/billing/capabilities", headers=AUTH_HEADERS)
 
     assert response.status == 502
     assert await response.json() == {"error": "Billing capabilities unavailable"}
 
 
-async def test_relay_converts_upstream_timeout_to_502(aiohttp_client, aiohttp_server, monkeypatch):
+async def test_relay_converts_upstream_timeout_to_502(
+    aiohttp_client, aiohttp_server, monkeypatch
+):
     async def upstream_handler(_request):
         await asyncio.sleep(5)
-        return web.json_response({"can_manage_subscription": True})
+        return web.json_response(CAPABILITY_BODY)
 
     upstream_app = web.Application()
     upstream_app.router.add_get("/api/billing/capabilities", upstream_handler)
     upstream = await aiohttp_server(upstream_app)
-    monkeypatch.setattr("comfy_api.billing_capabilities._TIMEOUT", aiohttp.ClientTimeout(total=0.05))
-    client = await _relay_client(aiohttp_client, monkeypatch, str(upstream.make_url("/")))
+    monkeypatch.setattr(
+        "comfy_api.billing_capabilities._TIMEOUT", aiohttp.ClientTimeout(total=0.05)
+    )
+    client = await _relay_client(
+        aiohttp_client, monkeypatch, str(upstream.make_url("/"))
+    )
 
-    response = await client.get("/api/billing/capabilities")
+    response = await client.get("/api/billing/capabilities", headers=AUTH_HEADERS)
 
     assert response.status == 502
     assert await response.json() == {"error": "Billing capabilities unavailable"}
 
 
-async def test_relay_drops_unlisted_upstream_response_headers(aiohttp_client, aiohttp_server, monkeypatch):
+async def test_relay_drops_unlisted_upstream_response_headers(
+    aiohttp_client, aiohttp_server, monkeypatch
+):
     async def upstream_handler(_request):
         return web.json_response(
-            {"can_manage_subscription": True},
+            CAPABILITY_BODY,
             headers={
                 "Cache-Control": "private, max-age=30",
                 "Set-Cookie": "upstream_session=secret",
@@ -190,9 +248,11 @@ async def test_relay_drops_unlisted_upstream_response_headers(aiohttp_client, ai
     upstream_app = web.Application()
     upstream_app.router.add_get("/api/billing/capabilities", upstream_handler)
     upstream = await aiohttp_server(upstream_app)
-    client = await _relay_client(aiohttp_client, monkeypatch, str(upstream.make_url("/")))
+    client = await _relay_client(
+        aiohttp_client, monkeypatch, str(upstream.make_url("/"))
+    )
 
-    response = await client.get("/api/billing/capabilities")
+    response = await client.get("/api/billing/capabilities", headers=AUTH_HEADERS)
 
     assert response.status == 200
     assert response.headers["Cache-Control"] == "private, max-age=30"
@@ -202,21 +262,113 @@ async def test_relay_drops_unlisted_upstream_response_headers(aiohttp_client, ai
     assert response.cookies == {}
 
 
-@pytest.mark.parametrize("request_headers", [{}, {"Authorization": "", "X-API-Key": ""}])
-async def test_relay_omits_absent_auth_headers(aiohttp_client, aiohttp_server, monkeypatch, request_headers):
-    received = {}
+@pytest.mark.parametrize(
+    "request_headers", [{}, {"Authorization": "", "X-API-Key": ""}]
+)
+async def test_relay_rejects_absent_auth_without_contacting_upstream(
+    aiohttp_client, aiohttp_server, monkeypatch, request_headers
+):
+    requests = []
 
     async def upstream_handler(request):
-        received["headers"] = request.headers
-        return web.json_response({"can_manage_subscription": False})
+        requests.append(request)
+        return web.json_response(CAPABILITY_BODY)
 
     upstream_app = web.Application()
     upstream_app.router.add_get("/api/billing/capabilities", upstream_handler)
     upstream = await aiohttp_server(upstream_app)
-    client = await _relay_client(aiohttp_client, monkeypatch, str(upstream.make_url("/")))
+    client = await _relay_client(
+        aiohttp_client, monkeypatch, str(upstream.make_url("/"))
+    )
 
     response = await client.get("/api/billing/capabilities", headers=request_headers)
 
-    assert response.status == 200
-    assert "Authorization" not in received["headers"]
-    assert "X-API-Key" not in received["headers"]
+    assert response.status == 401
+    assert await response.json() == {"error": "Authentication required"}
+    assert response.headers["Cache-Control"] == "private, no-store"
+    assert response.headers["Vary"] == "Authorization, X-API-Key"
+    assert requests == []
+
+
+@pytest.mark.parametrize(
+    ("status", "body", "content_type"),
+    [
+        (401, b"", None),
+        (403, b"<h1>Access denied</h1>", "text/html"),
+        (404, b"not found", "text/plain"),
+    ],
+)
+async def test_relay_preserves_non_json_error_responses(
+    aiohttp_client, aiohttp_server, monkeypatch, status, body, content_type
+):
+    async def upstream_handler(_request):
+        return web.Response(status=status, body=body, content_type=content_type)
+
+    upstream_app = web.Application()
+    upstream_app.router.add_get("/api/billing/capabilities", upstream_handler)
+    upstream = await aiohttp_server(upstream_app)
+    client = await _relay_client(
+        aiohttp_client, monkeypatch, str(upstream.make_url("/"))
+    )
+
+    response = await client.get("/api/billing/capabilities", headers=AUTH_HEADERS)
+
+    assert response.status == status
+    assert await response.read() == body
+
+
+@pytest.mark.parametrize("status", [429, 503])
+async def test_relay_preserves_upstream_backpressure(
+    aiohttp_client, aiohttp_server, monkeypatch, status
+):
+    async def upstream_handler(_request):
+        return web.Response(
+            status=status,
+            text="try later",
+            content_type="text/plain",
+            headers={"Retry-After": "120"},
+        )
+
+    upstream_app = web.Application()
+    upstream_app.router.add_get("/api/billing/capabilities", upstream_handler)
+    upstream = await aiohttp_server(upstream_app)
+    client = await _relay_client(
+        aiohttp_client, monkeypatch, str(upstream.make_url("/"))
+    )
+
+    response = await client.get("/api/billing/capabilities", headers=AUTH_HEADERS)
+
+    assert response.status == status
+    assert await response.text() == "try later"
+    assert response.headers["Retry-After"] == "120"
+
+
+async def test_relay_converts_malformed_base_to_502(aiohttp_client, monkeypatch):
+    client = await _relay_client(aiohttp_client, monkeypatch, "http://[::1")
+
+    response = await client.get("/api/billing/capabilities", headers=AUTH_HEADERS)
+
+    assert response.status == 502
+    assert await response.json() == {"error": "Billing capabilities unavailable"}
+
+
+async def test_relay_requires_non_persistent_cookie_jar(aiohttp_client, monkeypatch):
+    monkeypatch.setattr(
+        "comfy_api.billing_capabilities.args.comfy_api_base", "http://127.0.0.1"
+    )
+    session = aiohttp.ClientSession()
+    app = web.Application()
+
+    async def cleanup(_app):
+        await session.close()
+
+    async def relay_handler(request):
+        return await relay_billing_capabilities(request, session)
+
+    app.on_cleanup.append(cleanup)
+    app.router.add_get("/api/billing/capabilities", relay_handler)
+    client = await aiohttp_client(app)
+
+    response = await client.get("/api/billing/capabilities", headers=AUTH_HEADERS)
+
+    assert response.status == 500

--- a/tests-unit/billing_capabilities_test.py
+++ b/tests-unit/billing_capabilities_test.py
@@ -97,6 +97,9 @@ async def test_relay_preserves_expected_responses(aiohttp_client, aiohttp_server
     [
         (500, b'{"internal": "detail"}', "application/json"),
         (200, b"not json", "text/plain"),
+        (200, b'{"can_manage_subscription": true}', "text/plain"),
+        (200, b"[]", "application/json"),
+        (200, b"null", "application/json"),
         (200, b'\xff\xfe{"can_manage_subscription": true}', "application/json"),
     ],
 )

--- a/tests-unit/billing_capabilities_test.py
+++ b/tests-unit/billing_capabilities_test.py
@@ -120,6 +120,35 @@ async def test_relay_converts_invalid_upstream_responses_to_502(
     assert await response.json() == {"error": "Billing capabilities unavailable"}
 
 
+async def test_relay_refuses_to_follow_upstream_redirects(aiohttp_client, aiohttp_server, monkeypatch):
+    redirect_target_requests = []
+
+    async def redirect_target_handler(request):
+        redirect_target_requests.append(request.headers)
+        return web.json_response({"can_manage_subscription": True})
+
+    target_app = web.Application()
+    target_app.router.add_get("/api/billing/capabilities", redirect_target_handler)
+    target = await aiohttp_server(target_app)
+
+    async def upstream_handler(_request):
+        raise web.HTTPFound(str(target.make_url("/api/billing/capabilities")))
+
+    upstream_app = web.Application()
+    upstream_app.router.add_get("/api/billing/capabilities", upstream_handler)
+    upstream = await aiohttp_server(upstream_app)
+    client = await _relay_client(aiohttp_client, monkeypatch, str(upstream.make_url("/")))
+
+    response = await client.get(
+        "/api/billing/capabilities",
+        headers={"Authorization": "Bearer secret", "X-API-Key": "api-secret"},
+    )
+
+    assert response.status == 502
+    assert await response.json() == {"error": "Billing capabilities unavailable"}
+    assert redirect_target_requests == []
+
+
 async def test_relay_converts_connection_failure_to_502(aiohttp_client, monkeypatch, unused_tcp_port):
     client = await _relay_client(aiohttp_client, monkeypatch, f"http://127.0.0.1:{unused_tcp_port}")
 

--- a/tests-unit/billing_capabilities_test.py
+++ b/tests-unit/billing_capabilities_test.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import aiohttp
 import pytest
 from aiohttp import web
@@ -93,15 +95,16 @@ async def test_relay_preserves_expected_responses(aiohttp_client, aiohttp_server
 @pytest.mark.parametrize(
     ("status", "body", "content_type"),
     [
-        (500, '{"internal": "detail"}', "application/json"),
-        (200, "not json", "text/plain"),
+        (500, b'{"internal": "detail"}', "application/json"),
+        (200, b"not json", "text/plain"),
+        (200, b'\xff\xfe{"can_manage_subscription": true}', "application/json"),
     ],
 )
 async def test_relay_converts_invalid_upstream_responses_to_502(
     aiohttp_client, aiohttp_server, monkeypatch, status, body, content_type
 ):
     async def upstream_handler(_request):
-        return web.Response(status=status, text=body, content_type=content_type)
+        return web.Response(status=status, body=body, content_type=content_type)
 
     upstream_app = web.Application()
     upstream_app.router.add_get("/api/billing/capabilities", upstream_handler)
@@ -121,3 +124,67 @@ async def test_relay_converts_connection_failure_to_502(aiohttp_client, monkeypa
 
     assert response.status == 502
     assert await response.json() == {"error": "Billing capabilities unavailable"}
+
+
+async def test_relay_converts_upstream_timeout_to_502(aiohttp_client, aiohttp_server, monkeypatch):
+    async def upstream_handler(_request):
+        await asyncio.sleep(5)
+        return web.json_response({"can_manage_subscription": True})
+
+    upstream_app = web.Application()
+    upstream_app.router.add_get("/api/billing/capabilities", upstream_handler)
+    upstream = await aiohttp_server(upstream_app)
+    monkeypatch.setattr("comfy_api.billing_capabilities._TIMEOUT", aiohttp.ClientTimeout(total=0.05))
+    client = await _relay_client(aiohttp_client, monkeypatch, str(upstream.make_url("/")))
+
+    response = await client.get("/api/billing/capabilities")
+
+    assert response.status == 502
+    assert await response.json() == {"error": "Billing capabilities unavailable"}
+
+
+async def test_relay_drops_unlisted_upstream_response_headers(aiohttp_client, aiohttp_server, monkeypatch):
+    async def upstream_handler(_request):
+        return web.json_response(
+            {"can_manage_subscription": True},
+            headers={
+                "Cache-Control": "private, max-age=30",
+                "Set-Cookie": "upstream_session=secret",
+                "X-Upstream-Internal": "internal-detail",
+                "Access-Control-Allow-Origin": "https://upstream.example",
+            },
+        )
+
+    upstream_app = web.Application()
+    upstream_app.router.add_get("/api/billing/capabilities", upstream_handler)
+    upstream = await aiohttp_server(upstream_app)
+    client = await _relay_client(aiohttp_client, monkeypatch, str(upstream.make_url("/")))
+
+    response = await client.get("/api/billing/capabilities")
+
+    assert response.status == 200
+    assert response.headers["Cache-Control"] == "private, max-age=30"
+    assert "Set-Cookie" not in response.headers
+    assert "X-Upstream-Internal" not in response.headers
+    assert "Access-Control-Allow-Origin" not in response.headers
+    assert response.cookies == {}
+
+
+@pytest.mark.parametrize("request_headers", [{}, {"Authorization": "", "X-API-Key": ""}])
+async def test_relay_omits_absent_auth_headers(aiohttp_client, aiohttp_server, monkeypatch, request_headers):
+    received = {}
+
+    async def upstream_handler(request):
+        received["headers"] = request.headers
+        return web.json_response({"can_manage_subscription": False})
+
+    upstream_app = web.Application()
+    upstream_app.router.add_get("/api/billing/capabilities", upstream_handler)
+    upstream = await aiohttp_server(upstream_app)
+    client = await _relay_client(aiohttp_client, monkeypatch, str(upstream.make_url("/")))
+
+    response = await client.get("/api/billing/capabilities", headers=request_headers)
+
+    assert response.status == 200
+    assert "Authorization" not in received["headers"]
+    assert "X-API-Key" not in received["headers"]

--- a/tests-unit/billing_capabilities_test.py
+++ b/tests-unit/billing_capabilities_test.py
@@ -1,0 +1,123 @@
+import aiohttp
+import pytest
+from aiohttp import web
+
+from comfy_api.billing_capabilities import relay_billing_capabilities
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _relay_client(aiohttp_client, monkeypatch, upstream_url):
+    monkeypatch.setattr("comfy_api.billing_capabilities.args.comfy_api_base", upstream_url)
+    session = aiohttp.ClientSession()
+    app = web.Application()
+
+    async def cleanup(_app):
+        await session.close()
+
+    async def relay_handler(request):
+        return await relay_billing_capabilities(request, session)
+
+    app.on_cleanup.append(cleanup)
+    app.router.add_get("/api/billing/capabilities", relay_handler)
+    return await aiohttp_client(app)
+
+
+async def test_relay_uses_fixed_endpoint_and_header_allowlist(aiohttp_client, aiohttp_server, monkeypatch):
+    received = {}
+
+    async def upstream_handler(request):
+        received["path"] = request.path
+        received["headers"] = request.headers
+        return web.json_response({"can_manage_subscription": True})
+
+    upstream_app = web.Application()
+    upstream_app.router.add_get("/api/billing/capabilities", upstream_handler)
+    upstream = await aiohttp_server(upstream_app)
+    monkeypatch.setattr("comfy_api.billing_capabilities.get_deploy_environment", lambda: "local-test")
+    monkeypatch.setattr("comfy_api.billing_capabilities.comfyui_version", "1.2.3")
+    client = await _relay_client(aiohttp_client, monkeypatch, str(upstream.make_url("/")))
+
+    response = await client.get(
+        "/api/billing/capabilities",
+        headers={
+            "Authorization": "Bearer secret",
+            "X-API-Key": "api-secret",
+            "Cookie": "session=secret",
+            "Comfy-Env": "browser-value",
+            "Comfy-Core-Version": "browser-version",
+            "X-Forwarded-Host": "example.com",
+        },
+    )
+
+    assert response.status == 200
+    assert received["path"] == "/api/billing/capabilities"
+    assert received["headers"]["Authorization"] == "Bearer secret"
+    assert received["headers"]["X-API-Key"] == "api-secret"
+    assert received["headers"]["Accept"] == "application/json"
+    assert received["headers"]["Comfy-Env"] == "local-test"
+    assert received["headers"]["Comfy-Core-Version"] == "1.2.3"
+    assert "Cookie" not in received["headers"]
+    assert "X-Forwarded-Host" not in received["headers"]
+
+
+@pytest.mark.parametrize("status", [200, 401, 403, 404, 502])
+async def test_relay_preserves_expected_responses(aiohttp_client, aiohttp_server, monkeypatch, status):
+    async def upstream_handler(_request):
+        return web.json_response(
+            {"status": status},
+            status=status,
+            headers={
+                "Cache-Control": "private, max-age=30",
+                "Vary": "Authorization",
+                "X-Capability-Revision": "revision-1",
+            },
+        )
+
+    upstream_app = web.Application()
+    upstream_app.router.add_get("/api/billing/capabilities", upstream_handler)
+    upstream = await aiohttp_server(upstream_app)
+    client = await _relay_client(aiohttp_client, monkeypatch, str(upstream.make_url("/")))
+
+    response = await client.get("/api/billing/capabilities")
+
+    assert response.status == status
+    assert await response.json() == {"status": status}
+    assert response.headers["Cache-Control"] == "private, max-age=30"
+    assert response.headers["Vary"] == "Authorization"
+    assert response.headers["X-Capability-Revision"] == "revision-1"
+    assert response.headers["Content-Type"] == "application/json; charset=utf-8"
+
+
+@pytest.mark.parametrize(
+    ("status", "body", "content_type"),
+    [
+        (500, '{"internal": "detail"}', "application/json"),
+        (200, "not json", "text/plain"),
+    ],
+)
+async def test_relay_converts_invalid_upstream_responses_to_502(
+    aiohttp_client, aiohttp_server, monkeypatch, status, body, content_type
+):
+    async def upstream_handler(_request):
+        return web.Response(status=status, text=body, content_type=content_type)
+
+    upstream_app = web.Application()
+    upstream_app.router.add_get("/api/billing/capabilities", upstream_handler)
+    upstream = await aiohttp_server(upstream_app)
+    client = await _relay_client(aiohttp_client, monkeypatch, str(upstream.make_url("/")))
+
+    response = await client.get("/api/billing/capabilities")
+
+    assert response.status == 502
+    assert await response.json() == {"error": "Billing capabilities unavailable"}
+
+
+async def test_relay_converts_connection_failure_to_502(aiohttp_client, monkeypatch, unused_tcp_port):
+    client = await _relay_client(aiohttp_client, monkeypatch, f"http://127.0.0.1:{unused_tcp_port}")
+
+    response = await client.get("/api/billing/capabilities")
+
+    assert response.status == 502
+    assert await response.json() == {"error": "Billing capabilities unavailable"}

--- a/tests-unit/feature_flags_test.py
+++ b/tests-unit/feature_flags_test.py
@@ -215,7 +215,8 @@ class TestComfyApiEnv:
         "url, expected",
         [
             ("https://api.comfy.org", "https://cloud.comfy.org"),
-            ("https://stagingapi.comfy.org", "https://testcloud.comfy.org"),
+            ("https://stagingapi.comfy.org", "https://stagingcloud.comfy.org"),
+            ("https://testapi.comfy.org", "https://testcloud.comfy.org"),
             ("https://pr-4398.testenvs.comfy.org", "https://pr-4398.testenvs.comfy.org"),
             ("https://pr-4398-registry.testenvs.comfy.org", "https://pr-4398.testenvs.comfy.org"),
             ("http://localhost:8189", "http://localhost:8189"),

--- a/tests-unit/feature_flags_test.py
+++ b/tests-unit/feature_flags_test.py
@@ -12,6 +12,7 @@ from comfy_api.feature_flags import (
     _parse_cli_feature_flags,
 )
 from comfy.comfy_api_env import (
+    comfy_cloud_base_for_api_base,
     environment_overrides_for_base,
     get_environment_overrides,
     normalize_comfy_api_base,
@@ -209,6 +210,19 @@ class TestComfyApiEnv:
     )
     def test_normalize_comfy_api_base(self, url, expected):
         assert normalize_comfy_api_base(url) == expected
+
+    @pytest.mark.parametrize(
+        "url, expected",
+        [
+            ("https://api.comfy.org", "https://cloud.comfy.org"),
+            ("https://stagingapi.comfy.org", "https://testcloud.comfy.org"),
+            ("https://pr-4398.testenvs.comfy.org", "https://pr-4398.testenvs.comfy.org"),
+            ("https://pr-4398-registry.testenvs.comfy.org", "https://pr-4398.testenvs.comfy.org"),
+            ("http://localhost:8189", "http://localhost:8189"),
+        ],
+    )
+    def test_comfy_cloud_base_for_api_base(self, url, expected):
+        assert comfy_cloud_base_for_api_base(url) == expected
 
     def test_config_for_staging_tier_else_none(self):
         # ephemeral testenv: friendly main host -> -registry, staging platform, dev Firebase env

--- a/tests/execution/test_billing_capabilities_relay.py
+++ b/tests/execution/test_billing_capabilities_relay.py
@@ -24,10 +24,29 @@ import pytest
 CAPABILITIES_ROUTE = "/api/billing/capabilities"
 UNPREFIXED_CAPABILITIES_ROUTE = "/billing/capabilities"
 UPSTREAM_ROUTE = "/api/billing/capabilities"
-UPSTREAM_BODY = {"can_manage_subscription": True, "can_top_up": False}
-UPSTREAM_REVISION = "rev-42"
+UPSTREAM_BODY = {
+    "resolved_for": {"user_id": "user-1", "workspace_id": "workspace-1"},
+    "capabilities": {
+        "can_subscribe_self_serve": True,
+        "can_top_up": False,
+        "can_cancel": False,
+        "can_reactivate": False,
+        "can_change_seats": False,
+        "can_invite_members": True,
+        "can_downgrade_to_personal": False,
+    },
+    "rollout_defaults_applied": {
+        "can_downgrade_to_personal": False,
+        "can_subscribe_self_serve": False,
+        "can_top_up": False,
+    },
+    "revision": 42,
+    "expires_at": "2026-09-08T00:00:00Z",
+}
+UPSTREAM_REVISION = "42"
 UPSTREAM_CACHE_CONTROL = "private, max-age=30"
-UPSTREAM_VARY = "Authorization, X-API-Key"
+UPSTREAM_VARY = "Authorization"
+RELAY_VARY = "Authorization, X-API-Key"
 CALLER_SUPPLIED = "caller-supplied"
 SERVER_READY_TIMEOUT = 300
 
@@ -49,10 +68,14 @@ class UpstreamStub:
             protocol_version = "HTTP/1.1"
 
             def do_GET(self):
-                received.append({
-                    "path": self.path,
-                    "headers": {name.lower(): value for name, value in self.headers.items()},
-                })
+                received.append(
+                    {
+                        "path": self.path,
+                        "headers": {
+                            name.lower(): value for name, value in self.headers.items()
+                        },
+                    }
+                )
                 body = json.dumps(UPSTREAM_BODY).encode()
                 self.send_response(200)
                 self.send_header("Content-Type", "application/json")
@@ -85,31 +108,44 @@ def _wait_until_serving(process: subprocess.Popen, port: int) -> None:
     deadline = time.monotonic() + SERVER_READY_TIMEOUT
     while time.monotonic() < deadline:
         if process.poll() is not None:
-            raise RuntimeError(f"ComfyUI exited with code {process.returncode} before serving")
+            raise RuntimeError(
+                f"ComfyUI exited with code {process.returncode} before serving"
+            )
         try:
-            with urllib.request.urlopen(f"http://127.0.0.1:{port}/api/system_stats", timeout=5):
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{port}/api/system_stats", timeout=5
+            ):
                 return
         except (urllib.error.URLError, OSError):
             time.sleep(1)
-    raise RuntimeError(f"ComfyUI did not start serving on port {port} within {SERVER_READY_TIMEOUT}s")
+    raise RuntimeError(
+        f"ComfyUI did not start serving on port {port} within {SERVER_READY_TIMEOUT}s"
+    )
 
 
 @contextmanager
 def comfy_server(upstream_port: int, base_directory, *extra_args: str):
     port = _free_port()
-    process = subprocess.Popen([
-        sys.executable, "main.py",
-        "--cpu",
-        "--disable-all-custom-nodes",
-        "--listen", "127.0.0.1",
-        "--port", str(port),
-        "--base-directory", str(base_directory),
-        # Use the configured localhost hostname because aiohttp deliberately
-        # rejects cookies from IP hosts by default. This makes cookie-jar
-        # persistence observable against the loopback upstream.
-        "--comfy-api-base", f"http://localhost:{upstream_port}",
-        *extra_args,
-    ])
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "main.py",
+            "--cpu",
+            "--disable-all-custom-nodes",
+            "--listen",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--base-directory",
+            str(base_directory),
+            # Use the configured localhost hostname because aiohttp deliberately
+            # rejects cookies from IP hosts by default. This makes cookie-jar
+            # persistence observable against the loopback upstream.
+            "--comfy-api-base",
+            f"http://localhost:{upstream_port}",
+            *extra_args,
+        ]
+    )
     try:
         _wait_until_serving(process, port)
         yield port
@@ -123,9 +159,11 @@ def comfy_server(upstream_port: int, base_directory, *extra_args: str):
 
 
 def _request(port: int, route: str, headers: dict | None = None, method: str = "GET"):
+    request_headers = {"Authorization": "Bearer relay-test-token"}
+    request_headers.update(headers or {})
     request = urllib.request.Request(
         f"http://127.0.0.1:{port}{route}",
-        headers=headers or {},
+        headers=request_headers,
         method=method,
     )
     try:
@@ -154,7 +192,9 @@ def clear_upstream_history(upstream):
 
 @pytest.mark.execution
 class TestBillingCapabilitiesRelay:
-    @pytest.mark.parametrize("route", [CAPABILITIES_ROUTE, UNPREFIXED_CAPABILITIES_ROUTE])
+    @pytest.mark.parametrize(
+        "route", [CAPABILITIES_ROUTE, UNPREFIXED_CAPABILITIES_ROUTE]
+    )
     def test_route_relays_upstream_payload(self, relay_port, upstream, route):
         status, body, headers = _request(relay_port, route)
 
@@ -167,24 +207,33 @@ class TestBillingCapabilitiesRelay:
         _status, _body, headers = _request(relay_port, CAPABILITIES_ROUTE)
 
         assert headers["Cache-Control"] == UPSTREAM_CACHE_CONTROL
-        assert headers["Vary"] == UPSTREAM_VARY
+        assert headers["Vary"] == RELAY_VARY
         assert "Set-Cookie" not in headers
 
     def test_upstream_cookie_is_not_replayed(self, relay_port, upstream):
         _request(relay_port, CAPABILITIES_ROUTE)
         _request(relay_port, CAPABILITIES_ROUTE)
 
-        assert [request["headers"].get("cookie") for request in upstream.received] == [None, None]
+        assert [request["headers"].get("cookie") for request in upstream.received] == [
+            None,
+            None,
+        ]
 
-    def test_upstream_receives_allowlisted_headers_and_core_owned_context(self, relay_port, upstream):
-        status, _body, _headers = _request(relay_port, CAPABILITIES_ROUTE, {
-            "Authorization": "Bearer relay-test-token",
-            "X-API-Key": "relay-test-key",
-            "Cookie": "session=must-not-leak",
-            "X-Forwarded-Host": "attacker.example",
-            "Comfy-Env": CALLER_SUPPLIED,
-            "Comfy-Core-Version": CALLER_SUPPLIED,
-        })
+    def test_upstream_receives_allowlisted_headers_and_core_owned_context(
+        self, relay_port, upstream
+    ):
+        status, _body, _headers = _request(
+            relay_port,
+            CAPABILITIES_ROUTE,
+            {
+                "Authorization": "Bearer relay-test-token",
+                "X-API-Key": "relay-test-key",
+                "Cookie": "session=must-not-leak",
+                "X-Forwarded-Host": "attacker.example",
+                "Comfy-Env": CALLER_SUPPLIED,
+                "Comfy-Core-Version": CALLER_SUPPLIED,
+            },
+        )
 
         assert status == 200
         forwarded = upstream.received[-1]["headers"]

--- a/tests/execution/test_billing_capabilities_relay.py
+++ b/tests/execution/test_billing_capabilities_relay.py
@@ -26,6 +26,8 @@ UNPREFIXED_CAPABILITIES_ROUTE = "/billing/capabilities"
 UPSTREAM_ROUTE = "/api/billing/capabilities"
 UPSTREAM_BODY = {"can_manage_subscription": True, "can_top_up": False}
 UPSTREAM_REVISION = "rev-42"
+UPSTREAM_CACHE_CONTROL = "private, max-age=30"
+UPSTREAM_VARY = "Authorization, X-API-Key"
 CALLER_SUPPLIED = "caller-supplied"
 SERVER_READY_TIMEOUT = 300
 
@@ -56,7 +58,9 @@ class UpstreamStub:
                 self.send_header("Content-Type", "application/json")
                 self.send_header("Content-Length", str(len(body)))
                 self.send_header("X-Capability-Revision", UPSTREAM_REVISION)
-                self.send_header("Cache-Control", "private, max-age=60")
+                self.send_header("Cache-Control", UPSTREAM_CACHE_CONTROL)
+                self.send_header("Vary", UPSTREAM_VARY)
+                self.send_header("Set-Cookie", "upstream_session=must-not-leak")
                 self.end_headers()
                 self.wfile.write(body)
 
@@ -151,6 +155,13 @@ class TestBillingCapabilitiesRelay:
         assert json.loads(body) == UPSTREAM_BODY
         assert headers["X-Capability-Revision"] == UPSTREAM_REVISION
         assert [request["path"] for request in upstream.received] == [UPSTREAM_ROUTE]
+
+    def test_core_middleware_preserves_relayed_cache_headers(self, relay_port):
+        _status, _body, headers = _get(relay_port, CAPABILITIES_ROUTE)
+
+        assert headers["Cache-Control"] == UPSTREAM_CACHE_CONTROL
+        assert headers["Vary"] == UPSTREAM_VARY
+        assert "Set-Cookie" not in headers
 
     def test_upstream_receives_allowlisted_headers_and_core_owned_context(self, relay_port, upstream):
         status, _body, _headers = _get(relay_port, CAPABILITIES_ROUTE, {

--- a/tests/execution/test_billing_capabilities_relay.py
+++ b/tests/execution/test_billing_capabilities_relay.py
@@ -1,0 +1,183 @@
+"""End-to-end coverage for Core's billing capabilities relay route.
+
+The handler tests in `tests-unit/billing_capabilities_test.py` mount
+`relay_billing_capabilities` on a standalone aiohttp app, so a route registered
+on the wrong path, missing the automatic `/api` prefix, or surviving
+`--disable-api-nodes` would still pass them. These tests drive a real ComfyUI
+server whose upstream is a loopback stub, which also keeps a relayed upstream
+404 from being mistaken for a missing Core route.
+"""
+
+import json
+import socket
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+CAPABILITIES_ROUTE = "/api/billing/capabilities"
+UNPREFIXED_CAPABILITIES_ROUTE = "/billing/capabilities"
+UPSTREAM_ROUTE = "/api/billing/capabilities"
+UPSTREAM_BODY = {"can_manage_subscription": True, "can_top_up": False}
+UPSTREAM_REVISION = "rev-42"
+CALLER_SUPPLIED = "caller-supplied"
+SERVER_READY_TIMEOUT = 300
+
+
+def _free_port() -> int:
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return probe.getsockname()[1]
+
+
+class UpstreamStub:
+    """Stands in for the Comfy API so the relay never leaves loopback."""
+
+    def __init__(self):
+        self.received = []
+        received = self.received
+
+        class Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def do_GET(self):
+                received.append({
+                    "path": self.path,
+                    "headers": {name.lower(): value for name, value in self.headers.items()},
+                })
+                body = json.dumps(UPSTREAM_BODY).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.send_header("X-Capability-Revision", UPSTREAM_REVISION)
+                self.send_header("Cache-Control", "private, max-age=60")
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *_args):
+                pass
+
+        self._httpd = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self.port = self._httpd.server_port
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+
+    def __enter__(self):
+        self._thread.start()
+        return self
+
+    def __exit__(self, *_exc):
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        self._thread.join(timeout=10)
+
+
+def _wait_until_serving(process: subprocess.Popen, port: int) -> None:
+    deadline = time.monotonic() + SERVER_READY_TIMEOUT
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(f"ComfyUI exited with code {process.returncode} before serving")
+        try:
+            with urllib.request.urlopen(f"http://127.0.0.1:{port}/api/system_stats", timeout=5):
+                return
+        except (urllib.error.URLError, OSError):
+            time.sleep(1)
+    raise RuntimeError(f"ComfyUI did not start serving on port {port} within {SERVER_READY_TIMEOUT}s")
+
+
+@contextmanager
+def comfy_server(upstream_port: int, base_directory, *extra_args: str):
+    port = _free_port()
+    process = subprocess.Popen([
+        sys.executable, "main.py",
+        "--cpu",
+        "--disable-all-custom-nodes",
+        "--listen", "127.0.0.1",
+        "--port", str(port),
+        "--base-directory", str(base_directory),
+        "--comfy-api-base", f"http://127.0.0.1:{upstream_port}",
+        *extra_args,
+    ])
+    try:
+        _wait_until_serving(process, port)
+        yield port
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=60)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=60)
+
+
+def _get(port: int, route: str, headers: dict | None = None):
+    request = urllib.request.Request(f"http://127.0.0.1:{port}{route}", headers=headers or {})
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return response.status, response.read(), dict(response.headers)
+    except urllib.error.HTTPError as error:
+        return error.status, error.read(), dict(error.headers)
+
+
+@pytest.fixture(scope="module")
+def upstream():
+    with UpstreamStub() as stub:
+        yield stub
+
+
+@pytest.fixture(scope="module")
+def relay_port(upstream, tmp_path_factory):
+    with comfy_server(upstream.port, tmp_path_factory.mktemp("relay")) as port:
+        yield port
+
+
+@pytest.fixture(autouse=True)
+def clear_upstream_history(upstream):
+    upstream.received.clear()
+
+
+@pytest.mark.execution
+class TestBillingCapabilitiesRelay:
+    @pytest.mark.parametrize("route", [CAPABILITIES_ROUTE, UNPREFIXED_CAPABILITIES_ROUTE])
+    def test_route_relays_upstream_payload(self, relay_port, upstream, route):
+        status, body, headers = _get(relay_port, route)
+
+        assert status == 200
+        assert json.loads(body) == UPSTREAM_BODY
+        assert headers["X-Capability-Revision"] == UPSTREAM_REVISION
+        assert [request["path"] for request in upstream.received] == [UPSTREAM_ROUTE]
+
+    def test_upstream_receives_allowlisted_headers_and_core_owned_context(self, relay_port, upstream):
+        status, _body, _headers = _get(relay_port, CAPABILITIES_ROUTE, {
+            "Authorization": "Bearer relay-test-token",
+            "X-API-Key": "relay-test-key",
+            "Cookie": "session=must-not-leak",
+            "X-Forwarded-Host": "attacker.example",
+            "Comfy-Env": CALLER_SUPPLIED,
+            "Comfy-Core-Version": CALLER_SUPPLIED,
+        })
+
+        assert status == 200
+        forwarded = upstream.received[-1]["headers"]
+        assert forwarded["authorization"] == "Bearer relay-test-token"
+        assert forwarded["x-api-key"] == "relay-test-key"
+        assert "cookie" not in forwarded
+        assert "x-forwarded-host" not in forwarded
+        assert forwarded["comfy-env"] != CALLER_SUPPLIED
+        assert forwarded["comfy-core-version"] != CALLER_SUPPLIED
+
+    def test_disable_api_nodes_removes_route(self, upstream, tmp_path_factory):
+        with comfy_server(
+            upstream.port,
+            tmp_path_factory.mktemp("relay-disabled"),
+            "--disable-api-nodes",
+        ) as port:
+            status, _body, _headers = _get(port, CAPABILITIES_ROUTE)
+
+        assert status == 404
+        assert upstream.received == []

--- a/tests/execution/test_billing_capabilities_relay.py
+++ b/tests/execution/test_billing_capabilities_relay.py
@@ -104,9 +104,9 @@ def comfy_server(upstream_port: int, base_directory, *extra_args: str):
         "--listen", "127.0.0.1",
         "--port", str(port),
         "--base-directory", str(base_directory),
-        # Use a hostname because aiohttp deliberately rejects cookies from IP
-        # hosts by default. This lets the test catch accidental cookie-jar
-        # persistence against the real comfy.org hostname.
+        # Use the configured localhost hostname because aiohttp deliberately
+        # rejects cookies from IP hosts by default. This makes cookie-jar
+        # persistence observable against the loopback upstream.
         "--comfy-api-base", f"http://localhost:{upstream_port}",
         *extra_args,
     ])
@@ -122,8 +122,12 @@ def comfy_server(upstream_port: int, base_directory, *extra_args: str):
             process.wait(timeout=60)
 
 
-def _get(port: int, route: str, headers: dict | None = None):
-    request = urllib.request.Request(f"http://127.0.0.1:{port}{route}", headers=headers or {})
+def _request(port: int, route: str, headers: dict | None = None, method: str = "GET"):
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{port}{route}",
+        headers=headers or {},
+        method=method,
+    )
     try:
         with urllib.request.urlopen(request, timeout=30) as response:
             return response.status, response.read(), dict(response.headers)
@@ -152,7 +156,7 @@ def clear_upstream_history(upstream):
 class TestBillingCapabilitiesRelay:
     @pytest.mark.parametrize("route", [CAPABILITIES_ROUTE, UNPREFIXED_CAPABILITIES_ROUTE])
     def test_route_relays_upstream_payload(self, relay_port, upstream, route):
-        status, body, headers = _get(relay_port, route)
+        status, body, headers = _request(relay_port, route)
 
         assert status == 200
         assert json.loads(body) == UPSTREAM_BODY
@@ -160,20 +164,20 @@ class TestBillingCapabilitiesRelay:
         assert [request["path"] for request in upstream.received] == [UPSTREAM_ROUTE]
 
     def test_core_middleware_preserves_relayed_cache_headers(self, relay_port):
-        _status, _body, headers = _get(relay_port, CAPABILITIES_ROUTE)
+        _status, _body, headers = _request(relay_port, CAPABILITIES_ROUTE)
 
         assert headers["Cache-Control"] == UPSTREAM_CACHE_CONTROL
         assert headers["Vary"] == UPSTREAM_VARY
         assert "Set-Cookie" not in headers
 
     def test_upstream_cookie_is_not_replayed(self, relay_port, upstream):
-        _get(relay_port, CAPABILITIES_ROUTE)
-        _get(relay_port, CAPABILITIES_ROUTE)
+        _request(relay_port, CAPABILITIES_ROUTE)
+        _request(relay_port, CAPABILITIES_ROUTE)
 
         assert [request["headers"].get("cookie") for request in upstream.received] == [None, None]
 
     def test_upstream_receives_allowlisted_headers_and_core_owned_context(self, relay_port, upstream):
-        status, _body, _headers = _get(relay_port, CAPABILITIES_ROUTE, {
+        status, _body, _headers = _request(relay_port, CAPABILITIES_ROUTE, {
             "Authorization": "Bearer relay-test-token",
             "X-API-Key": "relay-test-key",
             "Cookie": "session=must-not-leak",
@@ -191,13 +195,39 @@ class TestBillingCapabilitiesRelay:
         assert forwarded["comfy-env"] != CALLER_SUPPLIED
         assert forwarded["comfy-core-version"] != CALLER_SUPPLIED
 
+    def test_cors_preflight_allows_api_key(self, upstream, tmp_path_factory):
+        with comfy_server(
+            upstream.port,
+            tmp_path_factory.mktemp("relay-cors"),
+            "--enable-cors-header",
+            "https://frontend.example",
+        ) as port:
+            status, _body, headers = _request(
+                port,
+                CAPABILITIES_ROUTE,
+                headers={
+                    "Origin": "https://frontend.example",
+                    "Access-Control-Request-Method": "GET",
+                    "Access-Control-Request-Headers": "X-API-Key",
+                },
+                method="OPTIONS",
+            )
+
+        allowed_headers = {
+            header.strip().lower()
+            for header in headers["Access-Control-Allow-Headers"].split(",")
+        }
+        assert status == 200
+        assert "x-api-key" in allowed_headers
+        assert upstream.received == []
+
     def test_disable_api_nodes_removes_route(self, upstream, tmp_path_factory):
         with comfy_server(
             upstream.port,
             tmp_path_factory.mktemp("relay-disabled"),
             "--disable-api-nodes",
         ) as port:
-            status, _body, _headers = _get(port, CAPABILITIES_ROUTE)
+            status, _body, _headers = _request(port, CAPABILITIES_ROUTE)
 
         assert status == 404
         assert upstream.received == []

--- a/tests/execution/test_billing_capabilities_relay.py
+++ b/tests/execution/test_billing_capabilities_relay.py
@@ -104,7 +104,10 @@ def comfy_server(upstream_port: int, base_directory, *extra_args: str):
         "--listen", "127.0.0.1",
         "--port", str(port),
         "--base-directory", str(base_directory),
-        "--comfy-api-base", f"http://127.0.0.1:{upstream_port}",
+        # Use a hostname because aiohttp deliberately rejects cookies from IP
+        # hosts by default. This lets the test catch accidental cookie-jar
+        # persistence against the real comfy.org hostname.
+        "--comfy-api-base", f"http://localhost:{upstream_port}",
         *extra_args,
     ])
     try:
@@ -162,6 +165,12 @@ class TestBillingCapabilitiesRelay:
         assert headers["Cache-Control"] == UPSTREAM_CACHE_CONTROL
         assert headers["Vary"] == UPSTREAM_VARY
         assert "Set-Cookie" not in headers
+
+    def test_upstream_cookie_is_not_replayed(self, relay_port, upstream):
+        _get(relay_port, CAPABILITIES_ROUTE)
+        _get(relay_port, CAPABILITIES_ROUTE)
+
+        assert [request["headers"].get("cookie") for request in upstream.received] == [None, None]
 
     def test_upstream_receives_allowlisted_headers_and_core_owned_context(self, relay_port, upstream):
         status, _body, _headers = _get(relay_port, CAPABILITIES_ROUTE, {


### PR DESCRIPTION
## Why this is needed

Billing and rollout policy is owned by Ingest, but today the OSS frontend has to *reconstruct* it. The frontend branches on a client-side `isCloud` signal and composes UI decisions (can this user manage a subscription, top up credits, see a plan upsell) out of fragments it happens to have on hand.

That is frontend-computed server state, and it fails in the ways frontend-computed server state always fails:

- **It drifts.** Every time Ingest changes a plan, a rollout gate, or an entitlement rule, the OSS frontend needs a matching release to agree with it. Between those two releases the UI is wrong.
- **It is not deterministic.** The same account can render differently depending on which fragments loaded, in what order, and which distribution the frontend thinks it is running in.
- **It duplicates policy.** The same rule now lives in two codebases with no mechanism keeping them in sync.

The fix is not a better client-side composition. It is to stop composing: the server that owns the policy should answer the question directly.

## Root cause

There is no path from the OSS frontend to Ingest's `/api/billing/capabilities`. The frontend cannot attach the user's credentials to a cross-origin call to the Comfy API, and Core deliberately makes no outbound internet requests, so no component was in a position to ask the owner of the policy what the answer is. Client-side composition filled that vacuum.

```
AS IS
  frontend ──(isCloud + fragments)──> composes capabilities locally ✗ drifts from Ingest

TO BE
  frontend ──> Core /api/billing/capabilities ──(auth passthrough)──> Ingest ──> capabilities ✓ single owner
```

## What this changes

Adds `GET /api/billing/capabilities` to Core as a **relay**, not a policy layer. Core forwards the authenticated request to the configured Comfy Cloud API and returns the answer; it never decides an answer itself.

The relay is deliberately narrow:

| Constraint | Behavior |
|---|---|
| Destination | Fixed upstream path. No caller-selected URL, host, or scope. Redirects are refused, so the destination stays fixed for the whole exchange rather than only the first hop. |
| Request headers | Allowlist of `Authorization` and `X-API-Key` only. `Cookie` and forwarding headers are dropped. |
| Context headers | `Comfy-Env` and `Comfy-Core-Version` are generated from Core-owned state, never accepted from the caller. |
| Response | A `200` must contain an `application/json` object. `401/403/404/429/502/503` pass through so denial and backpressure semantics survive; `Retry-After` is preserved. Any other status or invalid success payload becomes `502`. `Vary` always includes both accepted auth headers. |
| Authorization | The relay performs none. Ingest remains the sole authority. |
| Availability | Registered only when API nodes are enabled (`--disable-api-nodes` removes the route). |

`AGENTS.md` is updated so the "no internet requests" rule records this as an explicit, bounded exception rather than leaving a contradiction for the next reader. `openapi.yaml` documents the endpoint and its auth schemes.

## Tests

`tests-unit/billing_capabilities_test.py` — 25 handler tests:

- fixed upstream endpoint is used regardless of the incoming request
- request header allowlist holds; `Cookie` / `X-Forwarded-Host` are not forwarded
- caller-supplied `Comfy-Env` / `Comfy-Core-Version` are overwritten with Core-owned values
- `200/401/403/404/429/502/503` preserve their status, body, and relevant response headers; non-JSON denial/backpressure responses retain their semantics
- unexpected status, or a successful response with a non-JSON media type or non-object JSON (`[]`, `null`), collapses to `502`
- unauthenticated callers receive a local `401` without contacting upstream
- production/staging API bases resolve to their paired Ingest hosts, and malformed bases collapse to `502`
- the shared client session must use a non-persistent cookie jar
- an upstream `302` is not followed: the redirect target is never contacted and the caller gets `502`
- upstream connection failure or timeout collapses to `502`

`tests/execution/test_billing_capabilities_relay.py` — 7 integration tests against a real server:

- a live ComfyUI process, started with `--comfy-api-base` pointed at a loopback stub, serves both `/api/billing/capabilities` and the unprefixed `/billing/capabilities`, relaying the upstream body and `X-Capability-Revision`
- the stub records exactly the allowlisted request headers, with Core-owned `Comfy-Env` / `Comfy-Core-Version`
- Core’s middleware chain leaves the relayed `Cache-Control` and `Vary` intact and still drops the upstream `Set-Cookie`
- upstream cookies are not retained or replayed across relay requests
- CORS preflight explicitly allows `X-API-Key` when CORS is enabled
- `--disable-api-nodes` returns `404` and the upstream is never contacted

The handler tests mount `relay_billing_capabilities` on a standalone aiohttp app, so on their own they cannot see a route registered on the wrong path, a lost `/api` prefix, or a route that survives `--disable-api-nodes`. The stub keeps the whole path on loopback, so no test reaches the internet, and a relayed upstream `404` can never be misread as a missing Core route.

```
25 passed  tests-unit/billing_capabilities_test.py
5 passed   tests/execution/test_billing_capabilities_relay.py
1472 passed, 10 skipped  tests-unit
ruff: All checks passed!
```

## Screenshots

Backend-only change with no UI surface of its own; there is nothing to capture in Core. The user-visible AS IS / TO BE belongs to the consuming frontend change (`dante/centralize-billing-ui-policy` in `ComfyUI_frontend`), and will be posted on that PR once captured in a real app environment.

## Upstream availability

The relay resolves the configured registry base to its paired Ingest host: `api.comfy.org` maps to `cloud.comfy.org`, `stagingapi.comfy.org` maps to `stagingcloud.comfy.org`, `testapi.comfy.org` maps to `testcloud.comfy.org`, and testenv registry hosts map back to their main testenv host. Custom bases, including loopback test stubs, remain unchanged. A live unauthenticated request to the production Ingest route returns `401`, confirming that the route is registered on the selected host.

## Review notes

Draft until the frontend PR that consumes this endpoint is open, so the two can be reviewed against each other.

**Local is not yet wired to this route, and that work belongs to the frontend PR.** On `ComfyUI_frontend@dante/centralize-billing-ui-policy` (`6c55d0e`), `workspaceApiUrl()` still resolves a non-Cloud request to `${getComfyCloudBaseUrl()}/api${route}` rather than to Core, and `useBillingCapabilities.initialize()` returns early for `!isCloud`, so Local capability values stay client-computed. Nothing in Core can close that gap; the frontend change has to call Core `/api/billing/capabilities` for Local and drop the client-computed branches. This PR makes the route exist, correct, and provably reachable, which is the half Core owns.



