### PR TITLE
[review-stack 5/6] code — synap5e/feat/assets-di

### DIFF
--- a/app/assets/api/routes.py
+++ b/app/assets/api/routes.py
@@ -125,12 +125,6 @@ def register_assets_routes(
     app.add_routes(ROUTES)
 
 
-def disable_assets_routes() -> None:
-    """Disable asset routes at runtime (e.g. after DB init failure)."""
-    global _ASSETS_ENABLED
-    _ASSETS_ENABLED = False
-
-
 def _build_error_response(
     status: int, code: str, message: str, details: dict | None = None
 ) -> web.Response:

--- a/app/assets/lifecycle.py
+++ b/app/assets/lifecycle.py
@@ -13,7 +13,7 @@ from app.assets.helpers import sql_path_under_prefix
 from app.assets.services.hash_mode_state import drain_transition_queue
 from app.assets.services.hash_mode_state import enqueue_transition_work
 from app.assets.services.hash_mode_state import record_transition_intent
-from app.database.db import can_create_session, create_session, init_db
+from app.database.db import can_create_session, create_session
 from comfy.cli_args import args
 
 _excluded_scan_roots: set[str] = set()
@@ -42,11 +42,6 @@ def drain_mode_transition_work() -> None:
     with create_session() as session:
         drain_transition_queue(session)
         session.commit()
-
-
-def init_db_and_state() -> None:
-    init_db()
-    record_hash_mode_transition_intent()
 
 
 def wipe_temp_db_rows(session) -> tuple[int, int]:

--- a/app/assets/manager.py
+++ b/app/assets/manager.py
@@ -1,0 +1,217 @@
+import logging
+from typing import Any, Callable, Protocol
+
+from aiohttp import web
+
+from app.assets import mode
+from app.assets.api.routes import register_assets_routes
+from app.assets.lifecycle import record_hash_mode_transition_intent, run_shutdown, run_startup
+from app.assets.seeder import asset_seeder
+from app.assets.services.ingest import (
+    register_cached_output as ingest_register_cached_output,
+    register_executed_output as ingest_register_executed_output,
+    register_file_in_place,
+)
+from app.assets.services.path_utils import get_known_subfolder_tags
+from app.assets.services.schemas import RegisteredAsset, UploadAssetView
+from app.user_manager import UserManager
+from comfy.cli_args import args
+
+
+class AssetManager(Protocol):
+    @property
+    def enabled(self) -> bool: ...
+
+    def startup(self) -> None: ...
+
+    def shutdown(self) -> None: ...
+
+    def register_routes(
+        self, app: web.Application, user_manager: UserManager | None
+    ) -> None: ...
+
+    def ensure_scan_started(self) -> None: ...
+
+    def pause_background_scan(self) -> None: ...
+
+    def queue_output_enrichment(self) -> None: ...
+
+    def resume_background_scan(self) -> None: ...
+
+    def register_upload(
+        self,
+        abs_path: str,
+        name: str,
+        upload_type: str,
+        subfolder: str,
+        *,
+        content_written: bool,
+    ) -> UploadAssetView | None: ...
+
+    def register_executed_output(
+        self, abs_path: str, job_id: str | None
+    ) -> RegisteredAsset | None: ...
+
+    def register_cached_output(
+        self, abs_path: str, job_id: str | None
+    ) -> RegisteredAsset | None: ...
+
+    def set_event_sink(self, sink: Callable[[str, dict[str, Any]], None] | None) -> None: ...
+
+
+class _ArgsLike(Protocol):
+    enable_assets: bool
+    enable_asset_hashing: bool
+
+
+def _shutdown_assets() -> None:
+    asset_seeder.shutdown()
+    run_shutdown()
+
+
+class NoAssets:
+    def __init__(self, args: _ArgsLike) -> None:
+        self._args = args
+
+    @property
+    def enabled(self) -> bool:
+        return False
+
+    def startup(self) -> None:
+        mode.init(self._args)
+        record_hash_mode_transition_intent()
+        run_startup(enable_assets=False)
+
+    def shutdown(self) -> None:
+        _shutdown_assets()
+
+    def register_routes(
+        self, app: web.Application, user_manager: UserManager | None
+    ) -> None:
+        register_assets_routes(app)
+        asset_seeder.disable()
+
+    def ensure_scan_started(self) -> None:
+        return None
+
+    def pause_background_scan(self) -> None:
+        return None
+
+    def queue_output_enrichment(self) -> None:
+        return None
+
+    def resume_background_scan(self) -> None:
+        return None
+
+    def register_upload(
+        self,
+        abs_path: str,
+        name: str,
+        upload_type: str,
+        subfolder: str,
+        *,
+        content_written: bool,
+    ) -> UploadAssetView | None:
+        return None
+
+    def register_executed_output(
+        self, abs_path: str, job_id: str | None
+    ) -> RegisteredAsset | None:
+        return None
+
+    def register_cached_output(
+        self, abs_path: str, job_id: str | None
+    ) -> RegisteredAsset | None:
+        return None
+
+    def set_event_sink(self, sink: Callable[[str, dict[str, Any]], None] | None) -> None:
+        return None
+
+
+class AssetsEnabled:
+    def __init__(self, args: _ArgsLike) -> None:
+        self._args = args
+
+    @property
+    def enabled(self) -> bool:
+        return True
+
+    def startup(self) -> None:
+        mode.init(self._args)
+        record_hash_mode_transition_intent()
+        run_startup(enable_assets=True)
+
+    def shutdown(self) -> None:
+        _shutdown_assets()
+
+    def register_routes(
+        self, app: web.Application, user_manager: UserManager | None
+    ) -> None:
+        register_assets_routes(app, user_manager)
+
+    def ensure_scan_started(self) -> None:
+        asset_seeder.start(roots=("models", "input", "output"))
+
+    def pause_background_scan(self) -> None:
+        asset_seeder.pause()
+
+    def queue_output_enrichment(self) -> None:
+        if not asset_seeder.is_disabled():
+            asset_seeder.enqueue_enrich(
+                roots=("output",), compute_hashes=self._args.enable_asset_hashing
+            )
+
+    def resume_background_scan(self) -> None:
+        asset_seeder.resume()
+
+    def register_upload(
+        self,
+        abs_path: str,
+        name: str,
+        upload_type: str,
+        subfolder: str,
+        *,
+        content_written: bool,
+    ) -> UploadAssetView | None:
+        try:
+            tag = upload_type if upload_type in ("input", "output") else "input"
+            tags = [tag] + get_known_subfolder_tags(subfolder)
+            result = register_file_in_place(
+                abs_path=abs_path,
+                name=name,
+                tags=tags,
+                content_written=content_written,
+            )
+            asset = RegisteredAsset(
+                id=result.ref.id,
+                content_id=result.content_id,
+                job_id=result.ref.job_id,
+                name=result.ref.name,
+            )
+            return UploadAssetView(
+                asset=asset,
+                asset_hash=result.asset.hash,
+                size=result.asset.size_bytes,
+                mime_type=result.asset.mime_type,
+                tags=result.tags,
+            )
+        except Exception:
+            logging.warning("Failed to register uploaded image as asset", exc_info=True)
+            return None
+
+    def register_executed_output(
+        self, abs_path: str, job_id: str | None
+    ) -> RegisteredAsset | None:
+        return ingest_register_executed_output(abs_path, job_id)
+
+    def register_cached_output(
+        self, abs_path: str, job_id: str | None
+    ) -> RegisteredAsset | None:
+        return ingest_register_cached_output(abs_path, job_id)
+
+    def set_event_sink(self, sink: Callable[[str, dict[str, Any]], None] | None) -> None:
+        asset_seeder.set_event_sink(sink)
+
+
+def default_asset_manager() -> AssetManager:
+    return AssetsEnabled(args) if args.enable_assets else NoAssets(args)

--- a/app/assets/seeder.py
+++ b/app/assets/seeder.py
@@ -6,7 +6,7 @@ import threading
 import time
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Callable
+from typing import Any, Callable
 
 from app.assets.scanner import (
     RootType,
@@ -95,8 +95,12 @@ class _AssetSeeder:
         self._compute_hashes: bool = False
         self._prune_first: bool = False
         self._progress_callback: ProgressCallback | None = None
+        self._event_sink: Callable[[str, dict[str, Any]], None] | None = None
         self._disabled: bool = False
         self._pending_enrich: dict | None = None
+
+    def set_event_sink(self, sink: Callable[[str, dict[str, Any]], None] | None) -> None:
+        self._event_sink = sink
 
     def disable(self) -> None:
         """Disable the asset seeder, preventing any scans from starting."""
@@ -469,13 +473,11 @@ class _AssetSeeder:
         self._run_gate.wait()  # Blocks if paused
         return self._is_cancelled()
 
-    def _emit_event(self, event_type: str, data: dict) -> None:
+    def _emit_event(self, event_type: str, data: dict[str, Any]) -> None:
         """Emit a WebSocket event if server is available."""
         try:
-            from server import PromptServer
-
-            if hasattr(PromptServer, "instance") and PromptServer.instance:
-                PromptServer.instance.send_sync(event_type, data)
+            if self._event_sink is not None:
+                self._event_sink(event_type, data)
         except Exception:
             pass
 

--- a/app/assets/services/ingest.py
+++ b/app/assets/services/ingest.py
@@ -2,7 +2,6 @@ import contextlib
 import logging
 import mimetypes
 import os
-from types import SimpleNamespace
 from typing import Any, NamedTuple, Sequence
 
 from sqlalchemy import func, select
@@ -29,6 +28,7 @@ from app.assets.services.path_utils import (
 )
 from app.assets.services.schemas import (
     AssetData,
+    RegisteredAsset,
     ReferenceData,
     UploadResult,
     UserMetadata,
@@ -238,7 +238,13 @@ def _record_to_upload_result(
         size_bytes=content.size_bytes if content else None,
         mime_type=record.mime_type,
     )
-    return UploadResult(ref=ref, asset=asset, tags=tag_names, created_new=created_new)
+    return UploadResult(
+        ref=ref,
+        content_id=record.content_id,
+        asset=asset,
+        tags=tag_names,
+        created_new=created_new,
+    )
 
 
 class _ContentFacts(NamedTuple):
@@ -615,7 +621,9 @@ def create_from_hash(
         return _record_to_upload_result(session, record, created_new=True)
 
 
-def register_cached_output(abs_path: str, job_id: str | None = None):
+def register_cached_output(
+    abs_path: str, job_id: str | None = None
+) -> RegisteredAsset | None:
     locator = os.path.abspath(abs_path)
     try:
         with create_session() as session:
@@ -673,7 +681,7 @@ def register_cached_output(abs_path: str, job_id: str | None = None):
         logging.exception("Failed to register cached output: %s", locator)
         return None
 
-    return SimpleNamespace(
+    return RegisteredAsset(
         id=record_id,
         content_id=record_content_id,
         job_id=record_job_id,
@@ -681,7 +689,9 @@ def register_cached_output(abs_path: str, job_id: str | None = None):
     )
 
 
-def register_executed_output(abs_path: str, job_id: str | None = None):
+def register_executed_output(
+    abs_path: str, job_id: str | None = None
+) -> RegisteredAsset | None:
     locator = os.path.abspath(abs_path)
     try:
         stat_result = os.stat(locator, follow_symlinks=True)
@@ -729,7 +739,7 @@ def register_executed_output(abs_path: str, job_id: str | None = None):
         logging.exception("Failed to register executed output: %s", locator)
         return None
 
-    return SimpleNamespace(
+    return RegisteredAsset(
         id=record_id,
         content_id=record_content_id,
         job_id=record_job_id,

--- a/app/assets/services/schemas.py
+++ b/app/assets/services/schemas.py
@@ -81,8 +81,26 @@ class DownloadResolutionResult:
 
 
 @dataclass(frozen=True)
+class RegisteredAsset:
+    id: str
+    content_id: str
+    job_id: str | None
+    name: str
+
+
+@dataclass(frozen=True)
+class UploadAssetView:
+    asset: RegisteredAsset
+    asset_hash: str | None
+    size: int | None
+    mime_type: str | None
+    tags: list[str]
+
+
+@dataclass(frozen=True)
 class UploadResult:
     ref: ReferenceData
+    content_id: str
     asset: AssetData
     tags: list[str]
     created_new: bool

--- a/comfy_api/feature_flags.py
+++ b/comfy_api/feature_flags.py
@@ -109,6 +109,7 @@ _CORE_FEATURE_FLAGS: dict[str, Any] = {
     "max_upload_size": args.max_upload_size * 1024 * 1024, # Convert MB to bytes
     "extension": {"manager": {"supports_v4": True}},
     "node_replacements": True,
+    # Mirrors the constructed AssetManager; no degradation path exists, so this always agrees with it.
     "assets": args.enable_assets,
 }
 

--- a/comfy_execution/asset_enrichment.py
+++ b/comfy_execution/asset_enrichment.py
@@ -1,6 +1,13 @@
 import copy
 import logging
 import os
+from typing import TYPE_CHECKING, Callable
+
+if TYPE_CHECKING:
+    from app.assets.manager import AssetManager
+    from app.assets.services.schemas import RegisteredAsset
+    from comfy_execution.server_protocol import ExecutionServer
+    from execution import CacheEntry
 
 
 def _resolve_output_path(entry: dict) -> str | None:
@@ -26,7 +33,11 @@ def _resolve_output_path(entry: dict) -> str | None:
     return abs_path
 
 
-def _enrich_in_place(output_ui: dict, job_id, register) -> None:
+def _enrich_in_place(
+    output_ui: dict,
+    job_id: str | None,
+    register: Callable[[str, str | None], "RegisteredAsset | None"],
+) -> None:
     """S10.6: producers that write the same output path are not coalesced (unsupported)."""
     for entries in output_ui.values():
         if not isinstance(entries, list):
@@ -38,7 +49,7 @@ def _enrich_in_place(output_ui: dict, job_id, register) -> None:
                 abs_path = _resolve_output_path(entry)
                 if abs_path is None:
                     continue
-                result = register(abs_path, job_id=job_id)
+                result = register(abs_path, job_id)
                 if result is not None:
                     entry["id"] = result.id
             except Exception:
@@ -54,19 +65,16 @@ def _strip_ids(output_ui: dict) -> None:
                 entry.pop("id", None)
 
 
-def register_executed_outputs(output_ui: dict, job_id) -> dict:
-    from comfy.cli_args import args
-
+def register_executed_outputs(output_ui: dict, job_id: str, asset_manager: "AssetManager") -> dict:
     enriched = copy.deepcopy(output_ui)
-    if not args.enable_assets:
+    if not asset_manager.enabled:
         return enriched
-    from app.assets.services.ingest import register_executed_output
 
-    _enrich_in_place(enriched, job_id, register_executed_output)
+    _enrich_in_place(enriched, job_id, asset_manager.register_executed_output)
     return enriched
 
 
-def register_cached_outputs(ui_wrapper, job_id):
+def register_cached_outputs(ui_wrapper: dict | None, job_id: str, asset_manager: "AssetManager") -> dict | None:
     if ui_wrapper is None:
         return None
 
@@ -76,20 +84,17 @@ def register_cached_outputs(ui_wrapper, job_id):
         return enriched
     _strip_ids(output_ui)
 
-    from comfy.cli_args import args
-
-    if not args.enable_assets:
+    if not asset_manager.enabled:
         return enriched
-    from app.assets.services.ingest import register_cached_output
 
-    _enrich_in_place(output_ui, job_id, register_cached_output)
+    _enrich_in_place(output_ui, job_id, asset_manager.register_cached_output)
     return enriched
 
 
-def emit_cached_output(server, node_id, display_node_id, cached, prompt_id, ui_outputs) -> None:
+def emit_cached_output(server: "ExecutionServer", node_id: str, display_node_id: str, cached: "CacheEntry", prompt_id: str, ui_outputs: dict, asset_manager: "AssetManager") -> None:
     if node_id in ui_outputs:
         return
-    enriched = register_cached_outputs(cached.ui, prompt_id)
+    enriched = register_cached_outputs(cached.ui, prompt_id, asset_manager)
     if enriched is not None:
         ui_outputs[node_id] = enriched
     if server.client_id is None:

--- a/comfy_execution/progress.py
+++ b/comfy_execution/progress.py
@@ -7,6 +7,7 @@ from tqdm import tqdm
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from comfy_execution.graph import DynamicPrompt
+    from comfy_execution.server_protocol import ExecutionServer
 from protocol import BinaryEventTypes
 from comfy_api import feature_flags
 
@@ -150,7 +151,7 @@ class WebUIProgressHandler(ProgressHandler):
     Handler that sends progress updates to the WebUI via WebSockets.
     """
 
-    def __init__(self, server_instance):
+    def __init__(self, server_instance: "ExecutionServer"):
         super().__init__("webui")
         self.server_instance = server_instance
 

--- a/comfy_execution/server_protocol.py
+++ b/comfy_execution/server_protocol.py
@@ -1,0 +1,11 @@
+from typing import Protocol
+
+
+class ExecutionServer(Protocol):
+    client_id: str | None
+    last_node_id: str | None
+    sockets_metadata: dict[str, dict[str, object]]
+
+    def send_sync(self, event: str | int, data: object, sid: str | None = None) -> None: ...
+
+    def queue_updated(self) -> None: ...

--- a/execution.py
+++ b/execution.py
@@ -7,7 +7,7 @@ import threading
 import time
 import traceback
 from enum import Enum
-from typing import List, Literal, NamedTuple, Optional, Union
+from typing import TYPE_CHECKING, List, Literal, NamedTuple, Optional, Union
 import asyncio
 
 import torch
@@ -47,6 +47,10 @@ from comfy_execution.asset_enrichment import register_executed_outputs, emit_cac
 from comfy_api.internal import _ComfyNodeInternal, _NodeOutputInternal, first_real_override, is_class, make_locked_method_func
 from comfy_api.latest import io, _io
 from comfy_execution.cache_provider import _has_cache_providers, _get_cache_providers, _logger as _cache_logger
+from app.assets.manager import AssetManager, default_asset_manager
+
+if TYPE_CHECKING:
+    from comfy_execution.server_protocol import ExecutionServer
 
 
 class ExecutionResult(Enum):
@@ -427,7 +431,7 @@ def _is_intermediate_output(dynprompt, node_id):
     return getattr(class_def, 'HAS_INTERMEDIATE_OUTPUT', False)
 
 
-async def execute(server, dynprompt, caches, current_item, extra_data, executed, prompt_id, execution_list, pending_subgraph_results, pending_async_nodes, ui_outputs):
+async def execute(server: "ExecutionServer", dynprompt, caches, current_item, extra_data, executed, prompt_id, execution_list, pending_subgraph_results, pending_async_nodes, ui_outputs, asset_manager: AssetManager):
     unique_id = current_item
     real_node_id = dynprompt.get_real_node_id(unique_id)
     display_node_id = dynprompt.get_display_node_id(unique_id)
@@ -437,7 +441,7 @@ async def execute(server, dynprompt, caches, current_item, extra_data, executed,
     class_def = nodes.NODE_CLASS_MAPPINGS[class_type]
     cached = await caches.outputs.get(unique_id)
     if cached is not None:
-        emit_cached_output(server, unique_id, display_node_id, cached, prompt_id, ui_outputs)
+        emit_cached_output(server, unique_id, display_node_id, cached, prompt_id, ui_outputs, asset_manager)
         get_progress_state().finish_progress(unique_id)
         execution_list.cache_update(unique_id, cached)
         return (ExecutionResult.SUCCESS, None, None)
@@ -560,7 +564,7 @@ async def execute(server, dynprompt, caches, current_item, extra_data, executed,
                 "parent_node": parent_node_id,
                 "real_node_id": real_node_id,
             }
-            enriched_output_ui = register_executed_outputs(output_ui, prompt_id)
+            enriched_output_ui = register_executed_outputs(output_ui, prompt_id, asset_manager)
             ui_outputs[unique_id] = {"meta": meta, "output": enriched_output_ui}
             cache_ui_value = {"meta": meta, "output": output_ui}
             if server.client_id is not None:
@@ -651,10 +655,11 @@ async def execute(server, dynprompt, caches, current_item, extra_data, executed,
     return (ExecutionResult.SUCCESS, None, None)
 
 class PromptExecutor:
-    def __init__(self, server, cache_type=False, cache_args=None):
+    def __init__(self, server: "ExecutionServer", cache_type=False, cache_args=None, asset_manager: AssetManager | None = None):
         self.cache_args = cache_args
         self.cache_type = cache_type
         self.server = server
+        self.asset_manager = asset_manager if asset_manager is not None else default_asset_manager()
         self.prompt_model_tracker = comfy.model_patcher.PromptModelTracker()
         self.reset()
 
@@ -775,7 +780,7 @@ class PromptExecutor:
                         break
 
                     assert node_id is not None, "Node ID should not be None at this point"
-                    result, error, ex = await execute(self.server, dynamic_prompt, self.caches, node_id, extra_data, executed, prompt_id, execution_list, pending_subgraph_results, pending_async_nodes, ui_node_outputs)
+                    result, error, ex = await execute(self.server, dynamic_prompt, self.caches, node_id, extra_data, executed, prompt_id, execution_list, pending_subgraph_results, pending_async_nodes, ui_node_outputs, self.asset_manager)
                     self.success = result != ExecutionResult.FAILURE
                     if result == ExecutionResult.FAILURE:
                         self.handle_execution_error(prompt_id, dynamic_prompt.original_prompt, current_outputs, executed, error, ex)
@@ -809,7 +814,7 @@ class PromptExecutor:
                         cached = await self.caches.outputs.get(node_id)
                         if cached is not None:
                             display_node_id = dynamic_prompt.get_display_node_id(node_id)
-                            emit_cached_output(self.server, node_id, display_node_id, cached, prompt_id, ui_node_outputs)
+                            emit_cached_output(self.server, node_id, display_node_id, cached, prompt_id, ui_node_outputs, self.asset_manager)
                     self.add_message("execution_success", { "prompt_id": prompt_id }, broadcast=False)
 
                 ui_outputs = {}
@@ -1238,7 +1243,7 @@ async def validate_prompt(prompt_id, prompt, partial_execution_list: Union[list[
 MAXIMUM_HISTORY_SIZE = 10000
 
 class PromptQueue:
-    def __init__(self, server):
+    def __init__(self, server: "ExecutionServer"):
         self.server = server
         self.mutex = threading.RLock()
         self.not_empty = threading.Condition(self.mutex)

--- a/main.py
+++ b/main.py
@@ -22,9 +22,8 @@ console_log_level = get_console_log_level(args.verbose)
 file_log_outputs = get_file_log_outputs(args.verbose)
 setup_logger(log_level=console_log_level, file_outputs=file_log_outputs, use_stdout=args.log_stdout)
 
-from app.assets import mode
-from app.assets.lifecycle import cleanup_temp_filesystem, init_db_and_state, run_shutdown, run_startup
-from app.assets.seeder import asset_seeder
+from app.assets.lifecycle import cleanup_temp_filesystem
+from app.assets.manager import AssetManager, default_asset_manager
 import itertools
 import utils.extra_config
 from utils.mime_types import init_mime_types
@@ -35,7 +34,7 @@ import sys
 from comfy_execution.progress import get_progress_state
 from comfy_execution.utils import get_executing_context
 from comfy_api import feature_flags
-from app.database.db import dependencies_available
+from app.database.db import dependencies_available, init_db
 
 if __name__ == "__main__":
     #NOTE: These do not do anything on core ComfyUI, they are for custom nodes.
@@ -317,7 +316,7 @@ def cuda_malloc_warning():
             logging.warning("\nWARNING: this card most likely does not support cuda-malloc, if you get \"CUDA error\" please run ComfyUI with: --disable-cuda-malloc\n")
 
 
-def prompt_worker(q, server_instance):
+def prompt_worker(q, server_instance, asset_manager):
     current_time: float = 0.0
     cache_ram = 0
     cache_ram_inactive = 0
@@ -337,7 +336,7 @@ def prompt_worker(q, server_instance):
     elif args.cache_none:
         cache_type = execution.CacheType.NONE
 
-    e = execution.PromptExecutor(server_instance, cache_type=cache_type, cache_args={ "lru" : args.cache_lru, "ram" : cache_ram, "ram_inactive" : cache_ram_inactive } )
+    e = execution.PromptExecutor(server_instance, cache_type=cache_type, cache_args={ "lru" : args.cache_lru, "ram" : cache_ram, "ram_inactive" : cache_ram_inactive }, asset_manager=asset_manager )
     last_gc_collect = 0
     need_gc = False
     gc_collect_interval = 10.0
@@ -359,7 +358,7 @@ def prompt_worker(q, server_instance):
             for k in sensitive:
                 extra_data[k] = sensitive[k]
 
-            asset_seeder.pause()
+            asset_manager.pause_background_scan()
             e.execute(item[2], prompt_id, extra_data, item[4])
 
             need_gc = True
@@ -406,9 +405,8 @@ def prompt_worker(q, server_instance):
                 need_gc = False
                 hook_breaker_ac10a0.restore_functions()
 
-                if not asset_seeder.is_disabled():
-                    asset_seeder.enqueue_enrich(roots=("output",), compute_hashes=args.enable_asset_hashing)
-                asset_seeder.resume()
+                asset_manager.queue_output_enrichment()
+                asset_manager.resume_background_scan()
 
 
 async def run(server_instance, address='', port=8188, verbose=True, call_on_start=None):
@@ -451,13 +449,13 @@ def hijack_progress(server_instance):
     comfy.utils.set_progress_bar_global_hook(hook)
 
 
-def setup_database():
+def setup_database(asset_manager):
     if not dependencies_available():
         return
 
     try:
-        mode.init(args)
-        init_db_and_state()
+        init_db()
+        asset_manager.startup()
     except Exception as e:
         if "database is locked" in str(e):
             logging.error(
@@ -477,8 +475,6 @@ def setup_database():
             )
             sys.exit(1)
         logging.error(f"Failed to initialize database. Please ensure you have installed the latest requirements. If the error persists, please report this as in future the database will be required: {e}")
-    else:
-        run_startup(enable_assets=args.enable_assets)
 
 
 def start_comfyui(asyncio_loop=None):
@@ -491,13 +487,14 @@ def start_comfyui(asyncio_loop=None):
         logging.info(f"Setting temp directory to: {temp_dir}")
         folder_paths.set_temp_directory(temp_dir)
 
-    if not (args.enable_assets and dependencies_available()):
+    asset_manager: AssetManager = default_asset_manager()
+    if not (asset_manager.enabled and dependencies_available()):
         cleanup_temp_filesystem()
 
     if not asyncio_loop:
         asyncio_loop = asyncio.new_event_loop()
         asyncio.set_event_loop(asyncio_loop)
-    prompt_server = server.PromptServer(asyncio_loop)
+    prompt_server = server.PromptServer(asyncio_loop, asset_manager)
 
     if args.enable_manager and not args.disable_manager_ui:
         comfyui_manager.start()
@@ -515,12 +512,12 @@ def start_comfyui(asyncio_loop=None):
     hook_breaker_ac10a0.restore_functions()
 
     cuda_malloc_warning()
-    setup_database()
+    setup_database(asset_manager)
 
     prompt_server.add_routes()
     hijack_progress(prompt_server)
 
-    threading.Thread(target=prompt_worker, daemon=True, args=(prompt_server.prompt_queue, prompt_server,)).start()
+    threading.Thread(target=prompt_worker, daemon=True, args=(prompt_server.prompt_queue, prompt_server, asset_manager)).start()
 
     if args.quick_test_for_ci:
         exit(0)
@@ -568,7 +565,7 @@ if __name__ == "__main__":
             "dynamic vram enabled and using native ComfyUI model formats instead. "
             "ComfyUI native formats like fp8, int8 and w4a8 will be faster even if they are larger than your memory."
         )
-    event_loop, _, start_all_func = start_comfyui()
+    event_loop, prompt_server, start_all_func = start_comfyui()
     try:
         x = start_all_func()
         app.logger.print_startup_warnings()
@@ -576,5 +573,4 @@ if __name__ == "__main__":
     except KeyboardInterrupt:
         logging.info("\nStopped server")
     finally:
-        asset_seeder.shutdown()
-        run_shutdown()
+        prompt_server.asset_manager.shutdown()

--- a/server.py
+++ b/server.py
@@ -44,10 +44,6 @@ import node_helpers
 from comfyui_version import __version__
 from app.frontend_management import FrontendManager, parse_version
 from comfy_api.internal import _ComfyNodeInternal
-from app.assets.seeder import asset_seeder
-from app.assets.api.routes import register_assets_routes
-from app.assets.services.ingest import register_file_in_place
-from app.assets.services.path_utils import get_known_subfolder_tags
 from app.assets.services.asset_management import resolve_hash_to_path
 
 from app.user_manager import UserManager
@@ -55,9 +51,12 @@ from app.model_manager import ModelFileManager
 from app.custom_node_manager import CustomNodeManager
 from app.subgraph_manager import SubgraphManager
 from app.node_replace_manager import NodeReplaceManager
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 from api_server.routes.internal.internal_routes import InternalRoutes
 from protocol import BinaryEventTypes
+
+if TYPE_CHECKING:
+    from app.assets.manager import AssetManager
 
 # Import cache control middleware
 from middleware.cache_middleware import cache_control
@@ -213,9 +212,10 @@ def create_block_external_middleware():
 
 
 class PromptServer():
-    def __init__(self, loop):
+    def __init__(self, loop, asset_manager: "AssetManager"):
         PromptServer.instance = self
 
+        self.asset_manager = asset_manager
         self.user_manager = UserManager()
         self.model_file_manager = ModelFileManager()
         self.custom_node_manager = CustomNodeManager()
@@ -254,11 +254,8 @@ class PromptServer():
             else args.front_end_root
         )
         logging.info(f"[Prompt Server] web root: {self.web_root}")
-        if args.enable_assets:
-            register_assets_routes(self.app, self.user_manager)
-        else:
-            register_assets_routes(self.app)
-            asset_seeder.disable()
+        self.asset_manager.register_routes(self.app, self.user_manager)
+        self.asset_manager.set_event_sink(self.send_sync)
         routes = web.RouteTableDef()
         self.routes = routes
         self.last_node_id = None
@@ -440,27 +437,22 @@ class PromptServer():
 
                 resp = {"name" : filename, "subfolder": subfolder, "type": image_upload_type}
 
-                if args.enable_assets:
-                    try:
-                        tag = image_upload_type if image_upload_type in ("input", "output") else "input"
-                        tags = [tag]
-                        tags.extend(get_known_subfolder_tags(subfolder))
-                        result = register_file_in_place(
-                            abs_path=filepath,
-                            name=filename,
-                            tags=tags,
-                            content_written=not image_is_duplicate,
-                        )
-                        resp["asset"] = {
-                            "id": result.ref.id,
-                            "name": result.ref.name,
-                            "asset_hash": result.asset.hash,
-                            "size": result.asset.size_bytes,
-                            "mime_type": result.asset.mime_type,
-                            "tags": result.tags,
-                        }
-                    except Exception:
-                        logging.warning("Failed to register uploaded image as asset", exc_info=True)
+                view = self.asset_manager.register_upload(
+                    abs_path=filepath,
+                    name=filename,
+                    upload_type=image_upload_type,
+                    subfolder=subfolder,
+                    content_written=not image_is_duplicate,
+                )
+                if view is not None:
+                    resp["asset"] = {
+                        "id": view.asset.id,
+                        "name": view.asset.name,
+                        "asset_hash": view.asset_hash,
+                        "size": view.size,
+                        "mime_type": view.mime_type,
+                        "tags": view.tags,
+                    }
 
                 return web.json_response(resp)
             else:
@@ -807,7 +799,7 @@ class PromptServer():
 
         @routes.get("/object_info")
         async def get_object_info(request):
-            asset_seeder.start(roots=("models", "input", "output"))
+            self.asset_manager.ensure_scan_started()
             with folder_paths.cache_helper:
                 out = {}
                 for x in nodes.NODE_CLASS_MAPPINGS:


### PR DESCRIPTION
Layer 5/6 of the review-and-land stack for `synap5e/feat/assets-di`, generated by
`review-stack.py`. Full collapse procedure: `~/adocs/review-stack.md`. **Once the
stack starts collapsing, don't rerun `build`/`push` on it** — a rebuild resets every
layer to its original scope from the untouched source branch and discards the collapse.

**This is a continuation stack.** Two source branches are in review at once: layers 1–4 split `synap5e/feat/asset-record-content-split`, and layers 5+ split `synap5e/feat/assets-di`, which is a separate branch stacked on top of it. Every layer's base is the layer below, so the whole thing is one linear chain even though it splits two branches.

**Collapse runs top-down:** the highest layer merges into the one below it (fast-forward, no squash), repeatedly, until everything has landed in layer 1 — and only then does layer 1 (#15915) squash-merge into `master`. Merging any middle layer directly into the real base would swallow the layers below it.

Once approved, merge this into #15918 (ordinary "Merge" — a fast-forward). This is the bottom of *this* sub-stack but **not** of the whole chain: layer 4 below it is another review layer, not a real base, so this is a merge and not a squash. The squash happens once, at layer 1.

**Rule:** path not under tests-unit/ or tests/  
**Question for this layer:** Is the logic change right?  
**Source tip:** `eca2c74bffcb`

**Stack:**
1. #15915 `code` — Is the logic change right?
2. #15916 `tests-removed` — For each dropped assertion: obsolete by a ruling, or covered by a tests-new test?
3. #15917 `tests-changed` — Did the edits weaken an existing check?
4. #15918 `tests-new` — Is the code layer well covered?
5. #16008 `code` — Is the logic change right?
6. #16009 `tests` — Is the code layer well covered, and did any edit weaken an existing check?

**Files (13, +351/-104):**

| | +/- | path |
|---|---|---|
| M | +0/-6 | `app/assets/api/routes.py` |
| M | +1/-6 | `app/assets/lifecycle.py` |
| A | +217/-0 | `app/assets/manager.py` |
| M | +8/-6 | `app/assets/seeder.py` |
| M | +16/-6 | `app/assets/services/ingest.py` |
| M | +18/-0 | `app/assets/services/schemas.py` |
| M | +1/-0 | `comfy_api/feature_flags.py` |
| M | +21/-16 | `comfy_execution/asset_enrichment.py` |
| M | +2/-1 | `comfy_execution/progress.py` |
| A | +11/-0 | `comfy_execution/server_protocol.py` |
| M | +13/-8 | `execution.py` |
| M | +18/-22 | `main.py` |
| M | +25/-33 | `server.py` |