### PR TITLE
fix(model_management): set current CUDA device when loading multi-GPU model clones

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -1005,7 +1005,12 @@ def load_models_gpu(models, memory_required=0, force_patch_weights=False, minimu
         if vram_set_state == VRAMState.NO_VRAM:
             lowvram_model_memory = 0.1
 
-        loaded_model.model_load(lowvram_model_memory, force_patch_weights=force_patch_weights)
+        # Multi-GPU fix: custom CUDA kernels (e.g. comfy_kitchen quantize/
+        # dequantize) require torch.cuda.current_device() to match the model
+        # being loaded. Without this, loading a multi-GPU deepclone with LoRA
+        # patches can launch kernels on the wrong device.
+        with cuda_device_context(torch_dev):
+            loaded_model.model_load(lowvram_model_memory, force_patch_weights=force_patch_weights)
         vram_used = 0 if is_device_cpu(torch_dev) else loaded_model.model_loaded_memory()
         ram_used = model.loaded_ram_size() if model.is_dynamic() else loaded_model.model_memory() - vram_used
         detail("Model loaded: patcher=%s model=%s ram_mb=%.1f vram_mb=%.1f", model.__class__.__name__, model.model.__class__.__name__, ram_used / (1024 ** 2), vram_used / (1024 ** 2))


### PR DESCRIPTION
## PR Description

### Summary

Fixes multi-GPU workflows that combine `MultiGPU_WorkUnits` with LoRA patches (or any other weight patching that triggers `patch_weight_to_device` on a secondary CUDA device).

### Problem

When `MultiGPU_WorkUnits(max_gpus=2)` creates a deepclone on a secondary GPU, the clone's `ModelPatcher.load_device` is set to `cuda:1`, but `torch.cuda.current_device()` remains `cuda:0` while the clone is being loaded.

During sampling with LoRA nodes, `load_models_gpu()` → `model_load()` → `patch_weight_to_device()` calls into custom CUDA kernels (e.g. `comfy_kitchen` int8 ConvRot quantize/dequantize). These kernels require the current CUDA device to match the tensor's device.

This produces:

```
BufferError: Can't export tensors on a different CUDA device index. Expected: 1. Current device: 0.
```

If the check is bypassed at the DLPack layer, the subsequent kernel launch can run on the wrong device and cause:

```
CUDA error: an illegal memory access was encountered
```

which aborts the ComfyUI process.

### Root Cause

`load_models_gpu()` loads each `LoadedModel` without switching the thread's current CUDA device to `model.load_device`. ComfyUI already provides a `cuda_device_context()` helper for exactly this purpose, but it is not used in this load path.

### Reproduction

Environment:
- Dual RTX 2080 Ti (22 GB each)
- ComfyUI with `MultiGPU_WorkUnits(max_gpus=2)`
- Krea2 int8 ConvRot UNET (`krea2_turbo_int8_convrot.safetensors`)
- One or more `LoraLoaderModelOnly` nodes between `UNETLoader` and `MultiGPU_WorkUnits`

Steps:
1. Build a workflow: `UNETLoader → LoraLoaderModelOnly → MultiGPU_WorkUnits(max_gpus=2) → KSampler`
2. Queue a prompt.
3. Observe the `BufferError` during `model_load()`.

### Fix

In `comfy/model_management.py`, wrap `loaded_model.model_load(...)` with the existing `cuda_device_context(torch_dev)` so the entire model-loading path runs with the correct current CUDA device.

```diff
         if vram_set_state == VRAMState.NO_VRAM:
             lowvram_model_memory = 0.1
 
-        loaded_model.model_load(lowvram_model_memory, force_patch_weights=force_patch_weights)
+        # Multi-GPU fix: custom CUDA kernels (e.g. comfy_kitchen quantize/
+        # dequantize) require torch.cuda.current_device() to match the model
+        # being loaded. Without this, loading a multi-GPU deepclone with LoRA
+        # patches can launch kernels on the wrong device.
+        with cuda_device_context(torch_dev):
+            loaded_model.model_load(lowvram_model_memory, force_patch_weights=force_patch_weights)
         vram_used = 0 if is_device_cpu(torch_dev) else loaded_model.model_loaded_memory()
```

`cuda_device_context()` is already defined in the same file and is a no-op for CPU or when the device already matches, so this change has no effect on single-GPU or CPU loading.

### Testing

Validated on a dual-GPU Ubuntu host (2× RTX 2080 Ti 22GB, ComfyUI 0.33.0, PyTorch 2.13.0+cu130):

| Test | Configuration | Result |
|---|---|---|
| 4 LoRA + dual GPU | 512×512, batch 1, `max_gpus=2` | ✅ success |
| 4 LoRA + dual GPU | 576×1024, batch 4, `max_gpus=2` | ✅ success |
| Stability | Two consecutive prompts above, then service check | ✅ service remained active, no crash |

Also verified that the previous workaround of patching `_wrap_for_dlpack` in `comfy_kitchen` is **not** sufficient: it allows the DLPack export but leaves the subsequent kernel launch on the wrong device, causing delayed `CUDA illegal memory access` crashes. The correct fix is at the ComfyUI load boundary.

### Upstream Status Check

- Target repository: `Comfy-Org/ComfyUI` (canonical name; `comfyanonymous/ComfyUI` is a redirect alias).
- Latest `master` checked at commit `3216c62` (`Support SenseNova U1.5 (CORE-411) (#15922)`).
- `load_models_gpu()` in latest `master` still calls `loaded_model.model_load(...)` without wrapping it in `cuda_device_context(torch_dev)`.
- GitHub search for the exact error string `Can't export tensors on a different CUDA device index` in `Comfy-Org/ComfyUI`: **0 results**.
- Search for `cuda_device_context`: only one PR found (`#15498`), which is unrelated (AMD/ROCm APU preference).
- Search for `MultiGPU_WorkUnits`: related items are the feature PR (`#7063`), non-CUDA tracking issue (`#14069`), and a non-CUDA single-GPU fix (`#14068`); none address this CUDA + LoRA loading path.
- Conclusion: no existing fix PR was found for this bug on the latest version.

### Risks / Notes

- This change is scoped to the model-loading path only.
- `cuda_device_context()` restores the previous device on exit, so it does not change the global device state after loading.
- No behavior change for single-GPU or CPU workflows.
- The underlying `comfy_kitchen` kernels still assume the current device matches the tensor device; this fix makes ComfyUI uphold that contract for all model loads.

### Checklist

- [x] The change is minimal and targeted.
- [x] Existing `cuda_device_context()` helper is reused.
- [x] Validated on dual-GPU with LoRA at production resolution/batch size.
- [x] No changes to third-party packages (`comfy_kitchen`) required.
- [x] No behavior change for single-GPU/CPU paths.
