### PR TITLE
Fix MiniMax H3 memory estimation

### DIFF
--- a/comfy/model_base.py
+++ b/comfy/model_base.py
@@ -2133,9 +2133,70 @@ class Hunyuan3Dv2_1(BaseModel):
             out['guidance'] = comfy.conds.CONDRegular(torch.FloatTensor([guidance]))
         return out
 
+class _MiniMaxH3Payload(comfy.conds.CONDConstant):
+    def __init__(self, cond, shape):
+        super().__init__(cond)
+        self.shape = shape
+
+    def _copy_with(self, cond):
+        return self.__class__(cond, self.shape)
+
+    def size(self):
+        return self.shape
+
+
 class MiniMaxH3(BaseModel):
+    MEMORY_BYTES_PER_PACKED_ROW = 151_000  # Rounded-up vanilla one-block Windows process allocation slope.
+
     def __init__(self, model_config, model_type=ModelType.FLOW_AV, device=None):
         super().__init__(model_config, model_type, device=device, unet_model=comfy.ldm.minimax.model.MiniMaxH3Model)
+        self.memory_usage_factor_conds = ("minimax_payload",)
+
+    def _target_rows(self):
+        if self.latent_shapes is None or len(self.latent_shapes) < 2:
+            return None
+        video, audio = self.latent_shapes[:2]
+        frame_rows = ((video[3] + 1) // 2) * ((video[4] + 1) // 2)
+        return video[2] * frame_rows + audio[-1] * 2
+
+    def memory_required(self, input_shape, cond_shapes={}):
+        target_rows = self._target_rows()
+        if target_rows is None:
+            return super().memory_required(input_shape, cond_shapes)
+
+        rows = input_shape[0] * target_rows
+        for name in self.memory_usage_factor_conds:
+            for shape in cond_shapes.get(name, ()):
+                rows += shape[0] * math.prod(shape[2:])
+        return rows * self.MEMORY_BYTES_PER_PACKED_ROW
+
+    def extra_conds_shapes(self, **kwargs):
+        if self.latent_shapes is None or len(self.latent_shapes) < 2:
+            return {}
+
+        video = self.latent_shapes[0]
+        frame_rows = ((video[3] + 1) // 2) * ((video[4] + 1) // 2)
+        cross_attn = kwargs.get("cross_attn")
+        rows = cross_attn.shape[1] if cross_attn is not None else 0
+
+        for keyframe in kwargs.get("minimax_keyframes") or ():
+            latent = keyframe.get("latent")
+            if latent is not None:
+                rows += latent.shape[2] * frame_rows
+            audio_latent = keyframe.get("audio_latent")
+            if audio_latent is not None:
+                rows += audio_latent.shape[-1] * 2
+
+        for ref in kwargs.get("minimax_refs") or ():
+            kind = ref["kind"]
+            if kind in ("audio", "video", "video_audio"):
+                rows += ref["ref_audio_t"] * 2
+            if kind == "image":
+                rows += (ref["latent_h"] // 2) * (ref["latent_w"] // 2)
+            elif kind in ("video", "video_audio"):
+                rows += ref["latent_t"] * (ref["latent_h"] // 2) * (ref["latent_w"] // 2)
+
+        return {"minimax_payload": [1, 1, rows]}
 
     def audio_scale(self):
         """Scale the sampler carries the audio stream at, 1.0 when not sampling the packed latent."""
@@ -2209,7 +2270,8 @@ class MiniMaxH3(BaseModel):
                 cross_attn.shape[1], vs[2], (vs[3] + 1) // 2 * 2, (vs[4] + 1) // 2 * 2,
                 latent_shapes[1][-1], keyframes=payload.get("keyframes"),
                 refs=payload.get("refs"))
-        out['minimax_payload'] = comfy.conds.CONDConstant(payload)
+        payload_shape = self.extra_conds_shapes(**kwargs).get("minimax_payload", [1])
+        out['minimax_payload'] = _MiniMaxH3Payload(payload, payload_shape)
         return out
 
     def _pool_masks_to_token_grid(self, masks):

--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -1218,8 +1218,6 @@ class CFGGuider:
         return sampling_function(self.inner_model, x, timestep, self.conds.get("negative", None), self.conds.get("positive", None), self.cfg, model_options=model_options, seed=seed)
 
     def inner_sample(self, noise, latent_image, device, sampler, sigmas, denoise_mask, callback, disable_pbar, seed, latent_shapes=None):
-        self.inner_model.latent_shapes = latent_shapes
-
         if latent_image is not None and torch.count_nonzero(latent_image) > 0: #Don't shift the empty latent image.
             latent_image = self.inner_model.process_latent_in(latent_image)
 
@@ -1284,6 +1282,7 @@ class CFGGuider:
         else:
             latent_shapes = [latent_image.shape]
             sampler_shapes = [tuple(latent_image.shape)]
+        self.model_patcher.model.latent_shapes = latent_shapes
         detail("Sampler: model=%s latent_shapes=%s", self.model_patcher.model.__class__.__name__, sampler_shapes)
 
         if len(latent_shapes) > 1 and callback is not None:

--- a/comfy/supported_models.py
+++ b/comfy/supported_models.py
@@ -970,7 +970,7 @@ class MiniMaxH3(supported_models_base.BASE):
     unet_extra_config = {}
     latent_format = latent_formats.MiniMaxH3AV
 
-    memory_usage_factor = 0.114
+    memory_usage_factor = 0.24
 
     supported_inference_dtypes = [torch.bfloat16, torch.float32]
 

--- a/tests-unit/comfy_test/test_minimax_h3_memory.py
+++ b/tests-unit/comfy_test/test_minimax_h3_memory.py
@@ -1,0 +1,165 @@
+import math
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from comfy.cli_args import args as cli_args
+
+if not torch.cuda.is_available():
+    cli_args.cpu = True
+
+import comfy.model_base  # noqa: E402
+import comfy.model_management  # noqa: E402
+import comfy.nested_tensor  # noqa: E402
+import comfy.sampler_helpers  # noqa: E402
+import comfy.samplers  # noqa: E402
+import comfy.supported_models  # noqa: E402
+from comfy.ldm.minimax.model import PackedLayout  # noqa: E402
+
+
+def _model(monkeypatch, latent_shapes):
+    monkeypatch.setattr(comfy.model_base.BaseModel, "__init__", lambda self, *args, **kwargs: None)
+    model = comfy.model_base.MiniMaxH3.__new__(comfy.model_base.MiniMaxH3)
+    model.__init__(None)
+    model.memory_usage_factor = comfy.supported_models.MiniMaxH3.memory_usage_factor
+    model.memory_usage_shape_process = {}
+    model.latent_shapes = latent_shapes
+    model.model_sampling = SimpleNamespace(audio_scale=1.0)
+    return model
+
+
+def _packed_shape(latent_shapes, batch=1):
+    elements = sum(math.prod(shape[1:]) for shape in latent_shapes)
+    return [batch, 1, elements]
+
+
+def test_minimax_h3_without_latent_shapes_uses_generic_memory_fallback(monkeypatch):
+    model = _model(monkeypatch, None)
+    monkeypatch.setattr(comfy.model_management, "xformers_enabled", lambda: False)
+    monkeypatch.setattr(comfy.model_management, "pytorch_attention_flash_attention", lambda: False)
+    input_shape = (1, 24, 3, 4, 6)
+    area = input_shape[0] * math.prod(input_shape[2:])
+
+    assert model.memory_usage_factor == 0.24
+    assert model.memory_required(input_shape) == area * 0.15 * 0.24 * 1024 * 1024
+
+
+def test_sampler_exposes_nested_shapes_before_prepare_sampling(monkeypatch):
+    video = torch.empty(1, 24, 3, 4, 6)
+    audio = torch.empty(1, 32, 2, 5)
+    model = SimpleNamespace(latent_shapes=None)
+    guider = comfy.samplers.CFGGuider(SimpleNamespace(model=model, model_options={}))
+
+    class ShapesSeen(Exception):
+        pass
+
+    def check_shapes(*args, **kwargs):
+        assert model.latent_shapes == [video.shape, audio.shape]
+        raise ShapesSeen
+
+    monkeypatch.setattr(comfy.samplers, "detail", check_shapes)
+    with pytest.raises(ShapesSeen):
+        guider.sample(
+            comfy.nested_tensor.NestedTensor([video, audio]),
+            comfy.nested_tensor.NestedTensor([video, audio]),
+            sampler=None,
+            sigmas=torch.ones(1),
+        )
+
+
+def test_minimax_h3_estimates_real_packed_target_and_all_condition_rows(monkeypatch):
+    latent_shapes = [(1, 24, 3, 4, 6), (1, 32, 2, 5)]
+    model = _model(monkeypatch, latent_shapes)
+    keyframes = [
+        {"resolved_frame_index": 0, "latent": torch.empty(1, 24, 2, 4, 6)},
+        {"resolved_frame_index": 1, "audio_latent": torch.empty(1, 32, 2, 4)},
+    ]
+    refs = [
+        {"kind": "image", "latent_h": 4, "latent_w": 6},
+        {"kind": "audio", "ref_audio_t": 3},
+        {"kind": "video", "latent_t": 2, "latent_h": 4, "latent_w": 6, "ref_audio_t": 0},
+        {"kind": "video_audio", "latent_t": 2, "latent_h": 4, "latent_w": 6, "ref_audio_t": 3},
+    ]
+    cross_attn = torch.empty(1, 29, 8)
+
+    payload_shape = model.extra_conds_shapes(
+        cross_attn=cross_attn,
+        minimax_keyframes=keyframes,
+        minimax_refs=refs,
+    )["minimax_payload"]
+    layout = PackedLayout(29, 3, 4, 6, 5, keyframes=keyframes, refs=refs)
+    target_rows = 3 * 2 * 3 + 5 * 2
+
+    assert payload_shape == [1, 1, layout.seq_len - target_rows]
+    estimate = model.memory_required(
+        _packed_shape(latent_shapes),
+        cond_shapes={"minimax_payload": [payload_shape]},
+    )
+    assert estimate == layout.seq_len * model.MEMORY_BYTES_PER_PACKED_ROW
+
+    monkeypatch.setattr(comfy.model_base.BaseModel, "extra_conds", lambda self, **kwargs: {})
+    payload = model.extra_conds(minimax_keyframes=keyframes, minimax_refs=refs)["minimax_payload"]
+    expected_shape = model.extra_conds_shapes(minimax_keyframes=keyframes, minimax_refs=refs)["minimax_payload"]
+    assert payload.size() == expected_shape
+    assert payload.process_cond(batch_size=1).size() == expected_shape
+
+
+def test_minimax_h3_packed_scalar_count_does_not_become_row_count(monkeypatch):
+    latent_shapes = [(1, 24, 37, 48, 84), (1, 32, 2, 207)]
+    model = _model(monkeypatch, latent_shapes)
+    packed_shape = _packed_shape(latent_shapes)
+    cross_attn = torch.empty(1, 29, 8)
+
+    assert packed_shape == [1, 1, 3593664]
+    target_rows = 37 * 24 * 42 + 207 * 2
+    full, minimum = comfy.sampler_helpers.estimate_memory(
+        SimpleNamespace(model=model),
+        packed_shape,
+        {"positive": [{"cross_attn": cross_attn}]},
+    )
+    bytes_per_row = model.MEMORY_BYTES_PER_PACKED_ROW
+    assert minimum == (target_rows + 29) * bytes_per_row
+    assert full == (target_rows * 2 + 29) * bytes_per_row
+    assert minimum < 6 * 1024 ** 3
+    assert full < 12 * 1024 ** 3
+
+
+def test_minimax_h3_measured_process_memory_row_delta_envelope(monkeypatch):
+    # Windows process-dedicated allocation peaks from vanilla H3 runs stopped after
+    # the first transformer block. Peak differences between sequence sizes cancel
+    # fixed model/process allocation and isolate the row-dependent working-set slope.
+    cases = {
+        "t17": ((1, 24, 17, 30, 52), (1, 32, 2, 93), 1858949120),
+        "t37": ((1, 24, 37, 30, 52), (1, 32, 2, 207), 3066916864),
+        "t72": ((1, 24, 72, 30, 52), (1, 32, 2, 405), 5080199168),
+    }
+    estimates = {}
+    for name, (video_shape, audio_shape, _) in cases.items():
+        model = _model(monkeypatch, [video_shape, audio_shape])
+        payload_shape = model.extra_conds_shapes(cross_attn=torch.empty(1, 29, 8))["minimax_payload"]
+        estimates[name] = model.memory_required(
+            _packed_shape([video_shape, audio_shape]),
+            cond_shapes={"minimax_payload": [payload_shape]},
+        )
+
+    measured_deltas = (
+        ("t17", "t37", cases["t37"][2] - cases["t17"][2]),
+        ("t37", "t72", cases["t72"][2] - cases["t37"][2]),
+    )
+    for smaller, larger, measured in measured_deltas:
+        estimated = estimates[larger] - estimates[smaller]
+        assert measured <= estimated <= measured * 1.06
+
+    model = _model(monkeypatch, [cases["t37"][0], cases["t37"][1]])
+    ref = {"kind": "video", "latent_t": 37, "latent_h": 30, "latent_w": 52, "ref_audio_t": 0}
+    target_payload = model.extra_conds_shapes(cross_attn=torch.empty(1, 29, 8))["minimax_payload"]
+    ref_payload = model.extra_conds_shapes(cross_attn=torch.empty(1, 29, 8), minimax_refs=[ref])["minimax_payload"]
+    estimated_ref_delta = model.memory_required(
+        _packed_shape(model.latent_shapes), {"minimax_payload": [ref_payload]}
+    ) - model.memory_required(
+        _packed_shape(model.latent_shapes), {"minimax_payload": [target_payload]}
+    )
+    # The warm target/reference delta similarly isolates the reference-row working set.
+    measured_ref_delta = 5247971328 - 3100471296
+    assert measured_ref_delta <= estimated_ref_delta <= measured_ref_delta * 1.06


### PR DESCRIPTION
## The Problem

Issues such as #15781 come from two separate problems with the current MiniMax H3 memory estimate.

1. **The existing memory factor was never empirically calibrated for H3.**

   I have a local VRAM workbench that records process-dedicated memory peaks across different H3 packed-sequence sizes using the default ComfyUI settings. The measured working-set slope is approximately **151,000 bytes per packed row**.

   Fitting ComfyUI's existing generic area-based estimator to the same measurements gives a `memory_usage_factor` of approximately **0.24**. The current value of `0.114` substantially underestimates H3's actual memory requirements.

2. **The generic latent-area calculation does not represent H3's actual packed payload.**

   H3 combines video, audio, text, guides, and references into a single packed transformer sequence. The existing estimate only sees the sampler latent area, so it cannot correctly account for that sequence structure. In particular, it is blind to the additional reference rows used by Ref2VA.

## The Solution

This PR gives MiniMax H3 a model-specific memory estimate based on its actual packed input shapes.

When the AV stream shapes are available, the estimator counts the real packed rows contributed by the target video/audio streams, text conditioning, guides, and references, and applies the empirically measured **151,000 bytes/row** working-set estimate.

The generic H3 memory factor is also updated from `0.114` to the empirically calibrated `0.24` for paths where the packed AV geometry is not available.

Regression tests verify the row accounting against H3's actual `PackedLayout` and compare the estimator against measured process-memory deltas for both sequence-length growth and reference-video conditioning.
