### PR TITLE
Set disable_cfg1_optimization=True inside cfgpp_ud10_ab sampler

### DIFF
--- a/comfy/k_diffusion/sampling.py
+++ b/comfy/k_diffusion/sampling.py
@@ -416,7 +416,7 @@ def linear_multistep_coeff(order, t, i, j):
     return integrate.quad(fn, t[i], t[i + 1], epsrel=1e-4)[0]
 
 
-def _sample_cfgpp_history(model, x, sigmas, extra_args=None, callback=None, disable=None, history_weight=0.5, zero_weight=None, zero_order=1, uncond_history_weight=0.0):
+def _sample_cfgpp_history(model, x, sigmas, extra_args=None, callback=None, disable=None, history_weight=0.5, zero_weight=None, zero_order=1, uncond_history_weight=0.0, disable_cfg1_optimization=True):
     """CFG++ Euler with variable-step AB2 history and optional sigma-zero extrapolation."""
     extra_args = {} if extra_args is None else extra_args
     model_sampling = model.inner_model.model_patcher.get_model_object("model_sampling")
@@ -434,7 +434,7 @@ def _sample_cfgpp_history(model, x, sigmas, extra_args=None, callback=None, disa
         return args["denoised"]
 
     model_options = extra_args.get("model_options", {}).copy()
-    extra_args["model_options"] = comfy.model_patcher.set_model_options_post_cfg_function(model_options, post_cfg_function, disable_cfg1_optimization=True)
+    extra_args["model_options"] = comfy.model_patcher.set_model_options_post_cfg_function(model_options, post_cfg_function, disable_cfg1_optimization=disable_cfg1_optimization)
 
     for i in trange(len(sigmas) - 1, disable=disable):
         denoised = model(x, sigmas[i] * s_in, **extra_args)
@@ -480,8 +480,8 @@ def _sample_cfgpp_history(model, x, sigmas, extra_args=None, callback=None, disa
     return x
 
 
-def sample_cfgpp_ud10_ab(model, x, sigmas, extra_args=None, callback=None, disable=None):
-    return _sample_cfgpp_history(model, x, sigmas, extra_args=extra_args, callback=callback, disable=disable, history_weight=0.25, zero_weight=1.0, uncond_history_weight=0.1)
+def sample_cfgpp_ud10_ab(model, x, sigmas, extra_args=None, callback=None, disable=None, history_weight=0.25, uncond_history_weight=0.1, disable_cfg1_optimization=True):
+    return _sample_cfgpp_history(model, x, sigmas, extra_args=extra_args, callback=callback, disable=disable, history_weight=history_weight, zero_weight=1.0, uncond_history_weight=uncond_history_weight, disable_cfg1_optimization=disable_cfg1_optimization)
 
 
 @torch.no_grad()

--- a/comfy/k_diffusion/sampling.py
+++ b/comfy/k_diffusion/sampling.py
@@ -434,7 +434,7 @@ def _sample_cfgpp_history(model, x, sigmas, extra_args=None, callback=None, disa
         return args["denoised"]
 
     model_options = extra_args.get("model_options", {}).copy()
-    extra_args["model_options"] = comfy.model_patcher.set_model_options_post_cfg_function(model_options, post_cfg_function)
+    extra_args["model_options"] = comfy.model_patcher.set_model_options_post_cfg_function(model_options, post_cfg_function, disable_cfg1_optimization=True)
 
     for i in trange(len(sigmas) - 1, disable=disable):
         denoised = model(x, sigmas[i] * s_in, **extra_args)

--- a/comfy_extras/nodes_custom_sampler.py
+++ b/comfy_extras/nodes_custom_sampler.py
@@ -534,6 +534,35 @@ class SamplerEulerAncestralCFGPP(io.ComfyNode):
 
     get_sampler = execute
 
+class SamplerCFGPP_ud10_ab(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="SamplerCFGPP_ud10_ab",
+            display_name="SamplerCFG++_UD10_AB",
+            category="model/sampling/samplers",
+            inputs=[
+                io.Float.Input("history_weight", default=0.25, min=0.0, max=1.0, step=0.01, round=False, advanced=True),
+                io.Float.Input("uncond_history_weight", default=0.1, min=0.0, max=100.0, step=0.01, round=False, advanced=True),
+                io.Boolean.Input("cfg_distilled_model", default=False, tooltip="When set to true, speeds up sampling at CFG==1.0 by discarding negative cond.\nUseful for turbo/distilled models that can work without CFG.", advanced=True),
+            ],
+            outputs=[io.Sampler.Output()]
+        )
+
+    @classmethod
+    def execute(cls, history_weight, uncond_history_weight, cfg_distilled_model) -> io.NodeOutput:
+        sampler = comfy.samplers.ksampler(
+            "cfgpp_ud10_ab",
+            {
+                "history_weight": history_weight,
+                "uncond_history_weight": uncond_history_weight,
+                "disable_cfg1_optimization": not cfg_distilled_model,
+            },
+        )
+        return io.NodeOutput(sampler)
+
+    get_sampler = execute
+
 class SamplerLMS(io.ComfyNode):
     @classmethod
     def define_schema(cls):
@@ -1201,6 +1230,7 @@ class CustomSamplersExtension(ComfyExtension):
             KSamplerSelect,
             SamplerEulerAncestral,
             SamplerEulerAncestralCFGPP,
+            SamplerCFGPP_ud10_ab,
             SamplerLMS,
             SamplerDPMPP_3M_SDE,
             SamplerDPMPP_2M_SDE,


### PR DESCRIPTION
I believe there is a small typo inside `cfgpp_ud10_ab` sampler: `post_cfg_function` should be set with `disable_cfg1_optimization==True`, like in all other CFG++ samplers.

Image with implicit(default) `disable_cfg1_optimization=False` at CFG==1.0:
<img width="256" height="256" alt="without" src="https://github.com/user-attachments/assets/fa395242-b5d7-461b-98c4-cc6e702ea134" />
Image with explicitly passed `disable_cfg1_optimization=True` at CFG==1.0:
<img width="256" height="256" alt="with" src="https://github.com/user-attachments/assets/3f2b3de2-7b1c-4415-8f79-269cea503331" />
