### PR TITLE
Fix/aimdo windows pin budget

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import psutil
+import atexit
 import logging
 from enum import Enum
 from comfy.cli_args import args, PerformanceFeature
@@ -33,6 +34,7 @@ import comfy.memory_management
 import comfy.system_memory
 import comfy.utils
 import comfy.quant_ops
+import comfy.windows_dxgi
 import comfy_aimdo.host_buffer
 import comfy_aimdo.vram_buffer
 from comfy.internal_logging import detail
@@ -629,8 +631,11 @@ PIN_PRESSURE_HYSTERESIS = 256 * 1024 * 1024
 #Freeing registerables on pressure does imply a GPU sync, so go big on
 #the hysteresis so each expensive sync gives us back a good chunk.
 REGISTERABLE_PIN_HYSTERESIS = 2048 * 1024 * 1024
+WINDOWS_PIN_SAFETY_RESERVE = 2048 * 1024 * 1024
+WINDOWS_PIN_BUDGET_HYSTERESIS = 512 * 1024 * 1024
 WINDOWS_PIN_EVICTION_SWAP_PERCENT = 5.0
 WINDOWS_PIN_EVICTION_EMERGENCY_AVAILABLE = 512 * 1024 ** 2
+PIN_BUDGETS = {}
 
 def module_size(module):
     module_mem = 0
@@ -658,15 +663,15 @@ def models_for_pin_eviction(active, current_prompt=None):
             (current_prompt is None or pin_state["current_prompt"] == current_prompt)):
             yield model
 
-def free_model_pins(size, subsets, current_prompt, active, registrations=False):
+def free_model_pins(size, subsets, current_prompt, active, registrations=False, protected=None, prefetch_only=False):
     freed_total = 0
     for model in models_for_pin_eviction(active, current_prompt=current_prompt):
         if size <= 0:
             return freed_total
         if registrations:
-            freed = model.unregister_inactive_pins(size, subsets=subsets)
+            freed = model.unregister_inactive_pins(size, subsets=subsets, protected=protected, prefetch_only=prefetch_only)
         else:
-            freed = model.partially_unload_ram(size, subsets=subsets)
+            freed = model.partially_unload_ram(size, subsets=subsets, protected=protected)
         freed_total += freed
         size -= freed
     return freed_total
@@ -696,10 +701,12 @@ def registration_eviction_tiers(evict_active):
         ])
     return tiers
 
-def free_pins(size, evict_active=False, loaded=False):
+def free_pins(size, evict_active=False, loaded=False, protected=None):
+    if protected is None:
+        protected = set()
     freed = 0
     for subsets, current_prompt, active in pin_eviction_tiers(loaded, evict_active):
-        freed += free_model_pins(size - freed, subsets, current_prompt, active)
+        freed += free_model_pins(size - freed, subsets, current_prompt, active, protected=protected)
     return freed
 
 def should_free_pins_for_ram_pressure(shortfall):
@@ -715,10 +722,10 @@ def should_free_pins_for_ram_pressure(shortfall):
         logging.warning("Could not read Windows swap usage; falling back to RAM-pressure pin eviction: %s", err)
         return True
 
-def ensure_pin_budget(size, evict_active=False, loaded=False):
+def ensure_pin_budget(size, evict_active=False, loaded=False, device=None, protected=None):
     if args.high_ram:
         return True
-    if args.fast_disk:
+    if args.fast_disk and _pin_budget(device) is None:
         shortfall = TOTAL_PINNED_MEMORY + size - MAX_PINNED_MEMORY
     else:
         shortfall = size + max(comfy.memory_management.RAM_CACHE_HEADROOM / 2, 2048 * 1024 ** 2) - comfy.system_memory.virtual_memory_available()
@@ -726,21 +733,105 @@ def ensure_pin_budget(size, evict_active=False, loaded=False):
         return True
 
     to_free = shortfall + PIN_PRESSURE_HYSTERESIS
-    return free_pins(to_free, evict_active=evict_active, loaded=loaded) >= shortfall
+    return free_pins(to_free, evict_active=evict_active, loaded=loaded, protected=protected) >= shortfall
 
-def free_registrations(shortfall, evict_active=True):
+def _free_registrations(size, evict_active=True, protected=None, prefetch_first=False):
+    freed = 0
+    subsets = PIN_SUBSETS + LOADED_PIN_SUBSETS
+    if prefetch_first:
+        freed += free_model_pins(size, subsets, None, None, registrations=True, protected=protected, prefetch_only=True)
+    for tier_subsets, current_prompt, active in registration_eviction_tiers(evict_active):
+        if freed >= size:
+            break
+        freed += free_model_pins(size - freed, tier_subsets, current_prompt, active, registrations=True, protected=protected)
+    return freed
+
+
+def free_registrations(shortfall, evict_active=True, protected=None, prefetch_first=False):
     if MAX_PINNED_MEMORY <= 0:
         return False
     if shortfall <= 0:
         return True
 
-    shortfall += REGISTERABLE_PIN_HYSTERESIS
-    for subsets, current_prompt, active in registration_eviction_tiers(evict_active):
-        shortfall -= free_model_pins(shortfall, subsets, current_prompt, active, registrations=True)
-    return shortfall <= REGISTERABLE_PIN_HYSTERESIS
+    return _free_registrations(
+        shortfall + REGISTERABLE_PIN_HYSTERESIS,
+        evict_active=evict_active,
+        protected=protected,
+        prefetch_first=prefetch_first,
+    ) >= shortfall
 
-def ensure_pin_registerable(size, evict_active=True):
-    return free_registrations(TOTAL_PINNED_MEMORY + size - MAX_PINNED_MEMORY, evict_active=evict_active)
+
+def set_pin_budget_provider(device, provider):
+    previous = PIN_BUDGETS.get(device.index)
+    if previous is not None:
+        close = getattr(previous.provider, "close", None)
+        if close is not None:
+            close()
+    PIN_BUDGETS[device.index] = None if provider is None else comfy.windows_dxgi.LivePinBudget(
+        provider, WINDOWS_PIN_SAFETY_RESERVE, WINDOWS_PIN_BUDGET_HYSTERESIS
+    )
+
+
+def _pin_budget(device):
+    if args.disable_pinned_memory or not WINDOWS or device is None or not is_device_cuda(device):
+        return None
+    device_index = device.index
+    if device_index is None:
+        device_index = torch.cuda.current_device()
+    if device_index not in PIN_BUDGETS:
+        provider = comfy.windows_dxgi.create_dxgi_budget_provider(device_index)
+        PIN_BUDGETS[device_index] = None if provider is None else comfy.windows_dxgi.LivePinBudget(
+            provider, WINDOWS_PIN_SAFETY_RESERVE, WINDOWS_PIN_BUDGET_HYSTERESIS
+        )
+    return PIN_BUDGETS[device_index]
+
+
+def has_live_pin_budget(device):
+    return _pin_budget(device) is not None
+
+
+def clear_pin_budget_providers():
+    for budget in PIN_BUDGETS.values():
+        if budget is not None:
+            close = getattr(budget.provider, "close", None)
+            if close is not None:
+                close()
+    PIN_BUDGETS.clear()
+
+
+atexit.register(clear_pin_budget_providers)
+
+
+def pin_budget_status(device):
+    budget = _pin_budget(device)
+    if budget is None or budget.last_info is None:
+        return None
+    return budget.last_info, budget.last_headroom, budget.evicted
+
+
+def ensure_pin_registerable(size, evict_active=True, device=None, protected=None):
+    budget = _pin_budget(device)
+    if budget is not None:
+        try:
+            return budget.ensure(
+                size,
+                lambda target: _free_registrations(target, evict_active=evict_active, protected=protected, prefetch_first=True),
+            )
+        except (OSError, comfy.windows_dxgi.DXGIUnavailable) as err:
+            logging.debug("DXGI NON_LOCAL pin budget query failed: %s", err)
+            close = getattr(budget.provider, "close", None)
+            if close is not None:
+                close()
+            device_index = device.index
+            if device_index is None:
+                device_index = torch.cuda.current_device()
+            PIN_BUDGETS[device_index] = None
+    return free_registrations(
+        TOTAL_PINNED_MEMORY + size - MAX_PINNED_MEMORY,
+        evict_active=evict_active,
+        protected=protected,
+        prefetch_first=True,
+    )
 
 class LoadedModel:
     def __init__(self, model: ModelPatcher):

--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -809,6 +809,13 @@ def pin_budget_status(device):
     return budget.last_info, budget.last_headroom, budget.evicted
 
 
+def pin_budget_query_stats(device):
+    budget = _pin_budget(device)
+    if budget is None:
+        return None
+    return budget.query_count, budget.query_ns, budget.max_query_ns
+
+
 def ensure_pin_registerable(size, evict_active=True, device=None, protected=None):
     budget = _pin_budget(device)
     if budget is not None:

--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -996,8 +996,8 @@ def free_memory(memory_required, device, keep_loaded=[], for_dynamic=False, pins
         unloaded_models.append(current_loaded_models.pop(i))
 
     if not for_dynamic and pins_required > 0:
-        ensure_pin_budget(pins_required)
-        ensure_pin_registerable(pins_required)
+        ensure_pin_budget(pins_required, device=device)
+        ensure_pin_registerable(pins_required, device=device)
 
     if len(unloaded_model) > 0:
         soft_empty_cache()

--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -2072,62 +2072,12 @@ class ModelPatcherDynamic(ModelPatcher):
         return pin_state["weights"][3][0] + pin_state["weights-loaded"][3][0]
 
     def unregister_inactive_pins(self, ram_to_unload, subsets=[ "weights-loaded", "patches-loaded", "weights", "patches" ], protected=None, prefetch_only=False):
-        freed = 0
         pin_state = self.model.dynamic_pins[self.load_device]
-        for subset in subsets:
-            _, stack, stack_split, *_ = pin_state[subset]
-            candidates = []
-            for stack_index in range(stack_split[0] + 1):
-                module, _ = stack[stack_index]
-                module_pin = module._pins[subset]
-                if not module_pin["registered"]:
-                    continue
-                if protected is not None and (module, subset) in protected:
-                    continue
-                is_protected, order_state = comfy.pinned_memory.pin_eviction_state(module, subset)
-                preferred = order_state is not None and order_state[0]
-                if is_protected or (prefetch_only and (order_state is None or preferred)):
-                    continue
-                candidates.append((*comfy.pinned_memory.pin_eviction_priority(order_state), stack_index, module))
-
-            candidates.sort(reverse=True, key=lambda entry: entry[:3])
-            for *_, module in candidates:
-                size = comfy.pinned_memory.unregister_pin(module, subset)
-                freed += size
-                ram_to_unload -= size
-                if ram_to_unload <= 0:
-                    return freed
-        return freed
+        return comfy.pinned_memory.unregister_inactive_pins(pin_state, ram_to_unload, subsets, protected=protected, prefetch_only=prefetch_only)
 
     def partially_unload_ram(self, ram_to_unload, subsets=[ "weights-loaded", "patches-loaded", "weights", "patches" ], protected=None):
-        freed = 0
         pin_state = self.model.dynamic_pins[self.load_device]
-        for subset in subsets:
-            hostbuf, stack, stack_split, pinned_size, *_ = pin_state[subset]
-            while len(stack) > 0:
-                module, offset = stack.pop()
-                module_pin = module._pins[subset]
-                if protected is not None:
-                    is_protected, _ = comfy.pinned_memory.pin_eviction_state(module, subset)
-                    if is_protected or (module, subset) in protected:
-                        stack.append((module, offset))
-                        break
-                pin = module_pin["pin"]
-                size = pin.numel() * pin.element_size()
-                module_pin["balancer_entry"][-1] = None
-                del module_pin["balancer_entry"]
-                del module_pin["pin"]
-                registered = module_pin["registered"]
-                hostbuf.truncate(offset, do_unregister=registered)
-                stack_split[0] = min(stack_split[0], len(stack) - 1)
-                if registered:
-                    comfy.model_management.TOTAL_PINNED_MEMORY = max(0, comfy.model_management.TOTAL_PINNED_MEMORY - size)
-                    pinned_size[0] = max(0, pinned_size[0] - size)
-                freed += size
-                ram_to_unload -= size
-                if ram_to_unload <= 0:
-                    return freed
-        return freed
+        return comfy.pinned_memory.partially_unload_ram(pin_state, ram_to_unload, subsets, protected=protected)
 
     def patch_model(self, device_to=None, lowvram_model_memory=0, load_weights=True, force_patch_weights=False):
         #This isn't used by the core at all and can only be to load a model out of

--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -2085,10 +2085,10 @@ class ModelPatcherDynamic(ModelPatcher):
                 if protected is not None and (module, subset) in protected:
                     continue
                 is_protected, order_state = comfy.pinned_memory.pin_eviction_state(module, subset)
-                if is_protected or (prefetch_only and order_state is None):
+                preferred = order_state is not None and order_state[0]
+                if is_protected or (prefetch_only and (order_state is None or preferred)):
                     continue
-                distance = -1 if order_state is None else order_state[1]
-                candidates.append((order_state is not None, distance, stack_index, module))
+                candidates.append((*comfy.pinned_memory.pin_eviction_priority(order_state), stack_index, module))
 
             candidates.sort(reverse=True, key=lambda entry: entry[:3])
             for *_, module in candidates:

--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -24,6 +24,7 @@ import logging
 import math
 import time
 import uuid
+import weakref
 from typing import Callable, Optional
 
 import torch
@@ -1788,6 +1789,7 @@ class ModelPatcherDynamic(ModelPatcher):
                 "failed": False,
                 "active": False,
                 "current_prompt": False,
+                "prefetch_orders": weakref.WeakSet(),
             }
 
     def is_dynamic(self):

--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -35,6 +35,7 @@ import comfy.lora
 import comfy.model_management
 import comfy.ops
 import comfy.patcher_extension
+import comfy.pinned_memory
 import comfy.utils
 import comfy_aimdo.host_buffer
 from comfy.comfy_types import UnetWrapperFunction
@@ -1778,6 +1779,7 @@ class ModelPatcherDynamic(ModelPatcher):
         """
         if device not in self.model.dynamic_pins:
             self.model.dynamic_pins[device] = {
+                "device": device,
                 "weights": (comfy_aimdo.host_buffer.HostBuffer(0, 0, 0), [], [-1], [0], [0], {}),
                 "patches": (comfy_aimdo.host_buffer.HostBuffer(0, 0, 0), [], [-1], [0], [0], {}),
                 "weights-loaded": (comfy_aimdo.host_buffer.HostBuffer(0, 0, 0), [], [-1], [0], [0], {}),
@@ -2069,34 +2071,35 @@ class ModelPatcherDynamic(ModelPatcher):
         pin_state = self.model.dynamic_pins[self.load_device]
         return pin_state["weights"][3][0] + pin_state["weights-loaded"][3][0]
 
-    def unregister_inactive_pins(self, ram_to_unload, subsets=[ "weights-loaded", "patches-loaded", "weights", "patches" ]):
+    def unregister_inactive_pins(self, ram_to_unload, subsets=[ "weights-loaded", "patches-loaded", "weights", "patches" ], protected=None, prefetch_only=False):
         freed = 0
         pin_state = self.model.dynamic_pins[self.load_device]
         for subset in subsets:
-            hostbuf, stack, stack_split, pinned_size, *_ = pin_state[subset]
-            split = stack_split[0]
-            while split >= 0:
-                module, offset = stack[split]
+            _, stack, stack_split, *_ = pin_state[subset]
+            candidates = []
+            for stack_index in range(stack_split[0] + 1):
+                module, _ = stack[stack_index]
                 module_pin = module._pins[subset]
-                split -= 1
-                stack_split[0] = split
                 if not module_pin["registered"]:
                     continue
-                pin = module_pin["pin"]
-                size = pin.numel() * pin.element_size()
-                if torch.cuda.cudart().cudaHostUnregister(pin.data_ptr()) != 0:
-                    comfy.model_management.discard_cuda_async_error()
+                if protected is not None and (module, subset) in protected:
                     continue
-                module_pin["registered"] = False
-                comfy.model_management.TOTAL_PINNED_MEMORY = max(0, comfy.model_management.TOTAL_PINNED_MEMORY - size)
-                pinned_size[0] = max(0, pinned_size[0] - size)
+                is_protected, order_state = comfy.pinned_memory.pin_eviction_state(module, subset)
+                if is_protected or (prefetch_only and order_state is None):
+                    continue
+                distance = -1 if order_state is None else order_state[1]
+                candidates.append((order_state is not None, distance, stack_index, module))
+
+            candidates.sort(reverse=True, key=lambda entry: entry[:3])
+            for *_, module in candidates:
+                size = comfy.pinned_memory.unregister_pin(module, subset)
                 freed += size
                 ram_to_unload -= size
                 if ram_to_unload <= 0:
                     return freed
         return freed
 
-    def partially_unload_ram(self, ram_to_unload, subsets=[ "weights-loaded", "patches-loaded", "weights", "patches" ]):
+    def partially_unload_ram(self, ram_to_unload, subsets=[ "weights-loaded", "patches-loaded", "weights", "patches" ], protected=None):
         freed = 0
         pin_state = self.model.dynamic_pins[self.load_device]
         for subset in subsets:
@@ -2104,6 +2107,11 @@ class ModelPatcherDynamic(ModelPatcher):
             while len(stack) > 0:
                 module, offset = stack.pop()
                 module_pin = module._pins[subset]
+                if protected is not None:
+                    is_protected, _ = comfy.pinned_memory.pin_eviction_state(module, subset)
+                    if is_protected or (module, subset) in protected:
+                        stack.append((module, offset))
+                        break
                 pin = module_pin["pin"]
                 size = pin.numel() * pin.element_size()
                 module_pin["balancer_entry"][-1] = None

--- a/comfy/model_prefetch.py
+++ b/comfy/model_prefetch.py
@@ -4,14 +4,26 @@ import weakref
 
 import comfy_aimdo.model_vbar
 from comfy.cli_args import args
-import comfy.memory_management
 import comfy.model_management
 import comfy.ops
+import comfy.pin_order
+import comfy.pinned_memory
+from comfy.internal_logging import detail
 
 PREFETCH_QUEUES = []
 GRAPH_MODULES = weakref.WeakSet()
 GRAPH_WARMED_MODULES = weakref.WeakSet()
 GRAPH_CAPTURE_STREAMS = {}
+
+
+class PrefetchQueue(list):
+    def __init__(self, queue, pin_scheduler, live_budget):
+        self.pin_order = comfy.pin_order.PrefetchPinOrder(queue) if pin_scheduler else comfy.pin_order.NullPinOrder()
+        self.live_budget = live_budget
+        super().__init__([None] + queue + [None])
+
+    def close(self):
+        self.pin_order.close()
 
 def cleanup_prefetched_modules(module, comfy_modules):
     for s in comfy_modules:
@@ -52,6 +64,7 @@ def cleanup_prefetch_queues():
             prefetched_module, comfy_modules = prefetch_state
             if comfy_modules is not None:
                 cleanup_prefetched_modules(prefetched_module, comfy_modules)
+        queue.close()
     PREFETCH_QUEUES = []
     for module in GRAPH_MODULES:
         _drop_graph(module)
@@ -65,6 +78,8 @@ def prefetch_queue_pop(queue, device, module, dtype=None, core=None, enable_grap
         if core is not None:
             core()
         return
+
+    queue.pin_order.advance()
 
     capture_stream = None
     if enable_graph:
@@ -91,6 +106,11 @@ def prefetch_queue_pop(queue, device, module, dtype=None, core=None, enable_grap
         if comfy_modules is not None:
             cleanup_prefetched_modules(prefetched_module, comfy_modules)
 
+    if module is None:
+        queue.pin_order.close()
+    elif queue.live_budget:
+        queue.pin_order.budget_checked = comfy.model_management.ensure_pin_registerable(0, device=device)
+
     if graph_hit:
         queue[0] = (None, (module, []))
         graph["graph"].replay()
@@ -106,22 +126,31 @@ def prefetch_queue_pop(queue, device, module, dtype=None, core=None, enable_grap
                 if hasattr(s, "_v"):
                     comfy_modules.append(s)
 
-        registerable_size = 0
-        for s in comfy_modules:
-            registerable_size += comfy.memory_management.vram_aligned_size([s.weight, s.bias])
-            for param_key in ("weight", "bias"):
-                lowvram_fn = getattr(s, param_key + "_lowvram_function", None)
-                if lowvram_fn is not None:
-                    registerable_size += lowvram_fn.memory_required()
-
         offload_stream, fully_faulted = comfy.ops.cast_modules_with_vbar(comfy_modules, None, device, None, True, return_faulted=True)
-        if not comfy.model_management.args.fast_disk:
-            comfy.model_management.ensure_pin_registerable(registerable_size)
+        if queue.live_budget and not comfy.model_management.args.fast_disk:
+            comfy.model_management.ensure_pin_registerable(0, device=device)
         comfy.model_management.sync_stream(device, offload_stream)
+        if queue.pin_order.enabled:
+            comfy.pinned_memory.mark_modules_in_flight(comfy_modules, offload_stream)
         if fully_faulted and dtype is not None:
             for comfy_module in comfy_modules:
                 comfy.ops.resolve_cast_module_with_vbar(comfy_module, dtype, device, dtype, None, False, return_weights=False)
         queue[0] = (offload_stream, (module, comfy_modules))
+        budget_status = comfy.model_management.pin_budget_status(device)
+        if budget_status is not None:
+            info, headroom, evicted = budget_status
+            detail(
+                "AIMDO pin scheduler: block=%s dxgi_budget=%.1fGiB dxgi_usage=%.1fGiB safe_headroom=%.1fGiB comfy_registered=%.1fGiB protected=%s evicted=%.1fGiB register_failures=%s pageable_prefetches=%s",
+                queue.pin_order.current,
+                info.budget / (1024 ** 3),
+                info.current_usage / (1024 ** 3),
+                headroom / (1024 ** 3),
+                comfy.model_management.TOTAL_PINNED_MEMORY / (1024 ** 3),
+                queue.pin_order.protected_indices(),
+                evicted / (1024 ** 3),
+                comfy.pinned_memory.PIN_SCHEDULER_STATS["register_failures"],
+                comfy.pinned_memory.PIN_SCHEDULER_STATS["pageable_prefetches"],
+            )
 
     if core is not None:
         if enable_graph and fully_faulted and module in GRAPH_WARMED_MODULES:
@@ -158,6 +187,10 @@ def make_prefetch_queue(queue, device, transformer_options):
         or not comfy.model_management.device_supports_non_blocking(device)):
         return None
 
-    queue = [None] + queue + [None]
+    queue = PrefetchQueue(
+        queue,
+        pin_scheduler=not args.disable_pinned_memory,
+        live_budget=comfy.model_management.has_live_pin_budget(device),
+    )
     PREFETCH_QUEUES.append(queue)
     return queue

--- a/comfy/model_prefetch.py
+++ b/comfy/model_prefetch.py
@@ -17,9 +17,11 @@ GRAPH_CAPTURE_STREAMS = {}
 
 
 class PrefetchQueue(list):
-    def __init__(self, queue, pin_scheduler, live_budget):
+    def __init__(self, queue, pin_scheduler, live_budget, query_stats=None):
         self.pin_order = comfy.pin_order.PrefetchPinOrder(queue) if pin_scheduler else comfy.pin_order.NullPinOrder()
         self.live_budget = live_budget
+        self.query_count = 0 if query_stats is None else query_stats[0]
+        self.query_ns = 0 if query_stats is None else query_stats[1]
         super().__init__([None] + queue + [None])
 
     def close(self):
@@ -139,17 +141,27 @@ def prefetch_queue_pop(queue, device, module, dtype=None, core=None, enable_grap
         budget_status = comfy.model_management.pin_budget_status(device)
         if budget_status is not None:
             info, headroom, evicted = budget_status
+            query_count, query_ns, max_query_ns = comfy.model_management.pin_budget_query_stats(device)
+            block_query_count = query_count - queue.query_count
+            block_query_ns = query_ns - queue.query_ns
+            queue.query_count = query_count
+            queue.query_ns = query_ns
             detail(
-                "AIMDO pin scheduler: block=%s dxgi_budget=%.1fGiB dxgi_usage=%.1fGiB safe_headroom=%.1fGiB comfy_registered=%.1fGiB protected=%s evicted=%.1fGiB register_failures=%s pageable_prefetches=%s",
+                "AIMDO pin scheduler: block=%s dxgi_budget=%.1fGiB dxgi_usage=%.1fGiB safe_headroom=%.1fGiB comfy_registered=%.1fGiB preferred=%s evicted=%.1fGiB register_failures=%s pageable_prefetches=%s block_dxgi_queries=%s block_dxgi_query_ms=%.3f total_dxgi_queries=%s total_dxgi_query_ms=%.3f dxgi_query_max_ms=%.3f",
                 queue.pin_order.current,
                 info.budget / (1024 ** 3),
                 info.current_usage / (1024 ** 3),
                 headroom / (1024 ** 3),
                 comfy.model_management.TOTAL_PINNED_MEMORY / (1024 ** 3),
-                queue.pin_order.protected_indices(),
+                queue.pin_order.preferred_indices(),
                 evicted / (1024 ** 3),
                 comfy.pinned_memory.PIN_SCHEDULER_STATS["register_failures"],
                 comfy.pinned_memory.PIN_SCHEDULER_STATS["pageable_prefetches"],
+                block_query_count,
+                block_query_ns / 1_000_000,
+                query_count,
+                query_ns / 1_000_000,
+                max_query_ns / 1_000_000,
             )
 
     if core is not None:
@@ -187,10 +199,12 @@ def make_prefetch_queue(queue, device, transformer_options):
         or not comfy.model_management.device_supports_non_blocking(device)):
         return None
 
+    live_budget = comfy.model_management.has_live_pin_budget(device)
     queue = PrefetchQueue(
         queue,
         pin_scheduler=not args.disable_pinned_memory,
-        live_budget=comfy.model_management.has_live_pin_budget(device),
+        live_budget=live_budget,
+        query_stats=comfy.model_management.pin_budget_query_stats(device) if live_budget else None,
     )
     PREFETCH_QUEUES.append(queue)
     return queue

--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -236,6 +236,7 @@ def cast_modules_with_vbar(comfy_modules, dtype, device, bias_dtype, non_blockin
         for param_key in ("weight", "bias"):
             lowvram_source = getattr(s, param_key + "_lowvram_function", None)
             if lowvram_source is not None:
+                comfy.pinned_memory.copy_prefetch_order(s, lowvram_source)
                 ensure_offload_stream(s, cast_buffer_offset, False)
                 lowvram_size = lowvram_source.memory_required()
                 lowvram_dest = get_cast_buffer(lowvram_size)

--- a/comfy/pin_order.py
+++ b/comfy/pin_order.py
@@ -27,6 +27,7 @@ class PrefetchPinOrder:
         self.budget_checked = False
         self.positions = weakref.WeakKeyDictionary()
         self.modules = []
+        self.pin_states = []
         for index, unit in enumerate(units):
             roots = unit if isinstance(unit, (list, tuple)) else (unit,)
             modules = []
@@ -40,9 +41,22 @@ class PrefetchPinOrder:
                                 sources.append(lowvram_source)
                         for source in sources:
                             modules.append(source)
-                            self.positions[source] = index
-                            source._pin_prefetch_order = weakref.ref(self)
+                            self.add_source(source, index)
             self.modules.append(modules)
+
+    def add_source(self, source, index):
+        if source in self.positions:
+            return
+        self.positions[source] = index
+        pin_state = source._pin_state
+        if not any(state is pin_state for state in self.pin_states):
+            pin_state["prefetch_orders"].add(self)
+            self.pin_states.append(pin_state)
+
+    def copy_position(self, source, target):
+        index = self.positions.get(source)
+        if index is not None:
+            self.add_source(target, index)
 
     def advance(self):
         self.current += 1
@@ -66,21 +80,24 @@ class PrefetchPinOrder:
         return list(range(self.current, min(len(self.modules), self.current + self.window)))
 
     def close(self):
-        for module in self.positions:
-            order = getattr(module, "_pin_prefetch_order", None)
-            if order is not None and order() is self:
-                del module._pin_prefetch_order
+        for pin_state in self.pin_states:
+            pin_state["prefetch_orders"].discard(self)
+        self.pin_states.clear()
         self.positions.clear()
         self.modules.clear()
 
 
+def _prefetch_orders(module):
+    return [order for order in module._pin_state["prefetch_orders"] if module in order.positions]
+
+
 def prefetch_pin_state(module):
-    order = getattr(module, "_pin_prefetch_order", None)
-    order = None if order is None else order()
-    return None if order is None else order.state(module)
+    states = [state for order in _prefetch_orders(module) if (state := order.state(module)) is not None]
+    if not states:
+        return None
+    return min(states, key=lambda state: (not state[0], state[1]))
 
 
 def prefetch_budget_checked(module):
-    order = getattr(module, "_pin_prefetch_order", None)
-    order = None if order is None else order()
-    return order is not None and order.budget_checked
+    orders = _prefetch_orders(module)
+    return bool(orders) and all(order.budget_checked for order in orders)

--- a/comfy/pin_order.py
+++ b/comfy/pin_order.py
@@ -11,7 +11,7 @@ class NullPinOrder:
     def advance(self):
         self.current += 1
 
-    def protected_indices(self):
+    def preferred_indices(self):
         return []
 
     def close(self):
@@ -54,13 +54,13 @@ class PrefetchPinOrder:
             return None
         if index >= self.current:
             distance = index - self.current
-            protected = distance < self.window
+            preferred = distance < self.window
         else:
             distance = len(self.modules) + index
-            protected = False
-        return protected, distance
+            preferred = False
+        return preferred, distance
 
-    def protected_indices(self):
+    def preferred_indices(self):
         if self.current < 0:
             return []
         return list(range(self.current, min(len(self.modules), self.current + self.window)))

--- a/comfy/pin_order.py
+++ b/comfy/pin_order.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import weakref
+
+
+class NullPinOrder:
+    enabled = False
+    budget_checked = False
+    current = -1
+
+    def advance(self):
+        self.current += 1
+
+    def protected_indices(self):
+        return []
+
+    def close(self):
+        pass
+
+
+class PrefetchPinOrder:
+    enabled = True
+
+    def __init__(self, units, window=3):
+        self.window = window
+        self.current = -1
+        self.budget_checked = False
+        self.positions = weakref.WeakKeyDictionary()
+        self.modules = []
+        for index, unit in enumerate(units):
+            roots = unit if isinstance(unit, (list, tuple)) else (unit,)
+            modules = []
+            for root in roots:
+                for module in root.modules():
+                    if hasattr(module, "_v"):
+                        sources = [module]
+                        for param_key in ("weight", "bias"):
+                            lowvram_source = getattr(module, param_key + "_lowvram_function", None)
+                            if lowvram_source is not None:
+                                sources.append(lowvram_source)
+                        for source in sources:
+                            modules.append(source)
+                            self.positions[source] = index
+                            source._pin_prefetch_order = weakref.ref(self)
+            self.modules.append(modules)
+
+    def advance(self):
+        self.current += 1
+        self.budget_checked = False
+
+    def state(self, module):
+        index = self.positions.get(module)
+        if index is None or self.current < 0:
+            return None
+        if index >= self.current:
+            distance = index - self.current
+            protected = distance < self.window
+        else:
+            distance = len(self.modules) + index
+            protected = False
+        return protected, distance
+
+    def protected_indices(self):
+        if self.current < 0:
+            return []
+        return list(range(self.current, min(len(self.modules), self.current + self.window)))
+
+    def close(self):
+        for module in self.positions:
+            order = getattr(module, "_pin_prefetch_order", None)
+            if order is not None and order() is self:
+                del module._pin_prefetch_order
+        self.positions.clear()
+        self.modules.clear()
+
+
+def prefetch_pin_state(module):
+    order = getattr(module, "_pin_prefetch_order", None)
+    order = None if order is None else order()
+    return None if order is None else order.state(module)
+
+
+def prefetch_budget_checked(module):
+    order = getattr(module, "_pin_prefetch_order", None)
+    order = None if order is None else order()
+    return order is not None and order.budget_checked

--- a/comfy/pinned_memory.py
+++ b/comfy/pinned_memory.py
@@ -49,8 +49,14 @@ def _in_flight(module_pin):
 def pin_eviction_state(module, subset):
     module_pin = module._pins[subset]
     state = comfy.pin_order.prefetch_pin_state(module)
-    protected = _in_flight(module_pin) or (state is not None and state[0])
-    return protected, state
+    return _in_flight(module_pin), state
+
+
+def pin_eviction_priority(state):
+    if state is None:
+        return 1, -1
+    preferred, distance = state
+    return (0 if preferred else 2), distance
 
 
 def mark_modules_in_flight(comfy_modules, stream):
@@ -79,12 +85,12 @@ def _registered(module, subset, pin, size):
     pinned_size[0] += size
 
 
-def unregister_pin(module, subset, ignore_prefetch=False):
+def unregister_pin(module, subset):
     module_pin = module._pins[subset]
     if not module_pin["registered"]:
         return 0
     protected, _ = pin_eviction_state(module, subset)
-    if protected and not ignore_prefetch:
+    if protected:
         return 0
     pin = module_pin["pin"]
     size = pin.nbytes
@@ -121,7 +127,7 @@ def _steal_pin(module, stack, buckets, size, priority, subset):
 
     incoming_state = comfy.pin_order.prefetch_pin_state(module)
     victim_index = None
-    victim_distance = -1
+    victim_key = None
     for index in range(len(bucket) - 1, -1, -1):
         *_, candidate = bucket[index]
         if candidate is None:
@@ -132,10 +138,10 @@ def _steal_pin(module, stack, buckets, size, priority, subset):
         ordered_reuse = incoming_state is not None and incoming_state[0] and candidate_state is not None
         if not ordered_reuse and priority <= -bucket[index][0]:
             continue
-        distance = -1 if candidate_state is None else candidate_state[1]
-        if victim_index is None or distance > victim_distance:
+        candidate_key = pin_eviction_priority(candidate_state)
+        if victim_key is None or candidate_key > victim_key:
             victim_index = index
-            victim_distance = distance
+            victim_key = candidate_key
     if victim_index is None:
         return False
 
@@ -173,9 +179,8 @@ def get_pin(module, subset="weights"):
             return pin
         if comfy.model_management.ensure_pin_registerable(0, device=device, protected=protected):
             return pin
-        if not _in_flight(module_pin):
-            if unregister_pin(module, subset, ignore_prefetch=True):
-                PIN_SCHEDULER_STATS["pageable_prefetches"] += 1
+        if unregister_pin(module, subset):
+            PIN_SCHEDULER_STATS["pageable_prefetches"] += 1
         return pin
 
     live_budget = comfy.model_management.has_live_pin_budget(device)

--- a/comfy/pinned_memory.py
+++ b/comfy/pinned_memory.py
@@ -2,12 +2,104 @@ import bisect
 
 import comfy.model_management
 import comfy.memory_management
+import comfy.pin_order
 import comfy.utils
 import comfy_aimdo.host_buffer
 import comfy_aimdo.torch
 import torch
 
 from comfy.cli_args import args
+
+
+PIN_SCHEDULER_STATS = {
+    "register_failures": 0,
+    "pageable_prefetches": 0,
+    "evicted": 0,
+}
+
+
+def _host_register(pin, size):
+    return torch.cuda.cudart().cudaHostRegister(pin.data_ptr(), size, 1)
+
+
+def _host_unregister(pin):
+    return torch.cuda.cudart().cudaHostUnregister(pin.data_ptr())
+
+
+def _pin_device(module):
+    return module._pin_state.get("device")
+
+
+def copy_prefetch_order(source, target):
+    order = getattr(source, "_pin_prefetch_order", None)
+    if order is not None:
+        target._pin_prefetch_order = order
+
+
+def _in_flight(module_pin):
+    event = module_pin.get("in_flight")
+    if event is None:
+        return False
+    if not event.query():
+        return True
+    del module_pin["in_flight"]
+    return False
+
+
+def pin_eviction_state(module, subset):
+    module_pin = module._pins[subset]
+    state = comfy.pin_order.prefetch_pin_state(module)
+    protected = _in_flight(module_pin) or (state is not None and state[0])
+    return protected, state
+
+
+def mark_modules_in_flight(comfy_modules, stream):
+    if stream is None:
+        return
+    event = torch.cuda.Event()
+    event.record(stream)
+    for module in comfy_modules:
+        sources = [module]
+        for param_key in ("weight", "bias"):
+            lowvram_source = getattr(module, param_key + "_lowvram_function", None)
+            if lowvram_source is not None:
+                sources.append(lowvram_source)
+        for source in sources:
+            for module_pin in source.__dict__.get("_pins", {}).values():
+                if module_pin.get("registered"):
+                    module_pin["in_flight"] = event
+
+
+def _registered(module, subset, pin, size):
+    module_pin = module._pins[subset]
+    _, _, stack_split, pinned_size, *_ = module._pin_state[subset]
+    module_pin["registered"] = True
+    stack_split[0] = max(stack_split[0], module_pin["stack_index"])
+    comfy.model_management.TOTAL_PINNED_MEMORY += size
+    pinned_size[0] += size
+
+
+def unregister_pin(module, subset, ignore_prefetch=False):
+    module_pin = module._pins[subset]
+    if not module_pin["registered"]:
+        return 0
+    protected, _ = pin_eviction_state(module, subset)
+    if protected and not ignore_prefetch:
+        return 0
+    pin = module_pin["pin"]
+    size = pin.nbytes
+    if _host_unregister(pin) != 0:
+        comfy.model_management.discard_cuda_async_error()
+        return 0
+
+    module_pin["registered"] = False
+    _, stack, stack_split, pinned_size, *_ = module._pin_state[subset]
+    while stack_split[0] >= 0 and not stack[stack_split[0]][0]._pins[subset]["registered"]:
+        stack_split[0] -= 1
+    comfy.model_management.TOTAL_PINNED_MEMORY = max(0, comfy.model_management.TOTAL_PINNED_MEMORY - size)
+    pinned_size[0] = max(0, pinned_size[0] - size)
+    PIN_SCHEDULER_STATS["evicted"] += size
+    return size
 
 def _add_to_bucket(module, module_pin, buckets, size, priority):
     bucket = buckets.setdefault(size, [])
@@ -27,10 +119,27 @@ def _steal_pin(module, stack, buckets, size, priority, subset):
         del buckets[size]
         return False
 
-    if priority <= -bucket[-1][0]:
+    incoming_state = comfy.pin_order.prefetch_pin_state(module)
+    victim_index = None
+    victim_distance = -1
+    for index in range(len(bucket) - 1, -1, -1):
+        *_, candidate = bucket[index]
+        if candidate is None:
+            continue
+        protected, candidate_state = pin_eviction_state(candidate, subset)
+        if protected:
+            continue
+        ordered_reuse = incoming_state is not None and incoming_state[0] and candidate_state is not None
+        if not ordered_reuse and priority <= -bucket[index][0]:
+            continue
+        distance = -1 if candidate_state is None else candidate_state[1]
+        if victim_index is None or distance > victim_distance:
+            victim_index = index
+            victim_distance = distance
+    if victim_index is None:
         return False
 
-    *_, victim = bucket.pop()
+    *_, victim = bucket.pop(victim_index)
     module_pin = module._pins[subset]
     victim_pin = victim._pins[subset]
     module_pin["pin"] = victim_pin["pin"]
@@ -51,21 +160,43 @@ def get_pin(module, subset="weights"):
     pins = module.__dict__.get("_pins")
     module_pin = None if pins is None else pins.get(subset)
     pin = None if module_pin is None else module_pin.get("pin")
-    if pin is None or module_pin["registered"] or args.disable_pinned_memory:
+    if pin is None or args.disable_pinned_memory:
         return pin
 
-    _, _, stack_split, pinned_size, *_ = module._pin_state[subset]
     size = pin.nbytes
-    comfy.model_management.ensure_pin_registerable(size)
-
-    if torch.cuda.cudart().cudaHostRegister(pin.data_ptr(), size, 1) != 0:
-        comfy.model_management.discard_cuda_async_error()
+    device = _pin_device(module)
+    protected = {(module, subset)}
+    if module_pin["registered"]:
+        if not comfy.model_management.has_live_pin_budget(device):
+            return pin
+        if comfy.pin_order.prefetch_budget_checked(module):
+            return pin
+        if comfy.model_management.ensure_pin_registerable(0, device=device, protected=protected):
+            return pin
+        if not _in_flight(module_pin):
+            if unregister_pin(module, subset, ignore_prefetch=True):
+                PIN_SCHEDULER_STATS["pageable_prefetches"] += 1
         return pin
 
-    module_pin["registered"] = True
-    stack_split[0] = max(stack_split[0], module_pin["stack_index"])
-    comfy.model_management.TOTAL_PINNED_MEMORY += size
-    pinned_size[0] += size
+    live_budget = comfy.model_management.has_live_pin_budget(device)
+    registerable = comfy.model_management.ensure_pin_registerable(size, device=device, protected=protected)
+    if live_budget and not registerable:
+        PIN_SCHEDULER_STATS["pageable_prefetches"] += 1
+        return pin
+
+    if _host_register(pin, size) != 0:
+        PIN_SCHEDULER_STATS["register_failures"] += 1
+        comfy.model_management.discard_cuda_async_error()
+        if not live_budget:
+            return pin
+        comfy.model_management.free_registrations(size, protected=protected, prefetch_first=True)
+        if _host_register(pin, size) != 0:
+            PIN_SCHEDULER_STATS["register_failures"] += 1
+            comfy.model_management.discard_cuda_async_error()
+            PIN_SCHEDULER_STATS["pageable_prefetches"] += 1
+            return pin
+
+    _registered(module, subset, pin, size)
     return pin
 
 def pin_memory(module, subset="weights", size=None):
@@ -79,7 +210,7 @@ def pin_memory(module, subset="weights", size=None):
 
     pins = module.__dict__.setdefault("_pins", {})
     module_pin = pins.setdefault(subset, {})
-    hostbuf, stack, stack_split, pinned_size, counter, buckets = pin_state[subset]
+    hostbuf, stack, _, _, counter, buckets = pin_state[subset]
     if size is None:
         size = comfy.memory_management.vram_aligned_size([ module.weight, module.bias ])
     registerable_size = size
@@ -92,8 +223,9 @@ def pin_memory(module, subset="weights", size=None):
         module_pin["balancer_priority"] = priority
 
     comfy.memory_management.extra_ram_release(comfy.memory_management.RAM_CACHE_HEADROOM)
-    if (not comfy.model_management.ensure_pin_budget(size, loaded=loaded) or
-        not comfy.model_management.ensure_pin_registerable(registerable_size)):
+    protected = {(module, subset)}
+    if (not comfy.model_management.ensure_pin_budget(size, loaded=loaded, device=_pin_device(module), protected=protected) or
+        not comfy.model_management.ensure_pin_registerable(registerable_size, device=_pin_device(module), protected=protected)):
         return _steal_pin(module, stack, buckets, size, priority, subset)
 
     offset = hostbuf.size
@@ -103,10 +235,12 @@ def pin_memory(module, subset="weights", size=None):
         extended = True
         pin = comfy_aimdo.torch.hostbuf_to_tensor(hostbuf)[offset:offset + size]
         pin.untyped_storage()._comfy_hostbuf = hostbuf
-        if torch.cuda.cudart().cudaHostRegister(pin.data_ptr(), size, 1) != 0:
+        if _host_register(pin, size) != 0:
+            PIN_SCHEDULER_STATS["register_failures"] += 1
             comfy.model_management.discard_cuda_async_error()
-            comfy.model_management.free_registrations(size)
-            if torch.cuda.cudart().cudaHostRegister(pin.data_ptr(), size, 1) != 0:
+            comfy.model_management.free_registrations(size, protected={(module, subset)}, prefetch_first=True)
+            if _host_register(pin, size) != 0:
+                PIN_SCHEDULER_STATS["register_failures"] += 1
                 comfy.model_management.discard_cuda_async_error()
                 del pin
                 hostbuf.truncate(offset, do_unregister=False)
@@ -118,10 +252,7 @@ def pin_memory(module, subset="weights", size=None):
 
     module_pin["pin"] = pin
     stack.append((module, offset))
-    module_pin["registered"] = True
     module_pin["stack_index"] = len(stack) - 1
-    stack_split[0] = max(stack_split[0], module_pin["stack_index"])
-    comfy.model_management.TOTAL_PINNED_MEMORY += size
-    pinned_size[0] += size
+    _registered(module, subset, pin, size)
     _add_to_bucket(module, module_pin, buckets, size, priority)
     return True

--- a/comfy/pinned_memory.py
+++ b/comfy/pinned_memory.py
@@ -31,9 +31,8 @@ def _pin_device(module):
 
 
 def copy_prefetch_order(source, target):
-    order = getattr(source, "_pin_prefetch_order", None)
-    if order is not None:
-        target._pin_prefetch_order = order
+    for order in tuple(source._pin_state["prefetch_orders"]):
+        order.copy_position(source, target)
 
 
 def _in_flight(module_pin):

--- a/comfy/pinned_memory.py
+++ b/comfy/pinned_memory.py
@@ -107,6 +107,63 @@ def unregister_pin(module, subset):
     PIN_SCHEDULER_STATS["evicted"] += size
     return size
 
+
+def unregister_inactive_pins(pin_state, ram_to_unload, subsets, protected=None, prefetch_only=False):
+    freed = 0
+    for subset in subsets:
+        _, stack, stack_split, *_ = pin_state[subset]
+        candidates = []
+        for stack_index in range(stack_split[0] + 1):
+            module, _ = stack[stack_index]
+            module_pin = module._pins[subset]
+            if not module_pin["registered"]:
+                continue
+            if protected is not None and (module, subset) in protected:
+                continue
+            is_protected, order_state = pin_eviction_state(module, subset)
+            preferred = order_state is not None and order_state[0]
+            if is_protected or (prefetch_only and (order_state is None or preferred)):
+                continue
+            candidates.append((*pin_eviction_priority(order_state), stack_index, module))
+
+        candidates.sort(reverse=True, key=lambda entry: entry[:3])
+        for *_, module in candidates:
+            size = unregister_pin(module, subset)
+            freed += size
+            ram_to_unload -= size
+            if ram_to_unload <= 0:
+                return freed
+    return freed
+
+
+def partially_unload_ram(pin_state, ram_to_unload, subsets, protected=None):
+    freed = 0
+    for subset in subsets:
+        hostbuf, stack, stack_split, pinned_size, *_ = pin_state[subset]
+        while len(stack) > 0:
+            module, offset = stack.pop()
+            module_pin = module._pins[subset]
+            is_protected, _ = pin_eviction_state(module, subset)
+            if is_protected or (protected is not None and (module, subset) in protected):
+                stack.append((module, offset))
+                break
+            pin = module_pin["pin"]
+            size = pin.numel() * pin.element_size()
+            module_pin["balancer_entry"][-1] = None
+            del module_pin["balancer_entry"]
+            del module_pin["pin"]
+            registered = module_pin["registered"]
+            hostbuf.truncate(offset, do_unregister=registered)
+            stack_split[0] = min(stack_split[0], len(stack) - 1)
+            if registered:
+                comfy.model_management.TOTAL_PINNED_MEMORY = max(0, comfy.model_management.TOTAL_PINNED_MEMORY - size)
+                pinned_size[0] = max(0, pinned_size[0] - size)
+            freed += size
+            ram_to_unload -= size
+            if ram_to_unload <= 0:
+                return freed
+    return freed
+
 def _add_to_bucket(module, module_pin, buckets, size, priority):
     bucket = buckets.setdefault(size, [])
     entry = [-priority, 0, module]

--- a/comfy/windows_dxgi.py
+++ b/comfy/windows_dxgi.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import ctypes
+import logging
+import platform
+import uuid
+from dataclasses import dataclass
+
+
+DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL = 1
+DXGI_ERROR_NOT_FOUND = 0x887A0002
+
+
+class DXGIUnavailable(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class VideoMemoryInfo:
+    budget: int
+    current_usage: int
+    available_for_reservation: int = 0
+    current_reservation: int = 0
+
+
+def safe_headroom(info, reserve):
+    return max(0, info.budget - info.current_usage - reserve)
+
+
+class LivePinBudget:
+    def __init__(self, provider, reserve, hysteresis):
+        self.provider = provider
+        self.reserve = reserve
+        self.hysteresis = hysteresis
+        self.last_info = None
+        self.last_headroom = None
+        self.evicted = 0
+
+    def ensure(self, size, evict):
+        info = self.provider.query()
+        self.last_info = info
+        margin = info.budget - info.current_usage - self.reserve
+        self.last_headroom = max(0, margin)
+        if margin >= size:
+            return True
+
+        self.evicted += evict(size - margin + self.hysteresis)
+        info = self.provider.query()
+        self.last_info = info
+        margin = info.budget - info.current_usage - self.reserve
+        self.last_headroom = max(0, margin)
+        return margin >= size
+
+
+class _GUID(ctypes.Structure):
+    _fields_ = [
+        ("Data1", ctypes.c_uint32),
+        ("Data2", ctypes.c_uint16),
+        ("Data3", ctypes.c_uint16),
+        ("Data4", ctypes.c_ubyte * 8),
+    ]
+
+    def __init__(self, value):
+        parsed = uuid.UUID(value)
+        super().__init__(parsed.time_low, parsed.time_mid, parsed.time_hi_version, (ctypes.c_ubyte * 8)(*parsed.bytes[8:]))
+
+
+class _LUID(ctypes.Structure):
+    _fields_ = [("LowPart", ctypes.c_uint32), ("HighPart", ctypes.c_int32)]
+
+
+class _DXGI_ADAPTER_DESC1(ctypes.Structure):
+    _fields_ = [
+        ("Description", ctypes.c_wchar * 128),
+        ("VendorId", ctypes.c_uint32),
+        ("DeviceId", ctypes.c_uint32),
+        ("SubSysId", ctypes.c_uint32),
+        ("Revision", ctypes.c_uint32),
+        ("DedicatedVideoMemory", ctypes.c_size_t),
+        ("DedicatedSystemMemory", ctypes.c_size_t),
+        ("SharedSystemMemory", ctypes.c_size_t),
+        ("AdapterLuid", _LUID),
+        ("Flags", ctypes.c_uint32),
+    ]
+
+
+class _DXGI_QUERY_VIDEO_MEMORY_INFO(ctypes.Structure):
+    _fields_ = [
+        ("Budget", ctypes.c_uint64),
+        ("CurrentUsage", ctypes.c_uint64),
+        ("AvailableForReservation", ctypes.c_uint64),
+        ("CurrentReservation", ctypes.c_uint64),
+    ]
+
+
+_IID_IDXGIFACTORY1 = _GUID("770aae78-f26f-4dba-a829-253c83d1b387")
+_IID_IDXGIADAPTER3 = _GUID("645967a4-1392-4310-a798-8053ce3e93fd")
+_COMFUNCTYPE = getattr(ctypes, "WINFUNCTYPE", ctypes.CFUNCTYPE)
+
+
+def _com_method(pointer, index, result_type, *argument_types):
+    vtable = ctypes.cast(pointer, ctypes.POINTER(ctypes.POINTER(ctypes.c_void_p))).contents
+    return _COMFUNCTYPE(result_type, ctypes.c_void_p, *argument_types)(vtable[index])
+
+
+def _release(pointer):
+    if pointer:
+        _com_method(pointer, 2, ctypes.c_ulong)(pointer)
+
+
+class _DXGIAdapter:
+    def __init__(self, pointer, luid, description):
+        self.pointer = pointer
+        self.luid = luid
+        self.description = description
+
+    def close(self):
+        pointer = self.pointer
+        self.pointer = None
+        _release(pointer)
+
+    def query(self, node_index=0):
+        info = _DXGI_QUERY_VIDEO_MEMORY_INFO()
+        result = _com_method(
+            self.pointer,
+            14,
+            ctypes.c_long,
+            ctypes.c_uint32,
+            ctypes.c_int,
+            ctypes.POINTER(_DXGI_QUERY_VIDEO_MEMORY_INFO),
+        )(self.pointer, node_index, DXGI_MEMORY_SEGMENT_GROUP_NON_LOCAL, ctypes.byref(info))
+        if result != 0:
+            raise DXGIUnavailable(f"QueryVideoMemoryInfo failed with HRESULT 0x{result & 0xffffffff:08x}")
+        return VideoMemoryInfo(info.Budget, info.CurrentUsage, info.AvailableForReservation, info.CurrentReservation)
+
+    def __del__(self):
+        self.close()
+
+
+def _enumerate_adapters():
+    dxgi = ctypes.WinDLL("dxgi.dll")
+    create_factory = dxgi.CreateDXGIFactory1
+    create_factory.argtypes = [ctypes.POINTER(_GUID), ctypes.POINTER(ctypes.c_void_p)]
+    create_factory.restype = ctypes.c_long
+
+    factory = ctypes.c_void_p()
+    result = create_factory(ctypes.byref(_IID_IDXGIFACTORY1), ctypes.byref(factory))
+    if result != 0:
+        raise DXGIUnavailable(f"CreateDXGIFactory1 failed with HRESULT 0x{result & 0xffffffff:08x}")
+
+    adapters = []
+    try:
+        enum_adapters = _com_method(factory, 12, ctypes.c_long, ctypes.c_uint32, ctypes.POINTER(ctypes.c_void_p))
+        index = 0
+        while True:
+            adapter1 = ctypes.c_void_p()
+            result = enum_adapters(factory, index, ctypes.byref(adapter1))
+            if result & 0xffffffff == DXGI_ERROR_NOT_FOUND:
+                break
+            if result != 0:
+                raise DXGIUnavailable(f"EnumAdapters1 failed with HRESULT 0x{result & 0xffffffff:08x}")
+
+            try:
+                desc = _DXGI_ADAPTER_DESC1()
+                result = _com_method(adapter1, 10, ctypes.c_long, ctypes.POINTER(_DXGI_ADAPTER_DESC1))(adapter1, ctypes.byref(desc))
+                if result != 0:
+                    raise DXGIUnavailable(f"GetDesc1 failed with HRESULT 0x{result & 0xffffffff:08x}")
+
+                adapter3 = ctypes.c_void_p()
+                result = _com_method(adapter1, 0, ctypes.c_long, ctypes.POINTER(_GUID), ctypes.POINTER(ctypes.c_void_p))(
+                    adapter1, ctypes.byref(_IID_IDXGIADAPTER3), ctypes.byref(adapter3)
+                )
+                if result == 0:
+                    luid = ctypes.string_at(ctypes.byref(desc.AdapterLuid), ctypes.sizeof(desc.AdapterLuid))
+                    adapters.append(_DXGIAdapter(adapter3, luid, desc.Description))
+            finally:
+                _release(adapter1)
+            index += 1
+    except Exception:
+        for adapter in adapters:
+            adapter.close()
+        raise
+    finally:
+        _release(factory)
+    return adapters
+
+
+def _cuda_device_luid(device_index):
+    cuda = ctypes.WinDLL("nvcuda.dll")
+    cuda.cuInit.argtypes = [ctypes.c_uint]
+    cuda.cuInit.restype = ctypes.c_int
+    cuda.cuDeviceGet.argtypes = [ctypes.POINTER(ctypes.c_int), ctypes.c_int]
+    cuda.cuDeviceGet.restype = ctypes.c_int
+    cuda.cuDeviceGetLuid.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint), ctypes.c_int]
+    cuda.cuDeviceGetLuid.restype = ctypes.c_int
+
+    if cuda.cuInit(0) != 0:
+        raise DXGIUnavailable("cuInit failed")
+    device = ctypes.c_int()
+    if cuda.cuDeviceGet(ctypes.byref(device), device_index) != 0:
+        raise DXGIUnavailable(f"CUDA device {device_index} is unavailable")
+    luid = (ctypes.c_ubyte * 8)()
+    node_mask = ctypes.c_uint()
+    if cuda.cuDeviceGetLuid(ctypes.byref(luid), ctypes.byref(node_mask), device) != 0:
+        raise DXGIUnavailable(f"CUDA device {device_index} has no Windows LUID")
+    if node_mask.value == 0 or node_mask.value & (node_mask.value - 1):
+        raise DXGIUnavailable(f"CUDA device {device_index} has ambiguous DXGI node mask 0x{node_mask.value:x}")
+    return bytes(luid), node_mask.value.bit_length() - 1
+
+
+class DXGINonLocalBudgetProvider:
+    def __init__(self, device_index, cuda_luid_getter=_cuda_device_luid, adapter_enumerator=_enumerate_adapters):
+        self.adapter = None
+        cuda_mapping = cuda_luid_getter(device_index)
+        if isinstance(cuda_mapping, tuple):
+            cuda_luid, self.node_index = cuda_mapping
+        else:
+            cuda_luid, self.node_index = cuda_mapping, 0
+        adapters = adapter_enumerator()
+        matches = [adapter for adapter in adapters if adapter.luid == cuda_luid]
+        if len(matches) != 1:
+            for adapter in adapters:
+                adapter.close()
+            raise DXGIUnavailable(f"CUDA device {device_index} matched {len(matches)} DXGI adapters")
+        self.adapter = matches[0]
+        for adapter in adapters:
+            if adapter is not self.adapter:
+                adapter.close()
+
+    def query(self):
+        return self.adapter.query(self.node_index)
+
+    def close(self):
+        adapter = self.adapter
+        self.adapter = None
+        if adapter is not None:
+            adapter.close()
+
+    def __del__(self):
+        self.close()
+
+
+def create_dxgi_budget_provider(device_index):
+    if platform.system() != "Windows":
+        return None
+    try:
+        return DXGINonLocalBudgetProvider(device_index)
+    except (AttributeError, OSError, DXGIUnavailable) as err:
+        logging.debug("DXGI NON_LOCAL pin budget unavailable for CUDA device %s: %s", device_index, err)
+        return None

--- a/comfy/windows_dxgi.py
+++ b/comfy/windows_dxgi.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ctypes
 import logging
 import platform
+import time
 import uuid
 from dataclasses import dataclass
 
@@ -35,9 +36,22 @@ class LivePinBudget:
         self.last_info = None
         self.last_headroom = None
         self.evicted = 0
+        self.query_count = 0
+        self.query_ns = 0
+        self.max_query_ns = 0
+
+    def query(self):
+        start = time.perf_counter_ns()
+        try:
+            return self.provider.query()
+        finally:
+            elapsed = time.perf_counter_ns() - start
+            self.query_count += 1
+            self.query_ns += elapsed
+            self.max_query_ns = max(self.max_query_ns, elapsed)
 
     def ensure(self, size, evict):
-        info = self.provider.query()
+        info = self.query()
         self.last_info = info
         margin = info.budget - info.current_usage - self.reserve
         self.last_headroom = max(0, margin)
@@ -45,7 +59,7 @@ class LivePinBudget:
             return True
 
         self.evicted += evict(size - margin + self.hysteresis)
-        info = self.provider.query()
+        info = self.query()
         self.last_info = info
         margin = info.budget - info.current_usage - self.reserve
         self.last_headroom = max(0, margin)

--- a/script_examples/bench_aimdo_pin_scheduler.py
+++ b/script_examples/bench_aimdo_pin_scheduler.py
@@ -1,0 +1,376 @@
+"""Exercise AIMDO pin scheduling with real CUDA host registrations and H2D copies.
+
+The synthetic-baseline policy disables live DXGI budgeting and expects the
+injected Windows registration ceiling to return cudaErrorMemoryAllocation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import importlib.metadata
+import json
+import os
+from pathlib import Path
+import platform
+import sys
+import types
+
+
+MiB = 1024 ** 2
+GiB = 1024 ** 3
+RESULT_PREFIX = "AIMDO_PIN_SCHEDULER_RESULT="
+COMFY_ROOT = Path(__file__).resolve().parents[1]
+if str(COMFY_ROOT) not in sys.path:
+    sys.path.insert(0, str(COMFY_ROOT))
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device", type=int, default=0)
+    parser.add_argument("--blocks", type=int, default=50)
+    parser.add_argument("--block-mib", type=int, default=4)
+    parser.add_argument("--policy", choices=("synthetic", "synthetic-baseline", "native", "heuristic"), required=True)
+    parser.add_argument("--delay-cycles", type=int, default=5_000_000)
+    parser.add_argument("--output")
+    parser.add_argument("--i-understand-this-uses-gpu", action="store_true")
+    args = parser.parse_args()
+    if not args.i_understand_this_uses_gpu:
+        parser.error("pass --i-understand-this-uses-gpu after the required idle-GPU preflight")
+    if args.blocks < 6 or args.block_mib <= 0 or args.delay_cycles < 0:
+        parser.error("blocks must be at least 6 and sizes/delays must be non-negative")
+    return args
+
+
+class SyntheticBudgetProvider:
+    def __init__(self, model_management, capacity):
+        self.model_management = model_management
+        self.capacity = capacity
+        self.external_usage = 4 * GiB
+        self.reserve = model_management.WINDOWS_PIN_SAFETY_RESERVE
+
+    def query(self):
+        from comfy.windows_dxgi import VideoMemoryInfo
+
+        return VideoMemoryInfo(
+            self.external_usage + self.reserve + self.capacity,
+            self.external_usage + self.model_management.TOTAL_PINNED_MEMORY,
+        )
+
+    def close(self):
+        pass
+
+
+class Block:
+    def __init__(self, torch, index, pin_state):
+        self.index = index
+        self._v = object()
+        self._pin_state = pin_state
+        self.weight = torch.empty(0)
+        self.bias = None
+
+    def modules(self):
+        return (self,)
+
+
+def empty_bucket(host_buffer):
+    return (host_buffer.HostBuffer(0, 0, 0), [], [-1], [0], [0], {})
+
+
+def make_pin_state(host_buffer, device, total_bytes):
+    def bucket():
+        return (host_buffer.HostBuffer(0, 0, total_bytes), [], [-1], [0], [0], {})
+
+    return {
+        "device": device,
+        "active": True,
+        "current_prompt": True,
+        "weights": bucket(),
+        "weights-loaded": empty_bucket(host_buffer),
+        "patches": empty_bucket(host_buffer),
+        "patches-loaded": empty_bucket(host_buffer),
+    }
+
+
+def make_patcher(pinned_memory, pin_state, device):
+    model = types.SimpleNamespace(dynamic_pins={device: pin_state})
+    patcher = types.SimpleNamespace(model=model, load_device=device)
+    patcher.is_dynamic = lambda: True
+
+    def unregister_inactive_pins(self, ram_to_unload, subsets=("weights-loaded", "patches-loaded", "weights", "patches"), protected=None, prefetch_only=False):
+        state = self.model.dynamic_pins[self.load_device]
+        return pinned_memory.unregister_inactive_pins(state, ram_to_unload, subsets, protected=protected, prefetch_only=prefetch_only)
+
+    def partially_unload_ram(self, ram_to_unload, subsets=("weights-loaded", "patches-loaded", "weights", "patches"), protected=None):
+        state = self.model.dynamic_pins[self.load_device]
+        return pinned_memory.partially_unload_ram(state, ram_to_unload, subsets, protected=protected)
+
+    patcher.unregister_inactive_pins = types.MethodType(unregister_inactive_pins, patcher)
+    patcher.partially_unload_ram = types.MethodType(partially_unload_ram, patcher)
+    return patcher
+
+
+def registered_bytes(blocks):
+    return sum(
+        block._pins["weights"]["pin"].nbytes
+        for block in blocks
+        if block.__dict__.get("_pins", {}).get("weights", {}).get("registered")
+    )
+
+
+def run(args):
+    os.environ.setdefault(
+        "PYTORCH_CUDA_ALLOC_CONF",
+        "backend:native,garbage_collection_threshold:0.95,expandable_segments:False",
+    )
+    sys.argv = [sys.argv[0], "--enable-dynamic-vram", "--async-offload", "2"]
+
+    import comfy.options
+
+    comfy.options.enable_args_parsing()
+    import comfy_aimdo.control as aimdo_control
+
+    if not aimdo_control.init():
+        raise RuntimeError("AIMDO native library initialization failed")
+
+    import torch
+    import comfy.model_management as model_management
+    import comfy.pin_order as pin_order
+    import comfy.pinned_memory as pinned_memory
+    import comfy.system_memory
+    import comfy_aimdo.host_buffer as host_buffer
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is unavailable")
+    if args.device >= torch.cuda.device_count():
+        raise RuntimeError(f"CUDA device {args.device} is unavailable")
+    if args.policy == "native" and platform.system() != "Windows":
+        raise RuntimeError("native DXGI policy is Windows-only")
+    if args.policy.startswith("synthetic") and platform.system() != "Windows":
+        raise RuntimeError("synthetic Windows policies are Windows-only")
+    if args.policy == "heuristic" and platform.system() == "Windows":
+        raise RuntimeError("heuristic policy is for the non-Windows run")
+
+    device = torch.device("cuda", args.device)
+    torch.cuda.set_device(device)
+    if not aimdo_control.init_device(args.device):
+        raise RuntimeError(f"AIMDO device {args.device} initialization failed")
+
+    block_bytes = args.block_mib * MiB
+    pin_state = make_pin_state(host_buffer, device, args.blocks * block_bytes)
+    blocks = [Block(torch, index, pin_state) for index in range(args.blocks)]
+    patcher = make_patcher(pinned_memory, pin_state, device)
+    loaded = types.SimpleNamespace(model=patcher)
+    order = pin_order.PrefetchPinOrder(blocks, window=3)
+    streams = [torch.cuda.Stream(device=device), torch.cuda.Stream(device=device)]
+    pending = []
+    observations = []
+    failures = []
+    peak_registered = 0
+    hard_protection_checks = 0
+    original_max = model_management.MAX_PINNED_MEMORY
+    original_available = comfy.system_memory.virtual_memory_available
+    original_stats = dict(pinned_memory.PIN_SCHEDULER_STATS)
+    original_host_register = pinned_memory._host_register
+    provider = None
+    synthetic_cuda_ooms = []
+    budget_violations = []
+
+    def capacity_for(index):
+        if args.policy == "native":
+            return None
+        if index < args.blocks // 3:
+            return 6 * block_bytes
+        if index < (2 * args.blocks) // 3:
+            return 2 * block_bytes
+        return 4 * block_bytes
+
+    def validate(entry):
+        entry["event"].synchronize()
+        error_count = int((entry["output"] != entry["expected"]).sum().item())
+        if error_count:
+            failures.append(f"block {entry['index']} H2D mismatch in {error_count} bytes")
+
+    current_capacity = capacity_for(0)
+
+    def capacity_limited_host_register(pin, size):
+        if model_management.TOTAL_PINNED_MEMORY + size > current_capacity:
+            synthetic_cuda_ooms.append({
+                "block": order.current,
+                "registered_bytes": model_management.TOTAL_PINNED_MEMORY,
+                "requested_bytes": size,
+                "capacity_bytes": current_capacity,
+                "cuda_error": "cudaErrorMemoryAllocation",
+                "cuda_error_code": 2,
+            })
+            return 2
+        return original_host_register(pin, size)
+
+    model_management.current_loaded_models.append(loaded)
+    model_management.TOTAL_PINNED_MEMORY = 0
+    for key in pinned_memory.PIN_SCHEDULER_STATS:
+        pinned_memory.PIN_SCHEDULER_STATS[key] = 0
+    comfy.system_memory.virtual_memory_available = lambda: 1 << 60
+    if args.policy == "synthetic":
+        provider = SyntheticBudgetProvider(model_management, capacity_for(0))
+        model_management.set_pin_budget_provider(device, provider)
+        pinned_memory._host_register = capacity_limited_host_register
+    elif args.policy == "synthetic-baseline":
+        model_management.set_pin_budget_provider(device, None)
+        model_management.MAX_PINNED_MEMORY = args.blocks * block_bytes
+        pinned_memory._host_register = capacity_limited_host_register
+    elif args.policy == "heuristic":
+        model_management.MAX_PINNED_MEMORY = capacity_for(0)
+
+    torch.cuda.synchronize(device)
+    try:
+        for index, block in enumerate(blocks):
+            while len(pending) >= 2:
+                validate(pending.pop(0))
+
+            for entry in pending:
+                if not entry["event"].query():
+                    hard_protection_checks += 1
+                    state = entry["block"]._pins["weights"]
+                    if not state.get("registered"):
+                        failures.append(f"block {entry['index']} was unregistered during H2D")
+
+            order.advance()
+            capacity = capacity_for(index)
+            current_capacity = capacity
+            if provider is not None:
+                provider.capacity = capacity
+                order.budget_checked = model_management.ensure_pin_registerable(0, device=device)
+            elif capacity is not None and args.policy != "synthetic-baseline":
+                model_management.MAX_PINNED_MEMORY = capacity
+
+            low_ram_injected = index == args.blocks // 2
+            if low_ram_injected:
+                comfy.system_memory.virtual_memory_available = lambda: 0
+            try:
+                pinned_memory.pin_memory(block, size=block_bytes)
+            finally:
+                comfy.system_memory.virtual_memory_available = lambda: 1 << 60
+
+            module_pin = block.__dict__.get("_pins", {}).get("weights", {})
+            pin = module_pin.get("pin")
+            if pin is None:
+                failures.append(f"block {index} obtained no host buffer")
+                continue
+            registered = bool(module_pin.get("registered"))
+            pin.fill_(index % 251)
+            stream = streams[index % len(streams)]
+            output = torch.empty(block_bytes, dtype=torch.uint8, device=device)
+            with torch.cuda.stream(stream):
+                if args.delay_cycles:
+                    torch.cuda._sleep(args.delay_cycles)
+                output.copy_(pin, non_blocking=True)
+                event = torch.cuda.Event()
+                event.record(stream)
+            pinned_memory.mark_modules_in_flight([block], stream)
+            pending.append({
+                "index": index,
+                "block": block,
+                "event": event,
+                "output": output,
+                "expected": index % 251,
+            })
+
+            current_registered = registered_bytes(blocks)
+            peak_registered = max(peak_registered, current_registered)
+            if capacity is not None and current_registered > capacity:
+                violation = {
+                    "block": index,
+                    "registered_bytes": current_registered,
+                    "capacity_bytes": capacity,
+                }
+                budget_violations.append(violation)
+                if args.policy != "synthetic-baseline":
+                    failures.append(
+                        f"block {index} registered {current_registered} bytes above capacity {capacity}"
+                    )
+            if capacity is None or capacity >= block_bytes:
+                if not registered:
+                    failures.append(f"block {index} was pageable although one block fit")
+            observations.append({
+                "block": index,
+                "capacity_bytes": capacity,
+                "registered_bytes": current_registered,
+                "registered_before_h2d": registered,
+                "preferred": order.preferred_indices(),
+                "low_ram_injected": low_ram_injected,
+            })
+
+        while pending:
+            validate(pending.pop(0))
+
+        query_stats = model_management.pin_budget_query_stats(device)
+        if args.policy == "synthetic-baseline" and not synthetic_cuda_ooms:
+            failures.append("baseline did not reach the injected cudaErrorMemoryAllocation boundary")
+        if args.policy != "synthetic-baseline" and synthetic_cuda_ooms:
+            failures.append("scheduler attempted registration above the injected Windows capacity")
+        status = "pass"
+        if failures:
+            status = "fail"
+        elif args.policy == "synthetic-baseline":
+            status = "expected_cuda_oom"
+        result = {
+            "schema": 1,
+            "status": status,
+            "failures": failures,
+            "platform": platform.platform(),
+            "policy": args.policy,
+            "aimdo_version": importlib.metadata.version("comfy-aimdo"),
+            "torch_version": torch.__version__,
+            "cuda_version": torch.version.cuda,
+            "device": torch.cuda.get_device_name(device),
+            "blocks": args.blocks,
+            "block_bytes": block_bytes,
+            "preferred_window": order.window,
+            "peak_registered_bytes": peak_registered,
+            "final_registered_bytes": registered_bytes(blocks),
+            "hard_protection_checks": hard_protection_checks,
+            "synthetic_cuda_ooms": synthetic_cuda_ooms,
+            "budget_violations": budget_violations,
+            "scheduler_stats": dict(pinned_memory.PIN_SCHEDULER_STATS),
+            "budget_query_stats": None if query_stats is None else {
+                "count": query_stats[0],
+                "total_ns": query_stats[1],
+                "max_ns": query_stats[2],
+            },
+            "observations": observations,
+        }
+    finally:
+        torch.cuda.synchronize(device)
+        order.close()
+        for block in blocks:
+            state = block.__dict__.get("_pins", {}).get("weights")
+            if state is not None and state.get("registered"):
+                pinned_memory.unregister_pin(block, "weights")
+        model_management.current_loaded_models.remove(loaded)
+        model_management.clear_pin_budget_providers()
+        model_management.MAX_PINNED_MEMORY = original_max
+        model_management.TOTAL_PINNED_MEMORY = 0
+        pinned_memory._host_register = original_host_register
+        comfy.system_memory.virtual_memory_available = original_available
+        for key, value in original_stats.items():
+            pinned_memory.PIN_SCHEDULER_STATS[key] = value
+        del blocks, pin_state, streams
+        gc.collect()
+        torch.cuda.synchronize(device)
+        aimdo_control.deinit()
+    return result
+
+
+def main():
+    args = parse_args()
+    result = run(args)
+    payload = json.dumps(result, indent=2)
+    if args.output:
+        Path(args.output).write_text(payload, encoding="utf-8")
+    print(RESULT_PREFIX + json.dumps(result, separators=(",", ":")))
+    return 0 if result["status"] in ("pass", "expected_cuda_oom") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/script_examples/bench_aimdo_pin_scheduler.py
+++ b/script_examples/bench_aimdo_pin_scheduler.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import platform
 import sys
 import types
+import weakref
 
 
 MiB = 1024 ** 2
@@ -85,6 +86,7 @@ def make_pin_state(host_buffer, device, total_bytes):
         "device": device,
         "active": True,
         "current_prompt": True,
+        "prefetch_orders": weakref.WeakSet(),
         "weights": bucket(),
         "weights-loaded": empty_bucket(host_buffer),
         "patches": empty_bucket(host_buffer),

--- a/script_examples/bench_windows_dxgi.py
+++ b/script_examples/bench_windows_dxgi.py
@@ -1,0 +1,106 @@
+"""Measure the Windows DXGI NON_LOCAL budget query used by AIMDO pin scheduling."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import statistics
+import sys
+import time
+from pathlib import Path
+
+
+COMFY_ROOT = Path(__file__).resolve().parents[1]
+if str(COMFY_ROOT) not in sys.path:
+    sys.path.insert(0, str(COMFY_ROOT))
+
+from comfy.windows_dxgi import create_dxgi_budget_provider
+
+
+def percentile(values, percent):
+    position = (len(values) - 1) * percent / 100
+    lower = int(position)
+    upper = min(lower + 1, len(values) - 1)
+    fraction = position - lower
+    return values[lower] + (values[upper] - values[lower]) * fraction
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Benchmark IDXGIAdapter3.QueryVideoMemoryInfo latency for AIMDO.")
+    parser.add_argument("--device", type=int, default=0)
+    parser.add_argument("--warmup", type=int, default=100)
+    parser.add_argument("--iterations", type=int, default=1000)
+    parser.add_argument("--output")
+    parser.add_argument("--i-understand-this-initializes-cuda", action="store_true")
+    args = parser.parse_args()
+    if platform.system() != "Windows":
+        parser.error("the DXGI NON_LOCAL query is only available on Windows")
+    if args.device < 0:
+        parser.error("--device must be non-negative")
+    if args.warmup < 0:
+        parser.error("--warmup must be non-negative")
+    if args.iterations <= 0:
+        parser.error("--iterations must be positive")
+    if not args.i_understand_this_initializes_cuda:
+        parser.error("pass --i-understand-this-initializes-cuda after the required GPU preflight")
+    return args
+
+
+def main():
+    args = parse_args()
+    provider = create_dxgi_budget_provider(args.device)
+    if provider is None:
+        raise RuntimeError("the CUDA device could not be mapped unambiguously to a DXGI adapter")
+    adapter_description = provider.adapter.description
+    node_index = provider.node_index
+
+    try:
+        for _ in range(args.warmup):
+            provider.query()
+
+        samples_ns = []
+        info = None
+        for _ in range(args.iterations):
+            start = time.perf_counter_ns()
+            info = provider.query()
+            samples_ns.append(time.perf_counter_ns() - start)
+    finally:
+        provider.close()
+
+    samples_ns.sort()
+    result = {
+        "schema": 1,
+        "platform": platform.platform(),
+        "device": args.device,
+        "adapter": adapter_description,
+        "node_index": node_index,
+        "warmup_queries": args.warmup,
+        "measured_queries": args.iterations,
+        "query_latency_us": {
+            "median": round(statistics.median(samples_ns) / 1000, 3),
+            "p95": round(percentile(samples_ns, 95) / 1000, 3),
+            "p99": round(percentile(samples_ns, 99) / 1000, 3),
+            "maximum": round(max(samples_ns) / 1000, 3),
+            "total_ms": round(sum(samples_ns) / 1_000_000, 3),
+        },
+        "last_info": {
+            "budget": info.budget,
+            "current_usage": info.current_usage,
+            "available_for_reservation": info.available_for_reservation,
+            "current_reservation": info.current_reservation,
+        },
+        "metric_notes": {
+            "measured_queries": "Explicit provider.query calls made by this probe.",
+            "query_latency_us": "Python wall time around one QueryVideoMemoryInfo call; excludes CUDA LUID mapping and adapter creation.",
+            "production_counts": "Use AIMDO detail logs for cumulative scheduler query count and time during a real workload.",
+        },
+    }
+    output = json.dumps(result, indent=2)
+    if args.output is not None:
+        Path(args.output).write_text(output + "\n", encoding="utf-8")
+    print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests-unit/comfy_test/test_windows_pin_scheduler.py
+++ b/tests-unit/comfy_test/test_windows_pin_scheduler.py
@@ -357,6 +357,24 @@ def test_in_flight_pin_cannot_be_unregistered(monkeypatch):
     assert model_management.TOTAL_PINNED_MEMORY == pin.nbytes
 
 
+def test_ram_pressure_cannot_unload_in_flight_pin(monkeypatch):
+    pinned, _, _ = _load_pinned_memory(monkeypatch)
+
+    class HostBuffer:
+        def truncate(self, *args, **kwargs):
+            raise AssertionError("in-flight host buffer was truncated")
+
+    module = types.SimpleNamespace(_pins={"weights": {"registered": True}})
+    stack = [(module, 0)]
+    pin_state = {
+        "weights": (HostBuffer(), stack, [-1], [1024], [0], {}),
+    }
+    monkeypatch.setattr(pinned, "pin_eviction_state", lambda *args: (True, None))
+
+    assert pinned.partially_unload_ram(pin_state, 1024, subsets=["weights"]) == 0
+    assert stack == [(module, 0)]
+
+
 def test_unregister_failure_keeps_registration_and_ledger(monkeypatch):
     pinned, model_management, _ = _load_pinned_memory(monkeypatch)
     module, pin, module_pin = _retained_pin(True)

--- a/tests-unit/comfy_test/test_windows_pin_scheduler.py
+++ b/tests-unit/comfy_test/test_windows_pin_scheduler.py
@@ -1,0 +1,401 @@
+import ctypes
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from comfy.pin_order import PrefetchPinOrder
+from comfy import windows_dxgi
+from comfy.windows_dxgi import DXGINonLocalBudgetProvider, DXGIUnavailable, LivePinBudget, VideoMemoryInfo, create_dxgi_budget_provider, safe_headroom
+
+
+GiB = 1024 ** 3
+
+
+class SyntheticProvider:
+    def __init__(self, budget, usage):
+        self.budget = budget
+        self.usage = usage
+
+    def query(self):
+        return VideoMemoryInfo(self.budget, self.usage)
+
+
+class FakeAdapter:
+    def __init__(self, luid):
+        self.luid = luid
+        self.closed = False
+        self.queried_node = None
+
+    def query(self, node_index=0):
+        self.queried_node = node_index
+        return VideoMemoryInfo(16 * GiB, 8 * GiB)
+
+    def close(self):
+        self.closed = True
+
+
+class FakeBlock:
+    def __init__(self, index):
+        self.index = index
+        self._v = object()
+
+    def modules(self):
+        return [self]
+
+
+def test_dxgi_headroom_reserves_space_below_budget():
+    info = VideoMemoryInfo(16 * GiB, 8 * GiB)
+    assert safe_headroom(info, 2 * GiB) == 6 * GiB
+    assert safe_headroom(VideoMemoryInfo(16 * GiB, 15 * GiB), 2 * GiB) == 0
+
+
+def test_dxgi_ctypes_layouts_match_windows_abi():
+    assert ctypes.sizeof(windows_dxgi._GUID) == 16
+    assert ctypes.sizeof(windows_dxgi._LUID) == 8
+    assert ctypes.sizeof(windows_dxgi._DXGI_QUERY_VIDEO_MEMORY_INFO) == 32
+    if sys.platform == "win32":
+        assert ctypes.sizeof(windows_dxgi._DXGI_ADAPTER_DESC1) == 312
+
+
+def test_live_budget_evicts_with_hysteresis_and_rechecks():
+    provider = SyntheticProvider(16 * GiB, 13 * GiB)
+    budget = LivePinBudget(provider, reserve=2 * GiB, hysteresis=GiB // 2)
+    evictions = []
+
+    def evict(size):
+        evictions.append(size)
+        provider.usage -= size
+        return size
+
+    assert budget.ensure(2 * GiB, evict)
+    assert evictions == [GiB + GiB // 2]
+    assert budget.last_headroom == 2 * GiB + GiB // 2
+
+
+def test_budget_increase_does_not_evict_or_churn():
+    provider = SyntheticProvider(12 * GiB, 8 * GiB)
+    budget = LivePinBudget(provider, reserve=2 * GiB, hysteresis=GiB // 2)
+    evictions = []
+    assert budget.ensure(GiB, lambda size: evictions.append(size))
+    provider.budget = 16 * GiB
+    assert budget.ensure(4 * GiB, lambda size: evictions.append(size))
+    assert evictions == []
+
+
+def test_exact_cuda_luid_selects_the_matching_dxgi_adapter():
+    first = FakeAdapter(b"first000")
+    match = FakeAdapter(b"match000")
+    provider = DXGINonLocalBudgetProvider(2, lambda index: b"match000", lambda: [first, match])
+    assert provider.query().budget == 16 * GiB
+    assert first.closed
+    assert not match.closed
+    provider.close()
+    assert match.closed
+
+
+def test_cuda_node_mask_mapping_reaches_dxgi_query_node():
+    adapter = FakeAdapter(b"match000")
+    provider = DXGINonLocalBudgetProvider(0, lambda index: (b"match000", 3), lambda: [adapter])
+    provider.query()
+    assert adapter.queried_node == 3
+    provider.close()
+
+
+def test_ambiguous_cuda_luid_match_fails_conservative():
+    adapters = [FakeAdapter(b"same0000"), FakeAdapter(b"same0000")]
+    with pytest.raises(DXGIUnavailable, match="matched 2"):
+        DXGINonLocalBudgetProvider(0, lambda index: b"same0000", lambda: adapters)
+    assert all(adapter.closed for adapter in adapters)
+
+
+def test_missing_cuda_luid_match_fails_conservative():
+    adapter = FakeAdapter(b"other000")
+    with pytest.raises(DXGIUnavailable, match="matched 0"):
+        DXGINonLocalBudgetProvider(0, lambda index: b"cuda0000", lambda: [adapter])
+    assert adapter.closed
+
+
+def test_non_windows_does_not_create_dxgi_policy(monkeypatch):
+    monkeypatch.setattr("comfy.windows_dxgi.platform.system", lambda: "Linux")
+    assert create_dxgi_budget_provider(0) is None
+
+
+def test_prefetch_order_protects_upcoming_and_prefers_consumed_blocks():
+    blocks = [FakeBlock(index) for index in range(8)]
+    order = PrefetchPinOrder(blocks, window=3)
+    for _ in range(4):
+        order.advance()
+    assert order.state(blocks[3])[0]
+    assert order.state(blocks[4])[0]
+    assert order.state(blocks[5])[0]
+    assert not order.state(blocks[2])[0]
+    assert order.state(blocks[2])[1] > order.state(blocks[7])[1]
+    order.close()
+
+
+def test_fifty_sequential_blocks_cycle_through_bounded_pin_window():
+    blocks = [FakeBlock(index) for index in range(50)]
+    order = PrefetchPinOrder(blocks, window=3)
+    provider = SyntheticProvider(16 * GiB, 8 * GiB)
+    budget = LivePinBudget(provider, reserve=2 * GiB, hysteresis=GiB)
+    registered = set()
+    pinned_before_transfer = []
+    evicted = []
+    peak_registered = 0
+
+    def evict(size):
+        candidates = []
+        for block in registered:
+            state = order.state(block)
+            if state is not None and not state[0]:
+                candidates.append((state[1], block))
+        candidates.sort(reverse=True, key=lambda entry: entry[0])
+        freed = 0
+        for _, block in candidates:
+            assert not order.state(block)[0]
+            registered.remove(block)
+            evicted.append(block.index)
+            provider.usage -= GiB
+            freed += GiB
+            if freed >= size:
+                break
+        return freed
+
+    for block in blocks:
+        order.advance()
+        if block not in registered:
+            assert budget.ensure(GiB, evict)
+            provider.usage += GiB
+            registered.add(block)
+        pinned_before_transfer.append(block in registered)
+        peak_registered = max(peak_registered, len(registered))
+        assert provider.usage + budget.reserve <= provider.budget
+        assert all(not order.state(victim)[0] for victim in registered if victim.index < block.index - 3)
+
+    assert all(pinned_before_transfer)
+    assert peak_registered <= 6
+    assert evicted
+    assert len(registered) <= 6
+    order.close()
+
+
+def _load_pinned_memory(monkeypatch):
+    import comfy
+    import comfy.pin_order
+
+    model_management = types.ModuleType("comfy.model_management")
+    model_management.TOTAL_PINNED_MEMORY = 0
+    model_management.ensure_pin_registerable = lambda *args, **kwargs: True
+    model_management.has_live_pin_budget = lambda device: True
+    model_management.free_registrations = lambda *args, **kwargs: True
+    model_management.discard_cuda_async_error = lambda: None
+
+    memory_management = types.ModuleType("comfy.memory_management")
+    memory_management.RAM_CACHE_HEADROOM = 0
+    memory_management.extra_ram_release = lambda size: None
+    memory_management.vram_aligned_size = lambda values: sum(value.nbytes for value in values if value is not None)
+
+    utils = types.ModuleType("comfy.utils")
+    utils.bit_reverse_range = lambda value, bits: value
+
+    cli_args = types.ModuleType("comfy.cli_args")
+    cli_args.args = types.SimpleNamespace(disable_pinned_memory=False)
+
+    aimdo = types.ModuleType("comfy_aimdo")
+    aimdo.__path__ = []
+    aimdo_host_buffer = types.ModuleType("comfy_aimdo.host_buffer")
+    aimdo_torch = types.ModuleType("comfy_aimdo.torch")
+
+    monkeypatch.setitem(sys.modules, "comfy.model_management", model_management)
+    monkeypatch.setitem(sys.modules, "comfy.memory_management", memory_management)
+    monkeypatch.setitem(sys.modules, "comfy.utils", utils)
+    monkeypatch.setitem(sys.modules, "comfy.cli_args", cli_args)
+    monkeypatch.setitem(sys.modules, "comfy_aimdo", aimdo)
+    monkeypatch.setitem(sys.modules, "comfy_aimdo.host_buffer", aimdo_host_buffer)
+    monkeypatch.setitem(sys.modules, "comfy_aimdo.torch", aimdo_torch)
+    monkeypatch.setattr(comfy, "model_management", model_management, raising=False)
+    monkeypatch.setattr(comfy, "memory_management", memory_management, raising=False)
+    monkeypatch.setattr(comfy, "utils", utils, raising=False)
+
+    path = Path(__file__).parents[2] / "comfy" / "pinned_memory.py"
+    spec = importlib.util.spec_from_file_location("test_pinned_memory", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module, model_management, cli_args.args
+
+
+class FakePin:
+    def __init__(self, size=1024, pointer=1234):
+        self.nbytes = size
+        self.pointer = pointer
+
+    def data_ptr(self):
+        return self.pointer
+
+
+class FakeModule:
+    pass
+
+
+def _retained_pin(registered):
+    module = FakeModule()
+    pin = FakePin()
+    module_pin = {"pin": pin, "registered": registered, "stack_index": 0}
+    module._pins = {"weights": module_pin}
+    module._pin_state = {
+        "device": types.SimpleNamespace(index=0),
+        "weights": (None, [(module, 0)], [0], [pin.nbytes if registered else 0], [0], {}),
+    }
+    return module, pin, module_pin
+
+
+def test_registered_pin_is_reconsidered_after_budget_shrink(monkeypatch):
+    pinned, model_management, _ = _load_pinned_memory(monkeypatch)
+    module, pin, module_pin = _retained_pin(True)
+    model_management.TOTAL_PINNED_MEMORY = pin.nbytes
+    model_management.ensure_pin_registerable = lambda *args, **kwargs: False
+    monkeypatch.setattr(pinned, "_host_unregister", lambda value: 0)
+
+    assert pinned.get_pin(module) is pin
+    assert not module_pin["registered"]
+    assert model_management.TOTAL_PINNED_MEMORY == 0
+    assert module._pin_state["weights"][3][0] == 0
+
+
+def test_prefetch_boundary_check_avoids_per_module_budget_query(monkeypatch):
+    pinned, model_management, _ = _load_pinned_memory(monkeypatch)
+    module, pin, module_pin = _retained_pin(True)
+    module._v = object()
+    module.modules = lambda: [module]
+    order = PrefetchPinOrder([module])
+    order.advance()
+    order.budget_checked = True
+    checks = []
+    model_management.ensure_pin_registerable = lambda *args, **kwargs: checks.append(True)
+
+    assert pinned.get_pin(module) is pin
+    assert module_pin["registered"]
+    assert checks == []
+    order.close()
+
+
+def test_in_flight_pin_cannot_be_unregistered(monkeypatch):
+    pinned, model_management, _ = _load_pinned_memory(monkeypatch)
+    module, pin, module_pin = _retained_pin(True)
+    module_pin["in_flight"] = types.SimpleNamespace(query=lambda: False)
+    model_management.TOTAL_PINNED_MEMORY = pin.nbytes
+    unregister_calls = []
+    monkeypatch.setattr(pinned, "_host_unregister", lambda value: unregister_calls.append(value))
+
+    assert pinned.unregister_pin(module, "weights") == 0
+    assert module_pin["registered"]
+    assert unregister_calls == []
+    assert model_management.TOTAL_PINNED_MEMORY == pin.nbytes
+
+
+def test_unregister_failure_keeps_registration_and_ledger(monkeypatch):
+    pinned, model_management, _ = _load_pinned_memory(monkeypatch)
+    module, pin, module_pin = _retained_pin(True)
+    model_management.TOTAL_PINNED_MEMORY = pin.nbytes
+    monkeypatch.setattr(pinned, "_host_unregister", lambda value: 1)
+
+    assert pinned.unregister_pin(module, "weights") == 0
+    assert module_pin["registered"]
+    assert model_management.TOTAL_PINNED_MEMORY == pin.nbytes
+    assert module._pin_state["weights"][3][0] == pin.nbytes
+
+
+def test_non_live_policy_keeps_registered_pin_without_reconsidering(monkeypatch):
+    pinned, model_management, _ = _load_pinned_memory(monkeypatch)
+    module, pin, module_pin = _retained_pin(True)
+    model_management.has_live_pin_budget = lambda device: False
+    checks = []
+    model_management.ensure_pin_registerable = lambda *args, **kwargs: checks.append(True)
+
+    assert pinned.get_pin(module) is pin
+    assert module_pin["registered"]
+    assert checks == []
+
+
+def test_non_live_re_register_failure_keeps_original_single_attempt(monkeypatch):
+    pinned, model_management, _ = _load_pinned_memory(monkeypatch)
+    module, pin, module_pin = _retained_pin(False)
+    model_management.has_live_pin_budget = lambda device: False
+    register_calls = []
+    monkeypatch.setattr(pinned, "_host_register", lambda value, size: register_calls.append((value, size)) or 1)
+
+    assert pinned.get_pin(module) is pin
+    assert not module_pin["registered"]
+    assert len(register_calls) == 1
+    assert model_management.TOTAL_PINNED_MEMORY == 0
+
+
+def test_non_live_prefetch_order_steals_consumed_not_upcoming_pin(monkeypatch):
+    pinned, model_management, _ = _load_pinned_memory(monkeypatch)
+    model_management.has_live_pin_budget = lambda device: False
+    blocks = [FakeBlock(index) for index in range(5)]
+    order = PrefetchPinOrder(blocks, window=3)
+    for _ in range(3):
+        order.advance()
+
+    consumed = blocks[1]
+    current = blocks[2]
+    upcoming = blocks[3]
+    consumed_pin = FakePin(pointer=111)
+    upcoming_pin = FakePin(pointer=333)
+    consumed._pins = {"weights": {"pin": consumed_pin, "registered": True, "stack_index": 0}}
+    upcoming._pins = {"weights": {"pin": upcoming_pin, "registered": True, "stack_index": 1}}
+    current._pins = {"weights": {}}
+    stack = [(consumed, 0), (upcoming, consumed_pin.nbytes)]
+    buckets = {}
+    pinned._add_to_bucket(consumed, consumed._pins["weights"], buckets, consumed_pin.nbytes, 100)
+    pinned._add_to_bucket(upcoming, upcoming._pins["weights"], buckets, upcoming_pin.nbytes, 200)
+
+    assert pinned._steal_pin(current, stack, buckets, consumed_pin.nbytes, 0, "weights")
+    assert current._pins["weights"]["pin"] is consumed_pin
+    assert upcoming._pins["weights"]["pin"] is upcoming_pin
+    assert "pin" not in consumed._pins["weights"]
+    order.close()
+
+
+def test_register_failure_evicts_retries_and_updates_ledger_once(monkeypatch):
+    pinned, model_management, _ = _load_pinned_memory(monkeypatch)
+    module, pin, module_pin = _retained_pin(False)
+    results = iter([1, 0])
+    evictions = []
+    monkeypatch.setattr(pinned, "_host_register", lambda value, size: next(results))
+    model_management.free_registrations = lambda size, **kwargs: evictions.append(size) or True
+
+    assert pinned.get_pin(module) is pin
+    assert module_pin["registered"]
+    assert evictions == [pin.nbytes]
+    assert model_management.TOTAL_PINNED_MEMORY == pin.nbytes
+    assert module._pin_state["weights"][3][0] == pin.nbytes
+
+
+def test_double_register_failure_falls_back_pageable_without_accounting(monkeypatch):
+    pinned, model_management, _ = _load_pinned_memory(monkeypatch)
+    module, pin, module_pin = _retained_pin(False)
+    monkeypatch.setattr(pinned, "_host_register", lambda value, size: 1)
+
+    assert pinned.get_pin(module) is pin
+    assert not module_pin["registered"]
+    assert model_management.TOTAL_PINNED_MEMORY == 0
+    assert module._pin_state["weights"][3][0] == 0
+    assert pinned.PIN_SCHEDULER_STATS["register_failures"] == 2
+    assert pinned.PIN_SCHEDULER_STATS["pageable_prefetches"] == 1
+
+
+def test_disable_pinned_memory_keeps_existing_behavior(monkeypatch):
+    pinned, model_management, args = _load_pinned_memory(monkeypatch)
+    module, pin, module_pin = _retained_pin(False)
+    args.disable_pinned_memory = True
+    checks = []
+    model_management.ensure_pin_registerable = lambda *args, **kwargs: checks.append(True)
+
+    assert pinned.get_pin(module) is pin
+    assert not module_pin["registered"]
+    assert checks == []

--- a/tests-unit/comfy_test/test_windows_pin_scheduler.py
+++ b/tests-unit/comfy_test/test_windows_pin_scheduler.py
@@ -2,11 +2,12 @@ import ctypes
 import importlib.util
 import sys
 import types
+import weakref
 from pathlib import Path
 
 import pytest
 
-from comfy.pin_order import PrefetchPinOrder
+from comfy.pin_order import PrefetchPinOrder, prefetch_budget_checked, prefetch_pin_state
 from comfy import windows_dxgi
 from comfy.windows_dxgi import DXGINonLocalBudgetProvider, DXGIUnavailable, LivePinBudget, VideoMemoryInfo, create_dxgi_budget_provider, safe_headroom
 
@@ -38,9 +39,10 @@ class FakeAdapter:
 
 
 class FakeBlock:
-    def __init__(self, index):
+    def __init__(self, index, pin_state=None):
         self.index = index
         self._v = object()
+        self._pin_state = {"prefetch_orders": weakref.WeakSet()} if pin_state is None else pin_state
 
     def modules(self):
         return [self]
@@ -147,6 +149,33 @@ def test_prefetch_order_prefers_upcoming_over_consumed_blocks():
     assert not order.state(blocks[2])[0]
     assert order.state(blocks[2])[1] > order.state(blocks[7])[1]
     order.close()
+
+
+def test_overlapping_prefetch_orders_keep_independent_state():
+    pin_state = {"prefetch_orders": weakref.WeakSet()}
+    shared = FakeBlock(0, pin_state)
+    first_only = FakeBlock(1, pin_state)
+    second_only = FakeBlock(2, pin_state)
+    first = PrefetchPinOrder([shared, first_only])
+    second = PrefetchPinOrder([second_only, shared])
+
+    first.advance()
+    second.advance()
+    assert prefetch_pin_state(shared) == (True, 0)
+    first.advance()
+    assert prefetch_pin_state(shared) == (True, 1)
+
+    first.budget_checked = True
+    assert not prefetch_budget_checked(shared)
+    second.budget_checked = True
+    assert prefetch_budget_checked(shared)
+
+    first.close()
+    assert prefetch_pin_state(shared) == (True, 1)
+    second.close()
+    assert prefetch_pin_state(shared) is None
+    assert not prefetch_budget_checked(shared)
+    assert not hasattr(shared, "_pin_prefetch_order")
 
 
 def test_fifty_sequential_blocks_cycle_through_constrained_live_budget(monkeypatch):
@@ -283,9 +312,30 @@ def _retained_pin(registered):
     module._pins = {"weights": module_pin}
     module._pin_state = {
         "device": types.SimpleNamespace(index=0),
+        "prefetch_orders": weakref.WeakSet(),
         "weights": (None, [(module, 0)], [0], [pin.nbytes if registered else 0], [0], {}),
     }
     return module, pin, module_pin
+
+
+def test_lowvram_source_copies_all_active_prefetch_orders(monkeypatch):
+    pinned, _, _ = _load_pinned_memory(monkeypatch)
+    pin_state = {"prefetch_orders": weakref.WeakSet()}
+    source = FakeBlock(0, pin_state)
+    target = FakeBlock(3, pin_state)
+    first = PrefetchPinOrder([source, FakeBlock(1, pin_state)])
+    second = PrefetchPinOrder([FakeBlock(2, pin_state), source])
+    first.advance()
+    second.advance()
+
+    pinned.copy_prefetch_order(source, target)
+
+    assert first.state(target) == (True, 0)
+    assert second.state(target) == (True, 1)
+    assert prefetch_pin_state(target) == (True, 0)
+    first.close()
+    assert prefetch_pin_state(target) == (True, 1)
+    second.close()
 
 
 def test_registered_pin_is_reconsidered_after_budget_shrink(monkeypatch):

--- a/tests-unit/comfy_test/test_windows_pin_scheduler.py
+++ b/tests-unit/comfy_test/test_windows_pin_scheduler.py
@@ -73,6 +73,19 @@ def test_live_budget_evicts_with_hysteresis_and_rechecks():
     assert budget.ensure(2 * GiB, evict)
     assert evictions == [GiB + GiB // 2]
     assert budget.last_headroom == 2 * GiB + GiB // 2
+    assert budget.query_count == 2
+
+
+def test_live_budget_tracks_query_cost(monkeypatch):
+    timestamps = iter((100, 150, 200, 275))
+    monkeypatch.setattr(windows_dxgi.time, "perf_counter_ns", lambda: next(timestamps))
+    budget = LivePinBudget(SyntheticProvider(16 * GiB, 8 * GiB), reserve=2 * GiB, hysteresis=GiB // 2)
+
+    assert budget.ensure(GiB, lambda size: 0)
+    assert budget.ensure(GiB, lambda size: 0)
+    assert budget.query_count == 2
+    assert budget.query_ns == 125
+    assert budget.max_query_ns == 75
 
 
 def test_budget_increase_does_not_evict_or_churn():
@@ -123,7 +136,7 @@ def test_non_windows_does_not_create_dxgi_policy(monkeypatch):
     assert create_dxgi_budget_provider(0) is None
 
 
-def test_prefetch_order_protects_upcoming_and_prefers_consumed_blocks():
+def test_prefetch_order_prefers_upcoming_over_consumed_blocks():
     blocks = [FakeBlock(index) for index in range(8)]
     order = PrefetchPinOrder(blocks, window=3)
     for _ in range(4):
@@ -136,7 +149,8 @@ def test_prefetch_order_protects_upcoming_and_prefers_consumed_blocks():
     order.close()
 
 
-def test_fifty_sequential_blocks_cycle_through_bounded_pin_window():
+def test_fifty_sequential_blocks_cycle_through_constrained_live_budget(monkeypatch):
+    pinned, _, _ = _load_pinned_memory(monkeypatch)
     blocks = [FakeBlock(index) for index in range(50)]
     order = PrefetchPinOrder(blocks, window=3)
     provider = SyntheticProvider(16 * GiB, 8 * GiB)
@@ -147,15 +161,9 @@ def test_fifty_sequential_blocks_cycle_through_bounded_pin_window():
     peak_registered = 0
 
     def evict(size):
-        candidates = []
-        for block in registered:
-            state = order.state(block)
-            if state is not None and not state[0]:
-                candidates.append((state[1], block))
-        candidates.sort(reverse=True, key=lambda entry: entry[0])
+        candidates = sorted(registered, reverse=True, key=lambda block: pinned.pin_eviction_priority(order.state(block)))
         freed = 0
-        for _, block in candidates:
-            assert not order.state(block)[0]
+        for block in candidates:
             registered.remove(block)
             evicted.append(block.index)
             provider.usage -= GiB
@@ -173,12 +181,40 @@ def test_fifty_sequential_blocks_cycle_through_bounded_pin_window():
         pinned_before_transfer.append(block in registered)
         peak_registered = max(peak_registered, len(registered))
         assert provider.usage + budget.reserve <= provider.budget
-        assert all(not order.state(victim)[0] for victim in registered if victim.index < block.index - 3)
 
     assert all(pinned_before_transfer)
     assert peak_registered <= 6
     assert evicted
     assert len(registered) <= 6
+    order.close()
+
+
+def test_live_budget_smaller_than_preferred_band_evicts_farthest_first(monkeypatch):
+    pinned, _, _ = _load_pinned_memory(monkeypatch)
+    blocks = [FakeBlock(index) for index in range(3)]
+    order = PrefetchPinOrder(blocks, window=3)
+    order.advance()
+    provider = SyntheticProvider(4 * GiB, 3 * GiB)
+    budget = LivePinBudget(provider, reserve=2 * GiB, hysteresis=0)
+    registered = set(blocks)
+    evicted = []
+
+    def evict(size):
+        candidates = sorted(registered, reverse=True, key=lambda block: pinned.pin_eviction_priority(order.state(block)))
+        freed = 0
+        for block in candidates:
+            registered.remove(block)
+            evicted.append(block.index)
+            provider.usage -= GiB
+            freed += GiB
+            if freed >= size:
+                break
+        return freed
+
+    assert budget.ensure(0, evict)
+    assert evicted == [2]
+    assert blocks[0] in registered
+    assert blocks[1] in registered
     order.close()
 
 
@@ -265,6 +301,31 @@ def test_registered_pin_is_reconsidered_after_budget_shrink(monkeypatch):
     assert module._pin_state["weights"][3][0] == 0
 
 
+def test_requested_pin_survives_when_farther_preferred_pin_can_be_evicted(monkeypatch):
+    pinned, model_management, _ = _load_pinned_memory(monkeypatch)
+    requested, requested_pin, requested_state = _retained_pin(True)
+    farther, farther_pin, farther_state = _retained_pin(True)
+    for module in (requested, farther):
+        module._v = object()
+        module.modules = lambda module=module: [module]
+    order = PrefetchPinOrder([requested, farther], window=3)
+    order.advance()
+    model_management.TOTAL_PINNED_MEMORY = requested_pin.nbytes + farther_pin.nbytes
+    monkeypatch.setattr(pinned, "_host_unregister", lambda value: 0)
+
+    def ensure(size, **kwargs):
+        assert kwargs["protected"] == {(requested, "weights")}
+        return pinned.unregister_pin(farther, "weights") == farther_pin.nbytes
+
+    model_management.ensure_pin_registerable = ensure
+
+    assert pinned.get_pin(requested) is requested_pin
+    assert requested_state["registered"]
+    assert not farther_state["registered"]
+    assert model_management.TOTAL_PINNED_MEMORY == requested_pin.nbytes
+    order.close()
+
+
 def test_prefetch_boundary_check_avoids_per_module_budget_query(monkeypatch):
     pinned, model_management, _ = _load_pinned_memory(monkeypatch)
     module, pin, module_pin = _retained_pin(True)
@@ -333,7 +394,7 @@ def test_non_live_re_register_failure_keeps_original_single_attempt(monkeypatch)
     assert model_management.TOTAL_PINNED_MEMORY == 0
 
 
-def test_non_live_prefetch_order_steals_consumed_not_upcoming_pin(monkeypatch):
+def test_non_live_prefetch_order_steals_consumed_before_upcoming_pin(monkeypatch):
     pinned, model_management, _ = _load_pinned_memory(monkeypatch)
     model_management.has_live_pin_budget = lambda device: False
     blocks = [FakeBlock(index) for index in range(5)]
@@ -359,6 +420,39 @@ def test_non_live_prefetch_order_steals_consumed_not_upcoming_pin(monkeypatch):
     assert upcoming._pins["weights"]["pin"] is upcoming_pin
     assert "pin" not in consumed._pins["weights"]
     order.close()
+
+
+def test_severe_pressure_steals_far_future_before_current_pin(monkeypatch):
+    pinned, model_management, _ = _load_pinned_memory(monkeypatch)
+    model_management.has_live_pin_budget = lambda device: True
+    blocks = [FakeBlock(index) for index in range(3)]
+    order = PrefetchPinOrder(blocks, window=3)
+    order.advance()
+
+    current, incoming, far_future = blocks
+    current_pin = FakePin(pointer=111)
+    far_future_pin = FakePin(pointer=333)
+    current._pins = {"weights": {"pin": current_pin, "registered": True, "stack_index": 0}}
+    incoming._pins = {"weights": {}}
+    far_future._pins = {"weights": {"pin": far_future_pin, "registered": True, "stack_index": 1}}
+    stack = [(current, 0), (far_future, current_pin.nbytes)]
+    buckets = {}
+    pinned._add_to_bucket(current, current._pins["weights"], buckets, current_pin.nbytes, 100)
+    pinned._add_to_bucket(far_future, far_future._pins["weights"], buckets, far_future_pin.nbytes, 200)
+
+    assert pinned._steal_pin(incoming, stack, buckets, current_pin.nbytes, 0, "weights")
+    assert incoming._pins["weights"]["pin"] is far_future_pin
+    assert current._pins["weights"]["pin"] is current_pin
+    assert "pin" not in far_future._pins["weights"]
+    order.close()
+
+
+def test_eviction_hierarchy_prefers_stale_then_generic_then_upcoming(monkeypatch):
+    pinned, _, _ = _load_pinned_memory(monkeypatch)
+
+    assert pinned.pin_eviction_priority((False, 50)) > pinned.pin_eviction_priority(None)
+    assert pinned.pin_eviction_priority(None) > pinned.pin_eviction_priority((True, 2))
+    assert pinned.pin_eviction_priority((True, 2)) > pinned.pin_eviction_priority((True, 0))
 
 
 def test_register_failure_evicts_retries_and_updates_ledger_once(monkeypatch):


### PR DESCRIPTION
AIMDO currently assumes that up to 40% of total system RAM can be pinned on Windows. This static heuristic does not reflect how Windows manages pinned memory under WDDM and can eventually cause cudaHostRegister failures.
Rather than attempting to reproduce Windows’ internal budgeting, this PR queries the GPU’s live non-local memory budget and usage through DXGI. ComfyUI uses that information, with a safety reserve, to decide whether another host-memory registration is safe.
AIMDO already knows the upcoming transformer execution order, so the scheduler uses that information to retain current and in-flight blocks, prefer upcoming blocks, and unregister consumed or farther-future blocks when more headroom is required.
Linux and other non-Windows platforms continue using the existing heuristic.

All code has been verified to work locally on both Windows and Linux.

The failure typically surfaces as `CUDA error: out of memory`, despite sufficient VRAM, as seen in these issues:
https://github.com/Comfy-Org/ComfyUI/issues/11186
https://github.com/Comfy-Org/ComfyUI/issues/15255
https://github.com/Comfy-Org/ComfyUI/issues/11597
https://github.com/Comfy-Org/ComfyUI/issues/14250

While I can not guarantee this fix will remove all `CUDA error: out of memory` with sufficient VRAM, it almost certainly removes most reported cases.