### PR TITLE
Fix json extract string malformed output and add json array access

### DIFF
--- a/comfy_extras/nodes_string.py
+++ b/comfy_extras/nodes_string.py
@@ -437,10 +437,10 @@ class JsonExtractString(io.ComfyNode):
                 if value is None:
                     return io.NodeOutput("")
                 
-                if isinstance(value, (str, int, float)):
-                    return io.NodeOutput(str(value))
+                if isinstance(value, (dict, list)):
+                    return io.NodeOutput(json.dumps(value))
                 
-                return io.NodeOutput(json.dumps(value))
+                return io.NodeOutput(str(value))
 
             return io.NodeOutput("")
 

--- a/comfy_extras/nodes_string.py
+++ b/comfy_extras/nodes_string.py
@@ -428,8 +428,8 @@ class JsonExtractString(io.ComfyNode):
     def execute(cls, json_string, key):
         try:
             data = json.loads(json_string)
-            if (isinstance(data, dict) and key in data) or (isinstance(data, list) and key.isdigit()):
-                if isinstance(data, list) and key.isdigit():
+            if (isinstance(data, dict) and key in data) or (isinstance(data, list) and key.isdecimal()):
+                if isinstance(data, list) and key.isdecimal():
                     key = int(key)
 
                 value = data[key]

--- a/comfy_extras/nodes_string.py
+++ b/comfy_extras/nodes_string.py
@@ -428,12 +428,19 @@ class JsonExtractString(io.ComfyNode):
     def execute(cls, json_string, key):
         try:
             data = json.loads(json_string)
-            if isinstance(data, dict) and key in data:
+            if (isinstance(data, dict) and key in data) or (isinstance(data, list) and key.isdigit()):
+                if key.isdigit():
+                    key = int(key)
+
                 value = data[key]
+
                 if value is None:
                     return io.NodeOutput("")
-
-                return io.NodeOutput(str(value))
+                
+                if isinstance(value, (str, int, float)):
+                    return io.NodeOutput(str(value))
+                
+                return io.NodeOutput(json.dumps(value))
 
             return io.NodeOutput("")
 

--- a/comfy_extras/nodes_string.py
+++ b/comfy_extras/nodes_string.py
@@ -444,7 +444,7 @@ class JsonExtractString(io.ComfyNode):
 
             return io.NodeOutput("")
 
-        except (json.JSONDecodeError, TypeError):
+        except (json.JSONDecodeError, TypeError, IndexError):
             return io.NodeOutput("")
 
 

--- a/comfy_extras/nodes_string.py
+++ b/comfy_extras/nodes_string.py
@@ -429,7 +429,7 @@ class JsonExtractString(io.ComfyNode):
         try:
             data = json.loads(json_string)
             if (isinstance(data, dict) and key in data) or (isinstance(data, list) and key.isdigit()):
-                if key.isdigit():
+                if isinstance(data, list) and key.isdigit():
                     key = int(key)
 
                 value = data[key]


### PR DESCRIPTION
The current version of the Extract Text from JSON node uses `str()` to convert the value to text. If you are extracting a JSON object and wish to then pass that on to second or additional Extract node the output of `str()` is malformed JSON, preventing you from going any deeper into the JSON text.

This checks if the value is an object or array (list) and uses `json.dumps()` instead to return a properly formed JSON string. In the case of int, float, regular string, or any other non-object/list values it uses `str()` as before.

Additionally this adds the functionality to access array elements in JSON lists as this was low hanging fruit while making these changes. IndexErrors are suppressed if the key is out of range and returns an empty string, conforming to the current way invalid keys return.