### PR TITLE
Fix typo in ControlBase.deepclone_multigpu error message

### DIFF
--- a/comfy/controlnet.py
+++ b/comfy/controlnet.py
@@ -155,7 +155,7 @@ class ControlBase:
 
         When autoregister is set to True, the deep clone is also added to multigpu_clones dict.
         '''
-        raise NotImplementedError("Classes inheriting from ControlBase should define their own deepclone_multigpu funtion.")
+        raise NotImplementedError("Classes inheriting from ControlBase should define their own deepclone_multigpu function.")
 
     def get_extra_hooks(self):
         out = []


### PR DESCRIPTION
## Summary
- Fixes a typo ("funtion" -> "function") in the `NotImplementedError` message raised by `ControlBase.deepclone_multigpu` in `comfy/controlnet.py`.

## Test plan
- Text-only change to an error message string; no functional/behavioral changes.