### PR TITLE
feat(Video): add Concatenate Videos node

### DIFF
--- a/comfy_api/input_impl/__init__.py
+++ b/comfy_api/input_impl/__init__.py
@@ -1,7 +1,8 @@
 # This file only exists for backwards compatibility.
-from comfy_api.latest._input_impl import VideoFromFile, VideoFromComponents
+from comfy_api.latest._input_impl import VideoFromFile, VideoFromComponents, VideoConcatenated
 
 __all__ = [
     "VideoFromFile",
     "VideoFromComponents",
+    "VideoConcatenated",
 ]

--- a/comfy_api/latest/__init__.py
+++ b/comfy_api/latest/__init__.py
@@ -4,7 +4,7 @@ from comfy_api.internal import ComfyAPIBase
 from comfy_api.internal.singleton import ProxiedSingleton
 from comfy_api.internal.async_to_sync import create_sync_class
 from ._input import ImageInput, AudioInput, MaskInput, LatentInput, VideoInput
-from ._input_impl import VideoFromFile, VideoFromComponents
+from ._input_impl import VideoFromFile, VideoFromComponents, VideoConcatenated
 from ._util import VideoCodec, VideoContainer, VideoComponents, MESH, VOXEL, SPLAT, File3D
 from . import _io_public as io
 from . import _ui_public as ui
@@ -136,6 +136,7 @@ class Input:
 class InputImpl:
     VideoFromFile = VideoFromFile
     VideoFromComponents = VideoFromComponents
+    VideoConcatenated = VideoConcatenated
 
 class Types:
     VideoCodec = VideoCodec

--- a/comfy_api/latest/_input_impl/__init__.py
+++ b/comfy_api/latest/_input_impl/__init__.py
@@ -1,7 +1,8 @@
-from .video_types import VideoFromFile, VideoFromComponents
+from .video_types import VideoFromFile, VideoFromComponents, VideoConcatenated
 
 __all__ = [
     # Implementations
     "VideoFromFile",
     "VideoFromComponents",
+    "VideoConcatenated",
 ]

--- a/comfy_api/latest/_input_impl/video_types.py
+++ b/comfy_api/latest/_input_impl/video_types.py
@@ -2,8 +2,10 @@ from av.bitstream import BitStreamFilterContext
 from av.container import InputContainer
 from av.subtitles.stream import SubtitleStream
 from av.video.reformatter import ColorPrimaries, ColorRange, ColorTrc
+from dataclasses import dataclass
 from fractions import Fraction
-from typing import Optional
+from types import SimpleNamespace
+from typing import Optional, Sequence
 from .._input import AudioInput, VideoInput
 import av
 import io
@@ -357,7 +359,7 @@ class VideoFromFile(VideoInput):
                     duration_from_start = min(raw_duration, -self.__start_time)
                 else:
                     duration_from_start = raw_duration - self.__start_time
-                duration_seconds = min(self.__duration, duration_from_start)
+                duration_seconds = min(self.__duration, duration_from_start) if self.__duration else duration_from_start
                 estimated_frames = int(round(duration_seconds * float(video_stream.average_rate)))
                 if estimated_frames > 0:
                     return estimated_frames
@@ -366,7 +368,7 @@ class VideoFromFile(VideoInput):
             start_time, duration = self.get_active_trim_window()
             frame_count = 1
             start_pts = int(start_time / video_stream.time_base)
-            end_pts = int((start_time + duration) / video_stream.time_base)
+            end_pts = int((start_time + duration) / video_stream.time_base) if duration else None
             container.seek(start_pts, stream=video_stream)
             frame_iterator = (
                 container.decode(video_stream)
@@ -379,7 +381,7 @@ class VideoFromFile(VideoInput):
             else:
                 raise ValueError(f"Could not determine frame count for file '{self.__file}'\nNo frames exist for start_time {self.__start_time}")
             for frame in frame_iterator:
-                if frame.pts >= end_pts:
+                if end_pts is not None and frame.pts >= end_pts:
                     break
                 frame_count += 1
             return frame_count
@@ -1084,3 +1086,834 @@ class VideoFromComponents(VideoInput):
             return None
         #TODO Consider tracking duration and trimming at time of save?
         return VideoFromFile(self.get_stream_source(), start_time=start_time, duration=duration)
+
+
+def _fit_images(images: torch.Tensor, width: int, height: int) -> torch.Tensor:
+    """Scale a (N, H, W, C) batch to fit inside width x height, keeping the aspect ratio, centered on black."""
+    src_h, src_w = images.shape[1], images.shape[2]
+    scale = min(width / src_w, height / src_h)
+    new_w = max(1, int(round(src_w * scale)))
+    new_h = max(1, int(round(src_h * scale)))
+    samples = images.movedim(-1, 1)
+    if (new_w, new_h) != (src_w, src_h):
+        samples = torch.nn.functional.interpolate(samples, size=(new_h, new_w), mode="bilinear", align_corners=False)
+    left = (width - new_w) // 2
+    top = (height - new_h) // 2
+    samples = torch.nn.functional.pad(samples, (left, width - new_w - left, top, height - new_h - top))
+    return samples.movedim(1, -1)
+
+
+def _match_audio_channels(waveform: torch.Tensor, channels: int) -> torch.Tensor:
+    have = waveform.shape[1]
+    if have == channels:
+        return waveform
+    if channels == 1:
+        return waveform.mean(dim=1, keepdim=True)
+    if have == 1:
+        return waveform.repeat(1, channels, 1)
+    if have > channels:
+        return waveform[:, :channels]
+    return torch.nn.functional.pad(waveform, (0, 0, 0, channels - have))
+
+
+def _display_dimensions(video: VideoInput) -> tuple[int, int]:
+    """(width, height) as displayed. VideoFromFile.get_dimensions() reports the stored frame size,
+    which ignores a 90/270-degree display rotation that transcoding bakes in."""
+    if not isinstance(video, VideoFromFile):
+        return video.get_dimensions()
+    with av.open(video.get_stream_source(), mode="r") as container:
+        if not len(container.streams.video):
+            raise ValueError("No video stream found in video")
+        stream = container.streams.video[0]
+        width, height = stream.width, stream.height
+        try:
+            for frame in container.decode(stream):
+                if frame.rotation and (int(round(frame.rotation // 90)) % 4) % 2:
+                    width, height = height, width
+                break
+        except av.error.FFmpegError:
+            pass
+    return width, height
+
+
+_TRIM_EPSILON = 1e-6
+
+
+def _segment_filter_graph(frame, time_base: Fraction, rotation_k: int, target_size: tuple[int, int] | None):
+    """Bake the display rotation and, when the rotated frame differs from target_size, scale it to fit
+    inside the target (aspect preserved) and pad the remainder with black. Returns (graph, source, sink) or None;
+    the graph must stay referenced while its contexts are in use."""
+    steps = {
+        0: [],
+        1: [("transpose", "cclock")],
+        2: [("hflip", None), ("vflip", None)],
+        3: [("transpose", "clock")],
+    }[rotation_k]
+    rotated = (frame.height, frame.width) if rotation_k % 2 else (frame.width, frame.height)
+    if target_size is not None and rotated != target_size:
+        width, height = target_size
+        steps = steps + [
+            ("scale", f"{width}:{height}:force_original_aspect_ratio=decrease:force_divisible_by=2"),
+            ("pad", f"{width}:{height}:(ow-iw)/2:(oh-ih)/2"),
+        ]
+    if not steps:
+        return None
+    graph = av.filter.Graph()
+    source = graph.add_buffer(width=frame.width, height=frame.height, format=frame.format.name, time_base=time_base)
+    tail = source
+    for filter_name, filter_args in steps:
+        step = graph.add(filter_name, filter_args)
+        tail.link_to(step)
+        tail = step
+    sink = graph.add("buffersink")
+    tail.link_to(sink)
+    graph.configure()
+    return graph, source, sink
+
+
+@dataclass
+class _ConcatSegment:
+    """Header-level facts about one concatenation source, read once before encoding."""
+    time_base: Fraction
+    rate: Fraction
+    bit_depth: int
+    color_space: str | None
+    color_props: SimpleNamespace
+    audio_index: int | None
+    sample_rate: int
+    channels: int
+
+
+class _ConcatEncoder:
+    """Output side of ``VideoConcatenated.save_to``: one encoder that every source segment feeds in turn.
+
+    This mirrors the writer half of ``VideoFromFile._save_transcoded`` (lazy output open, pts
+    rebasing/clamping, audio drain) plus a per-segment base offset and silence padding so the audio
+    track stays gapless across segment boundaries. Keep the two in sync.
+
+    Every frame pushed here must already be rebased to its segment start, expressed in ``time_base``
+    units *and* stamped ``frame.time_base = time_base``: PyAV rescales ``frame.pts`` from
+    ``frame.time_base`` to the codec time base on encode.
+
+    The audio track must be gapless: PyAV does not reject pts gaps, it silently lets every later
+    segment's audio run ahead of its video.
+    """
+
+    def __init__(
+        self,
+        path: str | io.BytesIO,
+        open_kwargs: dict,
+        output_format: VideoContainer,
+        output_codec: VideoCodec,
+        metadata: dict | None,
+        *,
+        time_base: Fraction,
+        rate: Fraction,
+        pix_fmt: str,
+        crf: float | None,
+        color_space: str | None,
+        color_props: SimpleNamespace | None,
+        audio: tuple[int, str, int] | None,
+    ):
+        self.path = path
+        self.open_kwargs = open_kwargs
+        self.output_format = output_format
+        self.output_codec = output_codec
+        self.metadata = metadata
+        self.time_base = time_base
+        self.rate = rate
+        self.pix_fmt = pix_fmt
+        self.crf = crf
+        self.color_space = color_space
+        self.color_props = color_props
+        # (sample_rate, layout, channels) of the output audio stream, or None for no audio
+        self.audio = audio
+        self.audio_time_base = Fraction(1, audio[0]) if audio is not None else None
+
+        self.output = None
+        self.out_video = None
+        self.out_audio = None
+        self.output_size: tuple[int, int] | None = None
+        self.last_video_pts = None
+        self.last_video_end = None
+        # rebased pts -> true display duration: the mp4 muxer pads the last sample with 1/rate otherwise
+        self.video_frame_durations = {}
+        # one packet is held back so its duration can still be fixed up at a segment boundary
+        self.held_packet = None
+        self.samples_written = 0
+        self.pending_audio = []
+
+        self.seg_base = 0
+        self.seg_end = None
+        self.seg_video_done = False
+        self.seg_audio_done = True
+        self.duration_cap = None
+        self.pts_step = 1
+
+    @property
+    def segment_done(self) -> bool:
+        return self.seg_video_done and self.seg_audio_done
+
+    def _samples_at(self, pts: int) -> int:
+        return math.ceil(pts * self.time_base * self.audio[0])
+
+    def audio_frame_from_ndarray(self, nd_planar):
+        frame = av.AudioFrame.from_ndarray(np.ascontiguousarray(nd_planar), format="fltp", layout=self.audio[1])
+        frame.sample_rate = self.audio[0]
+        return frame
+
+    def begin_segment(self, *, pts_step: int, audio_cap_samples: int | None, has_audio: bool):
+        if self.out_audio is not None and not self.seg_audio_done:
+            self._drain_audio(final=True)
+        # a finished segment never leaves audio behind for the next one
+        self.pending_audio.clear()
+        self.seg_base = self.last_video_end or 0
+        self.seg_end = None
+        self.seg_video_done = False
+        self.pts_step = pts_step
+        self.duration_cap = None
+        if self.audio is None:
+            self.seg_audio_done = True
+            return
+        target = self._samples_at(self.seg_base)
+        if self.out_audio is not None:
+            self._pad_silence(target - self.samples_written)
+        if audio_cap_samples is not None:
+            self.duration_cap = target + audio_cap_samples
+        self.seg_audio_done = not has_audio
+
+    def _open(self, frame):
+        if frame.width % 2 or frame.height % 2:
+            raise ValueError(f"{self.output_codec.value.upper()} output requires even dimensions, got {frame.width}x{frame.height}")
+        self.output_size = (frame.width, frame.height)
+        self.output = av.open(self.path, **self.open_kwargs)
+        # Add metadata before writing any streams
+        if self.metadata is not None:
+            for key, value in self.metadata.items():
+                self.output.metadata[key] = value if isinstance(value, str) else json.dumps(value)
+        self.out_video = self.output.add_stream(VIDEO_ENCODERS[self.output_codec], rate=self.rate)
+        # no B-frames: reordering makes mp4 sample durations follow decode order,
+        # so irregular-VFR spans and segment boundaries land wrong
+        self.out_video.codec_context.max_b_frames = 0
+        self.out_video.width = frame.width
+        self.out_video.height = frame.height
+        self.out_video.pix_fmt = self.pix_fmt
+        self.out_video.options = video_encoder_options(self.output_codec, self.crf)
+        if self.color_props is not None:
+            copy_color_properties(self.color_props, self.out_video.codec_context)
+        elif self.color_space is not None:
+            set_video_color_properties(self.out_video.codec_context, self.color_space)
+        # all segments are rescaled into this time base, so variable frame rate survives
+        self.out_video.codec_context.time_base = self.time_base
+        if self.audio is not None:
+            sample_rate, layout, _ = self.audio
+            audio_codec = "libopus" if self.output_format == VideoContainer.WEBM else "aac"
+            self.out_audio = self.output.add_stream(audio_codec, rate=sample_rate, layout=layout)
+
+    def push_video(self, frame, frame_duration: int, segment_end: int | None):
+        if self.seg_end is None and segment_end is not None:
+            self.seg_end = self.seg_base + segment_end
+        if self.output is None:
+            self._open(frame)
+        end = self.seg_end
+        if frame.pts is not None:
+            frame.pts += self.seg_base
+            if end is not None and frame.pts + frame_duration > end:
+                clamped_pts = end - frame_duration
+                if clamped_pts >= self.seg_base and (self.last_video_pts is None or clamped_pts > self.last_video_pts):
+                    frame.pts = min(frame.pts, clamped_pts)
+                elif frame.pts < end:
+                    frame_duration = end - frame.pts
+                else:
+                    return
+        if frame.pts is None or (self.last_video_pts is not None and frame.pts <= self.last_video_pts):
+            # broken sources emit missing/backward timestamps mid-stream, which the
+            # muxer rejects; nudge them forward by one nominal frame interval
+            frame.pts = self.seg_base if self.last_video_pts is None else max(self.seg_base, self.last_video_pts + self.pts_step)
+            if end is not None and frame.pts + frame_duration > end:
+                if frame.pts >= end:
+                    return
+                frame_duration = end - frame.pts
+        self.last_video_pts = frame.pts
+        self.last_video_end = frame.pts + frame_duration
+        self.video_frame_durations[frame.pts] = frame_duration
+        # the decoded pict_type would force x264's frame types (intra-only
+        # sources like MJPEG/ProRes would come out all-keyframe)
+        frame.pict_type = 0
+        for packet in self.out_video.encode(frame):
+            self._emit(packet)
+        self._drain_audio()
+
+    def _emit(self, packet):
+        packet.duration = self.video_frame_durations.pop(packet.pts, 0)
+        held = self.held_packet
+        if held is not None:
+            if not held.duration and held.pts is not None and packet.pts is not None and packet.pts > held.pts:
+                held.duration = packet.pts - held.pts
+            self.output.mux(held)
+        self.held_packet = packet
+
+    def _mux_held(self):
+        held = self.held_packet
+        if held is None:
+            return
+        if held.pts == self.last_video_pts and self.last_video_end is not None:
+            held.duration = max(held.duration or 0, self.last_video_end - held.pts)
+        self.output.mux(held)
+        self.held_packet = None
+
+    def end_video(self, segment_end: int | None):
+        """The segment's video is complete; ``segment_end`` (segment-relative) is set when the source
+        continues past its trim window, so the last kept frame is held to the window end."""
+        self.seg_video_done = True
+        if segment_end is not None and self.last_video_pts is not None:
+            self.last_video_end = max(self.last_video_end, self.seg_base + segment_end)
+
+    def end_audio(self):
+        if not self.seg_audio_done:
+            self._drain_audio(final=True)
+            self.seg_audio_done = True
+
+    def push_audio(self, frame) -> bool:
+        """Queue a resampled audio frame; returns True once the segment's audio is complete."""
+        if self.seg_audio_done:
+            return True
+        self.pending_audio.append(frame)
+        if self.seg_video_done:
+            # the video window is complete so the cap is final, but containers
+            # that interleave audio behind video (fragmented mp4) still owe most
+            # of it: stop only once the demuxed audio covers the cap
+            cap = self._drain_audio()
+            if self.pending_audio or self.samples_written >= cap:
+                self._drain_audio(final=True)
+                self.seg_audio_done = True
+        return self.seg_audio_done
+
+    def push_audio_cap(self, samples: int):
+        cap = self._samples_at(self.seg_base) + samples
+        self.duration_cap = cap if self.duration_cap is None else min(self.duration_cap, cap)
+
+    def _drain_audio(self, final=False):
+        # Audio may cover the pts span of the video written so far, capped by the segment's window
+        if self.audio is None:
+            return 0
+        if self.last_video_end is None:
+            cap = 0
+        else:
+            cap = self._samples_at(self.last_video_end)
+        if self.duration_cap is not None:
+            cap = min(cap, self.duration_cap)
+        while self.pending_audio and not self.seg_audio_done:
+            frame = self.pending_audio[0]
+            if self.samples_written + frame.samples <= cap:
+                frame.pts = self.samples_written
+                frame.time_base = self.audio_time_base
+                self.output.mux(self.out_audio.encode(frame))
+                self.samples_written += frame.samples
+                self.pending_audio.pop(0)
+                continue
+            if final:
+                keep = frame.to_ndarray()[..., :cap - self.samples_written]
+                if keep.shape[-1] > 0:
+                    tail = self.audio_frame_from_ndarray(keep)
+                    tail.pts = self.samples_written
+                    tail.time_base = self.audio_time_base
+                    self.output.mux(self.out_audio.encode(tail))
+                    self.samples_written += keep.shape[-1]
+                self.pending_audio.clear()
+            break
+        if self.duration_cap is not None and self.samples_written >= self.duration_cap:
+            # the window is full: whatever is still queued belongs past this segment's end
+            self.seg_audio_done = True
+            self.pending_audio.clear()
+        return cap
+
+    def _pad_silence(self, samples: int):
+        channels = self.audio[2]
+        while samples > 0:
+            chunk = min(samples, 1024)
+            frame = self.audio_frame_from_ndarray(np.zeros((channels, chunk), dtype=np.float32))
+            frame.pts = self.samples_written
+            frame.time_base = self.audio_time_base
+            self.output.mux(self.out_audio.encode(frame))
+            self.samples_written += chunk
+            samples -= chunk
+
+    def end_segment(self):
+        """Hold the segment's last frame to the segment end (its window end for trimmed sources)."""
+        if self.last_video_pts is None:
+            return
+        hold = self.last_video_end - self.last_video_pts
+        held = self.held_packet
+        if held is not None and held.pts == self.last_video_pts:
+            held.duration = max(held.duration or 0, hold)
+        elif self.last_video_pts in self.video_frame_durations:
+            self.video_frame_durations[self.last_video_pts] = max(self.video_frame_durations[self.last_video_pts], hold)
+
+    def finish(self):
+        if self.output is None:
+            raise ValueError("No decodable video frames found in concatenated video")
+        if self.out_audio is not None:
+            if not self.seg_audio_done:
+                self._drain_audio(final=True)
+            # a final clip without (or with short) audio still needs the track to reach the video end
+            self._pad_silence(self._samples_at(self.last_video_end) - self.samples_written)
+        for packet in self.out_video.encode(None):
+            self._emit(packet)
+        self._mux_held()
+        if self.out_audio is not None:
+            self.output.mux(self.out_audio.encode(None))
+        self.output.close()
+        self.output = None
+
+    def abort(self):
+        if self.output is None:
+            return
+        self.output.close()
+        self.output = None
+        if isinstance(self.path, (str, os.PathLike)) and os.path.exists(self.path):
+            os.remove(self.path)
+
+
+class VideoConcatenated(VideoInput):
+    """
+    Lazy back-to-back concatenation of VideoInputs, in order. The sources are decoded and encoded
+    in a single streaming pass when the video is saved, so peak memory does not scale with length.
+    Saving keeps each clip's own frame timing (variable frame rate); get_components() returns a
+    constant-frame-rate tensor at the first clip's rate, retiming the others by repeating/dropping frames.
+    """
+
+    def __init__(self, sources: Sequence[VideoInput], *, resize: str = "fit"):
+        """
+        resize: "fit" scales later clips to fit inside the first clip's frame (aspect preserved,
+        black bars); "error" raises when the resolutions differ.
+        """
+        flat = []
+        for source in sources:
+            # a nested concatenation with the same resize mode is just more sources; a different
+            # mode stays opaque so its own canvas rule is honored
+            if isinstance(source, VideoConcatenated) and source._resize == resize:
+                flat.extend(source._sources)
+            else:
+                flat.append(source)
+        if not flat:
+            raise ValueError("VideoConcatenated needs at least one source video")
+        if resize not in ("fit", "error"):
+            raise ValueError(f"Unsupported resize mode: {resize}")
+        # single underscore on purpose: nested concatenations read each other's sources
+        self._sources = flat
+        self._resize = resize
+        self._stream_cache: io.BytesIO | None = None
+        self._dimensions: tuple[int, int] | None = None
+
+        color_spaces = {source.get_color_space() for source in flat} - {"auto"}
+        if len(color_spaces) > 1:
+            raise ValueError(
+                f"Cannot concatenate videos with different color spaces ({', '.join(sorted(color_spaces))}) without color conversion"
+            )
+        if resize == "error":
+            dimensions = [_display_dimensions(source) for source in flat]
+            self._dimensions = dimensions[0]
+            for index, dims in enumerate(dimensions):
+                if dims != dimensions[0]:
+                    raise ValueError(
+                        f"video {index} is {dims[0]}x{dims[1]}; expected {dimensions[0][0]}x{dimensions[0][1]} (resize is set to error)"
+                    )
+
+    def get_dimensions(self) -> tuple[int, int]:
+        # the first clip defines the canvas, as displayed (rotation baked in)
+        if self._dimensions is None:
+            self._dimensions = _display_dimensions(self._sources[0])
+        return self._dimensions
+
+    def get_frame_rate(self) -> Fraction:
+        return self._sources[0].get_frame_rate()
+
+    def get_duration(self) -> float:
+        return float(sum(source.get_duration() for source in self._sources))
+
+    def get_frame_count(self) -> int:
+        # the constant-frame-rate view at the first clip's rate, so that
+        # frame_count / get_frame_rate() == get_duration() and it matches get_components()
+        rate = self.get_frame_rate()
+        total = 0
+        for source in self._sources:
+            count = source.get_frame_count()
+            if count <= 0:
+                continue
+            source_rate = source.get_frame_rate()
+            total += count if source_rate == rate else max(1, int(round(Fraction(count) * rate / source_rate)))
+        return int(total)
+
+    def get_bit_depth(self) -> int:
+        return max(source.get_bit_depth() for source in self._sources)
+
+    def get_color_space(self) -> str:
+        for source in self._sources:
+            color_space = source.get_color_space()
+            if color_space != "auto":
+                return color_space
+        return "sRGB"
+
+    def get_container_format(self) -> str:
+        # what get_stream_source() materializes
+        return "mp4"
+
+    def get_stream_source(self) -> io.BytesIO:
+        if self._stream_cache is None:
+            buffer = io.BytesIO()
+            self.save_to(buffer, format=VideoContainer.MP4, codec=VideoCodec.H264)
+            self._stream_cache = buffer
+        self._stream_cache.seek(0)
+        return self._stream_cache
+
+    def get_components(self) -> VideoComponents:
+        parts = [source.get_components() for source in self._sources]
+        frame_rate = parts[0].frame_rate
+        height, width = parts[0].images.shape[1], parts[0].images.shape[2]
+        images = []
+        for index, part in enumerate(parts):
+            part_images = part.images
+            if part.frame_rate != frame_rate and part_images.shape[0] > 0:
+                # the tensor form is constant frame rate: repeat/drop frames (nearest) so the clip
+                # keeps its duration at the first clip's rate
+                count = max(1, int(round(Fraction(part_images.shape[0]) * frame_rate / part.frame_rate)))
+                positions = torch.arange(count, dtype=torch.float64) * float(part.frame_rate / frame_rate)
+                part_images = part_images[positions.floor().long().clamp(max=part_images.shape[0] - 1)]
+            if (part_images.shape[1], part_images.shape[2]) != (height, width):
+                if self._resize == "error":
+                    raise ValueError(f"video {index} is {part_images.shape[2]}x{part_images.shape[1]}; expected {width}x{height}")
+                part_images = _fit_images(part_images, width, height)
+            images.append(part_images)
+        images_per_part = images
+        images = torch.cat(images, dim=0)
+
+        audio = None
+        audio_parts = [part.audio for part in parts if part.audio is not None]
+        if audio_parts:
+            # never degrade a source: the output carries the best rate and channel count present
+            sample_rate = max(int(part_audio["sample_rate"]) for part_audio in audio_parts)
+            # same layout clamp as save_to (mono / stereo / 5.1)
+            channels = {1: 1, 2: 2, 6: 6}.get(max(part_audio["waveform"].shape[1] for part_audio in audio_parts), 2)
+            blocks = []
+            for part, part_images in zip(parts, images_per_part):
+                samples = int(round(part_images.shape[0] / frame_rate * sample_rate))
+                if part.audio is None:
+                    blocks.append(torch.zeros(1, channels, samples))
+                    continue
+                waveform = part.audio["waveform"]
+                part_rate = int(part.audio["sample_rate"])
+                if part_rate != sample_rate:
+                    import torchaudio
+                    waveform = torchaudio.functional.resample(waveform, part_rate, sample_rate)
+                waveform = _match_audio_channels(waveform, channels)[..., :samples]
+                if waveform.shape[-1] < samples:
+                    waveform = torch.nn.functional.pad(waveform, (0, samples - waveform.shape[-1]))
+                blocks.append(waveform)
+            audio = AudioInput({"waveform": torch.cat(blocks, dim=2), "sample_rate": sample_rate})
+        return VideoComponents(images=images, audio=audio, frame_rate=frame_rate)
+
+    def as_trimmed(
+        self, start_time: float = 0, duration: float = 0, strict_duration: bool = True
+    ) -> VideoInput | None:
+        start_time = start_time or 0.0
+        duration = duration or 0.0
+        total = self.get_duration()
+        if start_time < 0:
+            start_time = max(total + start_time, 0.0)
+        remaining = duration if duration else math.inf
+        pieces = []
+        offset = 0.0
+        for source in self._sources:
+            if remaining <= _TRIM_EPSILON:
+                break
+            source_duration = source.get_duration()
+            piece_start = start_time - offset
+            offset += source_duration
+            if piece_start >= source_duration - _TRIM_EPSILON:
+                continue
+            piece_start = max(piece_start, 0.0)
+            take = min(source_duration - piece_start, remaining)
+            if take <= _TRIM_EPSILON:
+                break
+            to_end = take >= source_duration - piece_start - _TRIM_EPSILON
+            if piece_start == 0 and to_end:
+                pieces.append(source)
+            else:
+                piece = source.as_trimmed(piece_start, take, strict_duration=False)
+                if piece is None and to_end:
+                    # float rounding can push an exact remainder one ulp past the source's own
+                    # duration; "to the end" (duration 0) is what was meant
+                    piece = source.as_trimmed(piece_start, 0, strict_duration=False)
+                if piece is None:
+                    return None
+                pieces.append(piece)
+            remaining -= take
+        if not pieces:
+            return None
+        if strict_duration and duration and sum(piece.get_duration() for piece in pieces) < duration - 1e-6:
+            return None
+        if len(pieces) == 1:
+            return pieces[0]
+        return VideoConcatenated(pieces, resize=self._resize)
+
+    @staticmethod
+    def _as_file_source(video: VideoInput) -> "VideoFromFile":
+        if isinstance(video, VideoFromFile):
+            return video
+        start_time, duration = 0.0, 0.0
+        # a subclass that streams its own untrimmed source still owes us its trim window;
+        # the base get_stream_source() encodes via save_to, which already applies it
+        if type(video).get_stream_source is not VideoInput.get_stream_source:
+            start_time, duration = video.get_active_trim_window()
+        return VideoFromFile(video.get_stream_source(), start_time=start_time, duration=duration)
+
+    @staticmethod
+    def _probe_segment(segment: "VideoFromFile", index: int) -> _ConcatSegment:
+        with av.open(segment.get_stream_source(), mode="r") as container:
+            if not len(container.streams.video):
+                raise ValueError(f"No video stream found in video {index}")
+            video_stream = container.streams.video[0]
+            audio_stream = last_decodable_audio_stream(container)
+            sample_rate = channels = 0
+            if audio_stream is not None:
+                sample_rate = audio_stream.codec_context.sample_rate
+                channels = audio_stream.codec_context.channels
+                if not sample_rate:
+                    sample_rate, channels = probe_audio_params(container, audio_stream)
+                    if not sample_rate:
+                        logging.warning("Audio stream parameters of video %d could not be determined; ignoring its audio.", index)
+                        audio_stream = None
+            return _ConcatSegment(
+                time_base=video_stream.time_base,
+                rate=Fraction(video_stream.average_rate) if video_stream.average_rate else Fraction(1),
+                bit_depth=video_stream_bit_depth(video_stream),
+                color_space=video_stream_color_space(video_stream),
+                color_props=SimpleNamespace(
+                    color_primaries=video_stream.color_primaries,
+                    color_trc=video_stream.color_trc,
+                    colorspace=video_stream.colorspace,
+                    color_range=video_stream.color_range,
+                ),
+                audio_index=audio_stream.index if audio_stream is not None else None,
+                sample_rate=int(sample_rate),
+                channels=int(channels),
+            )
+
+    def save_to(
+        self,
+        path: str | io.BytesIO,
+        format: VideoContainer = VideoContainer.AUTO,
+        codec: VideoCodec = VideoCodec.AUTO,
+        metadata: Optional[dict] = None,
+        bit_depth: int | None = None,
+        crf: float | None = None,
+        color_space: str | None = None,
+    ):
+        """Re-encode every source, one frame at a time, into a single output; peak memory does not scale with length."""
+        if color_space is not None and color_space not in VIDEO_COLOR_TRANSFERS:
+            raise ValueError(f"Unsupported video color space: {color_space}")
+        open_kwargs, output_format, output_codec = video_output_config(path, format, codec)
+        segments = [self._as_file_source(source) for source in self._sources]
+        infos = [self._probe_segment(segment, index) for index, segment in enumerate(segments)]
+
+        time_bases = {info.time_base for info in infos}
+        # exact for 24/25/30/50/60 and the NTSC 23.976/29.97/59.94 rates; every frame's pts is
+        # rescaled independently from its source, so rounding never accumulates
+        time_base = infos[0].time_base if len(time_bases) == 1 else Fraction(1, 360000)
+        rate = infos[0].rate
+        if bit_depth is None:
+            bit_depth = max(info.bit_depth for info in infos)
+        pix_fmt = "yuv420p10le" if bit_depth >= 10 else "yuv420p"
+
+        color_props = None
+        source_color_space = None
+        for info in infos:
+            if info.color_space is None:
+                continue
+            if color_space is not None and info.color_space != color_space:
+                raise ValueError(
+                    f"Cannot save {info.color_space} video as {color_space} without color conversion; "
+                    f"use auto or {info.color_space}"
+                )
+            if source_color_space is None:
+                source_color_space = info.color_space
+                color_props = info.color_props
+            elif info.color_space != source_color_space:
+                raise ValueError(
+                    f"Cannot concatenate {source_color_space} and {info.color_space} videos without color conversion"
+                )
+
+        audio = None
+        audio_infos = [info for info in infos if info.audio_index is not None]
+        if audio_infos:
+            # never degrade a source: the output carries the best rate and channel count present
+            sample_rate = 48000 if output_format == VideoContainer.WEBM else max(info.sample_rate for info in audio_infos)
+            layout = {1: "mono", 2: "stereo", 6: "5.1"}.get(max(info.channels for info in audio_infos), "stereo")
+            audio = (sample_rate, layout, {"mono": 1, "stereo": 2, "5.1": 6}[layout])
+
+        encoder = _ConcatEncoder(
+            path, open_kwargs, output_format, output_codec, metadata,
+            time_base=time_base, rate=rate, pix_fmt=pix_fmt, crf=crf,
+            color_space=color_space, color_props=color_props, audio=audio,
+        )
+        try:
+            for index, (segment, info) in enumerate(zip(segments, infos)):
+                # every open goes through get_stream_source() (it rewinds BytesIO sources), and
+                # segments run strictly one after another, so the same source may appear twice
+                with av.open(segment.get_stream_source(), mode="r") as container:
+                    self._encode_segment(encoder, container, segment, info, index, scale_to=encoder.output_size)
+            encoder.finish()
+        except BaseException:
+            encoder.abort()
+            raise
+
+    def _encode_segment(self, encoder: _ConcatEncoder, container: InputContainer, segment: "VideoFromFile", info: _ConcatSegment, index: int, *, scale_to: tuple[int, int] | None):
+        """Input side; mirrors the demux/decode half of VideoFromFile._save_transcoded for one source."""
+        video_stream = container.streams.video[0]
+        source_time_base = video_stream.time_base
+        start_time, duration = segment.get_active_trim_window()
+        start_pts = int(start_time / source_time_base)
+        end_pts = int((start_time + duration) / source_time_base) if duration else None
+        stream_end_pts = None
+        if video_stream.duration is not None:
+            stream_end_pts = (video_stream.start_time or 0) + video_stream.duration
+        output_end_pts = end_pts
+        if stream_end_pts is not None and (output_end_pts is None or stream_end_pts < output_end_pts):
+            output_end_pts = stream_end_pts
+        if start_pts != 0:
+            container.seek(start_pts, stream=video_stream)
+
+        audio_stream = None
+        resampler = None
+        audio_cap_samples = None
+        if encoder.audio is not None and info.audio_index is not None:
+            audio_stream = container.streams[info.audio_index]
+            target_rate, target_layout, _ = encoder.audio
+            resampler = av.audio.resampler.AudioResampler(format="fltp", layout=target_layout, rate=target_rate)
+            if duration:
+                audio_cap_samples = math.ceil(duration * target_rate)
+
+        def rescale(value: int) -> int:
+            return int(round(value * source_time_base / encoder.time_base))
+
+        source_pts_step = max(1, int(round((1 / info.rate) / source_time_base)))
+        encoder.begin_segment(
+            pts_step=max(1, int(round((1 / info.rate) / encoder.time_base))),
+            audio_cap_samples=audio_cap_samples,
+            has_audio=audio_stream is not None,
+        )
+
+        # per-source: a recognized tag means the frames already carry the output color space;
+        # an untagged full-range (yuvj/MJPEG) source is compressed to limited range instead
+        preserve_source_color = video_stream_color_space(video_stream) is not None
+        streams = [video_stream] if audio_stream is None else [video_stream, audio_stream]
+        video_done = False
+        video_pts_offset = None
+        source_size = None
+        filter_graph = None
+        audio_started = False
+        label = f"video {index}"
+
+        for packet in container.demux(*streams):
+            if encoder.segment_done:
+                break
+
+            if packet.stream == video_stream and not video_done:
+                try:
+                    frames = packet.decode()
+                except av.error.InvalidDataError:
+                    logging.info("pyav decode error")
+                    continue
+                for frame in frames:
+                    if frame.pts is not None and frame.pts < start_pts:
+                        continue
+                    if end_pts is not None and frame.pts is not None and frame.pts >= end_pts:
+                        video_done = True
+                        # the source continues past the window: hold the last kept frame to the window end
+                        end_offset = video_pts_offset if video_pts_offset is not None else start_pts
+                        encoder.end_video(rescale(end_pts - end_offset))
+                        break
+                    # the source's true display duration of this frame; average_rate is not a
+                    # frame duration (sparse/VFR sources), so it is only the fallback
+                    frame_duration = frame.duration if frame.duration else source_pts_step
+                    if end_pts is not None and frame.pts is not None:
+                        frame_duration = min(frame_duration, end_pts - frame.pts)
+                    if source_size is None:
+                        rotation_k = int(round(frame.rotation // 90)) % 4 if frame.rotation else 0
+                        rotated = (frame.height, frame.width) if rotation_k % 2 else (frame.width, frame.height)
+                        source_size = (frame.width, frame.height)
+                        target_size = scale_to
+                        if target_size is not None and rotated != target_size:
+                            if self._resize == "error":
+                                raise ValueError(f"{label} is {rotated[0]}x{rotated[1]}; expected {target_size[0]}x{target_size[1]}")
+                            if rotated[0] > target_size[0] or rotated[1] > target_size[1]:
+                                logging.warning(
+                                    "Concatenate: %s (%dx%d) is downscaled to fit the first video's %dx%d frame",
+                                    label, rotated[0], rotated[1], target_size[0], target_size[1],
+                                )
+                        filter_graph = _segment_filter_graph(frame, source_time_base, rotation_k, target_size)
+                    if (frame.width, frame.height) != source_size:
+                        # encoding would silently rescale the new geometry into the old one
+                        raise ValueError(
+                            f"Video resolution changes mid-stream in {label} "
+                            f"({source_size[0]}x{source_size[1]} -> {frame.width}x{frame.height}); cannot transcode"
+                        )
+                    if filter_graph is not None:
+                        filter_graph[1].push(frame)
+                        frame = filter_graph[2].pull()
+                    if frame.color_range == ColorRange.JPEG and not preserve_source_color:
+                        # compress full-range sources (yuvj/MJPEG) to limited range
+                        frame = frame.reformat(format=encoder.pix_fmt, src_color_range="JPEG", dst_color_range="MPEG")
+                    else:
+                        frame = frame.reformat(format=encoder.pix_fmt)
+                    if preserve_source_color:
+                        copy_color_properties(video_stream, frame)
+                    elif encoder.color_space is not None:
+                        set_video_color_properties(frame, encoder.color_space)
+                    segment_end = None
+                    if frame.pts is not None:
+                        # source pts pass through, rebased to the segment start and rescaled to the output time base
+                        if video_pts_offset is None:
+                            video_pts_offset = frame.pts
+                        frame.pts = rescale(frame.pts - video_pts_offset)
+                        if output_end_pts is not None:
+                            segment_end = rescale(output_end_pts - video_pts_offset)
+                    frame.time_base = encoder.time_base
+                    encoder.push_video(frame, max(1, rescale(frame_duration)), segment_end)
+
+            elif packet.stream == audio_stream and not encoder.seg_audio_done:
+                target_rate = encoder.audio[0]
+                for resampled in itertools.chain.from_iterable(map(resampler.resample, packet.decode())):
+                    frame_start = None
+                    if resampled.pts is not None:
+                        # passthrough frames keep the source stream's time base
+                        tb = resampled.time_base if resampled.time_base else encoder.audio_time_base
+                        frame_start = float(resampled.pts * tb)
+                        if duration and not audio_started and frame_start >= start_time + duration:
+                            encoder.end_audio()
+                            break
+                    if not audio_started:
+                        if frame_start is None:
+                            frame_start = 0.0
+                        to_skip = max(0, int((start_time - frame_start) * target_rate))
+                        if to_skip >= resampled.samples:
+                            continue
+                        audio_started = True
+                        if duration and frame_start > start_time:
+                            encoder.push_audio_cap(math.ceil((start_time + duration - frame_start) * target_rate))
+                        if to_skip:
+                            if encoder.push_audio(encoder.audio_frame_from_ndarray(resampled.to_ndarray()[..., to_skip:])):
+                                break
+                            continue
+                    if encoder.push_audio(resampled):
+                        break
+
+        if not video_done:
+            encoder.end_video(None)
+        if resampler is not None and audio_started and not encoder.seg_audio_done:
+            # the resampler holds a few samples of delay; release them so the segment's audio is complete
+            for resampled in resampler.resample(None):
+                if encoder.push_audio(resampled):
+                    break
+        encoder.end_segment()

--- a/comfy_extras/nodes_video.py
+++ b/comfy_extras/nodes_video.py
@@ -370,6 +370,44 @@ class VideoSlice(io.ComfyNode):
         )
 
 
+class VideoConcat(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        template = io.Autogrow.TemplatePrefix(io.Video.Input("video"), prefix="video", min=2, max=32)
+        return io.Schema(
+            node_id="VideoConcat",
+            display_name="Concatenate Videos",
+            search_aliases=["combine videos", "join videos", "chain videos", "merge videos", "stitch videos", "append video"],
+            category="video",
+            essentials_category="Video Tools",
+            description="Plays the connected videos back-to-back as one video, in input order, keeping audio. "
+                        "With resize=fit, later clips are scaled to fit inside the first clip's frame (black bars); "
+                        "with resize=error, mismatched resolutions fail. The result is re-encoded when saved, and all "
+                        "audio is conformed to one sample rate and channel layout.",
+            inputs=[
+                io.Autogrow.Input("videos", template=template, tooltip="Videos in playback order."),
+                io.Combo.Input(
+                    "resize",
+                    options=["fit", "error"],
+                    default="fit",
+                    tooltip="fit: scale later clips to fit inside the first clip's frame (black bars). error: fail if resolutions differ.",
+                ),
+            ],
+            outputs=[
+                io.Video.Output(),
+            ],
+        )
+
+    @classmethod
+    def execute(cls, videos: io.Autogrow.Type, resize: str) -> io.NodeOutput:
+        sources = [video for video in videos.values() if video is not None]
+        if not sources:
+            raise ValueError("Concatenate Videos: connect at least two videos.")
+        if len(sources) == 1:
+            return io.NodeOutput(sources[0])
+        return io.NodeOutput(InputImpl.VideoConcatenated(sources, resize=resize))
+
+
 class VideoExtension(ComfyExtension):
     @override
     async def get_node_list(self) -> list[type[io.ComfyNode]]:
@@ -380,6 +418,7 @@ class VideoExtension(ComfyExtension):
             GetVideoComponents,
             LoadVideo,
             VideoSlice,
+            VideoConcat,
         ]
 
 async def comfy_entrypoint() -> VideoExtension:

--- a/tests-unit/comfy_api_test/video_concat_test.py
+++ b/tests-unit/comfy_api_test/video_concat_test.py
@@ -1,0 +1,537 @@
+import io
+import json
+import os
+import tempfile
+from fractions import Fraction
+
+import av
+import numpy as np
+import pytest
+import torch
+from av.video.reformatter import ColorRange, ColorTrc
+
+# comfy_api.input_impl must come before comfy_api.input (circular import otherwise)
+from comfy_api.input_impl.video_types import VideoConcatenated, VideoFromComponents, VideoFromFile
+from comfy_api.util.video_types import VideoCodec, VideoComponents, VideoContainer
+from comfy_api.input.basic_types import AudioInput
+from comfy_api_test.video_types_test import create_hdr_av1_video, create_transcode_source, transcode_and_probe
+from comfy_api.latest._input_impl.video_types import _match_audio_channels
+
+
+def create_av_source(
+    width=64, height=64, frames=30, fps=30, sample_rate=44100, channels=1, tone_hz=None,
+    container_format="mp4", audio=True, level=None, metadata=None, audio_seconds=None,
+):
+    """h264 video plus (optionally) an AAC track carrying a sine tone or silence.
+    ``audio_seconds`` makes the track shorter/longer than the video (default: same length)."""
+    tmp = tempfile.NamedTemporaryFile(suffix=f".{container_format}", delete=False)
+    tmp.close()
+    layout = {1: "mono", 2: "stereo"}[channels]
+    with av.open(tmp.name, mode="w") as container:
+        if metadata:
+            for key, value in metadata.items():
+                container.metadata[key] = value
+        video_stream = container.add_stream("h264", rate=fps)
+        video_stream.width = width
+        video_stream.height = height
+        video_stream.pix_fmt = "yuv420p"
+        audio_stream = container.add_stream("aac", rate=sample_rate, layout=layout) if audio else None
+        for i in range(frames):
+            value = (i * 7) % 256 if level is None else level
+            frame = av.VideoFrame.from_ndarray(np.full((height, width, 3), value, dtype=np.uint8), format="rgb24")
+            container.mux(video_stream.encode(frame.reformat(format="yuv420p")))
+        if audio_stream is not None:
+            total = sample_rate * frames // fps if audio_seconds is None else int(sample_rate * audio_seconds)
+            t = np.arange(total, dtype=np.float32) / sample_rate
+            signal = 0.5 * np.sin(2 * np.pi * tone_hz * t) if tone_hz else np.zeros(total, dtype=np.float32)
+            data = np.tile(signal.astype(np.float32), (channels, 1))
+            for offset in range(0, total, 1024):
+                audio_frame = av.AudioFrame.from_ndarray(np.ascontiguousarray(data[:, offset:offset + 1024]), format="fltp", layout=layout)
+                audio_frame.sample_rate = sample_rate
+                audio_frame.pts = offset
+                container.mux(audio_stream.encode(audio_frame))
+        for stream in (video_stream, audio_stream):
+            if stream is not None:
+                container.mux(stream.encode(None))
+    return tmp.name
+
+
+@pytest.fixture
+def cleanup():
+    paths = []
+    yield paths
+    for path in paths:
+        os.unlink(path)
+
+
+def save_mp4(video, **kwargs):
+    buffer = io.BytesIO()
+    video.save_to(buffer, format=kwargs.pop("format", VideoContainer.MP4), codec=kwargs.pop("codec", VideoCodec.H264), **kwargs)
+    buffer.seek(0)
+    return buffer
+
+
+def video_packets(buffer):
+    buffer.seek(0)
+    with av.open(buffer) as container:
+        stream = container.streams.video[0]
+        return stream.time_base, [(p.pts, p.dts, p.duration) for p in container.demux(stream) if p.pts is not None]
+
+
+def decode_audio(buffer):
+    buffer.seek(0)
+    with av.open(buffer) as container:
+        stream = container.streams.audio[0]
+        chunks = [frame.to_ndarray() for frame in container.decode(stream)]
+        return stream.rate, stream.layout.name, np.concatenate(chunks, axis=1)
+
+
+def loud_windows(samples, rate, window=0.01, threshold=0.1):
+    """Start times of ``window``-second slices whose RMS exceeds ``threshold``."""
+    size = int(rate * window)
+    mono = samples[0]
+    starts = []
+    for offset in range(0, mono.shape[0] - size, size):
+        if np.sqrt(np.mean(mono[offset:offset + size] ** 2)) > threshold:
+            starts.append(offset / rate)
+    return starts
+
+
+def decode_frame(buffer, index):
+    buffer.seek(0)
+    with av.open(buffer) as container:
+        for i, frame in enumerate(container.decode(video=0)):
+            if i == index:
+                return frame.to_ndarray(format="rgb24")
+    raise IndexError(index)
+
+
+def test_concat_sums_duration_frames_and_audio(cleanup):
+    a, b = create_av_source(frames=30), create_av_source(frames=45)
+    cleanup += [a, b]
+    video = VideoConcatenated([VideoFromFile(a), VideoFromFile(b)])
+    assert video.get_duration() == pytest.approx(2.5, abs=0.01)
+    assert video.get_frame_count() == 75
+    assert video.get_dimensions() == (64, 64)
+    assert video.get_frame_rate() == Fraction(30)
+    assert video.get_active_trim_window() == (0.0, 0.0)
+
+    result = transcode_and_probe(video)
+    assert result["codec"] == "h264"
+    assert result["frames"] == 75
+    assert result["first_pts"] == 0
+    assert result["video_seconds"] == pytest.approx(2.5, abs=0.01)
+    assert result["audio_seconds"] == pytest.approx(2.5, abs=0.05)
+    assert result["audio_codecs"] == ["aac"]
+
+
+def test_concat_pts_strictly_increasing_and_audio_contiguous(cleanup):
+    a, b = create_av_source(frames=30), create_av_source(frames=45)
+    cleanup += [a, b]
+    buffer = save_mp4(VideoConcatenated([VideoFromFile(a), VideoFromFile(b)]))
+    _, packets = video_packets(buffer)
+    pts = [p[0] for p in packets]
+    dts = [p[1] for p in packets]
+    assert len(pts) == 75
+    assert all(later > earlier for earlier, later in zip(pts, pts[1:]))
+    assert all(later > earlier for earlier, later in zip(dts, dts[1:]))
+    rate, _, samples = decode_audio(buffer)
+    assert rate == 44100
+    assert samples.shape[1] == pytest.approx(2.5 * 44100, abs=2048)
+
+
+def test_concat_audio_stays_aligned_across_boundaries(cleanup):
+    """tone / silence / tone: the second tone must start exactly where the third clip starts.
+    The middle clip's audio is shorter than its video, so merely appending tracks would put the
+    second tone at 1.6 s instead of 2.0 s."""
+    a = create_av_source(frames=30, tone_hz=440)
+    b = create_av_source(frames=30, tone_hz=None, audio_seconds=0.6)
+    c = create_av_source(frames=30, tone_hz=440)
+    cleanup += [a, b, c]
+    buffer = save_mp4(VideoConcatenated([VideoFromFile(a), VideoFromFile(b), VideoFromFile(c)]))
+    rate, _, samples = decode_audio(buffer)
+    loud = loud_windows(samples, rate)
+    assert loud, "no tone decoded"
+    first_end = max(t for t in loud if t < 1.5)
+    second_start = min(t for t in loud if t > 1.5)
+    assert first_end == pytest.approx(1.0, abs=0.06)
+    assert second_start == pytest.approx(2.0, abs=0.06)
+    assert samples.shape[1] == pytest.approx(3.0 * rate, abs=2048)
+
+
+def test_concat_video_only_then_audio_clip_leads_with_silence(cleanup):
+    a = create_av_source(frames=30, audio=False)
+    b = create_av_source(frames=45, tone_hz=440)
+    cleanup += [a, b]
+    buffer = save_mp4(VideoConcatenated([VideoFromFile(a), VideoFromFile(b)]))
+    result = transcode_and_probe(VideoConcatenated([VideoFromFile(a), VideoFromFile(b)]))
+    assert result["audio_codecs"] == ["aac"]
+    assert result["audio_seconds"] == pytest.approx(result["video_seconds"], abs=0.05)
+    rate, _, samples = decode_audio(buffer)
+    assert np.abs(samples[:, :int(0.9 * rate)]).max() < 0.01
+    assert min(loud_windows(samples, rate)) == pytest.approx(1.0, abs=0.06)
+
+
+def test_concat_audio_clip_then_video_only_pads_trailing_silence(cleanup):
+    a = create_av_source(frames=30, tone_hz=440)
+    b = create_av_source(frames=45, audio=False)
+    cleanup += [a, b]
+    buffer = save_mp4(VideoConcatenated([VideoFromFile(a), VideoFromFile(b)]))
+    result = transcode_and_probe(VideoConcatenated([VideoFromFile(a), VideoFromFile(b)]))
+    assert result["video_seconds"] == pytest.approx(2.5, abs=0.01)
+    assert result["audio_seconds"] == pytest.approx(2.5, abs=0.05)
+    rate, _, samples = decode_audio(buffer)
+    assert samples.shape[1] == pytest.approx(2.5 * rate, abs=2048)
+    assert np.abs(samples[:, int(1.1 * rate):]).max() < 0.01
+
+
+def test_concat_no_audio_anywhere(cleanup):
+    a, b = create_av_source(frames=10, audio=False), create_av_source(frames=10, audio=False)
+    cleanup += [a, b]
+    result = transcode_and_probe(VideoConcatenated([VideoFromFile(a), VideoFromFile(b)]))
+    assert result["frames"] == 20
+    assert result["audio_codecs"] == []
+    assert result["audio_seconds"] is None
+
+
+def test_concat_trimmed_sources(cleanup):
+    a, b = create_av_source(frames=30), create_av_source(frames=45)
+    cleanup += [a, b]
+    video = VideoConcatenated([
+        VideoFromFile(a).as_trimmed(0.5, 0.5),
+        VideoFromFile(b, start_time=0.2, duration=0.3),
+    ])
+    assert video.get_duration() == pytest.approx(0.8, abs=0.01)
+    result = transcode_and_probe(video)
+    assert result["frames"] == pytest.approx(24, abs=2)
+    assert result["first_pts"] == 0
+    assert result["video_seconds"] == pytest.approx(0.8, abs=0.05)
+    assert result["audio_seconds"] == pytest.approx(0.8, abs=0.05)
+
+
+def test_concat_mixed_time_bases_and_frame_rates(cleanup):
+    """mp4 (1/15360) after mkv (1/1000): every frame is rescaled into one output time base and
+    stamped with it, so mixed frame rates keep their true timing (PyAV rescales frame.pts by
+    frame.time_base on encode; a stale time base would blow the timeline up by orders of magnitude)."""
+    a = create_av_source(frames=30, fps=30, audio=False)
+    b = create_av_source(frames=15, fps=15, audio=False, container_format="mkv")
+    cleanup += [a, b]
+    with av.open(a) as ca, av.open(b) as cb:
+        assert ca.streams.video[0].time_base != cb.streams.video[0].time_base
+
+    video = VideoConcatenated([VideoFromFile(a), VideoFromFile(b)])
+    buffer = save_mp4(video)
+    time_base, packets = video_packets(buffer)
+    assert time_base == Fraction(1, 360000)
+    pts = [p[0] for p in packets]
+    assert len(pts) == 45
+    assert all(later > earlier for earlier, later in zip(pts, pts[1:]))
+    assert pts[:30] == [i * 12000 for i in range(30)]
+    assert pts[30] == 360000  # second clip starts exactly where the first ends
+    for i, value in enumerate(pts[30:]):
+        assert value == pytest.approx(360000 + i * 24000, abs=400)  # mkv stores ms, so +-1 ms
+    buffer.seek(0)
+    with av.open(buffer) as container:
+        stream = container.streams.video[0]
+        assert float(stream.duration * stream.time_base) == pytest.approx(2.0, abs=0.005)
+
+
+def test_concat_resize_error_rejects_mismatched_resolution(cleanup):
+    a, b = create_av_source(frames=5), create_av_source(width=32, height=64, frames=5)
+    cleanup += [a, b]
+    with pytest.raises(ValueError, match="video 1 is 32x64; expected 64x64"):
+        VideoConcatenated([VideoFromFile(a), VideoFromFile(b)], resize="error")
+    with pytest.raises(ValueError):
+        VideoConcatenated([VideoFromFile(a), VideoFromFile(b)], resize="stretch")
+
+
+def test_concat_fit_letterboxes_into_first_clip(cleanup):
+    a = create_av_source(frames=30, level=200, audio=False)
+    b = create_av_source(width=32, height=64, frames=10, level=200, audio=False)
+    cleanup += [a, b]
+    video = VideoConcatenated([VideoFromFile(a), VideoFromFile(b)])
+    assert video.get_dimensions() == (64, 64)
+    buffer = save_mp4(video)
+    buffer.seek(0)
+    with av.open(buffer) as container:
+        stream = container.streams.video[0]
+        assert (stream.codec_context.width, stream.codec_context.height) == (64, 64)
+    assert transcode_and_probe(video)["frames"] == 40
+    frame = decode_frame(buffer, 35)
+    assert frame.shape == (64, 64, 3)
+    assert frame[:, :16].mean() < 20 and frame[:, 48:].mean() < 20  # pillarbox
+    assert frame[:, 16:48].mean() > 150
+
+
+def test_concat_mismatched_audio_params_conform_to_best_source(cleanup):
+    """44.1 kHz mono followed by 48 kHz stereo: nothing is degraded, the mono clip is upmixed/resampled."""
+    a = create_av_source(frames=30, sample_rate=44100, channels=1, tone_hz=440)
+    b = create_av_source(frames=45, sample_rate=48000, channels=2, tone_hz=440)
+    cleanup += [a, b]
+    buffer = save_mp4(VideoConcatenated([VideoFromFile(a), VideoFromFile(b)]))
+    rate, layout, samples = decode_audio(buffer)
+    assert rate == 48000
+    assert layout == "stereo"
+    assert samples.shape[1] == pytest.approx(2.5 * 48000, abs=2048)
+    loud = loud_windows(samples, rate)
+    assert min(loud) < 0.1 and max(loud) > 2.3  # both clips' tones are present
+    # reversed order gives the same output format
+    buffer = save_mp4(VideoConcatenated([VideoFromFile(b), VideoFromFile(a)]))
+    rate, layout, _ = decode_audio(buffer)
+    assert (rate, layout) == (48000, "stereo")
+
+
+def test_concat_bit_depth_is_max_of_sources(cleanup, tmp_path):
+    ramp = torch.linspace(0.25, 0.30, 64).view(1, 1, 64, 1).expand(6, 64, 64, 3).contiguous()
+    src8 = str(tmp_path / "src8.mp4")
+    src10 = str(tmp_path / "src10.mp4")
+    VideoFromComponents(VideoComponents(images=ramp, frame_rate=Fraction(30))).save_to(src8)
+    VideoFromComponents(VideoComponents(images=ramp, frame_rate=Fraction(30)), bit_depth=10).save_to(src10)
+    video = VideoConcatenated([VideoFromFile(src8), VideoFromFile(src10)])
+    assert video.get_bit_depth() == 10
+    buffer = save_mp4(video)
+    buffer.seek(0)
+    with av.open(buffer) as container:
+        stream = container.streams.video[0]
+        assert max(component.bits for component in stream.format.components) == 10
+    assert transcode_and_probe(video)["frames"] == 12
+
+
+def test_concat_color_space_mismatch_raises(cleanup, tmp_path):
+    hdr = str(tmp_path / "hdr.mkv")
+    create_hdr_av1_video(hdr, ColorTrc.SMPTE2084, ColorRange.MPEG)
+    sdr = create_av_source(frames=3, audio=False)
+    cleanup.append(sdr)
+    assert VideoFromFile(hdr).get_color_space() == "HDR PQ"
+    with pytest.raises(ValueError, match="color space"):
+        VideoConcatenated([VideoFromFile(sdr), VideoFromFile(hdr)])
+
+
+def test_concat_get_components(cleanup):
+    a = create_av_source(frames=30, tone_hz=440)
+    b = create_av_source(width=32, height=64, frames=15, fps=15, audio=False)
+    cleanup += [a, b]
+    video = VideoConcatenated([VideoFromFile(a), VideoFromFile(b)])
+    components = video.get_components()
+    assert components.frame_rate == Fraction(30)
+    # the 15 fps clip is retimed to 30 fps (each frame repeated), so the 2 s duration is kept
+    assert components.images.shape == (60, 64, 64, 3)
+    assert video.get_frame_count() == 60  # the same constant-frame-rate view
+    assert torch.equal(components.images[30], components.images[31])
+    assert video.get_duration() == pytest.approx(components.images.shape[0] / 30, abs=0.01)
+    # the fitted clip is pillarboxed: black columns on both sides
+    assert components.images[40, :, :16].max() < 0.05
+    source_audio = VideoFromFile(a).get_components().audio
+    assert components.audio["sample_rate"] == source_audio["sample_rate"]
+    assert components.audio["waveform"].shape[1] == source_audio["waveform"].shape[1]
+    assert components.audio["waveform"].shape[2] == round(2.0 * source_audio["sample_rate"])
+    assert components.audio["waveform"][..., int(1.1 * source_audio["sample_rate"]):].abs().max() == 0
+
+
+def test_concat_get_components_keeps_sub_frame_clips(cleanup):
+    """A clip shorter than one frame at the first clip's rate still contributes a frame."""
+    slow = create_av_source(frames=2, fps=1, audio=False)
+    short = create_av_source(frames=5, fps=30, audio=False)
+    cleanup += [slow, short]
+    video = VideoConcatenated([VideoFromFile(slow), VideoFromFile(short)])
+    assert video.get_components().images.shape[0] == 3
+    assert video.get_frame_count() == 3
+    assert transcode_and_probe(video)["frames"] == 7
+
+
+def test_match_audio_channels_downmixes():
+    stereo = torch.zeros(1, 2, 100)
+    stereo[:, 1] = 1.0
+    assert torch.allclose(_match_audio_channels(stereo, 1), torch.full((1, 1, 100), 0.5))
+    assert _match_audio_channels(torch.ones(1, 1, 10), 2).shape == (1, 2, 10)
+    assert _match_audio_channels(torch.ones(1, 2, 10), 6).shape == (1, 6, 10)
+    assert _match_audio_channels(torch.ones(1, 6, 10), 2).shape == (1, 2, 10)
+
+
+def test_concat_rotated_source_uses_display_dimensions(cleanup):
+    """A 64x32 source with a 90-degree display matrix shows as 32x64; resize=error must compare
+    displayed sizes, and get_dimensions() must report what gets encoded."""
+    rotated = create_transcode_source(width=64, height=32, frames=6, rotation=True)
+    plain = create_av_source(width=32, height=64, frames=6, audio=False)
+    square = create_av_source(frames=6, audio=False)
+    cleanup += [rotated, plain, square]
+    assert VideoFromFile(rotated).get_dimensions() == (64, 32)
+
+    video = VideoConcatenated([VideoFromFile(rotated), VideoFromFile(plain)], resize="error")
+    assert video.get_dimensions() == (32, 64)
+    result = transcode_and_probe(video)
+    assert (result["width"], result["height"]) == (32, 64)
+    assert result["frames"] == 12
+
+    with pytest.raises(ValueError, match="video 1 is 32x64; expected 64x64"):
+        VideoConcatenated([VideoFromFile(square), VideoFromFile(rotated)], resize="error")
+    assert VideoConcatenated([VideoFromFile(plain), VideoFromFile(rotated)]).get_dimensions() == (32, 64)
+
+
+def test_concat_get_components_resamples_audio_to_best_source():
+    images = torch.zeros(3, 8, 8, 3)
+    first = VideoFromComponents(VideoComponents(images=images, frame_rate=Fraction(30), audio=AudioInput({"waveform": torch.rand(1, 1, 4410), "sample_rate": 44100})))
+    second = VideoFromComponents(VideoComponents(images=images, frame_rate=Fraction(30), audio=AudioInput({"waveform": torch.rand(1, 2, 4800), "sample_rate": 48000})))
+    components = VideoConcatenated([first, second]).get_components()
+    assert components.audio["sample_rate"] == 48000
+    assert components.audio["waveform"].shape == (1, 2, 2 * 4800)
+    assert components.audio["waveform"][..., 4800:].abs().sum() > 0
+
+
+def test_concat_as_trimmed(cleanup):
+    a, b = create_av_source(frames=30), create_av_source(frames=45)
+    cleanup += [a, b]
+    video = VideoConcatenated([VideoFromFile(a), VideoFromFile(b)])
+
+    middle = video.as_trimmed(0.5, 1.0)
+    assert isinstance(middle, VideoConcatenated)
+    assert middle.get_duration() == pytest.approx(1.0, abs=0.01)
+    assert transcode_and_probe(middle)["frames"] == pytest.approx(30, abs=2)
+
+    tail = video.as_trimmed(1.0, 0)  # duration 0 means "to the end" (Trim Video passes 0)
+    assert tail.get_duration() == pytest.approx(1.5, abs=0.01)
+    assert video.as_trimmed(-1.0, 0).get_duration() == pytest.approx(1.0, abs=0.01)
+
+    assert video.as_trimmed(2.0, 1.0, strict_duration=True) is None
+    assert video.as_trimmed(2.0, 1.0, strict_duration=False).get_duration() == pytest.approx(0.5, abs=0.01)
+    assert video.as_trimmed(3.0, 1.0, strict_duration=False) is None
+
+
+def test_concat_as_trimmed_exact_boundaries_and_tensor_sources(cleanup):
+    """Float rounding must neither drop a clip (a source's as_trimmed returning None) nor append
+    a zero-length sliver past an exact clip boundary."""
+    files = [create_av_source(frames=n, audio=False) for n in (7, 11, 13)]
+    cleanup += files
+    clips = [VideoFromFile(path) for path in files]
+    video = VideoConcatenated(clips)
+    first_two = clips[0].get_duration() + clips[1].get_duration()  # 0.6000000000000001
+    trimmed = video.as_trimmed(0, first_two, strict_duration=True)
+    assert len(trimmed._sources) == 2
+    assert trimmed.get_frame_count() == 18
+    assert transcode_and_probe(trimmed)["frames"] == 18
+
+    tensor_clip = VideoFromComponents(VideoComponents(images=torch.rand(11, 64, 64, 3), frame_rate=Fraction(30)))
+    video = VideoConcatenated([tensor_clip, clips[2]])
+    start = 0.04270229789540167
+    assert start + (tensor_clip.get_duration() - start) > tensor_clip.get_duration()  # the ulp overshoot
+    trimmed = video.as_trimmed(start, 0.723964368771265, strict_duration=False)
+    assert len(trimmed._sources) == 2
+    assert trimmed.get_duration() == pytest.approx(0.724, abs=0.01)
+    assert video.as_trimmed(start, 0.723964368771265, strict_duration=True) is not None
+
+
+def test_concat_trimmed_sources_keep_their_windows_when_retrimmed(cleanup):
+    """Trim Video -> Concatenate -> Trim Video: re-trimming must stay inside each source's own window."""
+    a, b = create_av_source(frames=30), create_av_source(frames=30)
+    cleanup += [a, b]
+    video = VideoConcatenated([VideoFromFile(a, start_time=0.2, duration=0.5), VideoFromFile(b, duration=0.5)])
+    trimmed = video.as_trimmed(0.1, 0.9, strict_duration=True)
+    assert trimmed.get_duration() == pytest.approx(0.9, abs=0.01)
+    assert trimmed.get_frame_count() == 27
+    assert transcode_and_probe(trimmed)["frames"] == 27
+    tail = video.as_trimmed(-0.4, 0)
+    assert tail.get_duration() == pytest.approx(0.4, abs=0.01)
+    assert tail.get_frame_count() == 12
+
+
+def test_concat_trimmed_clip_audio_does_not_bleed_past_its_window(cleanup):
+    """A trim whose sample cap lands exactly on a decoded audio frame boundary (0.064 s = 3 x 1024
+    samples at 48 kHz) must not leak the clip's queued audio into the next clip."""
+    a = create_av_source(frames=30, sample_rate=48000, tone_hz=440)
+    b = create_av_source(frames=60, sample_rate=48000, tone_hz=None)
+    cleanup += [a, b]
+    video = VideoConcatenated([VideoFromFile(a).as_trimmed(0, 0.064), VideoFromFile(b)])
+    rate, _, samples = decode_audio(save_mp4(video))
+    loud = loud_windows(samples, rate)
+    assert loud and max(loud) < 0.08
+    assert np.abs(samples[:, int(0.1 * rate):]).max() < 0.01
+    assert samples.shape[1] == pytest.approx(2.064 * rate, abs=2048)
+
+
+def test_concat_flattens_nested(cleanup):
+    a, b, c = create_av_source(frames=6), create_av_source(frames=6), create_av_source(frames=6)
+    cleanup += [a, b, c]
+    inner = VideoConcatenated([VideoFromFile(a), VideoFromFile(b)])
+    outer = VideoConcatenated([inner, VideoFromFile(c)])
+    assert len(outer._sources) == 3
+    assert outer.get_frame_count() == 18
+    assert transcode_and_probe(outer)["frames"] == 18
+
+
+def test_concat_nested_keeps_inner_resize_mode(cleanup):
+    """An inner 'fit' concat already presents one frame size, so an outer 'error' concat accepts it."""
+    a = create_av_source(frames=6, audio=False)
+    small = create_av_source(width=32, height=32, frames=6, audio=False)
+    c = create_av_source(frames=6, audio=False)
+    cleanup += [a, small, c]
+    inner = VideoConcatenated([VideoFromFile(a), VideoFromFile(small)], resize="fit")
+    outer = VideoConcatenated([inner, VideoFromFile(c)], resize="error")
+    assert len(outer._sources) == 2 and outer._sources[0] is inner
+    result = transcode_and_probe(outer)
+    assert result["frames"] == 18
+    assert (result["width"], result["height"]) == (64, 64)
+
+
+def test_concat_tensor_source(cleanup):
+    a = create_av_source(frames=30)
+    cleanup.append(a)
+    components = VideoFromComponents(VideoComponents(images=torch.rand(12, 64, 64, 3), frame_rate=Fraction(30)))
+    result = transcode_and_probe(VideoConcatenated([VideoFromFile(a), components]))
+    assert result["frames"] == 42
+    assert result["video_seconds"] == pytest.approx(1.4, abs=0.01)
+    assert result["audio_seconds"] == pytest.approx(1.4, abs=0.05)
+
+
+def test_concat_same_bytesio_source_twice(cleanup):
+    a = create_av_source(frames=30)
+    cleanup.append(a)
+    with open(a, "rb") as f:
+        source = io.BytesIO(f.read())
+    clip = VideoFromFile(source)
+    result = transcode_and_probe(VideoConcatenated([clip, clip]))
+    assert result["frames"] == 60
+    assert result["video_seconds"] == pytest.approx(2.0, abs=0.01)
+    assert result["audio_seconds"] == pytest.approx(2.0, abs=0.05)
+
+
+def test_concat_writes_only_caller_metadata(cleanup):
+    a = create_av_source(frames=3, metadata={"prompt": "from clip one"})
+    b = create_av_source(frames=3)
+    cleanup += [a, b]
+    buffer = save_mp4(VideoConcatenated([VideoFromFile(a), VideoFromFile(b)]), metadata={"workflow": {"nodes": 2}})
+    buffer.seek(0)
+    with av.open(buffer) as container:
+        assert json.loads(container.metadata["workflow"]) == {"nodes": 2}
+        assert "prompt" not in container.metadata
+
+
+def test_concat_stream_source_is_cached_mp4(cleanup):
+    a, b = create_av_source(frames=6), create_av_source(frames=6)
+    cleanup += [a, b]
+    video = VideoConcatenated([VideoFromFile(a), VideoFromFile(b)])
+    assert video.get_container_format() == "mp4"
+    source = video.get_stream_source()
+    assert isinstance(source, io.BytesIO)
+    assert video.get_stream_source() is source
+    assert source.tell() == 0
+    with av.open(source) as container:
+        assert container.format.name.startswith("mov,mp4")
+        assert len(container.streams.video) == 1 and len(container.streams.audio) == 1
+        assert container.streams.video[0].frames == 12
+
+
+def test_concat_webm_output(cleanup):
+    a, b = create_av_source(frames=6), create_av_source(frames=6)
+    cleanup += [a, b]
+    buffer = save_mp4(VideoConcatenated([VideoFromFile(a), VideoFromFile(b)]), format=VideoContainer.WEBM, codec=VideoCodec.AV1)
+    with av.open(buffer) as container:
+        assert container.streams.video[0].codec.canonical_name == "av1"
+        assert container.streams.audio[0].codec.canonical_name == "opus"
+        assert container.streams.audio[0].rate == 48000
+    rate, _, samples = decode_audio(buffer)
+    assert samples.shape[1] == pytest.approx(0.4 * rate, abs=4096)
+
+
+def test_concat_requires_a_source():
+    with pytest.raises(ValueError):
+        VideoConcatenated([])

--- a/tests-unit/comfy_api_test/video_types_test.py
+++ b/tests-unit/comfy_api_test/video_types_test.py
@@ -2,12 +2,13 @@ import pytest
 import torch
 import tempfile
 import os
+import subprocess
 import sys
 import av
 import io
 import numpy as np
 from fractions import Fraction
-from comfy_api.input_impl.video_types import VideoFromFile, VideoFromComponents
+from comfy_api.input_impl.video_types import VideoFromFile, VideoFromComponents, VideoConcatenated
 from comfy_api.util.video_types import VideoComponents, VideoContainer, VideoCodec
 from comfy_api.input.basic_types import AudioInput
 from av.error import InvalidDataError
@@ -1469,3 +1470,50 @@ def test_save_to_transcode_skips_undecodable_audio():
         for path in (mixed, all_bad):
             if path:
                 os.unlink(path)
+
+
+def test_video_from_file_open_ended_trim_frame_count():
+    """start_time with duration 0 ("to the end") counts the remaining frames, not zero"""
+    file_path = create_transcode_source(frames=45)  # 1.5 s @ 30 fps
+    try:
+        assert VideoFromFile(file_path, start_time=0.5).get_frame_count() == 30
+        assert VideoFromFile(file_path).as_trimmed(0.5, 0, strict_duration=False).get_frame_count() == 30
+        assert VideoFromFile(file_path, start_time=0.5, duration=0.5).get_frame_count() == 15
+    finally:
+        os.unlink(file_path)
+
+
+def test_concatenated_save_to_streams_without_buffering_frames():
+    """Concatenation must decode/encode one frame at a time, never materializing the sources.
+
+    Measured in a fresh subprocess so the ru_maxrss delta is independent of whatever peak earlier
+    tests left in this process (two 640x480x300 sources would be ~2.2 GiB as float32 if buffered)."""
+    resource = pytest.importorskip("resource")  # no getrusage on Windows
+    del resource
+    rss_scale = 1 if sys.platform == "darwin" else 1024  # ru_maxrss: bytes on macOS, KiB elsewhere
+    repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    sources = [create_transcode_source(width=640, height=480, frames=300) for _ in range(2)]
+    child = f"""
+import io, resource, sys
+sys.path.insert(0, {repo_root!r})
+from comfy_api.input_impl.video_types import VideoConcatenated, VideoFromFile
+from comfy_api.util.video_types import VideoCodec, VideoContainer
+video = VideoConcatenated([VideoFromFile(path) for path in {sources!r}])
+before = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+video.save_to(io.BytesIO(), format=VideoContainer.MP4, codec=VideoCodec.H264)
+print("RSS_DELTA", resource.getrusage(resource.RUSAGE_SELF).ru_maxrss - before)
+"""
+    try:
+        completed = subprocess.run([sys.executable, "-c", child], capture_output=True, text=True, cwd=repo_root)
+        assert completed.returncode == 0, completed.stderr[-2000:]
+        rss_delta = int(completed.stdout.strip().rsplit("RSS_DELTA", 1)[1]) * rss_scale
+        assert rss_delta < 500 * 2**20, f"concat buffered frames in RAM (peak grew {rss_delta / 2**20:.0f} MiB)"
+
+        result = transcode_and_probe(VideoConcatenated([VideoFromFile(path) for path in sources]))
+        assert result["codec"] == "h264"
+        assert result["frames"] == 600
+        assert result["video_seconds"] == pytest.approx(20.0, abs=0.1)
+        assert result["audio_seconds"] == pytest.approx(20.0, abs=0.1)
+    finally:
+        for path in sources:
+            os.unlink(path)

--- a/tests-unit/comfy_extras_test/nodes_video_test.py
+++ b/tests-unit/comfy_extras_test/nodes_video_test.py
@@ -1,0 +1,93 @@
+import asyncio
+import os
+import tempfile
+
+import av
+import numpy as np
+import pytest
+
+from comfy_api.latest import io
+from comfy_api.latest._input_impl.video_types import VideoConcatenated, VideoFromFile
+from comfy_extras.nodes_video import VideoConcat, VideoExtension
+
+
+def create_h264_video(width=64, height=64, frames=30, fps=30):
+    tmp = tempfile.NamedTemporaryFile(suffix=".mp4", delete=False)
+    tmp.close()
+    with av.open(tmp.name, mode="w") as container:
+        stream = container.add_stream("h264", rate=fps)
+        stream.width = width
+        stream.height = height
+        stream.pix_fmt = "yuv420p"
+        for i in range(frames):
+            frame = av.VideoFrame.from_ndarray(np.full((height, width, 3), (i * 7) % 256, dtype=np.uint8), format="rgb24")
+            container.mux(stream.encode(frame.reformat(format="yuv420p")))
+        container.mux(stream.encode(None))
+    return tmp.name
+
+
+@pytest.fixture
+def two_clips():
+    a = create_h264_video(frames=30)
+    b = create_h264_video(frames=45)
+    yield VideoFromFile(a), VideoFromFile(b)
+    os.unlink(a)
+    os.unlink(b)
+
+
+def test_video_concat_schema():
+    schema = VideoConcat.define_schema()
+    assert schema.node_id == "VideoConcat"
+    assert schema.essentials_category == "Video Tools"
+    assert "combine videos" in schema.search_aliases
+    videos = schema.inputs[0]
+    assert isinstance(videos, io.Autogrow.Input)
+    assert videos.id == "videos"
+    assert videos.template.prefix == "video"
+    assert videos.template.min == 2
+    assert videos.template.names[:2] == ["video0", "video1"]
+    resize = next(i for i in schema.inputs if i.id == "resize")
+    assert resize.options == ["fit", "error"]
+    assert resize.default == "fit"
+    assert isinstance(schema.outputs[0], io.Video.Output)
+
+
+def test_video_concat_registered():
+    nodes = asyncio.run(VideoExtension().get_node_list())
+    assert VideoConcat in nodes
+
+
+def test_video_concat_execute_in_slot_order(two_clips):
+    a, b = two_clips
+    result = VideoConcat.execute({"video0": a, "video1": b}, "fit").args[0]
+    assert isinstance(result, VideoConcatenated)
+    assert result._sources == [a, b]
+    assert result.get_duration() == pytest.approx(2.5)
+    assert result.get_frame_count() == 75
+
+
+def test_video_concat_execute_skips_empty_slots(two_clips):
+    a, b = two_clips
+    result = VideoConcat.execute({"video0": a, "video1": None, "video2": b}, "fit").args[0]
+    assert result._sources == [a, b]
+
+
+def test_video_concat_single_video_passthrough(two_clips):
+    a, _ = two_clips
+    assert VideoConcat.execute({"video0": a}, "fit").args[0] is a
+
+
+def test_video_concat_no_videos_raises():
+    with pytest.raises(ValueError):
+        VideoConcat.execute({}, "fit")
+
+
+def test_video_concat_resize_error_rejects_mismatched_resolution(two_clips):
+    a, _ = two_clips
+    small = create_h264_video(width=32, height=64, frames=5)
+    try:
+        with pytest.raises(ValueError, match="32x64"):
+            VideoConcat.execute({"video0": a, "video1": VideoFromFile(small)}, "error")
+        assert isinstance(VideoConcat.execute({"video0": a, "video1": VideoFromFile(small)}, "fit").args[0], VideoConcatenated)
+    finally:
+        os.unlink(small)


### PR DESCRIPTION
## What

Adds a **Concatenate Videos** node (`VideoConcat`): connect two or more VIDEO inputs and get one video that plays them back-to-back in input order, keeping audio. Requested repeatedly by users who currently have to route through `Get Video Components -> Create Video`, which decodes every frame to tensors and loses VFR timing, bit depth, and audio sync.

## How

- New lazy `InputImpl.VideoConcatenated(VideoInput)` in `comfy_api/latest/_input_impl/video_types.py`. Nothing is decoded until the video is saved; `save_to` streams every source through one encoder frame-at-a-time (mirroring the demux/decode structure of `VideoFromFile._save_transcoded`, which is left untouched), so peak memory does not scale with video length.
- Handles: lazily trimmed sources (`Trim Video` chains stay a single encode pass), mixed frame rates and time bases (kept VFR via a common output time base, `1/360000` fallback — exact for NTSC rates), baked-in display rotation, mixed resolutions (default `fit`: aspect-preserving letterbox into the first clip's frame; `error` mode rejects, rotation-aware), mixed audio rates/layouts (conformed to the best present), clips without audio (gapless silence), 8/10-bit mixes, HDR tags (SDR+HDR mix is rejected, same rule as `save_to`), mp4/mkv/webm+opus outputs.
- Node inputs use `io.Autogrow` (`video0`/`video1` required, grows to 32) plus a `resize` combo; only caller metadata (prompt/workflow) is written to the output, never a source clip's embedded tags.
- `get_components()` returns a constant-frame-rate tensor at the first clip's rate (other clips retimed by frame repeat/drop) so duration and audio are preserved; `as_trimmed()` splits lazily across clip boundaries.
- Also fixes a pre-existing `VideoFromFile.get_frame_count()` bug for open-ended trim windows (`start_time` set, `duration=0` returned ~0 frames).

Known limitations (v1): the result is re-encoded once when saved (no same-codec stream-copy fast path), and non-file sources (`VideoFromComponents`) are materialized via `get_stream_source()` before decoding.

## Testing

- 35 new unit tests: `tests-unit/comfy_api_test/video_concat_test.py`, `tests-unit/comfy_extras_test/nodes_video_test.py`, an order-independent subprocess RSS canary in `video_types_test.py` (concat of two 300-frame sources must not buffer), and a `get_frame_count` regression test. Full `tests-unit` tree: 1493 passed.
- Boundary-level assertions: pts strictly increasing across clip joins, tone-onset timing at each boundary (a clip whose audio is shorter than its video), trailing-silence padding, exact sample caps on trimmed clips, mixed 1/15360 + 1/1000 time bases, letterbox pixel checks, rotated sources as first and later segments.
- End-to-end through the executor: `Load Video x2/x3 -> Concatenate Videos -> Save Video` on a running server produced exact 4.0 s / 6.0 s outputs with continuous audio; `resize=error` and missing required slots fail with clear messages.

`tests-unit/comfy_api_test/__init__.py` was added (mirroring `comfy_extras_test`) so the new test module's helper import also works under pytest's future-default `--import-mode=importlib`.