### PR TITLE
Declare dtype on the VideoPositionEmb.generate_embeddings stub

### DIFF
--- a/comfy/ldm/cosmos/position_embedding.py
+++ b/comfy/ldm/cosmos/position_embedding.py
@@ -50,7 +50,7 @@ class VideoPositionEmb(nn.Module):
 
         return embeddings
 
-    def generate_embeddings(self, B_T_H_W_C: torch.Size, fps=Optional[torch.Tensor], device=None):
+    def generate_embeddings(self, B_T_H_W_C: torch.Size, fps=Optional[torch.Tensor], device=None, dtype=None):
         raise NotImplementedError
 
 


### PR DESCRIPTION
One line: add `dtype=None` to the `VideoPositionEmb.generate_embeddings` stub.

`VideoPositionEmb.forward` passes `dtype` to it:

```python
# comfy/ldm/cosmos/position_embedding.py:49
embeddings = self.generate_embeddings(B_T_H_W_C, fps=fps, device=device, dtype=dtype)

# :53 — the stub in the same class
def generate_embeddings(self, B_T_H_W_C: torch.Size, fps=Optional[torch.Tensor], device=None):
    raise NotImplementedError
```

Both concrete subclasses in the file already declare `dtype`
(`VideoRopePosition3DEmb` at `:100`, `LearnablePosEmbAxis` at `:192`), so nothing
is broken at runtime today. The stub is the odd one out, and it is the thing a
new subclass gets written against — such an override raises
`TypeError: generate_embeddings() got an unexpected keyword argument 'dtype'`
on its first forward pass.

Checked by loading the module before and after, then generating an override that
copies whatever signature the stub advertises:

```
unpatched | stub: (self, B_T_H_W_C: torch.Size, fps=typing.Optional[torch.Tensor], device=None)
unpatched |   VideoRopePosition3DEmb: dtype declared = True
unpatched |   LearnablePosEmbAxis:   dtype declared = True
unpatched |   override copying the stub: (self, B_T_H_W_C, fps=None, device=None)
unpatched |   forward -> TypeError: NewEmb.generate_embeddings() got an unexpected keyword argument 'dtype'

patched   | stub: (self, B_T_H_W_C: torch.Size, fps=typing.Optional[torch.Tensor], device=None, dtype=None)
patched   |   override copying the stub: (self, B_T_H_W_C, fps=None, device=None, dtype=None)
patched   |   forward -> OK (1, 2, 3, 4, 5)
```

No behaviour change for either existing subclass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
