### PR TITLE
Fix MiniMax H3 audio VAE input cropping

### DIFF
--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -1035,6 +1035,7 @@ class VAE:
                 self.audio_sample_rate = 32000
                 self.upscale_ratio = 800
                 self.downscale_ratio = 800
+                self.crop_input = False
                 self.latent_dim = 2  # [B, 32, stereo 2, T]
                 self.process_output = lambda audio: audio
                 self.process_input = lambda audio: audio

--- a/tests-unit/comfy_test/test_minimax_h3_audio_vae_crop.py
+++ b/tests-unit/comfy_test/test_minimax_h3_audio_vae_crop.py
@@ -1,0 +1,56 @@
+import unittest
+from unittest.mock import patch
+
+import torch
+
+import comfy.sd
+
+
+class TestMiniMaxH3AudioVAECrop(unittest.TestCase):
+    def test_h3_audio_vae_preserves_unaligned_input_length(self):
+        device = torch.device("cpu")
+        state_dict = {
+            "pre_block.attn.zero_k_bias": torch.zeros(1),
+        }
+
+        class DummyPatcher:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def is_dynamic(self):
+                return False
+
+        with (
+            patch(
+                "comfy.sd.comfy.ldm.minimax.audio_vae.MiniMaxH3AudioVAE",
+                return_value=torch.nn.Identity(),
+            ),
+            patch(
+                "comfy.sd.comfy.model_patcher.CoreModelPatcher",
+                DummyPatcher,
+            ),
+            patch(
+                "comfy.sd.model_management.vae_offload_device",
+                return_value=device,
+            ),
+            patch(
+                "comfy.sd.model_management.intermediate_device",
+                return_value=device,
+            ),
+        ):
+            vae = comfy.sd.VAE(
+                sd=state_dict,
+                device=device,
+                dtype=torch.float32,
+            )
+
+        self.assertFalse(vae.crop_input)
+
+        audio = torch.zeros((1, 437333, 2))
+        prepared = vae.vae_encode_crop_pixels(audio)
+
+        self.assertEqual(prepared.shape, audio.shape)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #15970.

MiniMax H3 audio currently passes through the generic VAE center-crop before `MiniMaxH3AudioVAE.encode()`, which can remove leading PCM samples and produce one fewer audio latent than expected.

The fix is intentionally narrow and only changes the MiniMax H3 audio VAE configuration:

 self.audio_sample_rate = 32000
 self.upscale_ratio = 800
 self.downscale_ratio = 800
+self.crop_input = False
 self.latent_dim = 2

This allows the H3 AudioVAE's existing model-specific right-padding logic to handle non-aligned audio lengths instead of generic VAE preprocessing cropping them first.


Tested with stock ComfyUI and all custom nodes disabled using a 32 kHz WAV containing exactly 437333 samples.

Before the fix:

437333 input samples
-> 436800 decoded samples
-> 546 H3 audio latent steps


After the fix:

437333 input samples
-> 437600 decoded samples
-> 547 H3 audio latent steps


Also added a lightweight CPU-only regression test that verifies non-aligned H3 audio input is not cropped by generic VAE preprocessing.
