### PR TITLE
Support Bernini v2 single-file pipeline

### DIFF
--- a/comfy/ldm/bernini_v2/__init__.py
+++ b/comfy/ldm/bernini_v2/__init__.py
@@ -1,0 +1,1 @@
+"""Native Bernini v2 inference components."""

--- a/comfy/ldm/bernini_v2/guidance.py
+++ b/comfy/ldm/bernini_v2/guidance.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliate
+# SPDX-License-Identifier: Apache-2.0
+"""Framework-independent Bernini v2 renderer guidance math."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import torch
+
+
+def guidance_chunks(names: list[str], batch_size: str | int) -> list[list[str]]:
+    """Split condition arms without changing their evaluation or composition order."""
+
+    if batch_size == "all":
+        size = len(names)
+    elif batch_size == "auto":
+        # Video arms have very large activations. One arm at a time is the safe
+        # default; users can explicitly trade memory for throughput.
+        size = 1
+    else:
+        try:
+            size = int(batch_size)
+        except (TypeError, ValueError) as error:
+            raise ValueError(f"invalid guidance batch size: {batch_size!r}") from error
+    if size < 1:
+        raise ValueError("guidance batch size must be at least 1")
+    return [names[index : index + size] for index in range(0, len(names), size)]
+
+
+def unipc_flow_sigmas(steps: int, shift: float) -> torch.Tensor:
+    """Return the released Diffusers UniPC flow schedule without importing Diffusers."""
+    raw = torch.linspace(0.999, 0.0, steps + 1, dtype=torch.float32)[:-1]
+    shifted = shift * raw / (1.0 + (shift - 1.0) * raw)
+    return torch.cat([shifted, shifted.new_zeros(1)])
+
+
+def append_dims(value: torch.Tensor, ndim: int) -> torch.Tensor:
+    """Append singleton dimensions until ``value`` broadcasts over a latent."""
+    if value.ndim > ndim:
+        raise ValueError(
+            f"cannot broadcast a {value.ndim}D sigma over a {ndim}D latent"
+        )
+    return value.reshape(value.shape + (1,) * (ndim - value.ndim))
+
+
+def apg_delta(
+    delta: torch.Tensor,
+    reference: torch.Tensor,
+    *,
+    parallel_scale: float = 0.2,
+    orthogonal_scale: float = 1.0,
+    eps: float = 1e-8,
+) -> torch.Tensor:
+    """Project a guidance delta exactly as Bernini's renderer does."""
+    batch = delta.shape[0]
+    delta_flat = delta.reshape(batch, -1)
+    reference_flat = reference.reshape(batch, -1)
+    norm_squared = (
+        (reference_flat * reference_flat).sum(dim=1, keepdim=True).clamp_min(eps)
+    )
+    coefficient = (delta_flat * reference_flat).sum(dim=1, keepdim=True) / norm_squared
+    parallel = coefficient * reference_flat
+    orthogonal = delta_flat - parallel
+    return parallel_scale * parallel.reshape_as(
+        delta
+    ) + orthogonal_scale * orthogonal.reshape_as(delta)
+
+
+def denoised_to_velocity(
+    denoised: torch.Tensor,
+    sample: torch.Tensor,
+    sigma: torch.Tensor,
+) -> torch.Tensor:
+    sigma = append_dims(sigma, sample.ndim).clamp_min(torch.finfo(torch.float32).eps)
+    return (sample - denoised) / sigma
+
+
+def velocity_to_denoised(
+    velocity: torch.Tensor,
+    sample: torch.Tensor,
+    sigma: torch.Tensor,
+) -> torch.Tensor:
+    return sample - append_dims(sigma, sample.ndim) * velocity
+
+
+def compose_velocity_guidance(
+    predictions: Mapping[str, torch.Tensor],
+    *,
+    omega_video: float,
+    omega_image: float,
+    omega_text: float,
+    omega_target: float,
+    rv2v: bool,
+) -> torch.Tensor:
+    """Compose official Bernini renderer arms in flow-velocity space.
+
+    Required arms are ``base``, ``text`` and ``target``. ``source`` is the
+    combined source-media arm used by all tasks except rv2v. The rv2v chain
+    instead uses separate optional ``video`` and ``image`` arms.
+    """
+    base = predictions["base"]
+    if rv2v:
+        video = predictions.get("video", base)
+        image = predictions.get("image", video)
+        text = predictions["text"]
+        target = predictions["target"]
+        # Despite the upstream mode name rv2v_wapg, the released inference
+        # code uses direct chained deltas for this branch.
+        return (
+            base
+            + omega_video * (video - base)
+            + omega_image * (image - video)
+            + omega_text * (text - image)
+            + omega_target * (target - text)
+        )
+
+    source = predictions.get("source", base)
+    text = predictions["text"]
+    target = predictions["target"]
+    return (
+        base
+        + omega_image * apg_delta(source - base, source)
+        + omega_text * apg_delta(text - source, text)
+        + omega_target * apg_delta(target - text, target)
+    )
+
+
+def compose_denoised_guidance(
+    predictions: Mapping[str, torch.Tensor],
+    sample: torch.Tensor,
+    sigma: torch.Tensor,
+    **kwargs,
+) -> torch.Tensor:
+    velocities = {
+        name: denoised_to_velocity(prediction, sample, sigma)
+        for name, prediction in predictions.items()
+    }
+    guided = compose_velocity_guidance(velocities, **kwargs)
+    return velocity_to_denoised(guided, sample, sigma)

--- a/comfy/ldm/bernini_v2/media.py
+++ b/comfy/ldm/bernini_v2/media.py
@@ -1,0 +1,44 @@
+"""Shared source-media geometry matching Bernini's VAE transform."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from typing import TypeVar
+
+SourceT = TypeVar("SourceT")
+
+
+def fit_media_size(
+    height: int,
+    width: int,
+    *,
+    max_size: int,
+    min_size: int = 240,
+    stride: int = 16,
+) -> tuple[int, int]:
+    """Preserve aspect, cap the long edge, floor the short edge, and snap."""
+
+    def divisible(value: float) -> int:
+        return max(stride, int(round(value / stride) * stride))
+
+    scale = min(max_size / max(width, height), 1.0)
+    scale = max(scale, min_size / min(width, height))
+    resized_width = divisible(round(width * scale))
+    resized_height = divisible(round(height * scale))
+    if max(resized_width, resized_height) > max_size:
+        scale = max_size / max(resized_width, resized_height)
+        resized_width = max(stride, math.floor(resized_width * scale / stride) * stride)
+        resized_height = max(
+            stride, math.floor(resized_height * scale / stride) * stride
+        )
+    return resized_height, resized_width
+
+
+def ordered_renderer_sources(
+    *,
+    image_sources: Sequence[SourceT],
+    video_sources: Sequence[SourceT],
+) -> list[SourceT]:
+    """Pack renderer contexts in the release's image-then-video order."""
+    return [*image_sources, *video_sources]

--- a/comfy/ldm/bernini_v2/planner.py
+++ b/comfy/ldm/bernini_v2/planner.py
@@ -452,6 +452,8 @@ def create_plan(
         )[0]
         current = runtime.aux.vit_decoder.sample(
             decoder_condition,
+            # Upstream's ``imgcond`` branch is text-only, but the released
+            # pipeline intentionally applies these scale names in this order.
             cfg=vit_text_cfg,
             img_cfg=vit_image_cfg,
             num_inference_steps=vit_denoising_steps,

--- a/comfy/ldm/bernini_v2/planner.py
+++ b/comfy/ldm/bernini_v2/planner.py
@@ -1,0 +1,501 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliate
+# SPDX-License-Identifier: Apache-2.0
+"""Native three-branch Bernini v2 semantic planning."""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+
+import numpy as np
+import torch
+
+import comfy.model_management
+
+from .qwen import (
+    plan_forward,
+    planner_video_frame_indices,
+    process_qwen2vl_video,
+    qwen_grid_for_media,
+)
+from .rope import get_rope_index
+from .runtime import BerniniV2PlannerRuntime
+from .template import BerniniTemplate, build_conversation
+
+IMAGE_TASKS = {"t2i", "i2i"}
+VIDEO_TASKS = {"t2v", "v2v", "r2v", "rv2v"}
+SUPPORTED_TASKS = IMAGE_TASKS | VIDEO_TASKS
+MAX_VIT_TARGET_TOKENS = 4096
+MAX_BASE_LATENT_ELEMENTS = 128 * 1024 * 1024
+
+
+@dataclass
+class BerniniV2Plan:
+    """Renderer contexts and source media produced by the semantic planner."""
+
+    task: str
+    width: int
+    height: int
+    length: int
+    max_media_size: int
+    contexts: dict[str, torch.Tensor]
+    source_video: torch.Tensor | None
+    reference_images: list[torch.Tensor]
+
+
+def validate_task_inputs(
+    task: str,
+    source_video: torch.Tensor | None,
+    reference_images: list[torch.Tensor],
+) -> None:
+    if task not in SUPPORTED_TASKS:
+        raise ValueError(f"unsupported task {task!r}")
+    has_video = source_video is not None
+    has_images = bool(reference_images)
+    required = {
+        "t2i": (False, False),
+        "t2v": (False, False),
+        "i2i": (False, True),
+        "v2v": (True, False),
+        "r2v": (False, True),
+        "rv2v": (True, True),
+    }[task]
+    if (has_video, has_images) != required:
+        raise ValueError(
+            f"task {task} expects source_video={required[0]} and reference_images={required[1]}, "
+            f"got source_video={has_video}, reference_images={has_images}"
+        )
+    if task == "i2i" and len(reference_images) != 1:
+        raise ValueError("i2i requires exactly one source image")
+
+
+def validate_generation_request(
+    task: str,
+    *,
+    width: int,
+    height: int,
+    length: int,
+    source_fps: float,
+    planning_steps: int,
+    vit_denoising_steps: int,
+) -> None:
+    """Reject unsupported shapes before loading any multi-gigabyte model."""
+
+    if width < 16 or height < 16 or width % 16 or height % 16:
+        raise ValueError(
+            f"width and height must be positive multiples of 16, got {width}x{height}"
+        )
+    if task in VIDEO_TASKS and (length < 1 or (length - 1) % 4):
+        raise ValueError(f"video length must be 4n+1 frames, got {length}")
+    if task in IMAGE_TASKS and length < 1:
+        raise ValueError("image length must be positive")
+    if not math.isfinite(source_fps) or source_fps <= 0:
+        raise ValueError(f"source_fps must be finite and positive, got {source_fps}")
+    if planning_steps < 1 or vit_denoising_steps < 1:
+        raise ValueError("planning step counts must be positive")
+    target_length = 1 if task in IMAGE_TASKS else length
+    latent_elements = (
+        16 * (((target_length - 1) // 4) + 1) * (height // 8) * (width // 8)
+    )
+    if latent_elements > MAX_BASE_LATENT_ELEMENTS:
+        gib = latent_elements * 2 / 2**30
+        raise ValueError(
+            f"requested latent alone is about {gib:.2f} GiB before model activations; reduce frames or resolution"
+        )
+
+
+def split_reference_images(
+    reference_images: dict[str, torch.Tensor] | None,
+) -> list[torch.Tensor]:
+    def order(name: str) -> tuple[str, int]:
+        match = re.match(r"^(.*?)(\d+)$", name)
+        return (match.group(1), int(match.group(2))) if match else (name, -1)
+
+    output = []
+    for name in sorted(reference_images or {}, key=order):
+        images = reference_images[name]
+        if images is None:
+            continue
+        output.extend(images[index : index + 1] for index in range(images.shape[0]))
+    return output
+
+
+def maskgit_order(
+    target_count: int, seed: int, device: torch.device | str = "cpu"
+) -> torch.Tensor:
+    """Return the official NumPy-seeded order as a PyTorch scatter index."""
+    order = (
+        np.random.RandomState(seed % (2**32))
+        .permutation(target_count)
+        .astype(np.int64, copy=False)
+    )
+    return torch.from_numpy(order).to(device=device)
+
+
+def _visual_token_count(grid: torch.Tensor) -> int:
+    return int(grid.prod().item()) // 4
+
+
+def _encode_sources(
+    runtime: BerniniV2PlannerRuntime,
+    *,
+    source_video: torch.Tensor | None,
+    reference_images: list[torch.Tensor],
+    source_fps: float,
+    max_frames: int,
+) -> tuple[
+    list[torch.Tensor], list[torch.Tensor], list[torch.Tensor], list[torch.Tensor]
+]:
+    patches = []
+    grids = []
+    kinds = []
+    if source_video is not None:
+        indices = planner_video_frame_indices(
+            source_video.shape[0],
+            source_fps=source_fps,
+            planner_fps=2.0,
+            max_frames=max_frames,
+        )
+        video_patches, video_grid = process_qwen2vl_video(source_video[indices])
+        patches.append(video_patches)
+        grids.append(video_grid)
+        kinds.append("video")
+    for image in reference_images:
+        image_patches, image_grid = process_qwen2vl_video(image[:1])
+        patches.append(image_patches)
+        grids.append(image_grid)
+        kinds.append("image")
+    if not patches:
+        return [], [], [], []
+
+    runtime.load_vision()
+    device = runtime.load_device
+    packed_patches = torch.cat(patches).to(device=device, dtype=runtime.dtype)
+    packed_grids = torch.cat(grids).to(device=device)
+    embeddings = runtime.vision_model(packed_patches, image_grid_thw=packed_grids)
+    split_sizes = [int(grid.prod().item()) // 4 for grid in grids]
+    intermediate = comfy.model_management.intermediate_device()
+    split_embeddings = [
+        embedding.to(intermediate) for embedding in torch.split(embeddings, split_sizes)
+    ]
+    video_embeddings = [
+        embed
+        for embed, kind in zip(split_embeddings, kinds, strict=True)
+        if kind == "video"
+    ]
+    image_embeddings = [
+        embed
+        for embed, kind in zip(split_embeddings, kinds, strict=True)
+        if kind == "image"
+    ]
+    video_grids = [
+        grid[0].cpu()
+        for grid, kind in zip(grids, kinds, strict=True)
+        if kind == "video"
+    ]
+    image_grids = [
+        grid[0].cpu()
+        for grid, kind in zip(grids, kinds, strict=True)
+        if kind == "image"
+    ]
+    return video_embeddings, image_embeddings, video_grids, image_grids
+
+
+def _branch_grids(
+    branch: dict[str, object],
+    image_grids: list[torch.Tensor],
+    video_grids: list[torch.Tensor],
+    *,
+    device: torch.device,
+) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+    selected_images = []
+    selected_videos = []
+    for kind, source_index in zip(
+        branch["vit_type_list"].tolist(),
+        branch["vit_source_indices"].tolist(),
+        strict=True,
+    ):
+        if kind == 0:
+            selected_images.append(image_grids[source_index])
+        else:
+            selected_videos.append(video_grids[source_index])
+    image_grid = torch.stack(selected_images).to(device) if selected_images else None
+    video_grid = torch.stack(selected_videos).to(device) if selected_videos else None
+    return image_grid, video_grid
+
+
+def _prepare_branch(
+    runtime: BerniniV2PlannerRuntime,
+    branch: dict[str, object],
+    *,
+    source_embeddings: list[torch.Tensor],
+    image_grids: list[torch.Tensor],
+    video_grids: list[torch.Tensor],
+) -> dict[str, torch.Tensor]:
+    device = runtime.load_device
+    ids = branch["input_ids"].unsqueeze(0).to(device)
+    inputs = runtime.language_model.embed_tokens(ids, out_dtype=runtime.dtype)
+    visual_input_mask = branch["visual_input_token_mask"].to(device)
+    if visual_input_mask.any():
+        packed_sources = torch.cat(source_embeddings).to(
+            device=device, dtype=inputs.dtype
+        )
+        if int(visual_input_mask.sum()) != packed_sources.shape[0]:
+            raise ValueError(
+                f"source feature/token mismatch: {packed_sources.shape[0]} features vs "
+                f"{int(visual_input_mask.sum())} tokens"
+            )
+        inputs[:, visual_input_mask, :] = packed_sources.unsqueeze(0)
+    output_mask = branch["visual_output_token_mask"].to(device)
+    target_count = int(output_mask.sum())
+    if target_count > runtime.aux.mask_tokens.shape[1]:
+        raise ValueError(
+            f"target uses {target_count} VIT tokens, but checkpoint supports {runtime.aux.mask_tokens.shape[1]}"
+        )
+    inputs[:, output_mask, :] = (
+        runtime.aux.mask_tokens[:, :1].to(inputs).expand(1, target_count, -1)
+    )
+    image_grid, video_grid = _branch_grids(
+        branch,
+        image_grids,
+        video_grids,
+        device=device,
+    )
+    position_ids, _ = get_rope_index(
+        ids,
+        image_grid_thw=image_grid,
+        video_grid_thw=video_grid,
+        attention_mask=branch["attention_mask"].unsqueeze(0).to(device),
+    )
+    return {
+        "inputs": inputs,
+        "positions": position_ids,
+        "attention": branch["attention_mask_4d"].to(device),
+        "output_mask": output_mask,
+    }
+
+
+def _hidden(
+    runtime: BerniniV2PlannerRuntime, branch: dict[str, torch.Tensor]
+) -> torch.Tensor:
+    return plan_forward(
+        runtime.language_model,
+        branch["inputs"],
+        branch["positions"],
+        branch["attention"],
+        intermediate_output=-2,
+    )
+
+
+def _conditioning_tensor(conditioning, name: str) -> torch.Tensor:
+    if not conditioning or not isinstance(conditioning[0], (list, tuple)):
+        raise ValueError(f"{name} is not a Comfy CONDITIONING")
+    tensor = conditioning[0][0]
+    if not torch.is_tensor(tensor) or tensor.ndim != 3 or tensor.shape[-1] != 4096:
+        raise ValueError(f"{name} must contain [B,L,4096] UMT5 embeddings")
+    if tensor.shape[0] != 1:
+        raise ValueError("Bernini v2 currently supports batch size 1")
+    # Comfy's Wan tokenizer pads to at least 512 and zeroes masked rows. The
+    # official pipeline crops T5 to its attention-mask length before appending
+    # Qwen tokens, then pads the combined result (not T5 alone) to 512.
+    nonzero = tensor.abs().sum(dim=-1).ne(0)
+    valid = nonzero[0].nonzero(as_tuple=False)
+    length = int(valid[-1]) + 1 if valid.numel() else 0
+    return tensor[:, :length]
+
+
+def _pad_renderer_context(context: torch.Tensor, min_length: int = 512) -> torch.Tensor:
+    if context.shape[1] >= min_length:
+        return context
+    padding = context.new_zeros(
+        context.shape[0], min_length - context.shape[1], context.shape[2]
+    )
+    return torch.cat([context, padding], dim=1)
+
+
+def create_plan(
+    runtime: BerniniV2PlannerRuntime,
+    *,
+    positive,
+    negative,
+    prompt: str,
+    negative_prompt: str,
+    task: str,
+    width: int,
+    height: int,
+    length: int,
+    max_media_size: int,
+    source_video: torch.Tensor | None,
+    reference_images: list[torch.Tensor],
+    source_fps: float = 16.0,
+    planning_steps: int = 25,
+    vit_denoising_steps: int = 3,
+    vit_text_cfg: float = 1.4,
+    vit_image_cfg: float = 1.2,
+    seed: int = 42,
+) -> BerniniV2Plan:
+    validate_task_inputs(task, source_video, reference_images)
+    validate_generation_request(
+        task,
+        width=width,
+        height=height,
+        length=length,
+        source_fps=source_fps,
+        planning_steps=planning_steps,
+        vit_denoising_steps=vit_denoising_steps,
+    )
+    output_is_image = task in IMAGE_TASKS
+    target_length = 1 if output_is_image else length
+    if output_is_image:
+        target_grid = qwen_grid_for_media(1, height, width)[0]
+    else:
+        target_vit_frames = len(
+            planner_video_frame_indices(
+                target_length,
+                source_fps=16.0,
+                planner_fps=2.0,
+                max_frames=target_length,
+            )
+        )
+        target_grid = qwen_grid_for_media(target_vit_frames, height, width)[0]
+    target_token_count = _visual_token_count(target_grid)
+    if target_token_count > MAX_VIT_TARGET_TOKENS:
+        raise ValueError(
+            f"target requires {target_token_count} VIT tokens, but Bernini supports at most {MAX_VIT_TARGET_TOKENS}"
+        )
+    video_embeds, image_embeds, video_grids, image_grids = _encode_sources(
+        runtime,
+        source_video=source_video,
+        reference_images=reference_images,
+        source_fps=source_fps,
+        max_frames=target_length,
+    )
+    if output_is_image:
+        image_grids.append(target_grid)
+    else:
+        video_grids.append(target_grid)
+
+    image_counts = [_visual_token_count(grid) for grid in image_grids]
+    video_counts = [_visual_token_count(grid) for grid in video_grids]
+    conversation = build_conversation(
+        prompt,
+        source_videos=1 if source_video is not None else 0,
+        source_images=len(reference_images),
+        output_is_image=output_is_image,
+    )
+    template = BerniniTemplate(runtime.tokenizer)
+    counts = {"image": image_counts, "video": video_counts}
+    cond_tokens = template.encode(
+        conversation,
+        num_tokens=counts,
+        task=task,
+        mask_dtype=runtime.dtype,
+    )
+    uncond_tokens = template.encode(
+        conversation,
+        num_tokens=counts,
+        task=task,
+        drop_text=True,
+        drop_images=True,
+        drop_videos=True,
+        negative_prompt=negative_prompt,
+        mask_dtype=runtime.dtype,
+    )
+    image_cond_tokens = template.encode(
+        conversation,
+        num_tokens=counts,
+        task=task,
+        drop_images=True,
+        drop_videos=True,
+        mask_dtype=runtime.dtype,
+    )
+
+    runtime.load_planner()
+    ordered_source_embeddings = video_embeds + image_embeds
+    branches = [
+        _prepare_branch(
+            runtime,
+            tokens,
+            source_embeddings=ordered_source_embeddings if index == 0 else [],
+            image_grids=image_grids,
+            video_grids=video_grids,
+        )
+        for index, tokens in enumerate((cond_tokens, uncond_tokens, image_cond_tokens))
+    ]
+    cond, uncond, image_cond = branches
+    target_count = int(cond["output_mask"].sum())
+    generator = torch.Generator(device="cpu").manual_seed(seed)
+    order = maskgit_order(target_count, seed, runtime.load_device)
+    mask = torch.ones(target_count, device=runtime.load_device, dtype=torch.bool)
+    for step in range(planning_steps):
+        predicted = []
+        for branch in branches:
+            hidden = _hidden(runtime, branch)
+            predicted.append(
+                runtime.aux.connector.for_vit(hidden[:, branch["output_mask"], :])
+            )
+            del hidden
+        ratio = math.cos(math.pi * 0.5 * (step + 1) / planning_steps)
+        mask_length = max(1, min(int(mask.sum()) - 1, math.floor(target_count * ratio)))
+        next_mask = torch.zeros_like(mask)
+        next_mask.scatter_(0, order[:mask_length], True)
+        to_predict = (
+            mask if step == planning_steps - 1 else torch.logical_xor(mask, next_mask)
+        )
+        mask = next_mask
+        indices = to_predict.nonzero(as_tuple=False).squeeze(-1)
+        if indices.numel() == 0:
+            continue
+        decoder_condition = torch.cat(
+            [value[:, indices, :] for value in predicted], dim=1
+        )[0]
+        current = runtime.aux.vit_decoder.sample(
+            decoder_condition,
+            cfg=vit_text_cfg,
+            img_cfg=vit_image_cfg,
+            num_inference_steps=vit_denoising_steps,
+            generator=generator,
+        )
+        current = current[: current.shape[0] // 3].unsqueeze(0).to(runtime.dtype)
+        for branch in branches:
+            branch_target = branch["inputs"][:, branch["output_mask"], :]
+            branch_target[:, indices, :] = current
+            branch["inputs"][:, branch["output_mask"], :] = branch_target
+
+    cond_hidden = _hidden(runtime, cond)
+    cond_context = runtime.aux.connector.for_gen(cond_hidden)
+    del cond_hidden
+    uncond_hidden = _hidden(runtime, uncond)
+    uncond_context = runtime.aux.connector.for_gen(uncond_hidden)
+    del uncond_hidden
+    cond_text_mask = ~cond["output_mask"]
+    uncond_text_mask = ~uncond["output_mask"]
+    positive_t5 = _conditioning_tensor(positive, "positive").to(cond_context)
+    negative_t5 = _conditioning_tensor(negative, "negative").to(cond_context)
+    contexts = {
+        "wtxt_wvit": _pad_renderer_context(
+            torch.cat([positive_t5, cond_context], dim=1)
+        ),
+        "wtxt_wovit": _pad_renderer_context(
+            torch.cat([positive_t5, cond_context[:, cond_text_mask, :]], dim=1)
+        ),
+        "wotxt_wvit": _pad_renderer_context(
+            torch.cat([negative_t5, cond_context[:, cond["output_mask"], :]], dim=1)
+        ),
+        "wotxt_wovit": _pad_renderer_context(
+            torch.cat([negative_t5, uncond_context[:, uncond_text_mask, :]], dim=1)
+        ),
+    }
+    intermediate = comfy.model_management.intermediate_device()
+    contexts = {key: value.to(intermediate) for key, value in contexts.items()}
+    return BerniniV2Plan(
+        task=task,
+        width=width,
+        height=height,
+        length=target_length,
+        max_media_size=max_media_size,
+        contexts=contexts,
+        source_video=source_video,
+        reference_images=reference_images,
+    )

--- a/comfy/ldm/bernini_v2/planner_model.py
+++ b/comfy/ldm/bernini_v2/planner_model.py
@@ -1,0 +1,379 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliate
+# SPDX-License-Identifier: Apache-2.0
+"""Native PyTorch modules for Bernini v2 semantic planning.
+
+The parameter layout matches ByteDance/Bernini exactly. The implementation is
+adapted from the official Apache-2.0 source and cross-checked against the
+ComfyUI-oriented reference published in rzgar/Bernini-v2-ComfyUI.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+import torch.nn as nn
+
+
+class MLPConnector(nn.Module):
+    def __init__(
+        self,
+        in_dim: int = 3584,
+        out_dim_for_gen: int = 4096,
+        out_dim_for_vit: int = 3584,
+        *,
+        device=None,
+        dtype=None,
+        operations,
+    ):
+        super().__init__()
+        self.proj_gen = nn.Sequential(
+            operations.Linear(in_dim, out_dim_for_gen, device=device, dtype=dtype),
+            nn.GELU(),
+            operations.RMSNorm(out_dim_for_gen, eps=1e-6, device=device, dtype=dtype),
+            operations.Linear(
+                out_dim_for_gen, out_dim_for_gen, device=device, dtype=dtype
+            ),
+        )
+        self.pred_vit = nn.Sequential(
+            operations.Linear(in_dim, out_dim_for_vit, device=device, dtype=dtype),
+            nn.GELU(),
+            operations.Linear(
+                out_dim_for_vit, out_dim_for_vit, device=device, dtype=dtype
+            ),
+            operations.RMSNorm(out_dim_for_vit, eps=1e-6, device=device, dtype=dtype),
+            operations.Linear(
+                out_dim_for_vit, out_dim_for_vit, device=device, dtype=dtype
+            ),
+        )
+
+    def for_gen(self, x: torch.Tensor) -> torch.Tensor:
+        return self.proj_gen(x)
+
+    def for_vit(self, x: torch.Tensor) -> torch.Tensor:
+        return self.pred_vit(x)
+
+
+class TimestepEmbedder(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        frequency_embedding_size: int = 256,
+        *,
+        device=None,
+        dtype=None,
+        operations,
+    ):
+        super().__init__()
+        self.mlp = nn.Sequential(
+            operations.Linear(
+                frequency_embedding_size,
+                hidden_size,
+                bias=True,
+                device=device,
+                dtype=dtype,
+            ),
+            nn.SiLU(),
+            operations.Linear(
+                hidden_size, hidden_size, bias=True, device=device, dtype=dtype
+            ),
+        )
+        self.frequency_embedding_size = frequency_embedding_size
+
+    @staticmethod
+    def timestep_embedding(
+        t: torch.Tensor, dim: int, max_period: int = 10000
+    ) -> torch.Tensor:
+        half = dim // 2
+        freqs = torch.exp(
+            -math.log(max_period)
+            * torch.arange(half, dtype=torch.float32, device=t.device)
+            / half
+        )
+        args = t[:, None].float() * freqs[None]
+        embedding = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+        if dim % 2:
+            embedding = torch.cat(
+                [embedding, torch.zeros_like(embedding[:, :1])], dim=-1
+            )
+        return embedding
+
+    def forward(self, t: torch.Tensor) -> torch.Tensor:
+        frequency = self.timestep_embedding(t, self.frequency_embedding_size)
+        return self.mlp(frequency.to(t.dtype))
+
+
+def modulate(x: torch.Tensor, shift: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    return x * (1 + scale) + shift
+
+
+class ResBlock(nn.Module):
+    def __init__(self, channels: int, *, device=None, dtype=None, operations):
+        super().__init__()
+        self.in_ln = operations.LayerNorm(
+            channels, eps=1e-6, device=device, dtype=dtype
+        )
+        self.mlp = nn.Sequential(
+            operations.Linear(
+                channels, channels, bias=True, device=device, dtype=dtype
+            ),
+            nn.SiLU(),
+            operations.Linear(
+                channels, channels, bias=True, device=device, dtype=dtype
+            ),
+        )
+        self.adaLN_modulation = nn.Sequential(
+            nn.SiLU(),
+            operations.Linear(
+                channels, 3 * channels, bias=True, device=device, dtype=dtype
+            ),
+        )
+
+    def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        shift, scale, gate = self.adaLN_modulation(y).chunk(3, dim=-1)
+        hidden = self.mlp(modulate(self.in_ln(x), shift, scale))
+        return x + gate * hidden
+
+
+class FinalLayer(nn.Module):
+    def __init__(
+        self,
+        model_channels: int,
+        out_channels: int,
+        *,
+        device=None,
+        dtype=None,
+        operations,
+    ):
+        super().__init__()
+        self.norm_final = operations.LayerNorm(
+            model_channels,
+            elementwise_affine=False,
+            eps=1e-6,
+            device=device,
+            dtype=dtype,
+        )
+        self.linear = operations.Linear(
+            model_channels, out_channels, bias=True, device=device, dtype=dtype
+        )
+        self.adaLN_modulation = nn.Sequential(
+            nn.SiLU(),
+            operations.Linear(
+                model_channels,
+                2 * model_channels,
+                bias=True,
+                device=device,
+                dtype=dtype,
+            ),
+        )
+
+    def forward(self, x: torch.Tensor, condition: torch.Tensor) -> torch.Tensor:
+        shift, scale = self.adaLN_modulation(condition).chunk(2, dim=-1)
+        return self.linear(modulate(self.norm_final(x), shift, scale))
+
+
+class SimpleMLPAdaLN(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        model_channels: int,
+        out_channels: int,
+        z_channels: int,
+        num_res_blocks: int,
+        *,
+        device=None,
+        dtype=None,
+        operations,
+    ):
+        super().__init__()
+        settings = {"device": device, "dtype": dtype, "operations": operations}
+        self.in_channels = in_channels
+        self.time_embed = TimestepEmbedder(model_channels, **settings)
+        self.cond_embed = operations.Linear(
+            z_channels, model_channels, device=device, dtype=dtype
+        )
+        self.input_proj = operations.Linear(
+            in_channels, model_channels, device=device, dtype=dtype
+        )
+        self.res_blocks = nn.ModuleList(
+            [ResBlock(model_channels, **settings) for _ in range(num_res_blocks)]
+        )
+        self.final_layer = FinalLayer(model_channels, out_channels, **settings)
+
+    def forward(
+        self, x: torch.Tensor, t: torch.Tensor, c: torch.Tensor
+    ) -> torch.Tensor:
+        x = self.input_proj(x)
+        condition = self.time_embed(t) + self.cond_embed(c)
+        for block in self.res_blocks:
+            x = block(x, condition)
+        return self.final_layer(x, condition)
+
+    def forward_with_cfg(
+        self, x: torch.Tensor, t: torch.Tensor, c: torch.Tensor, cfg_scale: float
+    ) -> torch.Tensor:
+        half = x[: len(x) // 2]
+        output = self.forward(torch.cat([half, half], dim=0), t, c)
+        cond, uncond = torch.split(
+            output[:, : self.in_channels], len(output) // 2, dim=0
+        )
+        guided = uncond + cfg_scale * (cond - uncond)
+        return torch.cat([guided, guided], dim=0)
+
+    def forward_with_txt_img_cfg(
+        self,
+        x: torch.Tensor,
+        t: torch.Tensor,
+        c: torch.Tensor,
+        txt_cfg_scale: float,
+        img_cfg_scale: float,
+    ) -> torch.Tensor:
+        part = x[: len(x) // 3]
+        output = self.forward(torch.cat([part, part, part], dim=0), t, c)
+        cond, uncond, imgcond = torch.split(
+            output[:, : self.in_channels], len(output) // 3, dim=0
+        )
+        guided = (
+            uncond
+            + img_cfg_scale * (imgcond - uncond)
+            + txt_cfg_scale * (cond - imgcond)
+        )
+        return torch.cat([guided, guided, guided], dim=0)
+
+
+class FlowMatchScheduler:
+    def __init__(
+        self,
+        num_inference_steps: int = 100,
+        num_train_timesteps: int = 1000,
+        shift: float = 3.0,
+        sigma_max: float = 1.0,
+        sigma_min: float = 0.003 / 1.002,
+        extra_one_step: bool = False,
+    ):
+        self.num_train_timesteps = num_train_timesteps
+        self.shift = shift
+        self.sigma_max = sigma_max
+        self.sigma_min = sigma_min
+        self.extra_one_step = extra_one_step
+        self.sigmas = torch.empty(0)
+        self.timesteps = torch.empty(0)
+        self.set_timesteps(num_inference_steps, device="cpu")
+
+    def set_timesteps(
+        self,
+        num_inference_steps: int = 100,
+        denoising_strength: float = 1.0,
+        shift: float | None = None,
+        device=None,
+    ) -> None:
+        if shift is not None:
+            self.shift = shift
+        device = device or "cpu"
+        sigma_start = (
+            self.sigma_min + (self.sigma_max - self.sigma_min) * denoising_strength
+        )
+        count = num_inference_steps + 1 if self.extra_one_step else num_inference_steps
+        sigmas = torch.linspace(
+            sigma_start,
+            self.sigma_min,
+            count,
+            device=device,
+            dtype=torch.float32,
+        )
+        if self.extra_one_step:
+            sigmas = sigmas[:-1]
+        self.sigmas = self.shift * sigmas / (1 + (self.shift - 1) * sigmas)
+        self.timesteps = self.sigmas * self.num_train_timesteps
+
+    def step(
+        self,
+        model_output: torch.Tensor,
+        timestep: torch.Tensor | float,
+        sample: torch.Tensor,
+        to_final: bool = False,
+    ) -> torch.Tensor:
+        if not isinstance(timestep, torch.Tensor):
+            timestep = torch.tensor(timestep, device=self.timesteps.device)
+        else:
+            timestep = timestep.to(self.timesteps.device)
+        timestep_id = torch.argmin((self.timesteps - timestep).abs())
+        sigma = self.sigmas[timestep_id]
+        if to_final or timestep_id + 1 >= len(self.timesteps):
+            next_sigma = sample.new_zeros(())
+        else:
+            next_sigma = self.sigmas[timestep_id + 1]
+        return sample + model_output * (next_sigma - sigma)
+
+
+class DiffLossFM(nn.Module):
+    def __init__(
+        self,
+        target_channels: int = 3584,
+        z_channels: int = 3584,
+        depth: int = 16,
+        width: int = 4096,
+        shift: float = 2.0,
+        extra_one_step: bool = True,
+        *,
+        device=None,
+        dtype=None,
+        operations,
+    ):
+        super().__init__()
+        self.in_channels = target_channels
+        self.net = SimpleMLPAdaLN(
+            target_channels,
+            width,
+            target_channels,
+            z_channels,
+            depth,
+            device=device,
+            dtype=dtype,
+            operations=operations,
+        )
+        self.scheduler_shift = shift
+        self.scheduler_extra_one_step = extra_one_step
+
+    def sample(
+        self,
+        z: torch.Tensor,
+        *,
+        cfg: float,
+        num_inference_steps: int,
+        seed: int | None = None,
+        generator: torch.Generator | None = None,
+        img_cfg: float | None = None,
+    ) -> torch.Tensor:
+        device = z.device
+        if generator is None:
+            generator = torch.Generator(device="cpu").manual_seed(
+                0 if seed is None else seed
+            )
+        branch_count = 3 if img_cfg is not None else 2 if cfg > 1.0 else 1
+        noise = torch.randn(
+            z.shape[0] // branch_count, self.in_channels, generator=generator
+        )
+        samples = torch.cat([noise] * branch_count, dim=0).to(
+            device=device, dtype=z.dtype
+        )
+
+        if branch_count == 3:
+            sample_fn = self.net.forward_with_txt_img_cfg
+            kwargs = {"c": z, "txt_cfg_scale": cfg, "img_cfg_scale": img_cfg}
+        elif branch_count == 2:
+            sample_fn = self.net.forward_with_cfg
+            kwargs = {"c": z, "cfg_scale": cfg}
+        else:
+            sample_fn = self.net.forward
+            kwargs = {"c": z}
+
+        scheduler = FlowMatchScheduler(
+            shift=self.scheduler_shift,
+            extra_one_step=self.scheduler_extra_one_step,
+        )
+        scheduler.set_timesteps(num_inference_steps, device=device)
+        for timestep in scheduler.timesteps:
+            prediction = sample_fn(samples, timestep.unsqueeze(0).to(z.dtype), **kwargs)
+            samples = scheduler.step(prediction, timestep, samples)
+        return samples

--- a/comfy/ldm/bernini_v2/presets.py
+++ b/comfy/ldm/bernini_v2/presets.py
@@ -1,0 +1,79 @@
+"""Published Bernini v2 task defaults from the official demo."""
+
+from __future__ import annotations
+
+TASK_PRESETS = {
+    "t2i": {
+        "steps": 50,
+        "planning_steps": 25,
+        "vit_denoising_steps": 5,
+        "max_media_size": 842,
+        "omega_video": 1.0,
+        "omega_image": 1.0,
+        "omega_text": 4.0,
+        "omega_target": 0.5,
+        "omega_scale": 1.0,
+    },
+    "i2i": {
+        "steps": 40,
+        "planning_steps": 25,
+        "vit_denoising_steps": 5,
+        "max_media_size": 842,
+        "omega_video": 1.25,
+        "omega_image": 1.25,
+        "omega_text": 4.0,
+        "omega_target": 0.5,
+        "omega_scale": 0.75,
+    },
+    "t2v": {
+        "steps": 50,
+        "planning_steps": 50,
+        "vit_denoising_steps": 1,
+        "max_media_size": 842,
+        "omega_video": 1.0,
+        "omega_image": 1.0,
+        "omega_text": 5.0,
+        "omega_target": 1.2,
+        "omega_scale": 1.0,
+    },
+    "v2v": {
+        "steps": 40,
+        "planning_steps": 50,
+        "vit_denoising_steps": 1,
+        "max_media_size": 848,
+        "omega_video": 1.25,
+        "omega_image": 1.25,
+        "omega_text": 4.0,
+        "omega_target": 1.2,
+        "omega_scale": 0.75,
+    },
+    "r2v": {
+        "steps": 40,
+        "planning_steps": 50,
+        "vit_denoising_steps": 1,
+        "max_media_size": 842,
+        "omega_video": 1.0,
+        "omega_image": 3.0,
+        "omega_text": 4.5,
+        "omega_target": 1.5,
+        "omega_scale": 0.75,
+    },
+    "rv2v": {
+        "steps": 40,
+        "planning_steps": 50,
+        "vit_denoising_steps": 1,
+        "max_media_size": 848,
+        "omega_video": 1.5,
+        "omega_image": 3.0,
+        "omega_text": 3.6,
+        "omega_target": 1.5,
+        "omega_scale": 0.5,
+    },
+}
+
+
+def task_preset(task: str) -> dict[str, float | int]:
+    try:
+        return TASK_PRESETS[task].copy()
+    except KeyError as error:
+        raise ValueError(f"unsupported Bernini v2 task {task!r}") from error

--- a/comfy/ldm/bernini_v2/qwen.py
+++ b/comfy/ldm/bernini_v2/qwen.py
@@ -1,0 +1,192 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliate
+# SPDX-License-Identifier: Apache-2.0
+"""Bernini-specific helpers around ComfyUI's native Qwen2.5-VL model."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+import torch.nn.functional as F
+from comfy.ldm.modules.attention import optimized_attention_for_device
+
+
+def smart_resize_qwen(
+    height: int,
+    width: int,
+    *,
+    factor: int = 28,
+    min_pixels: int = 3136,
+    max_pixels: int = 50176,
+) -> tuple[int, int]:
+    """Qwen2-VL smart-resize geometry without importing a HF processor."""
+
+    if height < 1 or width < 1 or max(height, width) / min(height, width) > 200:
+        raise ValueError(f"invalid Qwen visual size: {height}x{width}")
+    target_h = round(height / factor) * factor
+    target_w = round(width / factor) * factor
+    if target_h * target_w > max_pixels:
+        beta = math.sqrt((height * width) / max_pixels)
+        target_h = max(factor, math.floor(height / beta / factor) * factor)
+        target_w = max(factor, math.floor(width / beta / factor) * factor)
+    elif target_h * target_w < min_pixels:
+        beta = math.sqrt(min_pixels / (height * width))
+        target_h = math.ceil(height * beta / factor) * factor
+        target_w = math.ceil(width * beta / factor) * factor
+    return target_h, target_w
+
+
+def qwen_grid_for_media(
+    frame_count: int,
+    height: int,
+    width: int,
+    *,
+    min_pixels: int = 3136,
+    max_pixels: int = 50176,
+    patch_size: int = 14,
+    temporal_patch_size: int = 2,
+    merge_size: int = 2,
+) -> torch.Tensor:
+    target_h, target_w = smart_resize_qwen(
+        height,
+        width,
+        factor=patch_size * merge_size,
+        min_pixels=min_pixels,
+        max_pixels=max_pixels,
+    )
+    grid_t = math.ceil(frame_count / temporal_patch_size)
+    return torch.tensor(
+        [[grid_t, target_h // patch_size, target_w // patch_size]], dtype=torch.long
+    )
+
+
+def planner_video_frame_indices(
+    total_frames: int,
+    *,
+    source_fps: float = 16.0,
+    planner_fps: float = 2.0,
+    frame_factor: int = 2,
+    max_frames: int | None = None,
+) -> list[int]:
+    """Match the official 2-fps, even-frame Bernini VIT sampling policy."""
+
+    if total_frames < 1 or source_fps <= 0 or planner_fps <= 0:
+        raise ValueError("frame counts and frame rates must be positive")
+    count = (
+        math.floor((total_frames / source_fps * planner_fps) / frame_factor)
+        * frame_factor
+    )
+    count = max(count, frame_factor)
+    if max_frames is not None:
+        count = min(count, math.floor(max_frames / frame_factor) * frame_factor)
+    count = max(count, frame_factor)
+    return torch.linspace(0, total_frames - 1, count).round().long().tolist()
+
+
+def process_qwen2vl_video(
+    frames: torch.Tensor,
+    *,
+    min_pixels: int = 3136,
+    max_pixels: int = 50176,
+    patch_size: int = 14,
+    temporal_patch_size: int = 2,
+    merge_size: int = 2,
+    image_mean: tuple[float, float, float] = (0.48145466, 0.4578275, 0.40821073),
+    image_std: tuple[float, float, float] = (0.26862954, 0.26130258, 0.27577711),
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Native Qwen2.5-VL video patchification for a Comfy ``IMAGE`` batch.
+
+    ``frames`` has shape ``[T,H,W,C]`` and values in ``[0,1]``. The last frame
+    is repeated when necessary to fill the two-frame temporal patch.
+    """
+
+    if frames.ndim != 4 or frames.shape[-1] < 3 or frames.shape[0] < 1:
+        raise ValueError(f"expected [T,H,W,C] video, got {tuple(frames.shape)}")
+    frames = frames[..., :3].permute(0, 3, 1, 2).float()
+    frame_count, _, height, width = frames.shape
+    target_h, target_w = smart_resize_qwen(
+        height,
+        width,
+        factor=patch_size * merge_size,
+        min_pixels=min_pixels,
+        max_pixels=max_pixels,
+    )
+
+    frames = F.interpolate(
+        frames,
+        size=(target_h, target_w),
+        mode="bicubic",
+        align_corners=False,
+        antialias=True,
+    )
+    mean = torch.tensor(image_mean, device=frames.device).view(1, 3, 1, 1)
+    std = torch.tensor(image_std, device=frames.device).view(1, 3, 1, 1)
+    frames = (frames - mean) / std
+    remainder = frame_count % temporal_patch_size
+    if remainder:
+        frames = torch.cat(
+            [frames, frames[-1:].expand(temporal_patch_size - remainder, -1, -1, -1)],
+            dim=0,
+        )
+
+    grid_t = frames.shape[0] // temporal_patch_size
+    grid_h = target_h // patch_size
+    grid_w = target_w // patch_size
+    patches = frames.reshape(
+        grid_t,
+        temporal_patch_size,
+        3,
+        grid_h // merge_size,
+        merge_size,
+        patch_size,
+        grid_w // merge_size,
+        merge_size,
+        patch_size,
+    )
+    patches = patches.permute(0, 3, 6, 4, 7, 2, 1, 5, 8)
+    flattened = patches.reshape(
+        grid_t * grid_h * grid_w, 3 * temporal_patch_size * patch_size * patch_size
+    )
+    grid = torch.tensor(
+        [[grid_t, grid_h, grid_w]], device=frames.device, dtype=torch.long
+    )
+    return flattened, grid
+
+
+def plan_forward(
+    model,
+    inputs_embeds: torch.Tensor,
+    position_ids: torch.Tensor,
+    additive_attention_mask: torch.Tensor,
+    *,
+    intermediate_output: int = -2,
+) -> torch.Tensor:
+    """Run native Comfy Qwen with Bernini's precomputed additive attention mask."""
+
+    x = inputs_embeds.clone()
+    if position_ids.ndim == 3 and position_ids.shape[1] == 1:
+        position_ids = position_ids.squeeze(1)
+    freqs_cis = model.compute_freqs_cis(position_ids, x.device)
+    mask = additive_attention_mask.unsqueeze(1)
+    attention = optimized_attention_for_device(x.device, mask=True, small_input=True)
+    target = (
+        len(model.layers) + intermediate_output
+        if intermediate_output < 0
+        else intermediate_output
+    )
+    intermediate = None
+    for index, layer in enumerate(model.layers):
+        x, _ = layer(
+            x=x,
+            attention_mask=mask,
+            freqs_cis=freqs_cis,
+            optimized_attention=attention,
+            past_key_value=None,
+        )
+        if index == target:
+            intermediate = x.clone()
+    if intermediate is None:
+        raise ValueError(
+            f"intermediate layer {intermediate_output} is outside the model"
+        )
+    return intermediate

--- a/comfy/ldm/bernini_v2/qwen.py
+++ b/comfy/ldm/bernini_v2/qwen.py
@@ -11,6 +11,27 @@ import torch.nn.functional as F
 from comfy.ldm.modules.attention import optimized_attention_for_device
 
 
+def _explicit_gqa_attention(attention):
+    def wrapped(query, key, value, heads, **kwargs):
+        if kwargs.pop("enable_gqa", False) and key.shape[1] != query.shape[1]:
+            if query.shape[1] % key.shape[1]:
+                raise ValueError(
+                    "Qwen query heads must be divisible by key/value heads"
+                )
+            repeats = query.shape[1] // key.shape[1]
+            key = (
+                key[:, :, None, :, :].expand(-1, -1, repeats, -1, -1).reshape_as(query)
+            )
+            value = (
+                value[:, :, None, :, :]
+                .expand(-1, -1, repeats, -1, -1)
+                .reshape_as(query)
+            )
+        return attention(query, key, value, heads, **kwargs)
+
+    return wrapped
+
+
 def smart_resize_qwen(
     height: int,
     width: int,
@@ -166,9 +187,13 @@ def plan_forward(
     x = inputs_embeds.clone()
     if position_ids.ndim == 3 and position_ids.shape[1] == 1:
         position_ids = position_ids.squeeze(1)
-    freqs_cis = model.compute_freqs_cis(position_ids, x.device)
+    freqs_cis = tuple(
+        value.to(x.dtype) for value in model.compute_freqs_cis(position_ids, x.device)
+    )
     mask = additive_attention_mask.unsqueeze(1)
-    attention = optimized_attention_for_device(x.device, mask=True, small_input=True)
+    attention = _explicit_gqa_attention(
+        optimized_attention_for_device(x.device, mask=True, small_input=True)
+    )
     target = (
         len(model.layers) + intermediate_output
         if intermediate_output < 0

--- a/comfy/ldm/bernini_v2/rope.py
+++ b/comfy/ldm/bernini_v2/rope.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliate
+# SPDX-License-Identifier: Apache-2.0
+"""Qwen2.5-VL MRoPE position indices used by Bernini v2."""
+
+from __future__ import annotations
+
+import torch
+
+
+def get_rope_index(
+    input_ids: torch.Tensor,
+    *,
+    image_grid_thw: torch.Tensor | None = None,
+    video_grid_thw: torch.Tensor | None = None,
+    attention_mask: torch.Tensor | None = None,
+    image_token_id: int = 151655,
+    video_token_id: int = 151656,
+    vision_start_token_id: int = 151652,
+    spatial_merge_size: int = 2,
+    tokens_per_second: int = 2,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return official token-based MRoPE positions and deltas."""
+
+    if image_grid_thw is None and video_grid_thw is None:
+        if attention_mask is None:
+            position_ids = torch.arange(
+                input_ids.shape[1], device=input_ids.device
+            ).view(1, 1, -1)
+            position_ids = position_ids.expand(3, input_ids.shape[0], -1)
+            deltas = torch.zeros(
+                input_ids.shape[0], 1, device=input_ids.device, dtype=input_ids.dtype
+            )
+            return position_ids, deltas
+        position_ids = attention_mask.long().cumsum(-1) - 1
+        position_ids.masked_fill_(attention_mask == 0, 1)
+        position_ids = position_ids.unsqueeze(0).expand(3, -1, -1)
+        maximum = position_ids.max(0).values.max(-1, keepdim=True).values
+        return position_ids, maximum + 1 - attention_mask.shape[-1]
+
+    if attention_mask is None:
+        attention_mask = torch.ones_like(input_ids)
+    positions = torch.ones(
+        3, *input_ids.shape, dtype=input_ids.dtype, device=input_ids.device
+    )
+    deltas = []
+    image_index = 0
+    video_index = 0
+    for batch_index, batch_ids in enumerate(input_ids):
+        active_ids = batch_ids[attention_mask[batch_index] == 1]
+        starts = torch.argwhere(active_ids == vision_start_token_id).squeeze(1)
+        visual_tokens = active_ids[starts + 1]
+        image_count = int((visual_tokens == image_token_id).sum())
+        video_count = int((visual_tokens == video_token_id).sum())
+        token_list = active_ids.tolist()
+        chunks = []
+        start = 0
+        remaining_images = image_count
+        remaining_videos = video_count
+        for _ in range(image_count + video_count):
+            image_end = (
+                token_list.index(image_token_id, start)
+                if remaining_images
+                else len(token_list) + 1
+            )
+            video_end = (
+                token_list.index(video_token_id, start)
+                if remaining_videos
+                else len(token_list) + 1
+            )
+            if image_end < video_end:
+                if image_grid_thw is None:
+                    raise ValueError("image grid is missing")
+                grid_t, grid_h, grid_w = image_grid_thw[image_index]
+                seconds_per_grid = 0.0
+                image_index += 1
+                remaining_images -= 1
+                end = image_end
+            else:
+                if video_grid_thw is None:
+                    raise ValueError("video grid is missing")
+                grid_t, grid_h, grid_w = video_grid_thw[video_index]
+                seconds_per_grid = 1.0
+                video_index += 1
+                remaining_videos -= 1
+                end = video_end
+            grid_t = int(grid_t)
+            grid_h = int(grid_h) // spatial_merge_size
+            grid_w = int(grid_w) // spatial_merge_size
+            text_length = end - start
+            chunk_start = int(chunks[-1].max()) + 1 if chunks else 0
+            chunks.append(
+                torch.arange(text_length).view(1, -1).expand(3, -1) + chunk_start
+            )
+            time = torch.arange(grid_t).view(-1, 1).expand(-1, grid_h * grid_w)
+            time = (time * seconds_per_grid * tokens_per_second).long().flatten()
+            height = (
+                torch.arange(grid_h).view(1, -1, 1).expand(grid_t, -1, grid_w).flatten()
+            )
+            width = (
+                torch.arange(grid_w).view(1, 1, -1).expand(grid_t, grid_h, -1).flatten()
+            )
+            chunks.append(
+                torch.stack((time, height, width)) + text_length + chunk_start
+            )
+            start = end + grid_t * grid_h * grid_w
+        if start < len(token_list):
+            chunk_start = int(chunks[-1].max()) + 1 if chunks else 0
+            text_length = len(token_list) - start
+            chunks.append(
+                torch.arange(text_length).view(1, -1).expand(3, -1) + chunk_start
+            )
+        batch_positions = torch.cat(chunks, dim=1).reshape(3, -1).to(positions.device)
+        positions[:, batch_index, attention_mask[batch_index] == 1] = batch_positions
+        deltas.append(batch_positions.max() + 1 - len(batch_ids))
+    return positions, torch.tensor(deltas, device=input_ids.device).unsqueeze(1)

--- a/comfy/ldm/bernini_v2/rope.py
+++ b/comfy/ldm/bernini_v2/rope.py
@@ -89,15 +89,28 @@ def get_rope_index(
             text_length = end - start
             chunk_start = int(chunks[-1].max()) + 1 if chunks else 0
             chunks.append(
-                torch.arange(text_length).view(1, -1).expand(3, -1) + chunk_start
+                torch.arange(text_length, device=input_ids.device)
+                .view(1, -1)
+                .expand(3, -1)
+                + chunk_start
             )
-            time = torch.arange(grid_t).view(-1, 1).expand(-1, grid_h * grid_w)
+            time = (
+                torch.arange(grid_t, device=input_ids.device)
+                .view(-1, 1)
+                .expand(-1, grid_h * grid_w)
+            )
             time = (time * seconds_per_grid * tokens_per_second).long().flatten()
             height = (
-                torch.arange(grid_h).view(1, -1, 1).expand(grid_t, -1, grid_w).flatten()
+                torch.arange(grid_h, device=input_ids.device)
+                .view(1, -1, 1)
+                .expand(grid_t, -1, grid_w)
+                .flatten()
             )
             width = (
-                torch.arange(grid_w).view(1, 1, -1).expand(grid_t, grid_h, -1).flatten()
+                torch.arange(grid_w, device=input_ids.device)
+                .view(1, 1, -1)
+                .expand(grid_t, grid_h, -1)
+                .flatten()
             )
             chunks.append(
                 torch.stack((time, height, width)) + text_length + chunk_start
@@ -107,9 +120,12 @@ def get_rope_index(
             chunk_start = int(chunks[-1].max()) + 1 if chunks else 0
             text_length = len(token_list) - start
             chunks.append(
-                torch.arange(text_length).view(1, -1).expand(3, -1) + chunk_start
+                torch.arange(text_length, device=input_ids.device)
+                .view(1, -1)
+                .expand(3, -1)
+                + chunk_start
             )
-        batch_positions = torch.cat(chunks, dim=1).reshape(3, -1).to(positions.device)
+        batch_positions = torch.cat(chunks, dim=1).reshape(3, -1)
         positions[:, batch_index, attention_mask[batch_index] == 1] = batch_positions
         deltas.append(batch_positions.max() + 1 - len(batch_ids))
     return positions, torch.tensor(deltas, device=input_ids.device).unsqueeze(1)

--- a/comfy/ldm/bernini_v2/runtime.py
+++ b/comfy/ldm/bernini_v2/runtime.py
@@ -1,0 +1,293 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliate
+# SPDX-License-Identifier: Apache-2.0
+"""Comfy-managed runtime objects for the Bernini v2 semantic planner."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+from safetensors.torch import load_file
+from tokenizers import Tokenizer
+from transformers import Qwen2TokenizerFast
+
+import comfy.model_management
+import comfy.ops
+import comfy.utils
+from comfy.model_patcher import CoreModelPatcher
+from comfy.text_encoders.llama import Llama2_, Qwen25_7BVLI_Config
+from comfy.text_encoders.qwen_vl import Qwen2VLVisionTransformer
+
+from .planner_model import DiffLossFM, MLPConnector
+
+
+class PlannerAux(nn.Module):
+    """Connector, VIT diffusion decoder, and learned mask-token table."""
+
+    def __init__(
+        self,
+        *,
+        num_mask_tokens: int = 4096,
+        hidden_size: int = 3584,
+        decoder_width: int = 4096,
+        decoder_depth: int = 16,
+        device=None,
+        dtype=None,
+        operations,
+    ):
+        super().__init__()
+        self.connector = MLPConnector(
+            in_dim=hidden_size,
+            out_dim_for_gen=4096,
+            out_dim_for_vit=hidden_size,
+            device=device,
+            dtype=dtype,
+            operations=operations,
+        )
+        self.vit_decoder = DiffLossFM(
+            target_channels=hidden_size,
+            z_channels=hidden_size,
+            depth=decoder_depth,
+            width=decoder_width,
+            shift=2.0,
+            extra_one_step=True,
+            device=device,
+            dtype=dtype,
+            operations=operations,
+        )
+        self.mask_tokens = nn.Parameter(
+            torch.empty(
+                1, num_mask_tokens, hidden_size, device=device, dtype=dtype
+            ),
+            requires_grad=False,
+        )
+
+
+@dataclass
+class BerniniV2PlannerRuntime:
+    """A lightweight handle tracked by Comfy through its model patchers."""
+
+    language_model: nn.Module
+    vision_model: nn.Module
+    aux: PlannerAux
+    language_patcher: object
+    vision_patcher: object
+    aux_patcher: object
+    tokenizer: object
+    dtype: torch.dtype
+    load_device: torch.device
+
+    def get_models(self) -> list[object]:
+        return [self.language_patcher, self.vision_patcher, self.aux_patcher]
+
+    def load_vision(self) -> None:
+        comfy.model_management.load_models_gpu([self.vision_patcher])
+
+    def load_planner(self) -> None:
+        comfy.model_management.load_models_gpu(
+            [self.language_patcher, self.aux_patcher]
+        )
+
+
+def _load_assign(
+    module: nn.Module, state_dict: dict[str, torch.Tensor], label: str
+) -> None:
+    result = module.load_state_dict(state_dict, strict=False, assign=True)
+    if result.missing_keys or result.unexpected_keys:
+        raise RuntimeError(
+            f"{label} checkpoint mismatch: missing={result.missing_keys[:12]}, "
+            f"unexpected={result.unexpected_keys[:12]}"
+        )
+
+
+def _uses_native_quant(state_dict: dict[str, torch.Tensor]) -> bool:
+    return any(key.endswith(".comfy_quant") for key in state_dict)
+
+
+def _module_init_device(
+    state_dict: dict[str, torch.Tensor], offload_device: torch.device
+) -> torch.device | str:
+    """Initialize quant hooks on storage and plain assign-loaded weights on meta."""
+
+    return offload_device if _uses_native_quant(state_dict) else "meta"
+
+
+def _embedded_bytes(state_dict: dict[str, torch.Tensor], key: str) -> bytes:
+    try:
+        tensor = state_dict.pop(key)
+    except KeyError as error:
+        raise ValueError(
+            f"standalone planner is missing embedded tensor {key!r}"
+        ) from error
+    if tensor.dtype != torch.uint8 or tensor.ndim != 1:
+        raise ValueError(
+            f"embedded tensor {key!r} must be a one-dimensional U8 tensor"
+        )
+    return tensor.contiguous().cpu().numpy().tobytes()
+
+
+def _embedded_json(
+    state_dict: dict[str, torch.Tensor], key: str
+) -> dict[str, object]:
+    try:
+        payload = json.loads(_embedded_bytes(state_dict, key).decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(
+            f"embedded tensor {key!r} is not valid UTF-8 JSON"
+        ) from error
+    if not isinstance(payload, dict):
+        raise ValueError(f"embedded tensor {key!r} must contain a JSON object")
+    return payload
+
+
+def _qwen_config(payload: dict[str, object]) -> dict[str, object]:
+    allowed = {field.name for field in dataclasses.fields(Qwen25_7BVLI_Config)}
+    return {key: value for key, value in payload.items() if key in allowed}
+
+
+def _build_qwen_tokenizer(
+    tokenizer_json: bytes, tokenizer_config: dict[str, object]
+) -> Qwen2TokenizerFast:
+    kwargs = dict(tokenizer_config)
+    kwargs.pop("tokenizer_class", None)
+    kwargs.pop("added_tokens_decoder", None)
+    return Qwen2TokenizerFast(
+        tokenizer_object=Tokenizer.from_str(tokenizer_json.decode("utf-8")),
+        **kwargs,
+    )
+
+
+def load_planner_runtime(
+    checkpoint: str | Path, *, dtype: torch.dtype = torch.bfloat16
+) -> BerniniV2PlannerRuntime:
+    """Load the complete Bernini planner from one standalone safetensors file."""
+
+    checkpoint = Path(checkpoint).resolve()
+    if checkpoint.suffix != ".safetensors":
+        raise ValueError(
+            f"expected one standalone planner .safetensors file: {checkpoint}"
+        )
+    if not checkpoint.is_file():
+        raise FileNotFoundError(checkpoint)
+
+    state_dict = load_file(str(checkpoint), device="cpu")
+    raw_config = _embedded_json(state_dict, "config_json")
+    tokenizer_json = _embedded_bytes(state_dict, "tokenizer_json")
+    tokenizer_config = _embedded_json(state_dict, "tokenizer_config")
+    if "scaled_fp8" in state_dict:
+        state_dict, _ = comfy.utils.convert_old_quants(state_dict)
+
+    config_obj = Qwen25_7BVLI_Config(**_qwen_config(raw_config))
+    rope_scaling = raw_config.get("rope_scaling")
+    rope_dims = (
+        rope_scaling.get("mrope_section")
+        if isinstance(rope_scaling, dict)
+        else None
+    )
+    if rope_dims is not None and list(rope_dims) != list(config_obj.rope_dims):
+        raise ValueError(
+            f"checkpoint mRoPE sections {rope_dims} do not match ComfyUI "
+            f"Qwen config {config_obj.rope_dims}"
+        )
+
+    mllm_state = {
+        key: value
+        for key, value in state_dict.items()
+        if key.startswith(("model.", "visual."))
+    }
+    aux_state = {
+        key: value
+        for key, value in state_dict.items()
+        if key == "mask_tokens"
+        or key.startswith(("connector.", "vit_decoder."))
+    }
+    recognized = set(mllm_state) | set(aux_state)
+    unexpected = sorted(set(state_dict) - recognized)
+    if unexpected:
+        raise ValueError(
+            f"standalone planner contains unexpected tensors: {unexpected[:12]}"
+        )
+    if not mllm_state or not aux_state:
+        raise ValueError(
+            "standalone planner is missing Qwen or Bernini auxiliary weights"
+        )
+    del state_dict
+
+    load_device = comfy.model_management.get_torch_device()
+    offload_device = comfy.model_management.text_encoder_offload_device()
+    mllm_quantized = _uses_native_quant(mllm_state)
+    operations = (
+        comfy.ops.mixed_precision_ops({}, dtype)
+        if mllm_quantized
+        else comfy.ops.manual_cast
+    )
+    init_device = _module_init_device(mllm_state, offload_device)
+    language_model = Llama2_(
+        config_obj, device=init_device, dtype=dtype, ops=operations
+    )
+    vision_model = Qwen2VLVisionTransformer(
+        hidden_size=1280,
+        output_hidden_size=config_obj.hidden_size,
+        intermediate_size=3420,
+        num_heads=16,
+        num_layers=32,
+        patch_size=14,
+        temporal_patch_size=2,
+        spatial_merge_size=2,
+        window_size=112,
+        device=init_device,
+        dtype=dtype,
+        ops=operations,
+    )
+    language_state = {
+        key.removeprefix("model."): value
+        for key, value in mllm_state.items()
+        if key.startswith("model.")
+    }
+    vision_state = {
+        key.removeprefix("visual."): value
+        for key, value in mllm_state.items()
+        if key.startswith("visual.")
+    }
+    _load_assign(language_model, language_state, "Qwen language model")
+    _load_assign(vision_model, vision_state, "Qwen vision model")
+    del language_state, vision_state, mllm_state
+
+    aux_quantized = _uses_native_quant(aux_state)
+    aux_operations = (
+        comfy.ops.mixed_precision_ops({}, dtype)
+        if aux_quantized
+        else comfy.ops.manual_cast
+    )
+    aux_init_device = _module_init_device(aux_state, offload_device)
+    aux = PlannerAux(
+        device=aux_init_device, dtype=dtype, operations=aux_operations
+    )
+    _load_assign(aux, aux_state, "Bernini planner auxiliary")
+    del aux_state
+
+    language_patcher = CoreModelPatcher(
+        language_model, load_device=load_device, offload_device=offload_device
+    )
+    vision_patcher = CoreModelPatcher(
+        vision_model, load_device=load_device, offload_device=offload_device
+    )
+    aux_patcher = CoreModelPatcher(
+        aux, load_device=load_device, offload_device=offload_device
+    )
+    tokenizer = _build_qwen_tokenizer(tokenizer_json, tokenizer_config)
+    return BerniniV2PlannerRuntime(
+        language_model=language_model,
+        vision_model=vision_model,
+        aux=aux,
+        language_patcher=language_patcher,
+        vision_patcher=vision_patcher,
+        aux_patcher=aux_patcher,
+        tokenizer=tokenizer,
+        dtype=dtype,
+        load_device=load_device,
+    )

--- a/comfy/ldm/bernini_v2/template.py
+++ b/comfy/ldm/bernini_v2/template.py
@@ -1,0 +1,251 @@
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliate
+# SPDX-License-Identifier: Apache-2.0
+"""Bernini v2 inference chat template and block attention mask."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import torch
+
+SYSTEM_PROMPTS = {
+    "default": "You are a helpful assistant.",
+    "t2i": "You are a helpful assistant specialized in text-to-image generation.",
+    "t2v": "You are a helpful assistant specialized in text-to-video generation.",
+    "i2i": "You are a helpful assistant specialized in image editing.",
+    "v2v": "You are a helpful assistant specialized in video editing.",
+    "r2v": "You are a helpful assistant specialized in subject-to-video generation.",
+    "rv2v": "You are a helpful assistant specialized in video editing with reference.",
+}
+
+
+def build_custom_attention_mask(
+    token_type: torch.Tensor,
+    token_segment_ids: torch.Tensor,
+    *,
+    dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    """Build Bernini's ``[B,L,L]`` additive text/source/target mask."""
+
+    _, length = token_type.shape
+    query_type = token_type.unsqueeze(2)
+    key_type = token_type.unsqueeze(1)
+    query_id = token_segment_ids.unsqueeze(2)
+    key_id = token_segment_ids.unsqueeze(1)
+    causal = torch.tril(
+        torch.ones(length, length, device=token_type.device, dtype=torch.bool)
+    ).unsqueeze(0)
+    key_is_text_or_input = (key_type == 0) | (key_type == 2)
+    input_visible = causal & key_is_text_or_input
+    planned_visible = (key_type == 1) & (query_id == key_id)
+    output_visible = (key_type == 3) & (query_id == key_id)
+    query_is_text_or_input = (query_type == 0) | (query_type == 2)
+    visible = query_is_text_or_input & input_visible
+    visible |= (query_type == 1) & (input_visible | planned_visible)
+    visible |= (query_type == 3) & (input_visible | output_visible)
+    mask = torch.zeros(visible.shape, device=token_type.device, dtype=dtype)
+    return mask.masked_fill(~visible, float("-inf"))
+
+
+class BerniniTemplate:
+    """Inference-only form of the official Bernini multimodal template."""
+
+    def __init__(self, tokenizer, max_visual_items: int = 64):
+        self.tokenizer = tokenizer
+        self.image_pad_id = 151655
+        self.video_pad_id = 151656
+        self.vision_start_id = tokenizer.convert_tokens_to_ids("<|vision_start|>")
+        self.visual_input_pads = [
+            f"<|visual_input_token_pad_{index}|>" for index in range(max_visual_items)
+        ]
+        self.visual_output_pads = [
+            f"<|visual_output_token_pad_{index}|>" for index in range(max_visual_items)
+        ]
+        tokenizer.add_special_tokens(
+            {
+                "additional_special_tokens": self.visual_input_pads
+                + self.visual_output_pads
+            }
+        )
+        self.visual_input_ids = tokenizer.convert_tokens_to_ids(self.visual_input_pads)
+        self.visual_output_ids = tokenizer.convert_tokens_to_ids(
+            self.visual_output_pads
+        )
+
+    def _visual_pattern(self, count: int, visual_id: int, *, output: bool) -> str:
+        pads = self.visual_output_pads if output else self.visual_input_pads
+        if not 0 <= visual_id < len(pads):
+            raise ValueError(
+                f"Bernini v2 supports at most {len(pads)} visual items, got {visual_id + 1}"
+            )
+        return "<|vision_start|>" + pads[visual_id] * count + "<|vision_end|>"
+
+    def encode(
+        self,
+        conversations: Sequence[dict[str, object]],
+        *,
+        num_tokens: dict[str, Sequence[int]],
+        task: str,
+        drop_text: bool = False,
+        drop_images: bool = False,
+        drop_videos: bool = False,
+        negative_prompt: str = "",
+        mask_dtype: torch.dtype = torch.float32,
+    ) -> dict[str, object]:
+        image_counts = iter(num_tokens.get("image", []))
+        video_counts = iter(num_tokens.get("video", []))
+        messages = [
+            {
+                "role": "system",
+                "content": SYSTEM_PROMPTS.get(task, SYSTEM_PROMPTS["default"]),
+            }
+        ]
+        content = ""
+        previous_has_loss = False
+        visual_id_to_type: dict[int, int] = {}
+        visual_types: list[int] = []
+        visual_source_indices: list[int] = []
+        image_id = 0
+        video_id = 0
+        visual_id = 0
+
+        def flush(has_loss: bool) -> None:
+            nonlocal content
+            if content.strip():
+                messages.append(
+                    {"role": "assistant" if has_loss else "user", "content": content}
+                )
+            content = ""
+
+        for raw_message in conversations:
+            message = dict(raw_message)
+            message_type = str(message["type"])
+            if message_type == "special_token":
+                continue
+            has_loss = bool(
+                message.get(
+                    "has_loss", message_type in ("image_gen", "video_gen", "frame_gen")
+                )
+            )
+            if has_loss != previous_has_loss:
+                flush(previous_has_loss)
+                previous_has_loss = has_loss
+
+            if message_type in ("text", "cot_text"):
+                if negative_prompt.strip():
+                    text = negative_prompt
+                else:
+                    text = "" if drop_text else str(message.get("text", ""))
+                content += text
+                continue
+
+            if message_type in ("image", "image_gen"):
+                token_count = int(next(image_counts))
+                include = has_loss or not drop_images
+                if include:
+                    content += self._visual_pattern(
+                        token_count, visual_id, output=has_loss
+                    )
+                    visual_types.append(0)
+                    visual_source_indices.append(image_id)
+                visual_id_to_type[visual_id] = 0
+                image_id += 1
+            elif message_type in ("video", "frame_gen", "video_gen"):
+                token_count = int(next(video_counts))
+                include = has_loss or not drop_videos
+                if include:
+                    content += self._visual_pattern(
+                        token_count, visual_id, output=has_loss
+                    )
+                    visual_types.append(1)
+                    visual_source_indices.append(video_id)
+                visual_id_to_type[visual_id] = 1
+                video_id += 1
+            else:
+                raise ValueError(f"unsupported Bernini message type: {message_type}")
+            visual_id += 1
+        flush(previous_has_loss)
+
+        input_ids: list[int] = []
+        attention_mask: list[int] = []
+        for message in messages:
+            role_ids = self.tokenizer.encode(
+                f"<|im_start|>{message['role']}\n",
+                add_special_tokens=False,
+            )
+            content_ids = self.tokenizer.encode(
+                str(message["content"]).strip(),
+                add_special_tokens=False,
+            )
+            message_ids = role_ids + content_ids
+            input_ids.extend(message_ids)
+            attention_mask.extend([1] * len(message_ids))
+
+        ids = torch.tensor(input_ids, dtype=torch.long)
+        token_types = torch.zeros_like(ids, dtype=torch.int)
+        token_segment_ids = torch.arange(len(ids), dtype=torch.long)
+        visual_input_mask = torch.zeros_like(ids, dtype=torch.bool)
+        visual_output_mask = torch.zeros_like(ids, dtype=torch.bool)
+
+        for current_id, token_id in enumerate(self.visual_input_ids):
+            selected = ids == token_id
+            if not selected.any():
+                continue
+            token_types[selected] = 2
+            visual_input_mask[selected] = True
+            token_segment_ids[selected] = current_id + 1
+            ids[selected] = (
+                self.image_pad_id
+                if visual_id_to_type[current_id] == 0
+                else self.video_pad_id
+            )
+
+        for current_id, token_id in enumerate(self.visual_output_ids):
+            selected = ids == token_id
+            if not selected.any():
+                continue
+            token_types[selected] = 3
+            visual_output_mask[selected] = True
+            token_segment_ids[selected] = current_id + 1
+            ids[selected] = (
+                self.image_pad_id
+                if visual_id_to_type[current_id] == 0
+                else self.video_pad_id
+            )
+
+        attention_4d = build_custom_attention_mask(
+            token_types.unsqueeze(0),
+            token_segment_ids.unsqueeze(0),
+            dtype=mask_dtype,
+        )
+        return {
+            "input_ids": ids,
+            "attention_mask": torch.tensor(attention_mask, dtype=torch.long),
+            "attention_mask_4d": attention_4d,
+            "visual_input_token_mask": visual_input_mask,
+            "visual_output_token_mask": visual_output_mask,
+            "vit_type_list": torch.tensor(visual_types, dtype=torch.long),
+            "vit_source_indices": torch.tensor(visual_source_indices, dtype=torch.long),
+        }
+
+
+def build_conversation(
+    prompt: str,
+    *,
+    source_videos: int,
+    source_images: int,
+    output_is_image: bool,
+) -> list[dict[str, object]]:
+    messages: list[dict[str, object]] = [
+        {"type": "special_token", "text": "[CLS]", "has_loss": 0}
+    ]
+    messages.extend({"type": "video", "has_loss": 0} for _ in range(source_videos))
+    messages.extend({"type": "image", "has_loss": 0} for _ in range(source_images))
+    messages.append({"type": "text", "text": prompt, "has_loss": 0})
+    messages.append(
+        {
+            "type": "image_gen" if output_is_image else "video_gen",
+            "has_loss": 1,
+        }
+    )
+    return messages

--- a/comfy/ldm/bernini_v2/unipc.py
+++ b/comfy/ldm/bernini_v2/unipc.py
@@ -180,6 +180,8 @@ def sample_flow_unipc_bh2(
         or bool((sigmas >= 1).any())
     ):
         raise ValueError("flow UniPC requires finite sigmas in [0, 1)")
+    if bool((sigmas[:-1] <= sigmas[1:]).any()):
+        raise ValueError("flow UniPC requires strictly decreasing sigmas")
 
     first_sigma = sigmas[0].to(device=noise.device, dtype=noise.dtype)
     sample = noise / first_sigma

--- a/comfy/ldm/bernini_v2/unipc.py
+++ b/comfy/ldm/bernini_v2/unipc.py
@@ -1,0 +1,221 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+# Copyright (c) 2026 ByteDance Ltd. and/or its affiliate
+# SPDX-License-Identifier: Apache-2.0
+"""Bernini v2's flow-prediction UniPC BH2 solver.
+
+The update equations are adapted from Diffusers' Apache-2.0 licensed
+``UniPCMultistepScheduler``.  They intentionally operate on flow sigmas where
+``alpha = 1 - sigma``; ComfyUI's generic UniPC sampler instead assumes a VP
+noise schedule and is therefore not interchangeable with the released model.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import torch
+
+
+def _alpha_sigma(sigma: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    return 1.0 - sigma, sigma
+
+
+def _lambda(sigma: torch.Tensor) -> torch.Tensor:
+    alpha, sigma = _alpha_sigma(sigma)
+    return torch.log(alpha) - torch.log(sigma)
+
+
+def _coefficients(
+    h: torch.Tensor, order: int, device: torch.device
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return the UniPC BH2 Vandermonde system and right-hand side."""
+    hh = -h
+    h_phi_1 = torch.expm1(hh)
+    h_phi_k = h_phi_1 / hh - 1.0
+    b_h = torch.expm1(hh)
+    factorial_i = 1
+    values = []
+    # The caller supplies the actual r_k values for the rows.  This helper only
+    # builds b; keeping it separate makes the flow-specific sign explicit.
+    for index in range(1, order + 1):
+        values.append(h_phi_k * factorial_i / b_h)
+        factorial_i *= index + 1
+        h_phi_k = h_phi_k / hh - 1.0 / factorial_i
+    return h_phi_1, torch.stack(values).to(device=device)
+
+
+def _uni_p_bh2_update(
+    sample: torch.Tensor,
+    model_outputs: list[torch.Tensor | None],
+    sigmas: torch.Tensor,
+    step_index: int,
+    order: int,
+) -> torch.Tensor:
+    """UniP predictor for an x0-prediction representation."""
+    m0 = model_outputs[-1]
+    if m0 is None:
+        raise RuntimeError("UniPC predictor is missing the current model output")
+
+    sigma_t = sigmas[step_index + 1].to(device=sample.device, dtype=torch.float32)
+    sigma_s0 = sigmas[step_index].to(device=sample.device, dtype=torch.float32)
+    alpha_t, sigma_t = _alpha_sigma(sigma_t)
+    _, sigma_s0 = _alpha_sigma(sigma_s0)
+    h = _lambda(sigmas[step_index + 1].to(sample.device)) - _lambda(
+        sigmas[step_index].to(sample.device)
+    )
+
+    rks = []
+    d1s = []
+    for history_index in range(1, order):
+        previous_step = step_index - history_index
+        previous = model_outputs[-(history_index + 1)]
+        if previous is None:
+            raise RuntimeError("UniPC predictor history is incomplete")
+        rk = (
+            _lambda(sigmas[previous_step].to(sample.device))
+            - _lambda(sigmas[step_index].to(sample.device))
+        ) / h
+        rks.append(rk)
+        d1s.append((previous - m0) / rk)
+    rks.append(torch.ones((), device=sample.device, dtype=h.dtype))
+    rks_tensor = torch.stack(rks)
+
+    h_phi_1, b = _coefficients(h, order, sample.device)
+    b_h = torch.expm1(-h)
+    rows = torch.stack([rks_tensor**index for index in range(order)])
+
+    pred_res: torch.Tensor | float = 0.0
+    if d1s:
+        stacked = torch.stack(d1s, dim=1)
+        if order == 2:
+            rhos_p = torch.tensor([0.5], dtype=sample.dtype, device=sample.device)
+        else:  # Kept for clarity if the published solver order ever changes.
+            rhos_p = torch.linalg.solve(rows[:-1, :-1], b[:-1]).to(sample.dtype)
+        pred_res = torch.einsum("k,bkc...->bc...", rhos_p, stacked)
+
+    result = sigma_t / sigma_s0 * sample - alpha_t * h_phi_1 * m0
+    result = result - alpha_t * b_h * pred_res
+    return result.to(sample.dtype)
+
+
+def _uni_c_bh2_update(
+    this_model_output: torch.Tensor,
+    last_sample: torch.Tensor,
+    this_sample: torch.Tensor,
+    model_outputs: list[torch.Tensor | None],
+    sigmas: torch.Tensor,
+    step_index: int,
+    order: int,
+) -> torch.Tensor:
+    """UniC corrector for an x0-prediction representation."""
+    m0 = model_outputs[-1]
+    if m0 is None:
+        raise RuntimeError("UniPC corrector is missing its previous model output")
+
+    sigma_t_value = sigmas[step_index].to(
+        device=this_sample.device, dtype=torch.float32
+    )
+    sigma_s0_value = sigmas[step_index - 1].to(
+        device=this_sample.device, dtype=torch.float32
+    )
+    alpha_t, sigma_t = _alpha_sigma(sigma_t_value)
+    _, sigma_s0 = _alpha_sigma(sigma_s0_value)
+    h = _lambda(sigma_t_value) - _lambda(sigma_s0_value)
+
+    rks = []
+    d1s = []
+    for history_index in range(1, order):
+        previous_step = step_index - (history_index + 1)
+        previous = model_outputs[-(history_index + 1)]
+        if previous is None:
+            raise RuntimeError("UniPC corrector history is incomplete")
+        rk = (
+            _lambda(sigmas[previous_step].to(this_sample.device))
+            - _lambda(sigma_s0_value)
+        ) / h
+        rks.append(rk)
+        d1s.append((previous - m0) / rk)
+    rks.append(torch.ones((), device=this_sample.device, dtype=h.dtype))
+    rks_tensor = torch.stack(rks)
+
+    h_phi_1, b = _coefficients(h, order, this_sample.device)
+    b_h = torch.expm1(-h)
+    rows = torch.stack([rks_tensor**index for index in range(order)])
+    if order == 1:
+        rhos_c = torch.tensor([0.5], dtype=last_sample.dtype, device=this_sample.device)
+    else:
+        rhos_c = torch.linalg.solve(rows, b).to(last_sample.dtype)
+
+    corr_res: torch.Tensor | float = 0.0
+    if d1s:
+        corr_res = torch.einsum("k,bkc...->bc...", rhos_c[:-1], torch.stack(d1s, dim=1))
+    d1_t = this_model_output - m0
+    result = sigma_t / sigma_s0 * last_sample - alpha_t * h_phi_1 * m0
+    result = result - alpha_t * b_h * (corr_res + rhos_c[-1] * d1_t)
+    return result.to(this_sample.dtype)
+
+
+def sample_flow_unipc_bh2(
+    model: Callable,
+    noise: torch.Tensor,
+    sigmas: torch.Tensor,
+    extra_args: dict | None = None,
+    callback: Callable | None = None,
+    disable: bool = False,
+) -> torch.Tensor:
+    """Sample with the released order-2 flow UniPC predictor/corrector.
+
+    ``model`` follows Comfy's sampler contract and returns denoised/x0.  Comfy's
+    sampler wrapper pre-multiplies the initial noise by the first flow sigma, so
+    it is divided back out to match Diffusers' unit-normal initial latent.
+    """
+    del disable
+    extra_args = {} if extra_args is None else extra_args
+    if len(sigmas) <= 1:
+        return noise
+
+    first_sigma = sigmas[0].to(device=noise.device, dtype=noise.dtype)
+    sample = noise / first_sigma
+    model_outputs: list[torch.Tensor | None] = [None, None]
+    last_sample = None
+    lower_order_nums = 0
+    previous_order = 1
+    total_steps = len(sigmas) - 1
+
+    for step_index in range(total_steps):
+        sigma = sigmas[step_index].to(device=sample.device)
+        sigma_batch = sigma * sample.new_ones([sample.shape[0]])
+        denoised = model(sample, sigma_batch, **extra_args)
+
+        if step_index > 0 and last_sample is not None:
+            sample = _uni_c_bh2_update(
+                denoised,
+                last_sample,
+                sample,
+                model_outputs,
+                sigmas,
+                step_index,
+                previous_order,
+            )
+
+        model_outputs[0] = model_outputs[1]
+        model_outputs[1] = denoised
+        this_order = min(2, total_steps - step_index, lower_order_nums + 1)
+        last_sample = sample
+        sample = _uni_p_bh2_update(
+            sample, model_outputs, sigmas, step_index, this_order
+        )
+        previous_order = this_order
+        lower_order_nums = min(lower_order_nums + 1, 2)
+
+        if callback is not None:
+            callback(
+                {
+                    "x": sample,
+                    "i": step_index,
+                    "sigma": sigma,
+                    "sigma_hat": sigma,
+                    "denoised": denoised,
+                }
+            )
+    return sample

--- a/comfy/ldm/bernini_v2/unipc.py
+++ b/comfy/ldm/bernini_v2/unipc.py
@@ -174,6 +174,13 @@ def sample_flow_unipc_bh2(
     if len(sigmas) <= 1:
         return noise
 
+    if (
+        not bool(torch.isfinite(sigmas).all())
+        or bool((sigmas < 0).any())
+        or bool((sigmas >= 1).any())
+    ):
+        raise ValueError("flow UniPC requires finite sigmas in [0, 1)")
+
     first_sigma = sigmas[0].to(device=noise.device, dtype=noise.dtype)
     sample = noise / first_sigma
     model_outputs: list[torch.Tensor | None] = [None, None]

--- a/comfy/text_encoders/qwen_vl.py
+++ b/comfy/text_encoders/qwen_vl.py
@@ -157,10 +157,12 @@ def rotate_half(x):
 
 
 def apply_rotary_pos_emb_vision(q, k, cos, sin):
+    q_dtype = q.dtype
+    k_dtype = k.dtype
     cos, sin = cos.unsqueeze(-2).float(), sin.unsqueeze(-2).float()
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
-    return q_embed, k_embed
+    return q_embed.to(q_dtype), k_embed.to(k_dtype)
 
 
 class VisionRotaryEmbedding(nn.Module):

--- a/comfy_extras/nodes_bernini_v2.py
+++ b/comfy_extras/nodes_bernini_v2.py
@@ -1,0 +1,811 @@
+"""Native ComfyUI support for ByteDance Bernini v2."""
+
+from __future__ import annotations
+
+import logging
+
+import torch
+import torch.nn.functional as F
+from typing_extensions import override
+
+import comfy.model_management
+import comfy.model_sampling
+import comfy.ops
+import comfy.sampler_helpers
+import comfy.samplers
+import comfy.sd
+import comfy.utils
+import folder_paths
+from comfy.ldm.bernini_v2.guidance import (
+    compose_denoised_guidance,
+    guidance_chunks,
+    unipc_flow_sigmas,
+)
+from comfy.ldm.bernini_v2.media import fit_media_size, ordered_renderer_sources
+from comfy.ldm.bernini_v2.planner import (
+    BerniniV2Plan,
+    create_plan,
+    split_reference_images,
+)
+from comfy.ldm.bernini_v2.presets import task_preset
+from comfy.ldm.bernini_v2.runtime import load_planner_runtime
+from comfy.ldm.bernini_v2.unipc import sample_flow_unipc_bh2
+from comfy_api.latest import ComfyExtension, io
+
+BerniniV2PlannerType = io.Custom("BERNINI_V2_PLANNER")
+
+
+class BerniniV2ModelSampling(
+    comfy.model_sampling.ModelSamplingDiscreteFlow, comfy.model_sampling.CONST
+):
+    pass
+
+
+def _portable_name(name: str) -> str:
+    """Keep serialized workflow model names stable across host platforms."""
+    return name.replace("\\", "/")
+
+
+def _model_options(folder: str) -> list[str]:
+    return [
+        _portable_name(name) for name in folder_paths.get_filename_list(folder)
+    ]
+
+
+class BerniniV2WanLoader(io.ComfyNode):
+    """Load one high- or low-noise renderer with Comfy's Wan model."""
+
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="BerniniV2WanLoader",
+            display_name="Load Bernini v2 Wan Renderer",
+            category="advanced/loaders/bernini_v2",
+            description=(
+                "Loads one Wan safetensors renderer from models/diffusion_models. "
+                "The output is a standard MODEL and uses ComfyUI device/offload management."
+            ),
+            inputs=[
+                io.Combo.Input(
+                    "unet_name", options=_model_options("diffusion_models")
+                ),
+                io.Float.Input(
+                    "flow_shift",
+                    default=5.0,
+                    min=0.01,
+                    max=100.0,
+                    step=0.01,
+                    advanced=True,
+                ),
+                io.Combo.Input(
+                    "weight_dtype",
+                    options=[
+                        "bfloat16",
+                        "float16",
+                        "default",
+                        "fp8_e4m3fn",
+                        "fp8_e4m3fn_fast",
+                        "fp8_e5m2",
+                    ],
+                    default="bfloat16",
+                    optional=True,
+                    advanced=True,
+                ),
+            ],
+            outputs=[io.Model.Output()],
+        )
+
+    @classmethod
+    def execute(
+        cls,
+        unet_name: str,
+        flow_shift: float = 5.0,
+        weight_dtype: str = "default",
+    ) -> io.NodeOutput:
+        model_path = folder_paths.get_full_path_or_raise(
+            "diffusion_models", unet_name
+        )
+        if not model_path.endswith(".safetensors"):
+            raise ValueError(
+                "Bernini v2 renderers must each be one .safetensors file"
+            )
+        state_dict = comfy.utils.load_torch_file(model_path, safe_load=True)
+        if "scaled_fp8" in state_dict:
+            state_dict, _ = comfy.utils.convert_old_quants(state_dict)
+        native_quant = any(key.endswith(".comfy_quant") for key in state_dict)
+        if native_quant and weight_dtype.startswith("fp8"):
+            raise ValueError(
+                "pre-quantized Comfy weights cannot be recast to FP8; choose bfloat16 or default"
+            )
+        model_options = {}
+        if weight_dtype == "bfloat16":
+            model_options["dtype"] = torch.bfloat16
+        elif weight_dtype == "float16":
+            model_options["dtype"] = torch.float16
+        elif weight_dtype == "fp8_e4m3fn":
+            model_options["dtype"] = torch.float8_e4m3fn
+        elif weight_dtype == "fp8_e4m3fn_fast":
+            model_options["dtype"] = torch.float8_e4m3fn
+            model_options["fp8_optimizations"] = True
+        elif weight_dtype == "fp8_e5m2":
+            model_options["dtype"] = torch.float8_e5m2
+        if native_quant:
+            compute_dtype = (
+                torch.float16 if weight_dtype == "float16" else torch.bfloat16
+            )
+            model_options["dtype"] = compute_dtype
+            model_options["custom_operations"] = comfy.ops.mixed_precision_ops(
+                {}, compute_dtype
+            )
+            logging.info(
+                "Bernini v2 quantized renderer compute dtype: %s", compute_dtype
+            )
+        model = comfy.sd.load_diffusion_model_state_dict(
+            state_dict, model_options=model_options
+        )
+        if model is None:
+            raise RuntimeError(
+                f"ComfyUI could not detect the Wan model in {model_path}"
+            )
+        model = model.clone()
+
+        model_sampling = BerniniV2ModelSampling(model.model.model_config)
+        model_sampling.set_parameters(shift=flow_shift, multiplier=1000)
+        model.add_object_patch("model_sampling", model_sampling)
+        return io.NodeOutput(model)
+
+
+class BerniniV2PlannerLoader(io.ComfyNode):
+    """Load Qwen2.5-VL and Bernini planning heads under Comfy model management."""
+
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="BerniniV2PlannerLoader",
+            display_name="Load Bernini v2 Planner",
+            category="advanced/loaders/bernini_v2",
+            description=(
+                "Loads one standalone planner from models/text_encoders. It contains "
+                "Qwen language/vision, Bernini heads, config, and tokenizer."
+            ),
+            inputs=[
+                io.Combo.Input(
+                    "planner_name", options=_model_options("text_encoders")
+                ),
+                io.Combo.Input(
+                    "dtype",
+                    options=["bfloat16", "float16"],
+                    default="bfloat16",
+                    optional=True,
+                    advanced=True,
+                ),
+            ],
+            outputs=[BerniniV2PlannerType.Output(display_name="planner")],
+        )
+
+    @classmethod
+    def execute(cls, planner_name: str, dtype: str = "bfloat16") -> io.NodeOutput:
+        torch_dtype = torch.bfloat16 if dtype == "bfloat16" else torch.float16
+        planner_path = folder_paths.get_full_path_or_raise(
+            "text_encoders", planner_name
+        )
+        planner = load_planner_runtime(planner_path, dtype=torch_dtype)
+        return io.NodeOutput(planner)
+
+
+BerniniV2PlanType = io.Custom("BERNINI_V2_PLAN")
+
+
+class BerniniV2PlanNode(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="BerniniV2Plan",
+            display_name="Bernini v2 Plan",
+            category="conditioning/bernini_v2",
+            description="Runs the native Qwen/VIT semantic planner and produces four renderer condition arms.",
+            inputs=[
+                BerniniV2PlannerType.Input("planner"),
+                io.Conditioning.Input("positive"),
+                io.Conditioning.Input("negative"),
+                io.String.Input("prompt", multiline=True, dynamic_prompts=True),
+                io.String.Input(
+                    "negative_prompt",
+                    multiline=True,
+                    dynamic_prompts=True,
+                    advanced=True,
+                ),
+                io.Combo.Input(
+                    "task",
+                    options=["t2i", "i2i", "t2v", "v2v", "r2v", "rv2v"],
+                    default="t2v",
+                ),
+                io.Int.Input("width", default=848, min=16, max=8192, step=16),
+                io.Int.Input("height", default=480, min=16, max=8192, step=16),
+                io.Int.Input("length", default=33, min=1, max=8192, step=4),
+                io.Image.Input("source_video", optional=True),
+                io.Video.Input("video", optional=True, advanced=True),
+                io.Autogrow.Input(
+                    "reference_images",
+                    optional=True,
+                    template=io.Autogrow.TemplatePrefix(
+                        input=io.Image.Input("reference_image"),
+                        prefix="reference_image_",
+                        min=0,
+                        max=8,
+                    ),
+                ),
+                io.Float.Input(
+                    "source_fps",
+                    default=16.0,
+                    min=0.01,
+                    max=240.0,
+                    step=0.01,
+                    advanced=True,
+                ),
+                io.Boolean.Input("use_task_defaults", default=True, advanced=True),
+                io.Boolean.Input("match_source_size", default=True, advanced=True),
+                io.Int.Input(
+                    "max_media_size",
+                    default=848,
+                    min=240,
+                    max=8192,
+                    step=16,
+                    advanced=True,
+                ),
+                io.Int.Input(
+                    "planning_steps", default=25, min=1, max=100, advanced=True
+                ),
+                io.Int.Input(
+                    "vit_denoising_steps", default=5, min=1, max=100, advanced=True
+                ),
+                io.Float.Input(
+                    "vit_text_cfg",
+                    default=1.2,
+                    min=0.0,
+                    max=20.0,
+                    step=0.05,
+                    advanced=True,
+                ),
+                io.Float.Input(
+                    "vit_image_cfg",
+                    default=1.0,
+                    min=0.0,
+                    max=20.0,
+                    step=0.05,
+                    advanced=True,
+                ),
+                io.Int.Input("seed", default=42, min=0, max=0xFFFFFFFFFFFFFFFF),
+            ],
+            outputs=[BerniniV2PlanType.Output(display_name="plan")],
+        )
+
+    @classmethod
+    def execute(
+        cls,
+        planner,
+        positive,
+        negative,
+        prompt,
+        negative_prompt,
+        task,
+        width,
+        height,
+        length,
+        source_video=None,
+        video=None,
+        reference_images=None,
+        source_fps=16.0,
+        use_task_defaults=True,
+        match_source_size=True,
+        max_media_size=848,
+        planning_steps=25,
+        vit_denoising_steps=5,
+        vit_text_cfg=1.2,
+        vit_image_cfg=1.0,
+        seed=42,
+    ) -> io.NodeOutput:
+        if video is not None:
+            if source_video is not None:
+                raise ValueError(
+                    "connect either source_video IMAGE batch or VIDEO, not both"
+                )
+            components = video.get_components()
+            source_video = components.images
+            source_fps = float(components.frame_rate)
+        references = split_reference_images(reference_images)
+        if use_task_defaults:
+            preset = task_preset(task)
+            planning_steps = preset["planning_steps"]
+            vit_denoising_steps = preset["vit_denoising_steps"]
+            max_media_size = preset["max_media_size"]
+        size_source = source_video
+        if task == "i2i" and references:
+            size_source = references[0]
+        if match_source_size and size_source is not None:
+            height, width = fit_media_size(
+                size_source.shape[1],
+                size_source.shape[2],
+                max_size=max_media_size,
+            )
+        plan = create_plan(
+            planner,
+            positive=positive,
+            negative=negative,
+            prompt=prompt,
+            negative_prompt=negative_prompt,
+            task=task,
+            width=width,
+            height=height,
+            length=length,
+            max_media_size=max_media_size,
+            source_video=source_video,
+            reference_images=references,
+            source_fps=source_fps,
+            planning_steps=planning_steps,
+            vit_denoising_steps=vit_denoising_steps,
+            vit_text_cfg=vit_text_cfg,
+            vit_image_cfg=vit_image_cfg,
+            seed=seed,
+        )
+        return io.NodeOutput(plan)
+
+
+def _resize_source_media(image: torch.Tensor, max_size: int) -> torch.Tensor:
+    resized_height, resized_width = fit_media_size(
+        image.shape[1],
+        image.shape[2],
+        max_size=max_size,
+    )
+    channels_first = image[..., :3].movedim(-1, 1).float()
+    if channels_first.shape[-2:] != (resized_height, resized_width):
+        channels_first = F.interpolate(
+            channels_first,
+            size=(resized_height, resized_width),
+            mode="bicubic",
+            align_corners=False,
+            antialias=True,
+        )
+    return channels_first.movedim(1, -1)
+
+
+def encode_renderer_sources(
+    plan: BerniniV2Plan,
+    vae,
+    *,
+    encode_mode: str = "auto",
+) -> tuple[list[torch.Tensor], list[torch.Tensor], dict[str, torch.Tensor]]:
+    """VAE encode source video and reference images as separate Wan streams."""
+    if encode_mode not in {"auto", "tiled"}:
+        raise ValueError(f"unsupported VAE encode mode: {encode_mode!r}")
+    encode = vae.encode_tiled if encode_mode == "tiled" else vae.encode
+    video_latents = []
+    if plan.source_video is not None:
+        video = _resize_source_media(
+            plan.source_video[: plan.length],
+            plan.max_media_size,
+        )
+        video_latents.append(encode(video))
+
+    image_latents = []
+    for image in plan.reference_images:
+        image_latents.append(
+            encode(_resize_source_media(image[:1], plan.max_media_size))
+        )
+
+    latent = torch.zeros(
+        [1, 16, ((plan.length - 1) // 4) + 1, plan.height // 8, plan.width // 8],
+        device=comfy.model_management.intermediate_device(),
+    )
+    return video_latents, image_latents, {"samples": latent}
+
+
+def _conditioning(context: torch.Tensor, context_latents: list[torch.Tensor]):
+    metadata = {}
+    if context_latents:
+        metadata["context_latents"] = context_latents
+    return [[context, metadata]]
+
+
+class BerniniV2Guider(comfy.samplers.CFGGuider):
+    """Four/five-arm guider matching the released Bernini v2 renderer."""
+
+    def __init__(
+        self,
+        model_patcher,
+        plan: BerniniV2Plan,
+        video_latents: list[torch.Tensor],
+        image_latents: list[torch.Tensor],
+        *,
+        omega_video: float,
+        omega_image: float,
+        omega_text: float,
+        omega_target: float,
+        scale: float,
+        guidance_batch_size: str | int = "auto",
+    ):
+        super().__init__(model_patcher)
+        self.omega_video = omega_video
+        self.omega_image = omega_image
+        self.omega_text = omega_text
+        self.omega_target = omega_target
+        self.scale = scale
+        self.guidance_batch_size = guidance_batch_size
+        self.rv2v = plan.task == "rv2v"
+
+        # The released renderer appends reference-image VAE tokens before
+        # source-video tokens. Wan assigns source ids/RoPE by list position, so
+        # reversing these streams corrupts only the combined RV2V condition.
+        all_sources = ordered_renderer_sources(
+            image_sources=image_latents,
+            video_sources=video_latents,
+        )
+        conditions = {
+            "base": _conditioning(plan.contexts["wotxt_wovit"], []),
+            "text": _conditioning(plan.contexts["wtxt_wovit"], all_sources),
+            "target": _conditioning(plan.contexts["wtxt_wvit"], all_sources),
+        }
+        if self.rv2v:
+            conditions["video"] = _conditioning(
+                plan.contexts["wotxt_wovit"], video_latents
+            )
+            conditions["image"] = _conditioning(
+                plan.contexts["wotxt_wovit"], all_sources
+            )
+        elif all_sources:
+            conditions["source"] = _conditioning(
+                plan.contexts["wotxt_wovit"], all_sources
+            )
+        self.arm_names = list(conditions)
+        self.inner_set_conds(conditions)
+
+    def _predict_arms(
+        self, inner_model, conditions, x, timestep, model_options, *, scale
+    ):
+        predictions = {}
+        for chunk in guidance_chunks(self.arm_names, self.guidance_batch_size):
+            outputs = comfy.samplers.calc_cond_batch(
+                inner_model,
+                [conditions[name] for name in chunk],
+                x,
+                timestep,
+                model_options,
+            )
+            predictions.update(zip(chunk, outputs, strict=True))
+        return compose_denoised_guidance(
+            predictions,
+            x,
+            timestep,
+            omega_video=self.omega_video * scale,
+            omega_image=self.omega_image * scale,
+            omega_text=self.omega_text * scale,
+            omega_target=self.omega_target * scale,
+            rv2v=self.rv2v,
+        )
+
+    def predict_noise(self, x, timestep, model_options=None, seed=None):
+        del seed
+        model_options = model_options or {}
+        return self._predict_arms(
+            self.inner_model,
+            self.conds,
+            x,
+            timestep,
+            model_options,
+            scale=self.scale,
+        )
+
+
+class BerniniV2DualExpertGuider(BerniniV2Guider):
+    """One guider that switches Wan experts without resetting sampler history."""
+
+    def __init__(
+        self,
+        high_noise_model,
+        low_noise_model,
+        *args,
+        boundary: float,
+        omega_scale: float,
+        **kwargs,
+    ):
+        super().__init__(high_noise_model, *args, scale=1.0, **kwargs)
+        self.low_noise_model = low_noise_model
+        self.boundary = boundary
+        self.omega_scale = omega_scale
+        self.low_inner = None
+        self.low_conds = None
+        self.low_loaded_models = []
+        self.switched = False
+
+    def outer_sample(
+        self,
+        noise,
+        latent_image,
+        sampler,
+        sigmas,
+        denoise_mask=None,
+        callback=None,
+        disable_pbar=False,
+        seed=None,
+        latent_shapes=None,
+    ):
+        low_conditions = {
+            name: [condition.copy() for condition in self.conds[name]]
+            for name in self.arm_names
+        }
+        self.low_inner, self.low_conds, self.low_loaded_models = (
+            comfy.sampler_helpers.prepare_sampling(
+                self.low_noise_model,
+                noise.shape,
+                low_conditions,
+                self.low_noise_model.model_options,
+            )
+        )
+        self.low_noise_model.pre_run()
+        self.switched = False
+        try:
+            return super().outer_sample(
+                noise,
+                latent_image,
+                sampler,
+                sigmas,
+                denoise_mask,
+                callback,
+                disable_pbar,
+                seed,
+                latent_shapes=latent_shapes,
+            )
+        finally:
+            self.low_noise_model.cleanup()
+            comfy.sampler_helpers.cleanup_models(self.low_conds, self.low_loaded_models)
+            self.low_inner = None
+            self.low_conds = None
+            self.low_loaded_models = []
+
+    def inner_sample(
+        self,
+        noise,
+        latent_image,
+        device,
+        sampler,
+        sigmas,
+        denoise_mask,
+        callback,
+        disable_pbar,
+        seed,
+        latent_shapes=None,
+    ):
+        self.low_inner.latent_shapes = latent_shapes
+        low_latent = latent_image
+        if low_latent is not None and torch.count_nonzero(low_latent) > 0:
+            low_latent = self.low_inner.process_latent_in(low_latent)
+        self.low_conds = comfy.samplers.process_conds(
+            self.low_inner,
+            noise,
+            self.low_conds,
+            device,
+            low_latent,
+            denoise_mask,
+            seed,
+            latent_shapes=latent_shapes,
+        )
+        return super().inner_sample(
+            noise,
+            latent_image,
+            device,
+            sampler,
+            sigmas,
+            denoise_mask,
+            callback,
+            disable_pbar,
+            seed,
+            latent_shapes=latent_shapes,
+        )
+
+    def predict_noise(self, x, timestep, model_options=None, seed=None):
+        del seed
+        model_options = model_options or {}
+        use_low_noise = bool((timestep[0] < self.boundary).item())
+        if use_low_noise:
+            if not self.switched:
+                memory_required, minimum_memory_required = (
+                    comfy.sampler_helpers.estimate_memory(
+                        self.low_noise_model,
+                        x.shape,
+                        self.low_conds,
+                    )
+                )
+                comfy.model_management.load_models_gpu(
+                    [self.low_noise_model, *self.low_loaded_models],
+                    memory_required=memory_required,
+                    minimum_memory_required=minimum_memory_required,
+                )
+                self.switched = True
+            return self._predict_arms(
+                self.low_inner,
+                self.low_conds,
+                x,
+                timestep,
+                model_options,
+                scale=self.omega_scale,
+            )
+        return self._predict_arms(
+            self.inner_model,
+            self.conds,
+            x,
+            timestep,
+            model_options,
+            scale=1.0,
+        )
+
+
+class BerniniV2RendererGuider(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="BerniniV2RendererGuider",
+            display_name="Bernini v2 Renderer Guider",
+            category="sampling/bernini_v2",
+            description=(
+                "VAE-encodes source media and creates one native Wan guider that switches "
+                "experts at the official boundary without resetting UniPC sampler history."
+            ),
+            inputs=[
+                BerniniV2PlanType.Input("plan"),
+                io.Model.Input("high_noise_model"),
+                io.Model.Input("low_noise_model"),
+                io.Vae.Input("vae"),
+                io.Float.Input(
+                    "omega_video", default=1.25, min=0.0, max=20.0, step=0.05
+                ),
+                io.Float.Input(
+                    "omega_image", default=3.0, min=0.0, max=20.0, step=0.05
+                ),
+                io.Float.Input("omega_text", default=4.0, min=0.0, max=20.0, step=0.05),
+                io.Float.Input(
+                    "omega_target", default=1.2, min=0.0, max=20.0, step=0.05
+                ),
+                io.Float.Input(
+                    "omega_scale", default=0.75, min=0.0, max=2.0, step=0.05
+                ),
+                io.Boolean.Input("use_task_defaults", default=True, advanced=True),
+                io.Float.Input(
+                    "boundary",
+                    default=0.875,
+                    min=0.0,
+                    max=1.0,
+                    step=0.001,
+                    advanced=True,
+                ),
+                io.Combo.Input(
+                    "guidance_batch_size",
+                    options=["auto", "1", "2", "all"],
+                    default="auto",
+                    advanced=True,
+                ),
+                io.Combo.Input(
+                    "vae_encode_mode",
+                    options=["auto", "tiled"],
+                    default="auto",
+                    advanced=True,
+                ),
+            ],
+            outputs=[
+                io.Guider.Output(display_name="guider"),
+                io.Latent.Output(display_name="latent"),
+            ],
+        )
+
+    @classmethod
+    def execute(
+        cls,
+        plan,
+        high_noise_model,
+        low_noise_model,
+        vae,
+        omega_video,
+        omega_image,
+        omega_text,
+        omega_target,
+        omega_scale,
+        use_task_defaults=True,
+        boundary=0.875,
+        guidance_batch_size="auto",
+        vae_encode_mode="auto",
+    ) -> io.NodeOutput:
+        video_latents, image_latents, latent = encode_renderer_sources(
+            plan, vae, encode_mode=vae_encode_mode
+        )
+        if use_task_defaults:
+            preset = task_preset(plan.task)
+            omega_video = preset["omega_video"]
+            omega_image = preset["omega_image"]
+            omega_text = preset["omega_text"]
+            omega_target = preset["omega_target"]
+            omega_scale = preset["omega_scale"]
+        common = {
+            "plan": plan,
+            "video_latents": video_latents,
+            "image_latents": image_latents,
+            "omega_video": omega_video,
+            "omega_image": omega_image,
+            "omega_text": omega_text,
+            "omega_target": omega_target,
+            "guidance_batch_size": guidance_batch_size,
+        }
+        guider = BerniniV2DualExpertGuider(
+            high_noise_model,
+            low_noise_model,
+            boundary=boundary,
+            omega_scale=omega_scale,
+            **common,
+        )
+        return io.NodeOutput(guider, latent)
+
+
+class BerniniV2Scheduler(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="BerniniV2Scheduler",
+            display_name="Bernini v2 UniPC Sigmas",
+            category="sampling/bernini_v2",
+            description=(
+                "Matches Diffusers UniPC flow-sigma spacing: linearly spaced training timesteps "
+                "from 999 to 0, followed by the terminal zero sigma."
+            ),
+            inputs=[
+                BerniniV2PlanType.Input("plan"),
+                io.Int.Input("steps", default=40, min=1, max=10000),
+                io.Float.Input(
+                    "flow_shift", default=5.0, min=0.01, max=100.0, step=0.01
+                ),
+                io.Boolean.Input("use_task_defaults", default=True, advanced=True),
+            ],
+            outputs=[io.Sigmas.Output()],
+        )
+
+    @classmethod
+    def execute(
+        cls, plan, steps, flow_shift=5.0, use_task_defaults=True
+    ) -> io.NodeOutput:
+        if use_task_defaults:
+            steps = task_preset(plan.task)["steps"]
+        return io.NodeOutput(unipc_flow_sigmas(steps, flow_shift))
+
+
+class BerniniV2UniPCSampler(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="BerniniV2UniPCSampler",
+            display_name="Bernini v2 Flow UniPC (BH2)",
+            category="sampling/bernini_v2",
+            description=(
+                "The released order-2 UniPC BH2 solver for flow prediction. "
+                "ComfyUI's generic UniPC uses a VP noise schedule and is not equivalent."
+            ),
+            inputs=[],
+            outputs=[io.Sampler.Output()],
+        )
+
+    @classmethod
+    def execute(cls) -> io.NodeOutput:
+        return io.NodeOutput(comfy.samplers.KSAMPLER(sample_flow_unipc_bh2))
+
+
+class BerniniV2Extension(ComfyExtension):
+    @override
+    async def get_node_list(self) -> list[type[io.ComfyNode]]:
+        return [
+            BerniniV2WanLoader,
+            BerniniV2PlannerLoader,
+            BerniniV2PlanNode,
+            BerniniV2RendererGuider,
+            BerniniV2Scheduler,
+            BerniniV2UniPCSampler,
+        ]
+
+
+async def comfy_entrypoint() -> BerniniV2Extension:
+    return BerniniV2Extension()

--- a/comfy_extras/nodes_bernini_v2.py
+++ b/comfy_extras/nodes_bernini_v2.py
@@ -100,7 +100,7 @@ class BerniniV2WanLoader(io.ComfyNode):
         cls,
         unet_name: str,
         flow_shift: float = 5.0,
-        weight_dtype: str = "default",
+        weight_dtype: str = "bfloat16",
     ) -> io.NodeOutput:
         model_path = folder_paths.get_full_path_or_raise(
             "diffusion_models", unet_name
@@ -656,17 +656,44 @@ class BerniniV2RendererGuider(io.ComfyNode):
                 io.Model.Input("low_noise_model"),
                 io.Vae.Input("vae"),
                 io.Float.Input(
-                    "omega_video", default=1.25, min=0.0, max=20.0, step=0.05
+                    "omega_video",
+                    default=1.25,
+                    min=0.0,
+                    max=20.0,
+                    step=0.05,
+                    advanced=True,
                 ),
                 io.Float.Input(
-                    "omega_image", default=3.0, min=0.0, max=20.0, step=0.05
+                    "omega_image",
+                    default=3.0,
+                    min=0.0,
+                    max=20.0,
+                    step=0.05,
+                    advanced=True,
                 ),
-                io.Float.Input("omega_text", default=4.0, min=0.0, max=20.0, step=0.05),
                 io.Float.Input(
-                    "omega_target", default=1.2, min=0.0, max=20.0, step=0.05
+                    "omega_text",
+                    default=4.0,
+                    min=0.0,
+                    max=20.0,
+                    step=0.05,
+                    advanced=True,
                 ),
                 io.Float.Input(
-                    "omega_scale", default=0.75, min=0.0, max=2.0, step=0.05
+                    "omega_target",
+                    default=1.2,
+                    min=0.0,
+                    max=20.0,
+                    step=0.05,
+                    advanced=True,
+                ),
+                io.Float.Input(
+                    "omega_scale",
+                    default=0.75,
+                    min=0.0,
+                    max=2.0,
+                    step=0.05,
+                    advanced=True,
                 ),
                 io.Boolean.Input("use_task_defaults", default=True, advanced=True),
                 io.Float.Input(
@@ -756,7 +783,7 @@ class BerniniV2Scheduler(io.ComfyNode):
             ),
             inputs=[
                 BerniniV2PlanType.Input("plan"),
-                io.Int.Input("steps", default=40, min=1, max=10000),
+                io.Int.Input("steps", default=40, min=1, max=10000, advanced=True),
                 io.Float.Input(
                     "flow_shift", default=5.0, min=0.01, max=100.0, step=0.01
                 ),

--- a/nodes.py
+++ b/nodes.py
@@ -2463,6 +2463,7 @@ async def init_builtin_extra_nodes():
         "nodes_lumina2.py",
         "nodes_wan.py",
         "nodes_bernini.py",
+        "nodes_bernini_v2.py",
         "nodes_lotus.py",
         "nodes_hunyuan3d.py",
         "nodes_primitive.py",

--- a/tests-unit/comfy_test/bernini_v2_test.py
+++ b/tests-unit/comfy_test/bernini_v2_test.py
@@ -287,6 +287,25 @@ def test_flow_unipc_is_deterministic_and_finite():
     assert torch.isfinite(first).all()
 
 
+@pytest.mark.parametrize(
+    "sigmas",
+    [
+        torch.tensor([1.0, 0.0]),
+        torch.tensor([1.01, 0.0]),
+        torch.tensor([-0.01, 0.0]),
+        torch.tensor([0.5, torch.nan]),
+    ],
+)
+def test_flow_unipc_rejects_non_flow_sigmas(sigmas):
+    with pytest.raises(ValueError, match=r"sigmas in \[0, 1\)"):
+        sample_flow_unipc_bh2(_ToyComfyModel(), torch.ones(1), sigmas)
+
+
+def test_flow_unipc_preserves_short_schedule_early_return():
+    noise = torch.randn(2, 3)
+    assert sample_flow_unipc_bh2(_ToyComfyModel(), noise, torch.tensor([1.0])) is noise
+
+
 def test_standalone_planner_embedded_payload_contract():
     payload = b'{"hidden_size":3584}'
     state_dict = {

--- a/tests-unit/comfy_test/bernini_v2_test.py
+++ b/tests-unit/comfy_test/bernini_v2_test.py
@@ -301,6 +301,15 @@ def test_flow_unipc_rejects_non_flow_sigmas(sigmas):
         sample_flow_unipc_bh2(_ToyComfyModel(), torch.ones(1), sigmas)
 
 
+@pytest.mark.parametrize(
+    "sigmas",
+    [torch.tensor([0.5, 0.5, 0.0]), torch.tensor([0.5, 0.75, 0.0])],
+)
+def test_flow_unipc_rejects_non_decreasing_sigmas(sigmas):
+    with pytest.raises(ValueError, match="strictly decreasing"):
+        sample_flow_unipc_bh2(_ToyComfyModel(), torch.ones(1), sigmas)
+
+
 def test_flow_unipc_preserves_short_schedule_early_return():
     noise = torch.randn(2, 3)
     assert sample_flow_unipc_bh2(_ToyComfyModel(), noise, torch.tensor([1.0])) is noise

--- a/tests-unit/comfy_test/bernini_v2_test.py
+++ b/tests-unit/comfy_test/bernini_v2_test.py
@@ -1,0 +1,370 @@
+import pytest
+import torch
+
+import comfy.ops
+from comfy.ldm.bernini_v2.guidance import (
+    apg_delta,
+    compose_denoised_guidance,
+    compose_velocity_guidance,
+    guidance_chunks,
+    unipc_flow_sigmas,
+)
+from comfy.ldm.bernini_v2.media import fit_media_size, ordered_renderer_sources
+from comfy.ldm.bernini_v2.planner import (
+    maskgit_order,
+    split_reference_images,
+    validate_generation_request,
+)
+from comfy.ldm.bernini_v2.planner_model import (
+    DiffLossFM,
+    FlowMatchScheduler,
+    MLPConnector,
+)
+from comfy.ldm.bernini_v2.presets import task_preset
+from comfy.ldm.bernini_v2.qwen import (
+    planner_video_frame_indices,
+    process_qwen2vl_video,
+    qwen_grid_for_media,
+)
+from comfy.ldm.bernini_v2.runtime import _embedded_bytes, _embedded_json
+from comfy.ldm.bernini_v2.template import (
+    BerniniTemplate,
+    build_conversation,
+    build_custom_attention_mask,
+)
+from comfy.ldm.bernini_v2.unipc import sample_flow_unipc_bh2
+from comfy.text_encoders.qwen_vl import apply_rotary_pos_emb_vision
+
+
+def test_guidance_chunks_default_to_low_memory_order():
+    names = ["base", "source", "text", "target"]
+    assert guidance_chunks(names, "auto") == [
+        ["base"],
+        ["source"],
+        ["text"],
+        ["target"],
+    ]
+    assert guidance_chunks(names, "2") == [["base", "source"], ["text", "target"]]
+    assert guidance_chunks(names, "all") == [names]
+
+
+def test_standard_and_rv2v_guidance_composition():
+    predictions = {
+        "base": torch.tensor([[1.0, 0.0]]),
+        "source": torch.tensor([[2.0, 1.0]]),
+        "text": torch.tensor([[2.0, 3.0]]),
+        "target": torch.tensor([[4.0, 3.0]]),
+    }
+    expected = (
+        predictions["base"]
+        + 2.0
+        * apg_delta(predictions["source"] - predictions["base"], predictions["source"])
+        + 3.0
+        * apg_delta(predictions["text"] - predictions["source"], predictions["text"])
+        + 4.0
+        * apg_delta(predictions["target"] - predictions["text"], predictions["target"])
+    )
+    torch.testing.assert_close(
+        compose_velocity_guidance(
+            predictions,
+            omega_video=0.0,
+            omega_image=2.0,
+            omega_text=3.0,
+            omega_target=4.0,
+            rv2v=False,
+        ),
+        expected,
+    )
+
+    rv2v = {
+        name: torch.tensor([[value]])
+        for name, value in zip(
+            ("base", "video", "image", "text", "target"),
+            (1.0, 2.0, 4.0, 7.0, 11.0),
+            strict=True,
+        )
+    }
+    torch.testing.assert_close(
+        compose_velocity_guidance(
+            rv2v,
+            omega_video=2.0,
+            omega_image=3.0,
+            omega_text=4.0,
+            omega_target=5.0,
+            rv2v=True,
+        ),
+        torch.tensor([[41.0]]),
+    )
+
+
+def test_denoised_guidance_round_trip():
+    sample = torch.tensor([[[[[8.0]]]]])
+    sigma = torch.tensor([0.5])
+    velocities = {
+        name: torch.tensor([[[[[value]]]]])
+        for name, value in {
+            "base": 1.0,
+            "text": 2.0,
+            "target": 3.0,
+        }.items()
+    }
+    denoised = {name: sample - sigma * value for name, value in velocities.items()}
+    guided = compose_velocity_guidance(
+        velocities,
+        omega_video=0.0,
+        omega_image=0.0,
+        omega_text=2.0,
+        omega_target=3.0,
+        rv2v=False,
+    )
+    actual = compose_denoised_guidance(
+        denoised,
+        sample,
+        sigma,
+        omega_video=0.0,
+        omega_image=0.0,
+        omega_text=2.0,
+        omega_target=3.0,
+        rv2v=False,
+    )
+    torch.testing.assert_close(actual, sample - sigma * guided)
+
+
+def test_media_geometry_and_source_order():
+    assert fit_media_size(1080, 1920, max_size=848) == (480, 848)
+    assert fit_media_size(1920, 1080, max_size=848) == (848, 480)
+    assert max(fit_media_size(1000, 1000, max_size=842)) <= 842
+    assert ordered_renderer_sources(
+        image_sources=["i0", "i1"], video_sources=["v0"]
+    ) == ["i0", "i1", "v0"]
+
+
+def test_planner_preflight_accepts_two_second_non_square_video():
+    values = {
+        "task": "t2v",
+        "width": 640,
+        "height": 368,
+        "length": 33,
+        "source_fps": 16.0,
+        "planning_steps": 25,
+        "vit_denoising_steps": 1,
+    }
+    validate_generation_request(**values)
+    validate_generation_request(**{**values, "width": 368, "height": 640})
+    with pytest.raises(ValueError, match="4n\\+1"):
+        validate_generation_request(**{**values, "length": 32})
+    with pytest.raises(ValueError, match="multiples of 16"):
+        validate_generation_request(**{**values, "width": 639})
+
+
+def test_reference_inputs_use_numeric_order():
+    references = {
+        "reference_image_10": torch.full((1, 1, 1, 1), 10),
+        "reference_image_2": torch.full((1, 1, 1, 1), 2),
+        "reference_image_1": torch.full((1, 1, 1, 1), 1),
+    }
+    assert [int(item.item()) for item in split_reference_images(references)] == [
+        1,
+        2,
+        10,
+    ]
+
+
+def test_small_planner_modules_and_weight_layout():
+    operations = comfy.ops.disable_weight_init
+    connector = MLPConnector(
+        in_dim=8,
+        out_dim_for_gen=6,
+        out_dim_for_vit=8,
+        operations=operations,
+    )
+    assert len(connector.state_dict()) == 12
+    x = torch.randn(2, 3, 8)
+    assert connector.for_gen(x).shape == (2, 3, 6)
+    assert connector.for_vit(x).shape == (2, 3, 8)
+
+    decoder = DiffLossFM(
+        target_channels=8,
+        z_channels=8,
+        depth=2,
+        width=16,
+        operations=operations,
+    )
+    output = decoder.net(torch.randn(4, 8), torch.ones(1), torch.randn(4, 8))
+    assert output.shape == (4, 8)
+
+    branches = decoder.sample(
+        torch.randn(3, 8),
+        cfg=0.5,
+        img_cfg=0.5,
+        num_inference_steps=1,
+        seed=1,
+    )
+    assert branches.shape == (3, 8)
+    assert not hasattr(decoder, "scheduler")
+
+
+def test_planner_flow_scheduler_lands_at_zero():
+    scheduler = FlowMatchScheduler(shift=2.0)
+    scheduler.set_timesteps(3)
+    sample = torch.ones(1)
+    result = scheduler.step(torch.ones(1), scheduler.timesteps[-1], sample)
+    torch.testing.assert_close(result, sample - scheduler.sigmas[-1])
+
+
+def test_planner_flow_scheduler_keeps_high_step_schedule_unique_and_float32():
+    scheduler = FlowMatchScheduler(shift=2.0, extra_one_step=True)
+    scheduler.set_timesteps(100)
+    assert scheduler.sigmas.dtype == torch.float32
+    assert scheduler.timesteps.dtype == torch.float32
+    assert torch.unique(scheduler.sigmas).numel() == 100
+    assert torch.unique(scheduler.timesteps).numel() == 100
+
+
+def test_qwen_patchification_and_frame_policy():
+    frames = torch.rand(3, 28, 28, 3)
+    patches, grid = process_qwen2vl_video(
+        frames, min_pixels=28 * 28, max_pixels=28 * 28
+    )
+    assert grid.tolist() == [[2, 2, 2]]
+    assert patches.shape == (8, 3 * 2 * 14 * 14)
+    assert qwen_grid_for_media(10, 480, 832).tolist() == [[5, 12, 20]]
+    indices = planner_video_frame_indices(
+        81, source_fps=16, planner_fps=2, max_frames=81
+    )
+    assert len(indices) == 10
+    assert indices[0] == 0
+    assert indices[-1] == 80
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_qwen_vision_rope_preserves_attention_dtype(dtype):
+    query = torch.randn(8, 2, 4, dtype=dtype)
+    key = torch.randn_like(query)
+    cos = torch.randn(8, 4)
+    sin = torch.randn(8, 4)
+    rotated_query, rotated_key = apply_rotary_pos_emb_vision(query, key, cos, sin)
+    assert rotated_query.dtype == dtype
+    assert rotated_key.dtype == dtype
+    cos = cos.unsqueeze(-2).float()
+    sin = sin.unsqueeze(-2).float()
+
+    def rotate_half(value):
+        midpoint = value.shape[-1] // 2
+        return torch.cat((-value[..., midpoint:], value[..., :midpoint]), dim=-1)
+
+    expected_query = (query.float() * cos + rotate_half(query.float()) * sin).to(dtype)
+    expected_key = (key.float() * cos + rotate_half(key.float()) * sin).to(dtype)
+    torch.testing.assert_close(rotated_query, expected_query)
+    torch.testing.assert_close(rotated_key, expected_key)
+
+
+def test_official_task_presets_and_sigma_spacing():
+    assert task_preset("t2i")["steps"] == 50
+    assert task_preset("t2v")["planning_steps"] == 50
+    sigmas = unipc_flow_sigmas(16, 5.0)
+    expected = torch.tensor(
+        [0.9997998476, 0.9866341949, 0.9720060229, 0.9556572437, 0.9372654557]
+    )
+    torch.testing.assert_close(sigmas[:5], expected)
+    assert sigmas[-1] == 0
+
+
+class _ToyComfyModel:
+    def __call__(self, sample, sigma, **_kwargs):
+        sigma = sigma.reshape(sigma.shape + (1,) * (sample.ndim - sigma.ndim))
+        velocity = 0.2 * sample + 0.1 * sigma
+        return sample - sigma * velocity
+
+
+def test_flow_unipc_is_deterministic_and_finite():
+    noise = torch.tensor([[[[0.25, -0.5], [1.0, -1.5]]]])
+    sigmas = unipc_flow_sigmas(8, 5.0)
+    scaled_noise = noise * sigmas[0]
+    first = sample_flow_unipc_bh2(_ToyComfyModel(), scaled_noise, sigmas)
+    second = sample_flow_unipc_bh2(_ToyComfyModel(), scaled_noise, sigmas)
+    torch.testing.assert_close(first, second)
+    assert torch.isfinite(first).all()
+
+
+def test_standalone_planner_embedded_payload_contract():
+    payload = b'{"hidden_size":3584}'
+    state_dict = {
+        "config_json": torch.tensor(list(payload), dtype=torch.uint8),
+        "tokenizer_json": torch.tensor([1, 2, 3], dtype=torch.uint8),
+    }
+    assert _embedded_json(state_dict, "config_json") == {"hidden_size": 3584}
+    assert _embedded_bytes(state_dict, "tokenizer_json") == b"\x01\x02\x03"
+    with pytest.raises(ValueError, match="missing embedded tensor"):
+        _embedded_bytes(state_dict, "tokenizer_config")
+
+
+def test_standalone_planner_embedded_payload_rejects_wrong_dtype():
+    state_dict = {"config_json": torch.ones(4, dtype=torch.float32)}
+    with pytest.raises(ValueError, match="one-dimensional U8"):
+        _embedded_json(state_dict, "config_json")
+
+
+def test_maskgit_order_is_seeded_and_scatter_compatible():
+    order = maskgit_order(8, 42)
+    assert torch.equal(order, maskgit_order(8, 42))
+    assert not torch.equal(order, maskgit_order(8, 43))
+    assert sorted(order.tolist()) == list(range(8))
+    selected = torch.zeros(8, dtype=torch.bool)
+    selected.scatter_(0, order[:3], True)
+    assert selected.sum() == 3
+    assert torch.equal(
+        maskgit_order(8, 0xFFFFFFFFFFFFFFFF),
+        maskgit_order(8, 0xFFFFFFFF),
+    )
+
+
+class _RecordingTokenizer:
+    def __init__(self):
+        self.texts = []
+        self.ids = {}
+
+    def convert_tokens_to_ids(self, value):
+        if isinstance(value, list):
+            return [self.convert_tokens_to_ids(item) for item in value]
+        if value not in self.ids:
+            self.ids[value] = len(self.ids) + 100
+        return self.ids[value]
+
+    def add_special_tokens(self, values):
+        for token in values["additional_special_tokens"]:
+            self.convert_tokens_to_ids(token)
+
+    def encode(self, text, add_special_tokens=False):
+        del add_special_tokens
+        self.texts.append(text)
+        return [len(self.texts)]
+
+
+def test_template_mask_dtype_negative_prompt_and_visual_limit():
+    token_type = torch.tensor([[0, 3]])
+    segment_ids = torch.tensor([[0, 1]])
+    mask = build_custom_attention_mask(token_type, segment_ids, dtype=torch.bfloat16)
+    assert mask.dtype == torch.bfloat16
+
+    tokenizer = _RecordingTokenizer()
+    template = BerniniTemplate(tokenizer)
+    conversation = build_conversation(
+        "replace the sky",
+        source_videos=0,
+        source_images=0,
+        output_is_image=True,
+    )
+    encoded = template.encode(
+        conversation,
+        num_tokens={"video": [], "image": [4]},
+        task="t2i",
+        drop_text=True,
+        negative_prompt="坏",
+        mask_dtype=torch.bfloat16,
+    )
+    assert encoded["attention_mask_4d"].dtype == torch.bfloat16
+    assert any("坏" in text for text in tokenizer.texts)
+    assert not any("replace the sky" in text for text in tokenizer.texts)
+    with pytest.raises(ValueError, match="at most 64 visual items, got 65"):
+        template._visual_pattern(1, 64, output=False)

--- a/tests-unit/comfy_test/bernini_v2_test.py
+++ b/tests-unit/comfy_test/bernini_v2_test.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 
 import comfy.ops
+import comfy.ldm.bernini_v2.qwen as bernini_qwen
 from comfy.ldm.bernini_v2.guidance import (
     apg_delta,
     compose_denoised_guidance,
@@ -22,6 +23,7 @@ from comfy.ldm.bernini_v2.planner_model import (
 )
 from comfy.ldm.bernini_v2.presets import task_preset
 from comfy.ldm.bernini_v2.qwen import (
+    _explicit_gqa_attention,
     planner_video_frame_indices,
     process_qwen2vl_video,
     qwen_grid_for_media,
@@ -235,6 +237,88 @@ def test_qwen_patchification_and_frame_policy():
     assert len(indices) == 10
     assert indices[0] == 0
     assert indices[-1] == 80
+
+
+def test_qwen_gqa_expands_kv_heads_in_official_order():
+    captured = {}
+
+    def attention(query, key, value, heads, **kwargs):
+        captured.update(key=key, value=value, heads=heads, kwargs=kwargs)
+        return query
+
+    query = torch.zeros(1, 4, 2, 3)
+    key = torch.arange(12).reshape(1, 2, 2, 3)
+    value = key + 100
+    result = _explicit_gqa_attention(attention)(
+        query,
+        key,
+        value,
+        4,
+        enable_gqa=True,
+        mask="mask",
+    )
+
+    assert result is query
+    assert captured["key"].shape == query.shape
+    assert captured["key"][0, :, 0, 0].tolist() == [0, 0, 6, 6]
+    assert captured["value"][0, :, 0, 0].tolist() == [100, 100, 106, 106]
+    assert captured["kwargs"] == {"mask": "mask"}
+
+
+def test_plan_forward_uses_input_dtype_rope_and_explicit_gqa(monkeypatch):
+    captured = {}
+
+    def attention(query, key, value, heads, **kwargs):
+        captured.update(key=key, value=value, heads=heads, kwargs=kwargs)
+        return query.transpose(1, 2).flatten(2)
+
+    monkeypatch.setattr(
+        bernini_qwen,
+        "optimized_attention_for_device",
+        lambda *args, **kwargs: attention,
+    )
+
+    class Layer:
+        def __call__(self, x, freqs_cis, optimized_attention, **kwargs):
+            captured["rope_dtypes"] = tuple(value.dtype for value in freqs_cis)
+            query = torch.zeros(1, 4, 1, 2, dtype=x.dtype)
+            key = torch.zeros(1, 2, 1, 2, dtype=x.dtype)
+            optimized_attention(
+                query,
+                key,
+                key,
+                4,
+                enable_gqa=True,
+                mask=kwargs["attention_mask"],
+                skip_reshape=True,
+            )
+            return x, None
+
+    class Model:
+        layers = [Layer()]
+
+        @staticmethod
+        def compute_freqs_cis(position_ids, device):
+            del position_ids
+            return tuple(torch.ones(1, device=device) for _ in range(3))
+
+    inputs = torch.ones(1, 1, 4, dtype=torch.bfloat16)
+    result = bernini_qwen.plan_forward(
+        Model(),
+        inputs,
+        torch.zeros(3, 1, 1, dtype=torch.long),
+        torch.zeros(1, 1, 1, dtype=torch.bfloat16),
+        intermediate_output=0,
+    )
+
+    assert torch.equal(result, inputs)
+    assert captured["rope_dtypes"] == (torch.bfloat16,) * 3
+    assert captured["key"].shape == (1, 4, 1, 2)
+    assert captured["kwargs"]["skip_reshape"] is True
+    assert torch.equal(
+        captured["kwargs"]["mask"],
+        torch.zeros(1, 1, 1, 1, dtype=torch.bfloat16),
+    )
 
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])


### PR DESCRIPTION
Adds native Bernini v2 support using only Core-compatible standalone model files.

- loads one planner from models/text_encoders and one Wan expert per file from models/diffusion_models
- reuses the existing Wan CLIPLoader for UMT5
- implements the six released planning/rendering tasks, dual-expert guidance, and flow UniPC sampler
- removes the sharded package, index, and runtime manifest design from the superseded PR

Validation:
- python -m pytest tests-unit/comfy_test/bernini_v2_test.py -q (25 passed)
- python -m ruff check on all changed files
- node import/schema smoke test, including the CoreModelPatcher alias and renderer dtype fallback
- real INT8 standalone load: planner, UMT5, high-noise Wan, and low-noise Wan
- real BF16 standalone load validated in the companion node repository

Supersedes #16001.

Closes #15702.