### PR TITLE
Add date-based output folders

### DIFF
--- a/comfy/cli_args.py
+++ b/comfy/cli_args.py
@@ -70,6 +70,8 @@ parser.add_argument("--max-upload-size", type=float, default=100, help="Set the 
 parser.add_argument("--base-directory", type=str, default=None, help="Set the ComfyUI base directory for models, custom_nodes, input, output, temp, and user directories.")
 parser.add_argument("--extra-model-paths-config", type=str, default=None, metavar="PATH", nargs='+', action='append', help="Load one or more extra_model_paths.yaml files.")
 parser.add_argument("--output-directory", type=str, default=None, help="Set the ComfyUI output directory. Overrides --base-directory.")
+parser.add_argument("--date-based-output", action="store_true", help="Save outputs into a date-based subfolder (e.g. YYYY-MM-DD).")
+parser.add_argument("--date-output-format", type=str, default="%Y-%m-%d", help="strftime format for date-based output folder (used with --date-based-output).")
 parser.add_argument("--temp-directory", type=str, default=None, help="Set the ComfyUI temp directory (default is in the ComfyUI directory). Overrides --base-directory.")
 parser.add_argument("--input-directory", type=str, default=None, help="Set the ComfyUI input directory. Overrides --base-directory.")
 parser.add_argument("--auto-launch", action="store_true", help="Automatically launch ComfyUI in the default browser.")

--- a/folder_paths.py
+++ b/folder_paths.py
@@ -547,6 +547,12 @@ def get_save_image_path(filename_prefix: str, output_dir: str, image_width=0, im
     subfolder = os.path.dirname(os.path.normpath(filename_prefix))
     filename = os.path.basename(os.path.normpath(filename_prefix))
 
+    if args.date_based_output:
+        # Automatically organize outputs into a date-based subfolder.
+        # This keeps working across midnight without restarting the server.
+        date_subfolder = time.strftime(args.date_output_format, time.localtime())
+        subfolder = os.path.join(date_subfolder, subfolder) if subfolder else date_subfolder
+
     full_output_folder = os.path.join(output_dir, subfolder)
 
     if not is_within_directory(output_dir, full_output_folder):

--- a/tests-unit/comfy_test/folder_path_test.py
+++ b/tests-unit/comfy_test/folder_path_test.py
@@ -3,6 +3,7 @@
 import sys
 import pytest
 import os
+import time
 import tempfile
 from unittest.mock import patch
 from importlib import reload
@@ -109,13 +110,30 @@ def test_get_filename_list(mock_folder_names_and_paths, mock_recursive_search):
     mock_recursive_search.return_value = (["file1.txt", "file2.jpg"], {})
     assert folder_paths.get_filename_list("test_folder") == ["file1.txt"]
 
-def test_get_save_image_path(temp_dir):
-    with patch("folder_paths.output_directory", temp_dir):
+def test_get_save_image_path_default(temp_dir):
+    with patch("folder_paths.output_directory", temp_dir), \
+         patch.object(folder_paths.args, "date_based_output", False, create=True):
         full_output_folder, filename, counter, subfolder, filename_prefix = folder_paths.get_save_image_path("test", temp_dir, 100, 100)
         assert os.path.samefile(full_output_folder, temp_dir)
         assert filename == "test"
         assert counter == 1
         assert subfolder == ""
+        assert filename_prefix == "test"
+
+
+def test_get_save_image_path_date_based(temp_dir):
+    fixed_time = time.struct_time((2025, 1, 15, 0, 0, 0, 2, 15, -1))
+    with patch("folder_paths.output_directory", temp_dir), \
+         patch.object(folder_paths.args, "date_based_output", True, create=True), \
+         patch.object(folder_paths.args, "date_output_format", "%Y-%m-%d", create=True), \
+         patch("folder_paths.time.localtime", return_value=fixed_time):
+        full_output_folder, filename, counter, subfolder, filename_prefix = folder_paths.get_save_image_path("test", temp_dir, 100, 100)
+        expected_date = "2025-01-15"
+        expected_folder = os.path.join(temp_dir, expected_date)
+        assert os.path.samefile(full_output_folder, expected_folder)
+        assert filename == "test"
+        assert counter == 1
+        assert subfolder == expected_date
         assert filename_prefix == "test"
 
 


### PR DESCRIPTION
## Summary

Adds opt-in CLI flags to organize generated files by the date they are written:

- --date-based-output stores outputs under a date subfolder; default behavior remains unchanged.
- --date-output-format accepts a standard strftime format, defaulting to %Y-%m-%d.
- Existing filename-prefix subfolders are preserved beneath the date folder.

## Operator quality of life

Long-running or high-volume installations accumulate large flat output directories that are slow to browse, harder to back up, and tedious to clean up. This gives operators a built-in, script-friendly organization policy without custom nodes, wrapper scripts, or manual file moves. The path is resolved for every save, so a process running across midnight automatically rolls into the next date folder without a restart. Per-folder counters also stay compact and meaningful.

## Compatibility

The behavior is entirely opt-in. Existing workflows, API integrations, output paths, and filename-prefix behavior are unchanged unless the flag is supplied.

## Tests

- ../python_embeded/python.exe -m pytest tests-unit/comfy_test/folder_path_test.py -q (15 passed)