### PR TITLE
Add SenseNova 1.x thinking support

### DIFF
--- a/comfy/ldm/sensenova/model.py
+++ b/comfy/ldm/sensenova/model.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+import comfy.model_management
 import comfy.patcher_extension
 import comfy.utils
 from comfy.ldm.common_dit import pad_to_patch_size
@@ -20,6 +21,9 @@ NUM_KV_HEADS = 8
 HEAD_DIM = 128
 MERGED_PATCH_SIZE = 32
 VOCAB_SIZE = 151936
+EOS_TOKEN_ID = 151645
+THINK_END_TOKEN_ID = 151668
+THINK_SUFFIX_TOKEN_IDS = (271, 151670)
 
 
 def _pad_to_merged_patch_size(value):
@@ -318,6 +322,24 @@ class Attention(nn.Module):
         )
         return self.o_proj_mot_gen(output)
 
+    def forward_decode(
+        self, hidden_states, rope, prefix_key, prefix_value, transformer_options
+    ):
+        query, key, value = self._project(hidden_states, rope, False)
+        key = torch.cat((prefix_key, key), dim=2)
+        value = torch.cat((prefix_value, value), dim=2)
+        output = optimized_attention(
+            query,
+            key,
+            value,
+            NUM_HEADS,
+            mask=None,
+            skip_reshape=True,
+            transformer_options=transformer_options,
+            enable_gqa=True,
+        )
+        return self.o_proj(output), key, value
+
 
 class DecoderLayer(nn.Module):
     def __init__(self, device=None, dtype=None, operations=None):
@@ -363,6 +385,22 @@ class DecoderLayer(nn.Module):
         image = image + self.mlp_mot_gen(self.post_attention_layernorm_mot_gen(image))
         return image
 
+    def forward_decode(
+        self, hidden_states, rope, prefix_key, prefix_value, transformer_options
+    ):
+        attention, key, value = self.self_attn.forward_decode(
+            self.input_layernorm(hidden_states),
+            rope,
+            prefix_key,
+            prefix_value,
+            transformer_options,
+        )
+        hidden_states = hidden_states + attention
+        hidden_states = hidden_states + self.mlp(
+            self.post_attention_layernorm(hidden_states)
+        )
+        return hidden_states, key, value
+
 
 class LanguageBackbone(nn.Module):
     def __init__(self, device=None, dtype=None, operations=None):
@@ -383,9 +421,17 @@ class LanguageBackbone(nn.Module):
 
 
 class LanguageModel(nn.Module):
-    def __init__(self, device=None, dtype=None, operations=None):
+    def __init__(self, has_lm_head=False, device=None, dtype=None, operations=None):
         super().__init__()
         self.model = LanguageBackbone(device=device, dtype=dtype, operations=operations)
+        if has_lm_head:
+            self.lm_head = operations.Linear(
+                HIDDEN_SIZE,
+                VOCAB_SIZE,
+                bias=False,
+                device=device,
+                dtype=dtype,
+            )
 
 
 class ConvDecoder(nn.Module):
@@ -409,15 +455,25 @@ class ConvDecoder(nn.Module):
 
 class SenseNovaU15(nn.Module):
     def __init__(
-        self, image_model=None, dtype=None, device=None, operations=None, **kwargs
+        self,
+        image_model=None,
+        has_lm_head=False,
+        dtype=None,
+        device=None,
+        operations=None,
+        **kwargs,
     ):
         super().__init__()
         self.dtype = dtype
+        self.has_lm_head = has_lm_head
         self.vision_model = VisionModel(
             device=device, dtype=dtype, operations=operations
         )
         self.language_model = LanguageModel(
-            device=device, dtype=dtype, operations=operations
+            has_lm_head=has_lm_head,
+            device=device,
+            dtype=dtype,
+            operations=operations,
         )
         self.fm_modules = nn.ModuleDict(
             {
@@ -485,12 +541,13 @@ class SenseNovaU15(nn.Module):
 
         return prefix, prefix_indexes, prefix_mask, prefix_time
 
-    def preprocess_prefix(
+    def _preprocess_prefix_state(
         self,
         text_input_ids,
         reference_images=None,
         prefix_indexes=None,
         prefix_mask=None,
+        transformer_options=None,
     ):
         prefix, prefix_indexes, prefix_mask, prefix_time = self._prepare_prefix(
             text_input_ids, reference_images, prefix_indexes, prefix_mask
@@ -498,7 +555,8 @@ class SenseNovaU15(nn.Module):
         prefix_keys = []
         prefix_values = []
         prefix_rope = _prepare_mrope(prefix_indexes, prefix.device, prefix.dtype)
-        transformer_options = {}
+        if transformer_options is None:
+            transformer_options = {}
         for layer_index, layer in enumerate(self.language_model.model.layers):
             transformer_options["block_index"] = layer_index
             prefix, prefix_key, prefix_value = layer.forward_prefix(
@@ -509,6 +567,134 @@ class SenseNovaU15(nn.Module):
             )
             prefix_keys.append(prefix_key)
             prefix_values.append(prefix_value)
+        return prefix, prefix_keys, prefix_values, prefix_time
+
+    def preprocess_prefix(
+        self,
+        text_input_ids,
+        reference_images=None,
+        prefix_indexes=None,
+        prefix_mask=None,
+        transformer_options=None,
+    ):
+        _, prefix_keys, prefix_values, prefix_time = (
+            SenseNovaU15._preprocess_prefix_state(
+                self,
+                text_input_ids,
+                reference_images,
+                prefix_indexes,
+                prefix_mask,
+                transformer_options,
+            )
+        )
+        return prefix_keys, prefix_values, prefix_time
+
+    def _next_text_token(self, hidden_states):
+        hidden_states = self.language_model.model.norm(hidden_states[:, -1:])
+        return self.language_model.lm_head(hidden_states)[:, -1].argmax(dim=-1)
+
+    def _decode_text_token(
+        self,
+        token,
+        prefix_keys,
+        prefix_values,
+        prefix_time,
+        transformer_options=None,
+    ):
+        hidden_states = self.language_model.model.embed_tokens(token[:, None])
+        positions = prefix_time[:, None]
+        zeros = torch.zeros_like(positions)
+        rope = _prepare_mrope(
+            torch.stack((positions, zeros, zeros)),
+            hidden_states.device,
+            hidden_states.dtype,
+        )
+        next_keys = []
+        next_values = []
+        if transformer_options is None:
+            transformer_options = {}
+        for layer_index, layer in enumerate(self.language_model.model.layers):
+            transformer_options["block_index"] = layer_index
+            hidden_states, key, value = layer.forward_decode(
+                hidden_states,
+                rope,
+                prefix_keys[layer_index],
+                prefix_values[layer_index],
+                transformer_options,
+            )
+            next_keys.append(key)
+            next_values.append(value)
+        return hidden_states, next_keys, next_values, prefix_time + 1
+
+    def preprocess_thinking_prefix(
+        self,
+        text_input_ids,
+        reference_images=None,
+        prefix_indexes=None,
+        prefix_mask=None,
+        max_think_tokens=1024,
+        transformer_options=None,
+    ):
+        if not self.has_lm_head:
+            raise RuntimeError(
+                "This SenseNova checkpoint does not contain language_model.lm_head.weight, "
+                "which is required for thinking."
+            )
+        if text_input_ids.shape[0] != 1:
+            raise ValueError("SenseNova thinking currently requires a single prompt batch.")
+
+        hidden_states, prefix_keys, prefix_values, prefix_time = (
+            self._preprocess_prefix_state(
+                text_input_ids,
+                reference_images,
+                prefix_indexes,
+                prefix_mask,
+                transformer_options,
+            )
+        )
+        next_token = self._next_text_token(hidden_states)
+        closed_thinking = False
+        progress = comfy.utils.ProgressBar(max_think_tokens)
+        for step in comfy.utils.model_trange(
+            max_think_tokens, desc="SenseNova thinking"
+        ):
+            comfy.model_management.throw_exception_if_processing_interrupted()
+            token_id = int(next_token.item())
+            if token_id == EOS_TOKEN_ID:
+                break
+            hidden_states, prefix_keys, prefix_values, prefix_time = (
+                self._decode_text_token(
+                    next_token,
+                    prefix_keys,
+                    prefix_values,
+                    prefix_time,
+                    transformer_options,
+                )
+            )
+            progress.update_absolute(step + 1)
+            if token_id == THINK_END_TOKEN_ID:
+                closed_thinking = True
+                break
+            next_token = self._next_text_token(hidden_states)
+
+        if not closed_thinking:
+            closing_token = torch.full_like(next_token, THINK_END_TOKEN_ID)
+            _, prefix_keys, prefix_values, prefix_time = self._decode_text_token(
+                closing_token,
+                prefix_keys,
+                prefix_values,
+                prefix_time,
+                transformer_options,
+            )
+        for token_id in THINK_SUFFIX_TOKEN_IDS:
+            suffix = torch.full_like(next_token, token_id)
+            _, prefix_keys, prefix_values, prefix_time = self._decode_text_token(
+                suffix,
+                prefix_keys,
+                prefix_values,
+                prefix_time,
+                transformer_options,
+            )
         return prefix_keys, prefix_values, prefix_time
 
     def _forward(
@@ -524,6 +710,8 @@ class SenseNovaU15(nn.Module):
         prefix_keys=None,
         prefix_values=None,
         prefix_time=None,
+        sensenova_thinking=False,
+        sensenova_max_think_tokens=1024,
         **kwargs,
     ):
         if text_input_ids is None and prefix_keys is None:
@@ -572,10 +760,24 @@ class SenseNovaU15(nn.Module):
         image = image + time_embedding[:, None, :]
 
         if prefix_keys is None:
-            prefix, prefix_indexes, prefix_mask, prefix_time = self._prepare_prefix(
-                text_input_ids, reference_images, prefix_indexes, prefix_mask
-            )
-            prefix_rope = _prepare_mrope(prefix_indexes, prefix.device, prefix.dtype)
+            if sensenova_thinking:
+                prefix_keys, prefix_values, prefix_time = (
+                    self.preprocess_thinking_prefix(
+                        text_input_ids,
+                        reference_images,
+                        prefix_indexes,
+                        prefix_mask,
+                        max_think_tokens=sensenova_max_think_tokens,
+                        transformer_options=transformer_options,
+                    )
+                )
+            else:
+                prefix, prefix_indexes, prefix_mask, prefix_time = self._prepare_prefix(
+                    text_input_ids, reference_images, prefix_indexes, prefix_mask
+                )
+                prefix_rope = _prepare_mrope(
+                    prefix_indexes, prefix.device, prefix.dtype
+                )
         image_time = prefix_time.repeat_interleave(generation_batch)
 
         image_positions = torch.arange(image_length, dtype=torch.long, device=x.device)

--- a/comfy/model_base.py
+++ b/comfy/model_base.py
@@ -2376,6 +2376,7 @@ class SenseNovaU15(BaseModel):
             if reference_images is not None:
                 reference_images = comfy.ldm.sensenova.conditioning.preprocess_references(reference_images)
             image_only = kwargs.get("prompt_type") == "negative"
+            thinking = bool(kwargs.get("sensenova_thinking", False)) and not image_only
             indexes = None
             prefix_mask = None
             if reference_images:
@@ -2396,23 +2397,37 @@ class SenseNovaU15(BaseModel):
                     indexes, dtype=self.get_dtype_inference()
                 )
 
-            if kwargs.get("hooks") is None:
+            hooks = kwargs.get("hooks")
+            if hooks is None:
                 dtype = self.get_dtype_inference()
-                prefix_keys, prefix_values, prefix_time = (
-                    self.diffusion_model.preprocess_prefix(
-                        text_input_ids.to(device=device),
-                        [
-                            image.to(device=device, dtype=dtype)
-                            for image in reference_images
-                        ]
-                        if reference_images
-                        else None,
-                        indexes.to(device=device) if indexes is not None else None,
-                        prefix_mask.to(device=device)
-                        if prefix_mask is not None
-                        else None,
-                    )
+                prefix_args = (
+                    text_input_ids.to(device=device),
+                    [
+                        image.to(device=device, dtype=dtype)
+                        for image in reference_images
+                    ]
+                    if reference_images
+                    else None,
+                    indexes.to(device=device) if indexes is not None else None,
+                    prefix_mask.to(device=device)
+                    if prefix_mask is not None
+                    else None,
                 )
+                if thinking:
+                    prefix_keys, prefix_values, prefix_time = (
+                        self.diffusion_model.preprocess_thinking_prefix(
+                            *prefix_args,
+                            max_think_tokens=int(
+                                kwargs.get("sensenova_max_think_tokens", 1024)
+                            ),
+                        )
+                    )
+                else:
+                    prefix_keys, prefix_values, prefix_time = (
+                        self.diffusion_model.preprocess_prefix(
+                            *prefix_args,
+                        )
+                    )
                 out["prefix_keys"] = SenseNovaSharedList(prefix_keys)
                 out["prefix_values"] = SenseNovaSharedList(prefix_values)
                 out["prefix_time"] = SenseNovaSharedRegular(prefix_time)
@@ -2422,6 +2437,11 @@ class SenseNovaU15(BaseModel):
                     out["prefix_mask"] = SenseNovaSharedRegular(prefix_mask)
                     out["reference_images"] = SenseNovaSharedList(reference_images)
                 out["text_input_ids"] = SenseNovaSharedRegular(text_input_ids)
+                if thinking:
+                    out["sensenova_thinking"] = comfy.conds.CONDConstant(True)
+                    out["sensenova_max_think_tokens"] = comfy.conds.CONDConstant(
+                        int(kwargs.get("sensenova_max_think_tokens", 1024))
+                    )
         return out
 
     def extra_conds_shapes(self, **kwargs):
@@ -2452,7 +2472,13 @@ class SenseNovaU15(BaseModel):
             else:
                 length = text_input_ids.shape[1]
             out["prefix_mask"] = [1, 1, length, length]
-            if kwargs.get("hooks") is None:
+            image_only = kwargs.get("prompt_type") == "negative"
+            thinking = bool(kwargs.get("sensenova_thinking", False)) and not image_only
+            if kwargs.get("hooks") is None or thinking:
+                if thinking:
+                    length += int(kwargs.get("sensenova_max_think_tokens", 1024))
+                    length += 1
+                    length += len(comfy.ldm.sensenova.model.THINK_SUFFIX_TOKEN_IDS)
                 prefix_shape = [
                     1,
                     comfy.ldm.sensenova.model.NUM_KV_HEADS,

--- a/comfy/model_detection.py
+++ b/comfy/model_detection.py
@@ -823,7 +823,11 @@ def detect_unet_config(state_dict, key_prefix, metadata=None):
         and state_dict[vision_key].shape[0] == 1024
         and state_dict[query_key].shape[0] == 4096
     ):  # SenseNova U1.5
-        return {"image_model": "sensenova_u15"}
+        return {
+            "image_model": "sensenova_u15",
+            "has_lm_head": f"{key_prefix}language_model.lm_head.weight"
+            in state_dict,
+        }
 
     if '{}caption_projection.0.linear.weight'.format(key_prefix) in state_dict_keys:  # HiDream
         dit_config = {}

--- a/comfy/supported_models.py
+++ b/comfy/supported_models.py
@@ -1743,10 +1743,6 @@ class SenseNovaU15(supported_models_base.BASE):
     def get_model(self, state_dict, prefix="", device=None):
         return model_base.SenseNovaU15(self, device=device)
 
-    def process_unet_state_dict(self, state_dict):
-        state_dict.pop("language_model.lm_head.weight", None)
-        return state_dict
-
     def process_vae_state_dict(self, state_dict):
         return {"pixel_space_vae": torch.tensor(1.0)}
 

--- a/comfy/text_encoders/sensenova.py
+++ b/comfy/text_encoders/sensenova.py
@@ -34,11 +34,12 @@ SYSTEM_MESSAGE = (
 )
 
 
-def build_generation_prompt(text):
+def build_generation_prompt(text, thinking=False):
+    assistant = "<think>\n" if thinking else "<think>\n\n</think>\n\n<img>"
     return (
         f"<|im_start|>system\n{SYSTEM_MESSAGE}<|im_end|>\n"
         f"<|im_start|>user\n{text}<|im_end|>\n"
-        "<|im_start|>assistant\n<think>\n\n</think>\n\n<img>"
+        f"<|im_start|>assistant\n{assistant}"
     )
 
 
@@ -108,7 +109,12 @@ class SenseNovaTokenizer(sd1_clip.SD1Tokenizer):
         )
 
     def tokenize_with_weights(self, text, return_word_ids=False, **kwargs):
-        prompt = build_generation_prompt(text) if text else build_unconditional_prompt()
+        thinking = kwargs.pop("thinking", False)
+        prompt = (
+            build_generation_prompt(text, thinking=thinking)
+            if text or thinking
+            else build_unconditional_prompt()
+        )
         tokens = super().tokenize_with_weights(
             prompt,
             return_word_ids=return_word_ids,

--- a/comfy_extras/nodes_sensenova.py
+++ b/comfy_extras/nodes_sensenova.py
@@ -28,10 +28,48 @@ class SenseNovaSamplingOptions(io.ComfyNode):
         return io.NodeOutput(patched)
 
 
+class SenseNovaTextEncode(io.ComfyNode):
+    @classmethod
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
+            node_id="SenseNovaTextEncode",
+            display_name="SenseNova 1.x Text Encode",
+            category="model/conditioning/sensenova",
+            description="Encode a SenseNova prompt with optional image-generation reasoning.",
+            inputs=[
+                io.Clip.Input(id="clip"),
+                io.String.Input(id="text", multiline=True, dynamic_prompts=True),
+                io.Boolean.Input(id="thinking", default=False),
+                io.Int.Input(
+                    id="max_think_tokens",
+                    default=1024,
+                    min=1,
+                    advanced=True,
+                ),
+            ],
+            outputs=[io.Conditioning.Output()],
+        )
+
+    @classmethod
+    def execute(
+        cls, *, clip, text: str, thinking: bool, max_think_tokens: int
+    ) -> io.NodeOutput:
+        tokens = clip.tokenize(text, thinking=thinking)
+        conditioning = clip.encode_from_tokens_scheduled(
+            tokens,
+            add_dict={
+                "sensenova_thinking": thinking,
+                "sensenova_max_think_tokens": max_think_tokens,
+            },
+        )
+        return io.NodeOutput(conditioning)
+
+
 class SenseNovaExtension(ComfyExtension):
     @override
     async def get_node_list(self) -> list[type[io.ComfyNode]]:
         return [
+            SenseNovaTextEncode,
             SenseNovaSamplingOptions,
         ]
 

--- a/tests-unit/comfy_test/test_sensenova.py
+++ b/tests-unit/comfy_test/test_sensenova.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from comfy.cli_args import args
@@ -24,13 +25,16 @@ from comfy.ldm.sensenova.sampling import (
     resolution_noise_scale,
     upstream_sigmas,
 )
-from comfy.text_encoders.sensenova import SenseNovaTokenizer
+from comfy.text_encoders.sensenova import SenseNovaTokenizer, build_generation_prompt
 from comfy_extras.nodes_hidream_o1 import HiDreamO1ReferenceImages
-from comfy_extras.nodes_sensenova import SenseNovaSamplingOptions
+from comfy_extras.nodes_sensenova import (
+    SenseNovaSamplingOptions,
+    SenseNovaTextEncode,
+)
 
 
-def _minimal_state_dict():
-    return {
+def _minimal_state_dict(has_lm_head=False):
+    state_dict = {
         "fm_modules.vision_model_mot_gen.embeddings.patch_embedding.weight": torch.empty(
             1024, 3, 16, 16, device="meta"
         ),
@@ -38,6 +42,11 @@ def _minimal_state_dict():
             4096, 4096, device="meta"
         ),
     }
+    if has_lm_head:
+        state_dict["language_model.lm_head.weight"] = torch.empty(
+            151936, 4096, device="meta"
+        )
+    return state_dict
 
 
 def _generation_input_ids():
@@ -77,12 +86,24 @@ def test_sensenova_top_level_checkpoint_detection():
 
     assert model_detection.unet_prefix_from_state_dict(state_dict) == ""
     assert model_detection.detect_unet_config(state_dict, "") == {
-        "image_model": "sensenova_u15"
+        "image_model": "sensenova_u15",
+        "has_lm_head": False,
     }
     assert (
         type(model_detection.model_config_from_unet(state_dict, "")).__name__
         == "SenseNovaU15"
     )
+
+
+def test_sensenova_checkpoint_detection_preserves_thinking_capability():
+    config = model_detection.detect_unet_config(
+        _minimal_state_dict(has_lm_head=True), ""
+    )
+
+    assert config == {
+        "image_model": "sensenova_u15",
+        "has_lm_head": True,
+    }
 
 
 def test_sensenova_detection_rejects_incompatible_dimensions():
@@ -102,7 +123,11 @@ def test_sensenova_model_config_builds_pixel_space_outputs():
     }
 
     processed = model_config.process_unet_state_dict(state_dict)
-    assert set(processed) == {"kept"}
+    assert set(processed) == {"language_model.lm_head.weight", "kept"}
+    assert torch.equal(
+        processed["language_model.lm_head.weight"],
+        state_dict["language_model.lm_head.weight"],
+    )
     assert torch.equal(processed["kept"], state_dict["kept"])
     assert "pixel_space_vae" in model_config.process_vae_state_dict({})
     assert "_sensenova_te_sentinel" in model_config.process_clip_state_dict({})
@@ -433,6 +458,174 @@ def test_sensenova_model_base_preprocesses_prefix_conditioning():
     assert conds["prefix_time"].cond.tolist() == [3]
 
 
+def test_sensenova_model_base_preprocesses_thinking_only_for_positive():
+    thinking_calls = []
+    regular_calls = []
+
+    def preprocess_thinking_prefix(*args, max_think_tokens):
+        thinking_calls.append((args, max_think_tokens))
+        return (
+            [torch.zeros(1, 1, 5, 1, dtype=torch.bfloat16)],
+            [torch.ones(1, 1, 5, 1, dtype=torch.bfloat16)],
+            torch.tensor([5]),
+        )
+
+    def preprocess_prefix(*args):
+        regular_calls.append(args)
+        return (
+            [torch.zeros(1, 1, 3, 1, dtype=torch.bfloat16)],
+            [torch.ones(1, 1, 3, 1, dtype=torch.bfloat16)],
+            torch.tensor([3]),
+        )
+
+    model = object.__new__(model_base.SenseNovaU15)
+    torch.nn.Module.__init__(model)
+    model.concat_keys = ()
+    model.manual_cast_dtype = None
+    model.diffusion_model = SimpleNamespace(
+        dtype=torch.bfloat16,
+        preprocess_prefix=preprocess_prefix,
+        preprocess_thinking_prefix=preprocess_thinking_prefix,
+    )
+    input_ids = torch.tensor([[1, 2, 3]])
+
+    positive = model.extra_conds(
+        text_input_ids=input_ids,
+        sensenova_thinking=True,
+        sensenova_max_think_tokens=17,
+        prompt_type="positive",
+        device=torch.device("cpu"),
+    )
+    model.extra_conds(
+        text_input_ids=input_ids,
+        sensenova_thinking=True,
+        prompt_type="negative",
+        device=torch.device("cpu"),
+    )
+    hooked = model.extra_conds(
+        text_input_ids=input_ids,
+        sensenova_thinking=True,
+        sensenova_max_think_tokens=23,
+        prompt_type="positive",
+        hooks=object(),
+        device=torch.device("cpu"),
+    )
+
+    assert len(thinking_calls) == 1
+    assert thinking_calls[0][1] == 17
+    assert len(regular_calls) == 1
+    assert positive["prefix_time"].cond.tolist() == [5]
+    assert hooked["text_input_ids"].cond.tolist() == input_ids.tolist()
+    assert hooked["sensenova_thinking"].cond is True
+    assert hooked["sensenova_max_think_tokens"].cond == 23
+
+
+def test_sensenova_thinking_decode_appends_stop_and_image_suffix(monkeypatch):
+    model = object.__new__(sensenova_model.SenseNovaU15)
+    torch.nn.Module.__init__(model)
+    model.has_lm_head = True
+    tokens = iter((42, sensenova_model.THINK_END_TOKEN_ID))
+    decoded = []
+
+    model._preprocess_prefix_state = lambda *args: (
+        torch.zeros(1, 1, 1),
+        [torch.zeros(1, 1, 1, 1)],
+        [torch.zeros(1, 1, 1, 1)],
+        torch.tensor([3]),
+    )
+    model._next_text_token = lambda hidden: torch.tensor([next(tokens)])
+
+    def decode(token, keys, values, prefix_time, transformer_options=None):
+        decoded.append(int(token.item()))
+        return torch.zeros(1, 1, 1), keys, values, prefix_time + 1
+
+    model._decode_text_token = decode
+    monkeypatch.setattr(
+        sensenova_model.comfy.utils,
+        "model_trange",
+        lambda count, desc: range(count),
+    )
+    monkeypatch.setattr(
+        sensenova_model.comfy.utils,
+        "ProgressBar",
+        lambda count: SimpleNamespace(update_absolute=lambda value: None),
+    )
+    monkeypatch.setattr(
+        sensenova_model.comfy.model_management,
+        "throw_exception_if_processing_interrupted",
+        lambda: None,
+    )
+
+    _, _, prefix_time = model.preprocess_thinking_prefix(
+        torch.tensor([[1, 2, 3]]), max_think_tokens=4
+    )
+
+    assert decoded == [
+        42,
+        sensenova_model.THINK_END_TOKEN_ID,
+        *sensenova_model.THINK_SUFFIX_TOKEN_IDS,
+    ]
+    assert prefix_time.tolist() == [7]
+
+
+@pytest.mark.parametrize(
+    ("tokens", "max_think_tokens", "expected_decoded"),
+    [
+        ((42, 43), 1, [42, sensenova_model.THINK_END_TOKEN_ID]),
+        ((sensenova_model.EOS_TOKEN_ID,), 4, [sensenova_model.THINK_END_TOKEN_ID]),
+    ],
+)
+def test_sensenova_thinking_closes_truncated_reasoning(
+    monkeypatch, tokens, max_think_tokens, expected_decoded
+):
+    model = object.__new__(sensenova_model.SenseNovaU15)
+    torch.nn.Module.__init__(model)
+    model.has_lm_head = True
+    token_iterator = iter(tokens)
+    decoded = []
+
+    model._preprocess_prefix_state = lambda *args: (
+        torch.zeros(1, 1, 1),
+        [torch.zeros(1, 1, 1, 1)],
+        [torch.zeros(1, 1, 1, 1)],
+        torch.tensor([3]),
+    )
+    model._next_text_token = lambda hidden: torch.tensor([next(token_iterator)])
+
+    def decode(token, keys, values, prefix_time, transformer_options=None):
+        decoded.append(int(token.item()))
+        return torch.zeros(1, 1, 1), keys, values, prefix_time + 1
+
+    model._decode_text_token = decode
+    monkeypatch.setattr(
+        sensenova_model.comfy.utils,
+        "model_trange",
+        lambda count, desc: range(count),
+    )
+    monkeypatch.setattr(
+        sensenova_model.comfy.utils,
+        "ProgressBar",
+        lambda count: SimpleNamespace(update_absolute=lambda value: None),
+    )
+    monkeypatch.setattr(
+        sensenova_model.comfy.model_management,
+        "throw_exception_if_processing_interrupted",
+        lambda: None,
+    )
+
+    _, _, prefix_time = model.preprocess_thinking_prefix(
+        torch.tensor([[1, 2, 3]]), max_think_tokens=max_think_tokens
+    )
+
+    assert decoded == [
+        *expected_decoded,
+        *sensenova_model.THINK_SUFFIX_TOKEN_IDS,
+    ]
+    assert prefix_time.tolist() == [
+        3 + len(expected_decoded) + len(sensenova_model.THINK_SUFFIX_TOKEN_IDS)
+    ]
+
+
 def test_sensenova_uses_prompt_type_for_negative_reference_conditioning():
     calls = []
 
@@ -552,10 +745,31 @@ def test_sensenova_preprocessed_prefix_matches_raw_forward():
         prefix_time=prefix_time,
         transformer_options={},
     )
+    thinking_calls = []
+
+    def preprocess_thinking_prefix(*args, **kwargs):
+        thinking_calls.append((args, kwargs))
+        return prefix_keys, prefix_values, prefix_time
+
+    model.preprocess_thinking_prefix = preprocess_thinking_prefix
+    thinking_options = {}
+    thinking = sensenova_model.SenseNovaU15._forward(
+        model,
+        image,
+        timesteps,
+        text_input_ids=input_ids,
+        sensenova_thinking=True,
+        sensenova_max_think_tokens=7,
+        transformer_options=thinking_options,
+    )
 
     assert torch.equal(raw, preprocessed)
-    assert timestep_embedder.shapes == [torch.Size([1]), torch.Size([1])]
-    assert noise_scale_embedder.shapes == [torch.Size([1]), torch.Size([1])]
+    assert torch.equal(thinking, preprocessed)
+    assert thinking_calls[0][0][:4] == (input_ids, None, None, None)
+    assert thinking_calls[0][1]["max_think_tokens"] == 7
+    assert thinking_calls[0][1]["transformer_options"] is thinking_options
+    assert timestep_embedder.shapes == [torch.Size([1])] * 3
+    assert noise_scale_embedder.shapes == [torch.Size([1])] * 3
 
 
 def test_sensenova_reference_tokens_and_indexes():
@@ -655,3 +869,61 @@ def test_sensenova_tokenizer_control_token_ids():
     assert "<|im_start|>" in backend.all_special_tokens
     assert "<|vision_pad|>" in backend.all_special_tokens
     assert tokenizer.tokenize_with_weights("")["sensenova_u15"][0][-1][0] == 151670
+
+
+def test_sensenova_generation_prompt_selects_thinking_protocol():
+    no_thinking = build_generation_prompt("test")
+    thinking = build_generation_prompt("test", thinking=True)
+
+    assert no_thinking.endswith("<think>\n\n</think>\n\n<img>")
+    assert thinking.endswith("<think>\n")
+    assert thinking.rsplit("<|im_start|>assistant\n", 1)[-1] == "<think>\n"
+
+
+def test_sensenova_text_encode_adds_reasoning_policy():
+    calls = []
+
+    class Clip:
+        def tokenize(self, text, **kwargs):
+            calls.append(("tokenize", text, kwargs))
+            return {"tokens": text}
+
+        def encode_from_tokens_scheduled(self, tokens, add_dict):
+            calls.append(("encode", tokens, add_dict))
+            return [[torch.empty(1), add_dict]]
+
+    output = SenseNovaTextEncode.execute(
+        clip=Clip(),
+        text="test",
+        thinking=True,
+        max_think_tokens=64,
+    ).args[0]
+
+    assert calls[0] == ("tokenize", "test", {"thinking": True})
+    assert calls[1][2] == {
+        "sensenova_thinking": True,
+        "sensenova_max_think_tokens": 64,
+    }
+    assert output[0][1]["sensenova_thinking"] is True
+
+
+def test_sensenova_thinking_memory_estimate_includes_decode_limit():
+    model = object.__new__(model_base.SenseNovaU15)
+    input_ids = torch.empty(1, 10, dtype=torch.long)
+
+    shapes = model.extra_conds_shapes(
+        text_input_ids=input_ids,
+        sensenova_thinking=True,
+        sensenova_max_think_tokens=5,
+        prompt_type="positive",
+    )
+
+    expected_length = 10 + 5 + 1 + len(sensenova_model.THINK_SUFFIX_TOKEN_IDS)
+    assert shapes["prefix_mask"] == [1, 1, 10, 10]
+    assert shapes["prefix_keys"] == [
+        1,
+        sensenova_model.NUM_KV_HEADS,
+        sensenova_model.NUM_LAYERS
+        * expected_length
+        * sensenova_model.HEAD_DIM,
+    ]


### PR DESCRIPTION
## Problem

SenseNova 1.x checkpoints can include an LM head for autoregressive reasoning before image generation, but the native loader currently discards that weight and the tokenizer always inserts an empty `<think>` block. This limits the native workflow to no-thinking generation.

## Changes

- Detect and preserve the optional SenseNova language-model head.
- Add a `SenseNova 1.x Text Encode` node with opt-in thinking and a configurable token limit.
- Autoregressively build the reasoning KV prefix, with interruption/progress support and correct EOS, `</think>`, and `<img>` handling.
- Keep negative conditioning in no-thinking mode and preserve the existing T2I/Edit reference-image workflow.
- Support both precomputed conditioning and the standard dynamic-hooks path.
- Account for the worst-case thinking KV cache in memory estimation.

## Tests

- `python -m pytest tests-unit/comfy_test/test_sensenova.py -q` — 31 passed
- `python -m pytest tests-unit/comfy_test/model_detection_test.py -q` — 16 passed
- `python -m ruff check` on all changed Python files
- `git diff --check`
