### PR TITLE
Fix: Respect --lowvram and --novram on Apple Silicon (MPS)

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -580,7 +580,10 @@ if cpu_state != CPUState.GPU:
     vram_state = VRAMState.DISABLED
 
 if cpu_state == CPUState.MPS:
-    vram_state = VRAMState.SHARED
+    if set_vram_to in (VRAMState.LOW_VRAM, VRAMState.NO_VRAM):
+        vram_state = set_vram_to
+    else:
+        vram_state = VRAMState.SHARED
 
 logging.info(f"Set vram state to: {vram_state.name}")
 


### PR DESCRIPTION
### Problem
On Apple Silicon macOS (`cpu_state == CPUState.MPS`), `vram_state` was unconditionally overridden to `VRAMState.SHARED` in `comfy/model_management.py`.

When users on 16GB–36GB MacBooks run modern large models (such as MiniMax H3, Flux, SD3.5, HunyuanVideo), passing `--lowvram` or `--novram` was ignored. This caused ComfyUI to attempt loading all models (e.g., a 15GB text encoder + 20GB diffusion model) into RAM simultaneously, triggering macOS OOM kernel kills (`Killed: 9 / SIGKILL 137`).

### Solution
Allow `VRAMState.LOW_VRAM` and `VRAMState.NO_VRAM` to take effect when requested on MPS systems, falling back to `VRAMState.SHARED` by default. This enables dynamic model/layer offloading between generation stages on Apple Silicon.

### Diff
```diff
diff --git a/comfy/model_management.py b/comfy/model_management.py
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -581,3 +581,6 @@ if cpu_state != CPUState.GPU:
 if cpu_state == CPUState.MPS:
-    vram_state = VRAMState.SHARED
+    if set_vram_to in (VRAMState.LOW_VRAM, VRAMState.NO_VRAM):
+        vram_state = set_vram_to
+    else:
+        vram_state = VRAMState.SHARED
```
