### PR TITLE
chore: remove redundant GLIGEN embedding assignment

### DIFF
--- a/comfy/gligen.py
+++ b/comfy/gligen.py
@@ -175,7 +175,6 @@ class PositionNet(nn.Module):
     def forward(self, boxes, masks, positive_embeddings):
         B, N, _ = boxes.shape
         masks = masks.unsqueeze(-1)
-        positive_embeddings = positive_embeddings
 
         # embedding position (it may includes padding as placeholder)
         xyxy_embedding = self.fourier_embedder(boxes)  # B*N*4 --> B*N*C


### PR DESCRIPTION
Remove the redundant positive_embeddings self-assignment in PositionNet.forward. The tensor is consumed unchanged by the existing mask operation.

QA not required: this is a no-op cleanup with no API-node or pricing impact.