### PR TITLE
Fix SeedVR2 partial rope for flat 3D q/k layout

### DIFF
--- a/comfy/ldm/seedvr/model.py
+++ b/comfy/ldm/seedvr/model.py
@@ -370,11 +370,20 @@ def _apply_rope1_partial(t: torch.Tensor, freqs_cis: torch.Tensor) -> torch.Tens
     seq_len = out.shape[-2]
     for start in range(0, seq_len, SEEDVR2_ROPE_PARTIAL_CHUNK_TOKENS):
         end = min(start + SEEDVR2_ROPE_PARTIAL_CHUNK_TOKENS, seq_len)
-        freqs_chunk = freqs_cis[start:end]
-        if rot_d == out.shape[-1]:
-            out[..., start:end, :] = apply_rope1(out[..., start:end, :], freqs_chunk).to(out.dtype)
-        else:
-            out[..., start:end, :rot_d] = apply_rope1(out[..., start:end, :rot_d], freqs_chunk).to(out.dtype)
+        freqs_chunk = freqs_cis[start:end]  # [Ls, K, 2, 2] rotation matrices
+        target = out[..., start:end, :]
+        sub = target[..., :rot_d] if rot_d != out.shape[-1] else target
+        # comfy-kitchen/flux apply_rope1 mis-handle this 3D layout; the freqs are
+        # explicit 2x2 rotation matrices, so rotate each pair directly.
+        if sub.numel():
+            pairs = sub.reshape(*sub.shape[:-1], -1, 2).to(freqs_chunk.dtype)
+            f0 = freqs_chunk[..., 0, :]  # [Ls, K, 2]
+            f1 = freqs_chunk[..., 1, :]
+            rope = (pairs[..., 0:1] * f0 + pairs[..., 1:2] * f1).reshape(sub.shape).to(out.dtype)
+            if rot_d == out.shape[-1]:
+                target[...] = rope
+            else:
+                target[..., :rot_d] = rope
     return out
 
 


### PR DESCRIPTION
# SeedVR2 (NaDiT 3B) crashes in `_apply_rope1_partial` with comfy-kitchen apply_rope1

## Environment

- Windows 10/11, AMD ROCm (RX 7900 XT, gfx1100), torch 2.13.0+rocm10.0.0 (TheRock stable wheel)
- comfy-kitchen 0.2.31, `--enable-triton-backend`
- ComfyUI master `comfy/ldm/seedvr/model.py` — identical code on master at time of writing
- Model: seedvr2 3B (int8), SeedVR2 image restoration workflow (KSampler, 1 step)

## Symptom

Running a SeedVR2 workflow aborts inside `comfy/ldm/seedvr/model.py:377`:

```
comfy_kitchen/backends/triton/rope.py:174, in _apply_rope
    batch, dim1, dim2, head_dim = x1.shape
ValueError: not enough values to unpack (expected 4, got 3)
```

`_apply_rope1_partial` calls `apply_rope1` (flux, overridden to `comfy.quant_ops.ck.apply_rope1`)
with the flat SeedVR2 layout `[h, L, d]` (heads, sequence, head_dim — the caller transposes to
`[heads, L, d]`), while comfy-kitchen's rope kernels require 4D `[B, H, S, D]`.

## Root cause analysis

- SeedVR2's mmrope3d freqs are built by `_to_flux_freqs_cis()` as **explicit 2x2 rotation
  matrices** with shape `[L, K, 2, 2]` (K = head_dim/2).
- The correct rotation for this layout is a per-pair matrix apply:
  `out[h, s, k, j] = Σ_i pairs[h, s, k, i] * freqs[s, k, i, j]`.
- Neither comfy-kitchen's triton kernel nor flux's reference `_apply_rope1` handles this
  3D-layout + matrix-freqs combination (verified numerically: both produce garbage vs the
  matrix definition; the triton path crashes on unpack, an einsum-shaped variant fails on
  chunked L), so the crash is not specific to the triton backend — any route through
  `apply_rope1` with these shapes is broken.

## Minimal repro (GPU)

```python
import torch, comfy.quant_ops as q
h, L, d, K = 20, 1013, 128, 64
x = torch.randn(h, L, d, device="cuda", dtype=torch.bfloat16)
th = torch.linspace(0.1, 1.5, L, device="cuda")
cos, sin = th.cos().float(), th.sin().float()
freqs = torch.stack([cos, -sin, sin, cos], dim=-1).reshape(L, 1, 2, 2).expand(L, K, 2, 2).contiguous().to(torch.bfloat16)
# crash: q.ck.apply_rope1(x, freqs)
# reference (correct): torch.einsum('hLki,Lkij->hLkj', x.reshape(h, L, K, 2), freqs)
```

## Suggestion

Either teach comfy-kitchen's `apply_rope1` to accept the SeedVR2 3D `[h, L, d]` +
`[L, K, 2, 2]` matrix-freqs layout, or make `_apply_rope1_partial` use the matrix
rotation directly (local workaround attached as `.diff` — verified numerically exact,
full rotation, partial rotation `rot_d < head_dim`, and multi-chunk `L > 4096` cases).

Attached: `seedvr_rope_fix.diff`