### PR TITLE
[review-stack 8/8] deps-semantics — synap5e/feat/assets-di-v2

### DIFF
--- a/app/assets/api/routes.py
+++ b/app/assets/api/routes.py
@@ -1,3 +1,11 @@
+"""Serves the asset HTTP API: listing, detail, upload, tagging, hash-addressed
+creation and scan control. A feature gate wraps every handler and answers 503
+when the asset system is switched off or its database dependencies are absent,
+and failures leave as a JSON envelope carrying a stable machine-readable code
+rather than aiohttp's default text. Handlers own request parsing and error
+shaping only; the work itself belongs to the services layer.
+"""
+
 import asyncio
 import functools
 import json
@@ -139,12 +147,18 @@ def _build_validation_error_response(code: str, ve: ValidationError) -> web.Resp
     return _build_error_response(400, code, "Validation failed.", {"errors": errors})
 
 
+class SystemTagForbiddenError(Exception):
+    def __init__(self, tag: str):
+        super().__init__(
+            f"Tag '{tag}' is system-managed and cannot be modified via the API"
+        )
+        self.tag = tag
+
+
 def _reject_system_tags(tags: list[str]) -> None:
     for tag in tags:
         if tag in SYSTEM_TAGS:
-            raise web.HTTPBadRequest(
-                reason=f"Tag '{tag}' is system-managed and cannot be modified via the API"
-            )
+            raise SystemTagForbiddenError(tag)
 
 
 class InvalidTagFilterError(Exception):
@@ -896,9 +910,8 @@ async def add_asset_tags(request: web.Request) -> web.Response:
             400, "INVALID_JSON", "Request body must be valid JSON."
         )
 
-    _reject_system_tags(data.tags)
-
     try:
+        _reject_system_tags(data.tags)
         result = apply_tags(
             reference_id=reference_id,
             tags=data.tags,
@@ -908,6 +921,10 @@ async def add_asset_tags(request: web.Request) -> web.Response:
             added=result.added,
             already_present=result.already_present,
             total_tags=result.total_tags,
+        )
+    except SystemTagForbiddenError as se:
+        return _build_error_response(
+            400, "SYSTEM_TAG_FORBIDDEN", str(se), {"tag": se.tag}
         )
     except PermissionError as pe:
         return _build_error_response(403, "FORBIDDEN", str(pe), {"id": reference_id})
@@ -945,9 +962,8 @@ async def delete_asset_tags(request: web.Request) -> web.Response:
             400, "INVALID_JSON", "Request body must be valid JSON."
         )
 
-    _reject_system_tags(data.tags)
-
     try:
+        _reject_system_tags(data.tags)
         result = remove_tags(
             reference_id=reference_id,
             tags=data.tags,
@@ -957,6 +973,10 @@ async def delete_asset_tags(request: web.Request) -> web.Response:
             not_present=result.not_present,
             total_tags=result.total_tags,
             protected=result.protected,
+        )
+    except SystemTagForbiddenError as se:
+        return _build_error_response(
+            400, "SYSTEM_TAG_FORBIDDEN", str(se), {"tag": se.tag}
         )
     except PermissionError as pe:
         return _build_error_response(403, "FORBIDDEN", str(pe), {"id": reference_id})

--- a/app/assets/api/schemas_in.py
+++ b/app/assets/api/schemas_in.py
@@ -1,3 +1,10 @@
+"""Parses and validates everything the asset API accepts from a client, so
+handlers receive typed values instead of raw JSON. Query strings, JSON bodies
+and multipart upload specs each get a model that rejects malformed input at the
+boundary, normalizes tags and hashes, and raises errors already carrying the
+HTTP status and code the handler should return.
+"""
+
 import json
 from dataclasses import dataclass
 from typing import Any, Literal

--- a/app/assets/api/schemas_out.py
+++ b/app/assets/api/schemas_out.py
@@ -1,3 +1,9 @@
+"""Defines the response bodies the asset API returns, fixing the field names,
+types and serialization its HTTP contract promises. Routes dump these models
+with null fields omitted, so whether a field is absent and whether it is empty
+stay distinguishable to a client.
+"""
+
 from datetime import datetime
 from typing import Any
 

--- a/app/assets/api/upload.py
+++ b/app/assets/api/upload.py
@@ -1,3 +1,11 @@
+"""Reads a multipart upload off the wire and lands its bytes in a temporary file
+the ingest service can hash and move. The body is consumed in chunks so a large
+model never has to fit in memory, and the temporary file is removed on every
+failure path so an abandoned upload leaves nothing behind. Field values are
+validated as they arrive, letting a bad request fail before its bytes are
+written.
+"""
+
 import logging
 import os
 import uuid

--- a/app/assets/database/models.py
+++ b/app/assets/database/models.py
@@ -1,3 +1,11 @@
+"""Declares the asset schema: content rows describing bytes on disk, records
+describing what a user sees, and the tag and metadata tables hanging off them.
+The split is the point — many records can name one content row, and retiring
+content by marking it missing rather than deleting it is what keeps a path's
+history intact. Constraints declared here, not application code, are what make
+a negative size or a second live row at one path impossible.
+"""
+
 from __future__ import annotations
 
 import uuid

--- a/app/assets/database/queries/__init__.py
+++ b/app/assets/database/queries/__init__.py
@@ -1,3 +1,9 @@
+"""Re-exports the record and tag query functions so callers import them from one
+place instead of reaching into individual query modules. A module-level
+``__getattr__`` resolves names that live in the tag module, keeping this import
+surface flat as queries are split across more files.
+"""
+
 from importlib import import_module
 
 from app.assets.database.queries.records import (

--- a/app/assets/database/queries/records.py
+++ b/app/assets/database/queries/records.py
@@ -1,3 +1,11 @@
+"""Owns every write to content rows, records and their tag links, plus the paged
+reads that list them. Inserts that can lose a race — a content row at a path, a
+tag, a tag link — run inside a savepoint and re-read the conflicting row, so a
+concurrent writer settles the call instead of raising, while a genuine
+constraint failure still surfaces. This is the sole writer of a content row's
+path, which is what lets other modules trust raw-column path predicates.
+"""
+
 from __future__ import annotations
 
 import os
@@ -64,15 +72,40 @@ def create_content(session: Session, path: str, hash: str | None = None, size_by
         return winner
 
 
+def ensure_tag(session: Session, name: str) -> None:
+    if session.get(Tag, name) is not None:
+        return
+    try:
+        with session.begin_nested():
+            session.add(Tag(name=name))
+            session.flush()
+    except IntegrityError:
+        # Only a row that is now present proves a lost race; anything else is a real failure.
+        if session.get(Tag, name) is None:
+            raise
+
+
+def ensure_tag_link(session: Session, *, asset_id: str, tag_name: str, origin: str) -> bool:
+    if session.get(AssetTag, (asset_id, tag_name)) is not None:
+        return False
+    try:
+        with session.begin_nested():
+            session.add(AssetTag(asset_id=asset_id, tag_name=tag_name, origin=origin))
+            session.flush()
+    except IntegrityError:
+        if session.get(AssetTag, (asset_id, tag_name)) is None:
+            raise
+        return False
+    return True
+
+
 def create_record(session: Session, content_id: str, name: str, mime_type: str | None = None, job_id: str | None = None, loader_path: str | None = None, tags: Sequence[str] | None = None, *, system_metadata: dict[str, Any] | None = None) -> Asset:
     record = Asset(content_id=content_id, name=name, mime_type=mime_type, job_id=job_id, loader_path=loader_path, system_metadata=system_metadata)
     session.add(record)
     session.flush()
-    for tag_name in tags or ():
-        if session.get(Tag, tag_name) is None:
-            session.add(Tag(name=tag_name))
-            session.flush()
-        session.add(AssetTag(asset_id=record.id, tag_name=tag_name))
+    for tag_name in dict.fromkeys(tags or ()):
+        ensure_tag(session, tag_name)
+        ensure_tag_link(session, asset_id=record.id, tag_name=tag_name, origin="manual")
     session.flush()
     return record
 
@@ -280,12 +313,9 @@ def mark_content_missing(session: Session, content_id: str) -> None:
     if content is None:
         raise LookupError(content_id)
     content.is_missing = True
-    if session.get(Tag, "missing") is None:
-        session.add(Tag(name="missing"))
-        session.flush()
+    ensure_tag(session, "missing")
     for record_id in session.scalars(sa.select(Asset.id).where(Asset.content_id == content_id)):
-        if session.get(AssetTag, {"asset_id": record_id, "tag_name": "missing"}) is None:
-            session.add(AssetTag(asset_id=record_id, tag_name="missing", origin="automatic"))
+        ensure_tag_link(session, asset_id=record_id, tag_name="missing", origin="automatic")
     session.flush()
 
 

--- a/app/assets/database/queries/tags.py
+++ b/app/assets/database/queries/tags.py
@@ -1,3 +1,10 @@
+"""Answers questions about tag usage: which tags exist with how many assets, and
+how those counts narrow once a filter is applied. Both queries reuse the record
+listing's own joins and filter clauses, so the counts a client sees always
+describe the same assets the listing endpoint would return for that filter,
+records with missing content included.
+"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/app/assets/docs/README.md
+++ b/app/assets/docs/README.md
@@ -1,6 +1,6 @@
 # Assets
 
-The asset system is only active when explicitly enabled at startup; it is off by default. When it is not enabled, asset API routes return a disabled-service error and no background filesystem scanning occurs.
+The asset system is only active when explicitly enabled at startup; it is off by default. When it is not enabled, asset API routes return a disabled-service error and no background filesystem scanning occurs. Routes answer that same disabled-service error when the system is enabled but its database dependencies are unavailable.
 
 ## Data model
 
@@ -54,7 +54,7 @@ stateDiagram-v2
 
 A reappeared file that matches no missing candidate, or more than one, does not recover any of them. The scanner creates a new content row for the file instead, and the missing candidates stay missing. The same old-missing-plus-new-content shape applies to a same-path edit or reuse: the old row is marked missing and a separate new row and record are created for the new bytes, never transformed in place.
 
-Only a hash can recover a missing content row, with one narrow exception for rows that were never hashed. The scanner hashes the file now present at the missing path and recovers the row only when exactly one missing candidate for that path has the same hash. If no candidate matches, the scanner creates new content. If multiple candidates match, none recover.
+Only a hash can recover a missing content row, with one narrow exception for rows that were never hashed. The scanner hashes the file now present at the missing path and recovers the row only when exactly one missing candidate for that path has the same hash. If no candidate matches, the scanner creates new content. If multiple candidates match, none recover. Recovery also never fires for a path a live content row already occupies: the file there belongs to that row, and ordinary change detection owns it.
 
 A missing row can have a null hash, for example a file deleted before it was ever hashed while every server was down during an off-to-on hashing transition. Such a row can never satisfy the hash comparison, so it has its own narrower recovery condition: it recovers only when it is the single missing null-hash candidate at that path, and its recorded byte size and modification time exactly match the reappeared file's verified stat. The freshly computed hash is set on the row as part of recovery. The stat facts are the only recorded identity a never-hashed row has, so a same-path reappearance that does not preserve them creates new content instead, and the old row stays missing rather than risk recovering the wrong record.
 
@@ -73,7 +73,7 @@ With hashing on, the scanner uses modification time as the cheap change detector
 - If the hash is unchanged, refresh the stored file facts on the existing content row.
 - If the hash changed, mark the old content missing and create a new content row and asset record for the path.
 
-The system persists the previous hashing mode. On a transition from off to on, it hashes every live row without a hash and revalidates every live row that already has one. On a transition from on to off, it retains existing hashes as inert data.
+The system persists the previous hashing mode. On a transition from off to on, it hashes every live row without a hash and revalidates every live row that already has one. A file that cannot be read after a bounded number of attempts keeps its record live with its stored hash cleared, and the transition completes without it. On a transition from on to off, it retains existing hashes as inert data.
 
 Hashing must use a stable file snapshot. The worker checks file facts before and after hashing and accepts the digest only when they still match each other. Otherwise it retries later.
 
@@ -131,13 +131,13 @@ Classification is fixed at record creation. A newly visible path receives the re
 
 ### Delete through the API
 
-Delete the target asset record. Leave its content row and file intact. Do not soft-delete the record, retain a tombstone, or revive the deleted identity during later discovery.
+Delete the target asset record. Leave its content row and file intact. Do not soft-delete the record or revive the deleted identity during later discovery. The retained content row is not a tombstone: it is ordinary live content describing bytes that are still there, and nothing records that a deletion happened.
 
 Deleting a record never deletes any other record. A preview record the deleted asset nominated stays untouched; references to a preview clear only when the preview record itself is deleted. The preview reference points from the deleted record to its target, so deleting the pointer must not destroy the target.
 
 Content left behind after all its asset records are deleted can still be resolved by hash lookup, falling back to a generic name and a guessed content type when no record is left to supply one. There is currently no mechanism that reclaims or removes such orphaned content.
 
-If the file can be found again, a later scan may create a fresh asset record. It must never recreate the deleted identity.
+That retained row is also what makes the deletion durable. A scan seeds only paths with no live content row, so an unchanged file is never given a new record however often it is rediscovered. Only new content at that path produces a fresh asset record: bytes that changed and retired the old row, or content minted after the old row itself is gone. Such a record describes the new content and must never recreate the deleted identity.
 
 ### Rename
 
@@ -313,7 +313,7 @@ Accept a digest only from a stable snapshot (see Hashing modes).
 
 ### Concurrent writers
 
-Database constraints choose the winner when scanners, hooks, or uploads race within one process. Losing writers retry or discard their work, with one known exception: tag creation checks for an existing tag and then inserts without conflict handling, so a genuine race there can surface as an unhandled server error rather than a clean retry-or-discard outcome.
+Database constraints choose the winner when scanners, hooks, or uploads race within one process. Losing writers retry or discard their work. Tag and tag-link inserts run inside a savepoint and re-read the row they collided with, so a duplicate-key collision between concurrent tag writers settles quietly instead of surfacing an error. That covers duplicate keys only; lock contention is a separate limit (see Write pressure and reader starvation).
 
 A file lock prevents more than one server process from opening the same database, so a second process never becomes a concurrent writer in the first place. Do not add advisory locks.
 
@@ -339,4 +339,4 @@ When startup finds the schema that predates the record/content split, it drops a
 
 Scanning runs in the background after startup returns, so the asset API can already be serving requests while the rebuilt tables are still being populated.
 
-The rebuild discards data that a scan cannot reconstruct: manual tags, user metadata, preview assignments, API-created records, `job_id` links, and any record renames.
+The rebuild discards data that a scan cannot reconstruct: manual tags, user metadata, preview assignments, API-created records, `job_id` links, any record renames, and deletions — nothing records which assets were deleted, so the scan mints a record for every file still on disk. When the rebuild runs, startup logs a warning naming the backup file and what was discarded.

--- a/app/assets/docs/README.md
+++ b/app/assets/docs/README.md
@@ -1,6 +1,6 @@
 # Assets
 
-The asset system is only active when explicitly enabled at startup; it is off by default. When it is not enabled, asset API routes return a disabled-service error and no background filesystem scanning occurs. Routes answer that same disabled-service error when the system is enabled but its database dependencies are unavailable.
+The asset system is only active when explicitly enabled at startup; it is off by default. When it is not enabled, asset API routes return a disabled-service error and no background filesystem scanning occurs. Enabling the asset system without its database dependencies is a startup failure with an actionable error; without the flag those dependencies are not imported at all.
 
 ## Data model
 

--- a/app/assets/helpers.py
+++ b/app/assets/helpers.py
@@ -1,3 +1,9 @@
+"""Small conversions the asset system needs in more than one layer: canonical
+stored-hash strings, UTC timestamps, tag normalization, and a SQL predicate for
+path containment. That predicate is deliberately case-sensitive and
+component-bounded, because callers use it to choose rows for hard deletion.
+"""
+
 import os
 from datetime import datetime, timezone
 

--- a/app/assets/lifecycle.py
+++ b/app/assets/lifecycle.py
@@ -1,3 +1,11 @@
+"""Runs the asset system's startup and shutdown maintenance: clearing temp rows
+and files, recording a hash-mode transition, and handing the filesystem scan to
+the background seeder. Startup only enqueues transition work — draining it
+belongs to the seeder, so a large library cannot stall the server before it
+accepts requests. It also settles, before any of that, whether the database
+dependencies exist at all, disabling the asset routes when they do not.
+"""
+
 from __future__ import annotations
 
 import logging
@@ -10,7 +18,6 @@ from sqlalchemy import select
 from app.assets.database.models import Asset, AssetContent
 from app.assets.database.queries.records import delete_record
 from app.assets.helpers import sql_path_under_prefix
-from app.assets.services.hash_mode_state import drain_transition_queue
 from app.assets.services.hash_mode_state import enqueue_transition_work
 from app.assets.services.hash_mode_state import record_transition_intent
 from app.database.db import can_create_session, create_session
@@ -35,12 +42,6 @@ def record_hash_mode_transition_intent() -> None:
 def enqueue_mode_transition_work() -> None:
     with create_session() as session:
         enqueue_transition_work(session, _hash_mode_transition)
-        session.commit()
-
-
-def drain_mode_transition_work() -> None:
-    with create_session() as session:
-        drain_transition_queue(session)
         session.commit()
 
 
@@ -113,12 +114,10 @@ def run_asset_startup() -> None:
     except Exception:
         logging.exception("Temp DB row wipe failed; skipping filesystem cleanup")
         enqueue_mode_transition_work()
-        drain_mode_transition_work()
         start_asset_seeder()
         return
     cleanup_temp_filesystem()
     enqueue_mode_transition_work()
-    drain_mode_transition_work()
     start_asset_seeder()
 
 

--- a/app/assets/manager.py
+++ b/app/assets/manager.py
@@ -1,21 +1,33 @@
+from __future__ import annotations
+
 import logging
+import sys
 from typing import Any, Callable, Protocol
 
 from aiohttp import web
 
 from app.assets import mode
-from app.assets.api.routes import register_assets_routes
-from app.assets.lifecycle import record_hash_mode_transition_intent, run_shutdown, run_startup
-from app.assets.seeder import asset_seeder
-from app.assets.services.ingest import (
-    register_cached_output as ingest_register_cached_output,
-    register_executed_output as ingest_register_executed_output,
-    register_file_in_place,
-)
-from app.assets.services.path_utils import get_known_subfolder_tags
-from app.assets.services.schemas import RegisteredAsset, UploadAssetView
+from app.database.db import dependencies_available
 from app.user_manager import UserManager
 from comfy.cli_args import args
+from utils.install_util import get_missing_requirements_message
+
+
+try:
+    from app.assets.api.routes import register_assets_routes
+    from app.assets.lifecycle import record_hash_mode_transition_intent, run_shutdown, run_startup
+    from app.assets.seeder import asset_seeder
+    from app.assets.services.ingest import (
+        register_cached_output as ingest_register_cached_output,
+        register_executed_output as ingest_register_executed_output,
+        register_file_in_place,
+    )
+    from app.assets.services.path_utils import get_known_subfolder_tags
+    from app.assets.services.schemas import RegisteredAsset, UploadAssetView
+except ImportError as error:
+    _IMPORT_ERROR = error
+else:
+    _IMPORT_ERROR = None
 
 
 class AssetManager(Protocol):
@@ -88,6 +100,9 @@ class NoAssets:
     def register_routes(
         self, app: web.Application, user_manager: UserManager | None
     ) -> None:
+        if _IMPORT_ERROR is not None:
+            logging.warning("Asset routes unavailable because dependencies are missing: %s", _IMPORT_ERROR)
+            return
         register_assets_routes(app)
         asset_seeder.disable()
 
@@ -214,4 +229,22 @@ class AssetsEnabled:
 
 
 def default_asset_manager() -> AssetManager:
-    return AssetsEnabled(args) if args.enable_assets else NoAssets(args)
+    if not args.enable_assets:
+        return NoAssets(args)
+    if _IMPORT_ERROR is not None or not dependencies_available():
+        import_error_message = f"\nImport error: {_IMPORT_ERROR}" if _IMPORT_ERROR is not None else ""
+        logging.error(
+            "The --enable-assets flag requires the asset system's database dependencies.\n"
+            f"{get_missing_requirements_message()}{import_error_message}"
+        )
+        sys.exit(1)
+    if args.enable_asset_hashing:
+        try:
+            import blake3
+        except ImportError:
+            logging.error(
+                "The --enable-assets and --enable-asset-hashing flags require blake3.\n"
+                f"{get_missing_requirements_message()}"
+            )
+            sys.exit(1)
+    return AssetsEnabled(args)

--- a/app/assets/mode.py
+++ b/app/assets/mode.py
@@ -1,3 +1,9 @@
+"""Holds whether asset hashing is enabled for this process, taken from the
+command-line flag once at startup. Callers ask here rather than reading
+arguments themselves, and asking before initialization raises instead of
+defaulting, so a route can never quietly answer as though hashing were off.
+"""
+
 from __future__ import annotations
 
 from typing import Protocol

--- a/app/assets/scanner.py
+++ b/app/assets/scanner.py
@@ -1,3 +1,12 @@
+"""Walks the asset roots and turns what it finds into catalog rows: collecting
+paths, building specs, seeding new content and records, then enriching them
+with metadata and hashes. Each spec is seeded inside its own savepoint, so one
+file whose row conflicts cannot discard the work done for the files around it.
+Enrichment counts as progress only when it produced what was asked of it — a
+requested hash that could not be computed is no progress, which is what bounds
+a pass over a file the server cannot read.
+"""
+
 import logging
 import os
 from dataclasses import dataclass
@@ -6,6 +15,7 @@ from typing import Callable, Literal, TypedDict
 
 import folder_paths
 import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from app.assets import mode
 from app.assets.database.queries import (
@@ -315,45 +325,50 @@ def seed_asset_specs(session: Session, specs: list[SeedAssetSpec]) -> int:
         for spec in specs:
             path = os.path.abspath(spec["abs_path"])
             try:
-                stat_result = os.stat(path, follow_symlinks=True)
-            except OSError:
-                logging.warning("Skipping vanished asset during scan: %s", path)
+                with session.begin_nested():
+                    try:
+                        stat_result = os.stat(path, follow_symlinks=True)
+                    except OSError:
+                        logging.warning("Skipping vanished asset during scan: %s", path)
+                        continue
+                    try:
+                        recovery = recover_missing_content(
+                            session,
+                            path,
+                            stat_result,
+                            hashing_is_enabled=mode.hashing_enabled(),
+                        )
+                    except OSError:
+                        logging.warning("Skipping vanished asset during scan: %s", path)
+                        continue
+                    if recovery != "no_match":
+                        continue
+                    content = create_content(
+                        session,
+                        path=path,
+                        hash=None,
+                        size_bytes=spec["size_bytes"],
+                        mtime_ns=spec["mtime_ns"],
+                    )
+                    created_content_ids.append(content.id)
+                    existing_record = session.scalar(
+                        sa.select(Asset.id).where(Asset.content_id == content.id).limit(1)
+                    )
+                    if existing_record is not None:
+                        continue
+                    create_record(
+                        session,
+                        content_id=content.id,
+                        name=spec["info_name"],
+                        mime_type=spec["mime_type"],
+                        job_id=spec["job_id"],
+                        loader_path=spec["fname"],
+                        tags=spec["tags"],
+                    )
+                    created += 1
+            except IntegrityError:
+                logging.warning("Skipping asset whose row conflicts during scan: %s", path)
                 continue
-            try:
-                recovery = recover_missing_content(
-                    session,
-                    path,
-                    stat_result,
-                    hashing_is_enabled=mode.hashing_enabled(),
-                )
-            except OSError:
-                logging.warning("Skipping vanished asset during scan: %s", path)
-                continue
-            if recovery != "no_match":
-                continue
-            content = create_content(
-                session,
-                path=path,
-                hash=None,
-                size_bytes=spec["size_bytes"],
-                mtime_ns=spec["mtime_ns"],
-            )
-            created_content_ids.append(content.id)
-            existing_record = session.scalar(
-                sa.select(Asset.id).where(Asset.content_id == content.id).limit(1)
-            )
-            if existing_record is not None:
-                continue
-            create_record(
-                session,
-                content_id=content.id,
-                name=spec["info_name"],
-                mime_type=spec["mime_type"],
-                job_id=spec["job_id"],
-                loader_path=spec["fname"],
-                tags=spec["tags"],
-            )
-            created += 1
     except Exception:
         session.rollback()
         for content_id in created_content_ids:
@@ -456,7 +471,8 @@ def enrich_asset(
     digest: str | None = None
     stored_hash: str | None = None
     verified_stat: os.stat_result | None = None
-    if compute_hash and content is not None and content.hash is None:
+    hash_requested = compute_hash and content is not None and content.hash is None
+    if hash_requested:
         try:
             snapshot = snapshot_hash(file_path)
             if snapshot is None:
@@ -508,6 +524,8 @@ def enrich_asset(
 
     session.commit()
 
+    if hash_requested and stored_hash is None:
+        return False
     return stored_hash is not None or metadata is not None or mime_type is not None
 
 

--- a/app/assets/scanner_admission.py
+++ b/app/assets/scanner_admission.py
@@ -1,3 +1,11 @@
+"""Decides whether a file observed during a filesystem walk is settled enough to
+catalog, and parks the ones that are not. Admission requires two stats taken a
+moment apart to agree; a file still changing, or carrying a partial-download
+extension, goes onto a bounded watch list that later scans re-check until it
+settles, vanishes, or exhausts its retries. This is what keeps a model that is
+still downloading out of the catalog.
+"""
+
 from __future__ import annotations
 
 import mimetypes

--- a/app/assets/scanner_changes.py
+++ b/app/assets/scanner_changes.py
@@ -1,3 +1,10 @@
+"""Reconciles catalogued content against what is actually on disk: retiring rows
+whose file is gone, splitting a row whose bytes changed, and recovering one
+whose file came back. Recovery fires only when the returning file's hash
+identifies exactly one missing row and no live row already occupies that path,
+so a restored file can never leave two live rows describing one location.
+"""
+
 from __future__ import annotations
 
 import os
@@ -40,6 +47,13 @@ def recover_missing_content(
     session: Session, path: str, stat_result: os.stat_result, hashing_is_enabled: bool
 ) -> Literal["recovered", "no_match", "unstable"]:
     if not hashing_is_enabled:
+        return "no_match"
+    occupied = session.scalar(
+        sa.select(AssetContent.id)
+        .where(AssetContent.path == path, AssetContent.is_missing.is_(False))
+        .limit(1)
+    )
+    if occupied is not None:
         return "no_match"
     snapshot = snapshot_hash(path)
     if snapshot is None:

--- a/app/assets/seeder.py
+++ b/app/assets/seeder.py
@@ -1,4 +1,10 @@
-"""Background asset seeder with thread management and cancellation support."""
+"""Runs the filesystem scan on a background thread so startup never waits for it,
+exposing pause, resume, cancel and progress to the API. A run seeds
+newly-observed files first, then enriches records in batches, and settles any
+pending hash-mode transition at the start of the enrich phase so a server that
+receives no prompts still completes the switch. A pass stops once batches stop
+making progress, bounding a scan over files that cannot be read.
+"""
 
 import logging
 import os
@@ -23,7 +29,7 @@ from app.assets.scanner import (
     drain_pending_verifications,
     tick_watch_list,
 )
-from app.assets.services.hash_mode_state import drain_transition_queue
+from app.assets.services.hash_mode_state import drain_transition_queue, pending_transition_count
 from app.database.db import create_session, dependencies_available
 
 
@@ -785,8 +791,11 @@ class _AssetSeeder:
         with create_session() as session:
             drain_pending_verifications(session)
             tick_watch_list(session)
-            drain_transition_queue(session)
-            session.commit()
+            for _ in range(3):
+                drain_transition_queue(session)
+                session.commit()
+                if pending_transition_count() == 0:
+                    break
         batch_size = 100
         last_progress_time = time.perf_counter()
         progress_interval = 1.0

--- a/app/assets/services/__init__.py
+++ b/app/assets/services/__init__.py
@@ -1,3 +1,7 @@
+"""Re-exports the asset service functions so routes and the seeder import them
+from one place instead of reaching into individual service modules.
+"""
+
 from app.assets.services.ingest import (
     DependencyMissingError,
     HashMismatchError,

--- a/app/assets/services/asset_management.py
+++ b/app/assets/services/asset_management.py
@@ -1,10 +1,17 @@
+"""Serves the per-asset operations behind the API: reading an asset's detail,
+updating its name, tags, metadata and preview, deleting a record, and resolving
+a hash to a servable path. An update moves ``updated_at`` only when it actually
+changed something, so a call that requests what is already true is not recorded
+as a user edit.
+"""
+
 import mimetypes
 import os
 from typing import Sequence
 
 from sqlalchemy import delete, select, update
 
-from app.assets.database.models import Asset, AssetContent, AssetTag, Tag
+from app.assets.database.models import Asset, AssetContent, AssetTag
 from app.assets.database.queries import (
     delete_record,
     fetch_record_tags,
@@ -13,6 +20,8 @@ from app.assets.database.queries import (
 )
 from app.assets.database.queries.records import (
     bump_record_updated_at,
+    ensure_tag,
+    ensure_tag_link,
     get_preview_file_paths_by_ids,
     rename_record,
 )
@@ -124,17 +133,13 @@ def update_asset_metadata(
             )
         if tags is not None:
             for tag_name in normalize_tags(list(tags)):
-                if session.get(Tag, tag_name) is None:
-                    session.add(Tag(name=tag_name))
-                    session.flush()
-                if session.get(AssetTag, (reference_id, tag_name)) is None:
-                    session.add(
-                        AssetTag(
-                            asset_id=reference_id,
-                            tag_name=tag_name,
-                            origin=tag_origin,
-                        )
-                    )
+                ensure_tag(session, tag_name)
+                ensure_tag_link(
+                    session,
+                    asset_id=reference_id,
+                    tag_name=tag_name,
+                    origin=tag_origin,
+                )
             session.flush()
             if _fetch_manual_tags(session, reference_id) != manual_tags_before:
                 bump_record_updated_at(session, reference_id)

--- a/app/assets/services/hash_mode_state.py
+++ b/app/assets/services/hash_mode_state.py
@@ -1,7 +1,18 @@
+"""Tracks the persisted hashing mode and carries the existing catalog across an
+off-to-on switch. Turning hashing on enqueues every live content row for
+verification and the queue is drained in the background; a path that cannot be
+read is retried a bounded number of times and then has its stored hash cleared,
+so the queue can empty and the mode can flip. An unverifiable digest never
+survives into the persisted enabled state.
+"""
+
 from __future__ import annotations
 
 import logging
 import os
+from collections import deque
+from dataclasses import dataclass
+from typing import Final
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -14,7 +25,17 @@ from app.assets.services.path_utils import compute_loader_path, get_name_and_tag
 from app.assets.services.snapshot_hash import snapshot_hash
 
 _KEY = "hash_mode"
-_PENDING_QUEUE: list[str] = []
+_MAX_VERIFY_ATTEMPTS: Final = 3
+
+
+@dataclass
+class _PendingEntry:
+    path: str
+    ticks: int = 0
+
+
+_PENDING_QUEUE: deque[_PendingEntry] = deque()
+_PENDING_PATHS: set[str] = set()
 _off_to_on_transition_in_flight = False
 
 
@@ -22,6 +43,7 @@ def clear_transition_queue() -> None:
     global _off_to_on_transition_in_flight
 
     _PENDING_QUEUE.clear()
+    _PENDING_PATHS.clear()
     _off_to_on_transition_in_flight = False
 
 
@@ -67,8 +89,30 @@ def enqueue_transition_work(session: Session, transition: str | None) -> None:
         select(AssetContent).where(AssetContent.is_missing.is_(False))
     )
     for row in rows:
-        if row.path not in _PENDING_QUEUE:
-            _PENDING_QUEUE.append(row.path)
+        if row.path not in _PENDING_PATHS:
+            _PENDING_QUEUE.append(_PendingEntry(row.path))
+            _PENDING_PATHS.add(row.path)
+
+
+def _retry_or_retire(session: Session, entry: _PendingEntry) -> None:
+    entry.ticks += 1
+    if entry.ticks < _MAX_VERIFY_ATTEMPTS:
+        _PENDING_QUEUE.append(entry)
+        _PENDING_PATHS.add(entry.path)
+        return
+    content = session.scalars(
+        select(AssetContent).where(
+            AssetContent.path == entry.path, AssetContent.is_missing.is_(False)
+        )
+    ).first()
+    if content is not None:
+        content.hash = None
+    logging.warning(
+        "Could not verify %s in %d attempts; clearing its stored hash so the hash-mode "
+        "transition can complete",
+        entry.path,
+        _MAX_VERIFY_ATTEMPTS,
+    )
 
 
 def drain_transition_queue(session: Session) -> None:
@@ -76,11 +120,13 @@ def drain_transition_queue(session: Session) -> None:
 
     pending_count = len(_PENDING_QUEUE)
     for _ in range(pending_count):
-        path = _PENDING_QUEUE.pop(0)
+        entry = _PENDING_QUEUE.popleft()
+        _PENDING_PATHS.discard(entry.path)
+        path = entry.path
         try:
             snapshot = snapshot_hash(path)
         except OSError:
-            _PENDING_QUEUE.append(path)
+            _retry_or_retire(session, entry)
             continue
         if snapshot is None:
             # snapshot_hash returns None for vanished and unstable files; stat distinguishes them.
@@ -95,9 +141,9 @@ def drain_transition_queue(session: Session) -> None:
                 if gone is not None:
                     mark_content_missing(session, gone.id)
             except OSError:
-                _PENDING_QUEUE.append(path)
+                _retry_or_retire(session, entry)
             else:
-                _PENDING_QUEUE.append(path)
+                _retry_or_retire(session, entry)
             continue
         digest, stat = snapshot
         stored_hash = to_stored_hash(digest)

--- a/app/assets/services/ingest.py
+++ b/app/assets/services/ingest.py
@@ -1,3 +1,12 @@
+"""Turns incoming bytes into catalogued assets: multipart uploads moved into a
+hash-addressed destination, files registered where they already sit, and
+records created from a hash the catalog already holds. Every path persists the
+stat that hashing verified, so a row's recorded size and mtime describe the
+same observation as its hash. A live row already at the destination is
+reconciled before the write, so an upload never adopts a fresh hash onto
+records created for bytes it just replaced.
+"""
+
 import contextlib
 import logging
 import mimetypes
@@ -128,12 +137,11 @@ def _remove_temp_path(temp_path: str | None) -> None:
             os.rmdir(parent)
 
 
-def _snapshot_hash_with_retry(path: str) -> str:
+def _snapshot_hash_with_retry(path: str) -> tuple[str, os.stat_result]:
     for _ in range(_UPLOAD_HASH_ATTEMPTS):
         snapshot = snapshot_hash(path)
         if snapshot is not None:
-            digest, _ = snapshot
-            return digest
+            return snapshot
     raise UploadUnstableError("upload file changed during hashing")
 
 
@@ -364,14 +372,18 @@ def _settle_destination_before_write(session: Session, dest_abs: str) -> None:
     ):
         return
     try:
-        incumbent_digest = _snapshot_hash_with_retry(dest_abs)
+        incumbent_digest, verified_stat = _snapshot_hash_with_retry(dest_abs)
     except (UploadUnstableError, OSError):
         mark_content_missing(session, existing.id)
         return
     _reconcile_live_content_at_path(
         session,
         dest_abs,
-        _ContentFacts(to_stored_hash(incumbent_digest), size_bytes, mtime_ns),
+        _ContentFacts(
+            to_stored_hash(incumbent_digest),
+            verified_stat.st_size,
+            verified_stat.st_mtime_ns,
+        ),
         content_written=False,
     )
 
@@ -427,7 +439,7 @@ def upload_from_temp_path(
     user_metadata = user_metadata or {}
 
     try:
-        digest = _snapshot_hash_with_retry(temp_path)
+        digest, verified_stat = _snapshot_hash_with_retry(temp_path)
     except UploadUnstableError:
         _remove_temp_path(temp_path)
         raise
@@ -446,7 +458,7 @@ def upload_from_temp_path(
             stored_hash,
             _UploadRecordSpec(
                 display_name,
-                [*(tags or []), "uploaded"],
+                normalize_tags([*(tags or []), "uploaded"]),
                 mime_type,
                 user_metadata,
                 preview_id,
@@ -465,7 +477,7 @@ def upload_from_temp_path(
         mime_type, client_filename, name, os.path.basename(dest_abs)
     )
     _move_temp_to_dest(temp_path, dest_abs)
-    size_bytes, mtime_ns = get_size_and_mtime_ns(dest_abs)
+    size_bytes, mtime_ns = verified_stat.st_size, verified_stat.st_mtime_ns
     with create_session() as session:
         _reconcile_live_content_at_path(
             session,
@@ -483,7 +495,7 @@ def upload_from_temp_path(
                 content.id,
                 display_name,
                 dest_abs,
-                [*(tags or []), "uploaded"],
+                normalize_tags([*(tags or []), "uploaded"]),
                 content_type,
                 user_metadata,
                 preview_id,
@@ -540,9 +552,8 @@ def register_file_in_place(
     content_type = _guess_upload_mime_type(
         mime_type, name, name, os.path.basename(locator)
     )
-    size_bytes, mtime_ns = get_size_and_mtime_ns(locator)
-
-    digest = _snapshot_hash_with_retry(locator)
+    digest, verified_stat = _snapshot_hash_with_retry(locator)
+    size_bytes, mtime_ns = verified_stat.st_size, verified_stat.st_mtime_ns
     stored_hash = to_stored_hash(digest)
     with create_session() as session:
         _reconcile_live_content_at_path(

--- a/app/assets/services/lookup.py
+++ b/app/assets/services/lookup.py
@@ -1,3 +1,10 @@
+"""Resolves a hash to a content row that can actually be served, and claims that
+row so a concurrent writer cannot retire it mid-use. A row qualifies only if
+its file exists, sits outside the temp directory, and its recorded size and
+mtime still match the file — an unrecorded mtime excuses the mtime comparison
+but never the size comparison.
+"""
+
 from __future__ import annotations
 
 import os
@@ -28,7 +35,7 @@ def _stat_consistent(content: AssetContent) -> bool:
         return False
     if content.mtime_ns is not None and stat.st_mtime_ns != content.mtime_ns:
         return False
-    if content.mtime_ns is not None and stat.st_size != content.size_bytes:
+    if stat.st_size != content.size_bytes:
         return False
     return True
 

--- a/app/assets/services/schemas.py
+++ b/app/assets/services/schemas.py
@@ -1,3 +1,9 @@
+"""Defines the frozen result types the service layer hands back to routes and to
+the seeder, keeping those callers off ORM objects and the sessions that own
+them. Each type carries only what its caller renders, so nothing can be lazily
+loaded from a row after its session has closed.
+"""
+
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, NamedTuple

--- a/app/assets/services/snapshot_hash.py
+++ b/app/assets/services/snapshot_hash.py
@@ -11,9 +11,6 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 
-from blake3 import blake3
-
-
 @dataclass(frozen=True, slots=True)
 class _Snapshot:
     dev: int
@@ -34,6 +31,8 @@ def _snapshot(stat_result: os.stat_result) -> _Snapshot:
 def snapshot_hash(
     path: str, chunk_size: int = 8 * 1024 * 1024
 ) -> tuple[str, os.stat_result] | None:
+    from blake3 import blake3
+
     try:
         pre_stat = _snapshot(os.stat(path))
         hasher = blake3()

--- a/app/assets/services/snapshot_hash.py
+++ b/app/assets/services/snapshot_hash.py
@@ -1,3 +1,11 @@
+"""Hashes a file and returns the stat it proved describes those exact bytes.
+Identity, size and mtime are sampled before the read, on the open handle at
+both ends of it, and once more afterwards; if any sample disagrees the file
+moved under the reader and the result is discarded rather than returned.
+Callers persist the stat that comes back, which is what makes a stored hash and
+a stored size describe one observation.
+"""
+
 from __future__ import annotations
 
 import os

--- a/app/assets/services/tagging.py
+++ b/app/assets/services/tagging.py
@@ -1,3 +1,10 @@
+"""Applies and removes tags on a record and answers tag listing and histogram
+queries. Adding reports what it actually inserted, read back after the write,
+so a caller that lost a race is told the tag was already present rather than
+that it added one. Removal leaves automatically applied tags in place and
+reports them as protected instead of silently skipping them.
+"""
+
 from typing import Sequence
 
 from sqlalchemy import delete, select
@@ -7,9 +14,13 @@ from app.assets.database.queries import (
     RemoveTagsResult,
     list_tags_with_usage,
 )
-from app.assets.database.queries.records import bump_record_updated_at
+from app.assets.database.queries.records import (
+    bump_record_updated_at,
+    ensure_tag,
+    ensure_tag_link,
+)
 from app.assets.database.queries.tags import list_tag_counts_for_filtered_assets
-from app.assets.database.models import Asset, AssetTag, Tag
+from app.assets.database.models import Asset, AssetTag
 from app.assets.helpers import normalize_tags
 from app.assets.services.schemas import TagUsage
 from app.database.db import create_session
@@ -25,26 +36,19 @@ def apply_tags(
             raise ValueError(f"Asset {reference_id} not found")
 
         normalized_tags = normalize_tags(tags)
-        current_tags = set(
-            session.scalars(
-                select(AssetTag.tag_name).where(AssetTag.asset_id == reference_id)
-            )
-        )
         requested_tags = set(normalized_tags)
+        added: list[str] = []
         for tag_name in normalized_tags:
-            if session.get(Tag, tag_name) is None:
-                session.add(Tag(name=tag_name))
-                session.flush()
-            if tag_name not in current_tags:
-                session.add(
-                    AssetTag(
-                        asset_id=reference_id,
-                        tag_name=tag_name,
-                        origin=origin,
-                    )
-                )
+            ensure_tag(session, tag_name)
+            if ensure_tag_link(
+                session,
+                asset_id=reference_id,
+                tag_name=tag_name,
+                origin=origin,
+            ):
+                added.append(tag_name)
         session.flush()
-        if requested_tags - current_tags:
+        if added:
             bump_record_updated_at(session, reference_id)
         total_tags = list(
             session.scalars(
@@ -56,8 +60,8 @@ def apply_tags(
         session.commit()
 
     return AddTagsResult(
-        added=sorted(requested_tags - current_tags),
-        already_present=sorted(requested_tags & current_tags),
+        added=sorted(added),
+        already_present=sorted((requested_tags & set(total_tags)) - set(added)),
         total_tags=total_tags,
     )
 

--- a/app/database/db.py
+++ b/app/database/db.py
@@ -148,6 +148,16 @@ def _init_file_db(db_url):
         raise
 
 
+_DESTRUCTIVE_REVISION = "0007_record_content_split"
+
+
+def _upgrade_discards_the_catalog(script, target_rev, current_rev):
+    return any(
+        revision.revision == _DESTRUCTIVE_REVISION
+        for revision in script.iterate_revisions(upper=target_rev, lower=current_rev)
+    )
+
+
 def _migrate_and_bind(db_url, db_path, db_exists):
     config = get_alembic_config()
 
@@ -189,6 +199,14 @@ def _migrate_and_bind(db_url, db_path, db_exists):
                 os.remove(backup_path)
             logging.exception("Error upgrading database: ")
             raise e
+
+        if backup_path and _upgrade_discards_the_catalog(script, target_rev, current_rev):
+            log_startup_warning(
+                f"The asset catalog was rebuilt from scratch by migration "
+                f"{_DESTRUCTIVE_REVISION}: manual tags, user metadata, previews, renames, "
+                f"API-created records and job_id links from the previous database were "
+                f"discarded. The database from before the upgrade was kept at {backup_path}."
+            )
 
     conn.close()
 

--- a/comfy_execution/asset_enrichment.py
+++ b/comfy_execution/asset_enrichment.py
@@ -1,3 +1,11 @@
+"""Registers the files a prompt produced as assets, at the moment the execution
+result is emitted. Each output is matched to a path inside its declared base
+directory and skipped when it escapes that directory or is not on disk, and a
+run served from cache replays the same registration so cached results still
+yield assets. Registering at emission rather than by inspecting the cache
+afterwards keeps this independent of any cache eviction policy.
+"""
+
 import copy
 import logging
 import os

--- a/main.py
+++ b/main.py
@@ -22,7 +22,10 @@ console_log_level = get_console_log_level(args.verbose)
 file_log_outputs = get_file_log_outputs(args.verbose)
 setup_logger(log_level=console_log_level, file_outputs=file_log_outputs, use_stdout=args.log_stdout)
 
-from app.assets.lifecycle import cleanup_temp_filesystem
+try:
+    from app.assets.lifecycle import cleanup_temp_filesystem
+except ImportError:
+    cleanup_temp_filesystem = None
 from app.assets.manager import AssetManager, default_asset_manager
 import itertools
 import utils.extra_config
@@ -515,8 +518,11 @@ def start_comfyui(asyncio_loop=None):
         folder_paths.set_temp_directory(temp_dir)
 
     asset_manager: AssetManager = default_asset_manager()
-    if not (asset_manager.enabled and dependencies_available()):
-        cleanup_temp_filesystem()
+    if not asset_manager.enabled:
+        if cleanup_temp_filesystem is None:
+            logging.warning("Skipping temporary filesystem cleanup because asset dependencies are missing")
+        else:
+            cleanup_temp_filesystem()
 
     if not asyncio_loop:
         asyncio_loop = asyncio.new_event_loop()

--- a/server.py
+++ b/server.py
@@ -44,7 +44,10 @@ import node_helpers
 from comfyui_version import __version__
 from app.frontend_management import FrontendManager, parse_version
 from comfy_api.internal import _ComfyNodeInternal
-from app.assets.services.asset_management import resolve_hash_to_path
+try:
+    from app.assets.services.asset_management import resolve_hash_to_path
+except ImportError:
+    resolve_hash_to_path = None
 
 from app.user_manager import UserManager
 from app.model_manager import ModelFileManager
@@ -524,6 +527,8 @@ class PromptServer():
                     # system user in multi-user mode, which is what gates hash resolution.
                     # The returned id is deliberately unused (resolution is not owner-scoped).
                     self.user_manager.get_request_user_id(request)
+                    if resolve_hash_to_path is None:
+                        return web.Response(status=404)
                     result = resolve_hash_to_path(filename)
                     if result is None:
                         return web.Response(status=404)

--- a/tests-unit/app_test/test_migration_warning.py
+++ b/tests-unit/app_test/test_migration_warning.py
@@ -1,0 +1,110 @@
+import os
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+import app.database.db as db_module
+
+_BASELINE_0006 = "0006_add_loader_path"
+_BASELINE_0002 = "0002_merge_to_asset_references"
+_DESTRUCTIVE = "0007_record_content_split"
+
+_DISCARDED_CLASSES = (
+    "manual tags",
+    "user metadata",
+    "previews",
+    "renames",
+    "API-created records",
+    "job_id",
+)
+
+
+def _make_config(db_path: str) -> Config:
+    root = os.path.join(os.path.dirname(__file__), "../..")
+    cfg = Config(os.path.abspath(os.path.join(root, "alembic.ini")))
+    cfg.set_main_option("script_location", os.path.abspath(os.path.join(root, "alembic_db")))
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    return cfg
+
+
+@pytest.fixture
+def captured_warnings(monkeypatch):
+    warnings: list[str] = []
+    monkeypatch.setattr(db_module, "log_startup_warning", warnings.append)
+    return warnings
+
+
+@pytest.fixture
+def db_url_for(monkeypatch):
+    def _set(db_path: str) -> str:
+        url = f"sqlite:///{db_path}"
+        monkeypatch.setattr(db_module.args, "database_url", url)
+        return url
+
+    return _set
+
+
+def _migrate(db_path: str, db_url: str, db_exists: bool) -> None:
+    db_module._migrate_and_bind(db_url, db_path, db_exists)
+
+
+def test_upgrade_across_the_destructive_revision_warns_and_names_the_backup(
+    tmp_path, captured_warnings, db_url_for
+):
+    db_path = str(tmp_path / "existing.db")
+    command.upgrade(_make_config(db_path), _BASELINE_0006)
+    db_url = db_url_for(db_path)
+    assert os.path.exists(db_path)
+
+    _migrate(db_path, db_url, db_exists=True)
+
+    assert len(captured_warnings) == 1, (
+        "the destructive rebuild is one startup event, not one warning per traversed revision"
+    )
+    message = captured_warnings[0]
+    assert db_path + ".bkp" in message, "the warning must name the backup it left behind"
+    for discarded in _DISCARDED_CLASSES:
+        assert discarded in message, (
+            f"the warning must inventory what the rebuild discarded; {discarded!r} is missing"
+        )
+
+
+def test_fresh_install_warns_nothing(tmp_path, captured_warnings, db_url_for):
+    db_path = str(tmp_path / "fresh.db")
+    db_url = db_url_for(db_path)
+    assert not os.path.exists(db_path)
+
+    _migrate(db_path, db_url, db_exists=False)
+
+    assert captured_warnings == [], (
+        "a fresh install discarded nothing and took no backup, so it has nothing to warn about"
+    )
+
+
+def test_upgrade_that_does_not_cross_the_destructive_revision_warns_nothing(
+    tmp_path, captured_warnings, db_url_for, monkeypatch
+):
+    db_path = str(tmp_path / "partial.db")
+    command.upgrade(_make_config(db_path), _BASELINE_0002)
+    db_url = db_url_for(db_path)
+    monkeypatch.setattr(ScriptDirectory, "get_current_head", lambda _self: _BASELINE_0006)
+
+    _migrate(db_path, db_url, db_exists=True)
+
+    assert captured_warnings == [], (
+        "a multi-revision upgrade that never traverses the rebuild keeps every row it had"
+    )
+
+
+def test_database_already_at_head_warns_nothing(tmp_path, captured_warnings, db_url_for):
+    db_path = str(tmp_path / "current.db")
+    command.upgrade(_make_config(db_path), "head")
+    db_url = db_url_for(db_path)
+
+    _migrate(db_path, db_url, db_exists=True)
+
+    assert captured_warnings == [], (
+        "an up-to-date database migrates nothing, so it must stay silent on every boot"
+    )

--- a/tests-unit/assets_test/queries/test_lookup.py
+++ b/tests-unit/assets_test/queries/test_lookup.py
@@ -87,7 +87,7 @@ def test_upload_content_lookup_not_gated_on_hashing_flag(session, tmp_path):
 
     mode_module.init(FakeArgs())
     f = _make_file(tmp_path, "f4.png")
-    content = create_content(session, path=f, hash="abc123")
+    content = create_content(session, path=f, hash="abc123", size_bytes=os.path.getsize(f))
     session.commit()
     result = lookup_for_view(session, "abc123")
     assert result is not None
@@ -99,7 +99,7 @@ def test_stale_older_newer_live_returns_newer(session, tmp_path):
     old_time = datetime(2020, 1, 1)
     new_time = datetime(2024, 1, 1)
     c_old = create_content(session, path="/nonexistent/old.png", hash="xyz")
-    c_new = create_content(session, path=f_newer, hash="xyz")
+    c_new = create_content(session, path=f_newer, hash="xyz", size_bytes=os.path.getsize(f_newer))
     session.execute(update(AssetContent).where(AssetContent.id == c_old.id).values(created_at=old_time))
     session.execute(update(AssetContent).where(AssetContent.id == c_new.id).values(created_at=new_time))
     session.commit()
@@ -157,3 +157,15 @@ def test_refresh_qualified_content_none_when_file_vanishes(session, tmp_path):
     os.unlink(f)
 
     assert refresh_qualified_content(session, content.id) is None
+
+
+def test_size_mismatch_disqualifies_a_row_that_never_recorded_an_mtime(session, tmp_path):
+    f = _make_file(tmp_path, "size_mismatch.png", content=b"the real bytes on disk")
+    content = create_content(session, path=f, hash="dup", size_bytes=999_999)
+    session.commit()
+
+    assert content.mtime_ns is None, "fixture must exercise the unrecorded-mtime case"
+    assert lookup_for_view(session, "dup") is None, (
+        "a row whose recorded size disagrees with the file must not be served; an "
+        "unrecorded mtime is no reason to skip the size check too"
+    )

--- a/tests-unit/assets_test/queries/test_records.py
+++ b/tests-unit/assets_test/queries/test_records.py
@@ -3,7 +3,7 @@ from sqlalchemy import create_engine, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from app.assets.database.models import Asset, AssetContent
+from app.assets.database.models import Asset, AssetContent, AssetTag
 from app.assets.database.queries.records import (
     RecordPageSpec,
     create_content,
@@ -118,3 +118,17 @@ def test_create_content_uniqueness_race_returns_existing_live_row(session):
     second = create_content(session, path="/tmp/race")
 
     assert second.id == first.id
+
+
+def test_create_record_links_a_repeated_tag_name_once(session):
+    content = create_content(session, path="/tmp/repeated-tag")
+
+    record = create_record(session, content_id=content.id, name="repeat", tags=["x", "x"])
+    session.commit()
+
+    linked = session.scalars(
+        select(AssetTag.tag_name).where(AssetTag.asset_id == record.id)
+    ).all()
+    assert list(linked) == ["x"], (
+        "a tag name repeated within one call must link once, not raise on the composite PK"
+    )

--- a/tests-unit/assets_test/services/test_enrichment_snapshot.py
+++ b/tests-unit/assets_test/services/test_enrichment_snapshot.py
@@ -155,6 +155,32 @@ def test_enrichment_lands_metadata_and_hash_from_one_stable_observation(
     }
 
 
+def test_enrichment_reports_no_progress_when_a_requested_hash_fails(
+    session, temp_dir: Path
+):
+    path = temp_dir / "unreadable-for-hashing.bin"
+    path.write_bytes(b"metadata reads fine, hashing does not")
+    content, record = _create_unhashed_record(session, path)
+
+    with patch("app.assets.scanner.snapshot_hash", side_effect=PermissionError("denied")):
+        enriched = enrich_asset(
+            session,
+            file_path=str(path),
+            content_id=content.id,
+            record_id=record.id,
+            extract_metadata=True,
+            compute_hash=True,
+        )
+
+    assert enriched is False, (
+        "a record whose requested hash could not be computed has made no progress; "
+        "counting the metadata as progress keeps the record out of failed_ids, so the "
+        "enrich pass re-selects it forever"
+    )
+    session.expire_all()
+    assert session.get(AssetContent, content.id).hash is None
+
+
 def test_off_mode_enrichment_still_lands_metadata_without_a_hash(
     session, temp_dir: Path
 ):

--- a/tests-unit/assets_test/services/test_ingest_orphan_content.py
+++ b/tests-unit/assets_test/services/test_ingest_orphan_content.py
@@ -101,20 +101,43 @@ def _seed_spec(path: str, size_bytes: int, mtime_ns: int, name: str) -> SeedAsse
     }
 
 
-def test_seed_asset_specs_discards_content_on_record_failure(
+def _content_at(session: Session, path: str) -> AssetContent | None:
+    return session.scalar(select(AssetContent).where(AssetContent.path == path))
+
+
+def _reference_count(session: Session, content_id: str) -> int:
+    return session.scalar(
+        select(func.count()).select_from(Asset).where(Asset.content_id == content_id)
+    )
+
+
+def _orphaned_content_paths(session: Session) -> list[str]:
+    return [
+        content.path
+        for content in session.scalars(select(AssetContent))
+        if _reference_count(session, content.id) == 0
+    ]
+
+
+def test_seed_asset_specs_orphans_nothing_and_keeps_earlier_specs_on_record_failure(
     session: Session, tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     specs: list[SeedAssetSpec] = []
+    paths: dict[str, str] = {}
     fail_name = "vanished.bin"
     for name in ("first.bin", fail_name, "last.bin"):
         file_path = tmp_path / name
         file_path.write_bytes(name.encode())
         stat_result = file_path.stat()
+        paths[name] = str(file_path)
         specs.append(
             _seed_spec(str(file_path), stat_result.st_size, stat_result.st_mtime_ns, name)
         )
 
+    attempted: list[str] = []
+
     def _create_record_or_raise(session_arg, content_id, name, *args, **kwargs):
+        attempted.append(name)
         if name == fail_name:
             raise RuntimeError("forced create_record failure")
         return create_record_query(session_arg, content_id, name, *args, **kwargs)
@@ -125,5 +148,21 @@ def test_seed_asset_specs_discards_content_on_record_failure(
         seed_asset_specs(session, specs)
     session.rollback()
 
-    assert _live_content_count(session) == 0
-    assert session.scalar(select(func.count()).select_from(Asset)) == 0
+    assert _content_at(session, paths[fail_name]) is None, (
+        "the failed spec's content must not outlive the record that would have referenced it"
+    )
+    assert session.scalar(select(Asset).where(Asset.name == fail_name)) is None
+    assert _orphaned_content_paths(session) == []
+
+    survivor = _content_at(session, paths["first.bin"])
+    assert survivor is not None, (
+        "a spec that already succeeded must not be retroactively erased by a later "
+        "unrelated failure; its savepoint was released before that failure happened"
+    )
+    assert session.scalar(select(Asset).where(Asset.name == "first.bin")) is not None
+    assert _reference_count(session, survivor.id) == 1
+
+    assert attempted == ["first.bin", fail_name]
+    assert _content_at(session, paths["last.bin"]) is None, (
+        "the raise aborts the loop, so the spec after the failed one is never attempted"
+    )

--- a/tests-unit/assets_test/services/test_lifecycle.py
+++ b/tests-unit/assets_test/services/test_lifecycle.py
@@ -23,6 +23,8 @@ from app.assets.lifecycle import (
 from app.assets.scanner import get_temp_prefixes, sync_temp_references_safely
 from app.assets.scanner_changes import is_path_under_prefixes
 from app.assets.seeder import asset_seeder
+from app.assets.services import hash_mode_state
+from app.assets.services.hash_mode_state import clear_transition_queue, write_stored_mode
 
 from .path_prefix_cases import prefix_case_paths
 
@@ -32,6 +34,15 @@ def autoclean_unit_test_assets():
     lifecycle._excluded_scan_roots.clear()
     yield
     lifecycle._excluded_scan_roots.clear()
+
+
+@pytest.fixture(autouse=True)
+def autoclean_transition_queue():
+    clear_transition_queue()
+    lifecycle._hash_mode_transition = None
+    yield
+    clear_transition_queue()
+    lifecycle._hash_mode_transition = None
 
 
 @pytest.fixture
@@ -85,12 +96,39 @@ def test_startup_order_wipe_before_rmtree_before_seeder(mock_create_session):
         patch("app.assets.lifecycle.wipe_temp_db_rows", side_effect=_wipe),
         patch("app.assets.lifecycle.cleanup_temp_filesystem", side_effect=lambda: calls.append("rmtree") or True),
         patch("app.assets.lifecycle.enqueue_mode_transition_work", side_effect=lambda: calls.append("enqueue")),
-        patch("app.assets.lifecycle.drain_mode_transition_work", side_effect=lambda: calls.append("drain")),
         patch("app.assets.lifecycle.start_asset_seeder", side_effect=lambda: calls.append("seeder") or True),
     ):
         run_asset_startup()
 
-    assert calls == ["wipe", "rmtree", "enqueue", "drain", "seeder"]
+    assert calls == ["wipe", "rmtree", "enqueue", "seeder"]
+
+
+@pytest.mark.parametrize("wipe_fails", [False, True], ids=["wipe_succeeds", "wipe_fails"])
+def test_startup_defers_transition_drain_to_the_seeder(
+    session, mock_create_session, tmp_path, monkeypatch, wipe_fails
+):
+    asset_file = tmp_path / "model.safetensors"
+    asset_file.write_bytes(b"weights")
+    stat = asset_file.stat()
+    create_content(session, path=str(asset_file), size_bytes=stat.st_size, mtime_ns=stat.st_mtime_ns)
+    write_stored_mode(session, "off")
+    session.commit()
+    monkeypatch.setattr(hash_mode_state._mode, "hashing_enabled", lambda: True)
+
+    wipe_side_effect = RuntimeError("db wipe failed") if wipe_fails else (lambda _session: (0, 0))
+
+    with (
+        patch("app.assets.lifecycle.wipe_temp_db_rows", side_effect=wipe_side_effect),
+        patch("app.assets.lifecycle.cleanup_temp_filesystem", return_value=True),
+        patch("app.assets.lifecycle.start_asset_seeder", return_value=True),
+        patch.object(hash_mode_state, "drain_transition_queue") as drain_spy,
+    ):
+        lifecycle.record_hash_mode_transition_intent()
+        run_asset_startup()
+
+    drain_spy.assert_not_called()
+    assert hash_mode_state.pending_transition_count() > 0
+    assert hash_mode_state.read_stored_mode(session) == "off"
 
 
 def test_db_wipe_failure_skips_rmtree_and_continues(mock_create_session):

--- a/tests-unit/assets_test/services/test_recovery_gate.py
+++ b/tests-unit/assets_test/services/test_recovery_gate.py
@@ -12,6 +12,7 @@ from app.assets.scanner import (
     pending_recovery_count,
     seed_asset_specs,
 )
+from app.assets.scanner_changes import recover_missing_content
 from app.assets.services.snapshot_hash import snapshot_hash
 
 
@@ -135,3 +136,33 @@ def test_unstable_hash_requeues(session, temp_dir: Path):
     assert created == 0
     assert pending_recovery_count() == 1
     assert session.get(AssetContent, missing.id).is_missing is True
+
+
+def test_recovery_skips_a_path_a_live_row_already_occupies(session, temp_dir: Path):
+    path = temp_dir / "contested.bin"
+    path.write_bytes(b"bytes restored under a path someone else already owns")
+    digest = _stored_hash(path)
+    stat_result = path.stat()
+    missing_a, _ = _missing_content(session, path, digest)
+    live_b = AssetContent(
+        path=str(path),
+        hash=digest,
+        is_missing=False,
+        size_bytes=stat_result.st_size,
+        mtime_ns=stat_result.st_mtime_ns,
+    )
+    session.add(live_b)
+    session.commit()
+    live_b_id = live_b.id
+
+    result = recover_missing_content(
+        session, str(path), stat_result, hashing_is_enabled=True
+    )
+    session.commit()
+
+    assert result == "no_match", (
+        "the file at an occupied path belongs to the live row's story; change detection "
+        "owns it, and recovering onto it would put two live rows on one path"
+    )
+    assert session.get(AssetContent, missing_a.id).is_missing is True
+    assert session.get(AssetContent, live_b_id).is_missing is False

--- a/tests-unit/assets_test/services/test_scanner_seed_resilience.py
+++ b/tests-unit/assets_test/services/test_scanner_seed_resilience.py
@@ -4,11 +4,9 @@ from unittest.mock import patch
 
 import pytest
 from sqlalchemy import select
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.assets.database.models import Asset
-from app.assets.database.queries import create_record as create_record_query
 from app.assets.scanner import SeedAssetSpec, seed_asset_specs
 from app.assets.services.snapshot_hash import snapshot_hash
 
@@ -114,36 +112,21 @@ def test_seed_logs_once_for_each_vanished_path(
     assert messages == [f"Skipping vanished asset during scan: {vanished_path}"]
 
 
-def test_seed_propagates_integrity_error_and_aborts_batch(
-    session: Session, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+def test_seed_isolates_a_poisoned_spec_and_persists_the_specs_around_it(
+    session: Session, temp_dir: Path
 ) -> None:
-    specs, vanished_path = _specs_with_vanished_path(temp_dir)
+    specs, poisoned_path = _specs_with_vanished_path(temp_dir)
+    specs[1]["size_bytes"] = -1
 
-    def _create_record_or_raise(
-        session: Session,
-        content_id: str,
-        name: str,
-        mime_type: str | None = None,
-        job_id: str | None = None,
-        loader_path: str | None = None,
-        tags: tuple[str, ...] | None = None,
-    ) -> Asset:
-        if name == vanished_path.name:
-            raise IntegrityError("insert asset content", {}, Exception("forced failure"))
-        return create_record_query(
-            session,
-            content_id,
-            name,
-            mime_type,
-            job_id,
-            loader_path,
-            tags,
-        )
+    created = seed_asset_specs(session, specs)
+    session.commit()
 
-    monkeypatch.setattr("app.assets.scanner.create_record", _create_record_or_raise)
-
-    with pytest.raises(IntegrityError):
-        _ = seed_asset_specs(session, specs)
-    session.rollback()
-
-    assert _record_count(session) == 0
+    assert created == 2
+    assert _record_count(session) == 2
+    assert {record.name for record in session.scalars(select(Asset))} == {
+        "first.bin",
+        "last.bin",
+    }, (
+        "the batch shares one transaction, so a bare rollback would erase the spec BEFORE "
+        f"the poisoned one; both neighbours of {poisoned_path.name} must survive"
+    )

--- a/tests-unit/assets_test/services/test_serving_b.py
+++ b/tests-unit/assets_test/services/test_serving_b.py
@@ -136,7 +136,7 @@ def test_resolve_hash_to_path_uses_newest_record_for_name_and_content_type(
     digest = "c" * 64
     f = temp_dir / "shared.bin"
     f.write_bytes(b"data")
-    content = create_content(session, path=str(f), hash=to_stored_hash(digest))
+    content = create_content(session, path=str(f), hash=to_stored_hash(digest), size_bytes=f.stat().st_size)
     older = create_record(
         session,
         content_id=content.id,
@@ -170,7 +170,7 @@ def test_resolve_hash_to_path_serves_content_with_zero_records(
     digest = "d" * 64
     f = temp_dir / "orphan.png"
     f.write_bytes(b"data")
-    content = create_content(session, path=str(f), hash=to_stored_hash(digest))
+    content = create_content(session, path=str(f), hash=to_stored_hash(digest), size_bytes=f.stat().st_size)
     record = create_record(
         session,
         content_id=content.id,
@@ -232,7 +232,7 @@ def test_view_hash_read_updates_last_access_time(
     digest = "a" * 64
     f = temp_dir / "view.bin"
     f.write_bytes(b"view")
-    content = create_content(session, path=str(f), hash=to_stored_hash(digest))
+    content = create_content(session, path=str(f), hash=to_stored_hash(digest), size_bytes=f.stat().st_size)
     record = create_record(session, content_id=content.id, name="view.bin")
     session.commit()
     record_id = record.id

--- a/tests-unit/assets_test/services/test_tag_protection.py
+++ b/tests-unit/assets_test/services/test_tag_protection.py
@@ -2,11 +2,17 @@ import json
 from types import SimpleNamespace
 
 import pytest
-from aiohttp import web
 
 from app.assets.api import routes
 
 _RECORD_ID = "00000000-0000-0000-0000-000000000001"
+_SYSTEM_TAG_ENVELOPE = {
+    "error": {
+        "code": "SYSTEM_TAG_FORBIDDEN",
+        "message": "Tag 'missing' is system-managed and cannot be modified via the API",
+        "details": {"tag": "missing"},
+    }
+}
 
 
 class _JsonRequest:
@@ -32,10 +38,10 @@ async def test_add_missing_tag_returns_400(monkeypatch):
         lambda **_kwargs: SimpleNamespace(added=[], already_present=[], total_tags=[]),
     )
 
-    with pytest.raises(web.HTTPBadRequest) as error:
-        await routes.add_asset_tags.__wrapped__(_JsonRequest(["missing"]))
+    response = await routes.add_asset_tags.__wrapped__(_JsonRequest(["missing"]))
 
-    assert error.value.status == 400
+    assert response.status == 400
+    assert json.loads(response.body) == _SYSTEM_TAG_ENVELOPE
 
 
 @pytest.mark.asyncio
@@ -47,10 +53,10 @@ async def test_remove_missing_tag_returns_400(monkeypatch):
         lambda **_kwargs: SimpleNamespace(removed=[], not_present=[], total_tags=[]),
     )
 
-    with pytest.raises(web.HTTPBadRequest) as error:
-        await routes.delete_asset_tags.__wrapped__(_JsonRequest(["missing"]))
+    response = await routes.delete_asset_tags.__wrapped__(_JsonRequest(["missing"]))
 
-    assert error.value.status == 400
+    assert response.status == 400
+    assert json.loads(response.body) == _SYSTEM_TAG_ENVELOPE
 
 
 @pytest.mark.asyncio

--- a/tests-unit/assets_test/services/test_tag_write_conflicts.py
+++ b/tests-unit/assets_test/services/test_tag_write_conflicts.py
@@ -1,0 +1,166 @@
+from contextlib import contextmanager
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine, select, update
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session as SASession
+
+import app.assets.database.queries.records as records_module
+import app.assets.services.asset_management as asset_management_module
+import app.assets.services.tagging as tagging_module
+from app.assets.database.models import Asset, AssetTag, Base, Tag
+from app.assets.database.queries.records import (
+    create_content,
+    create_record,
+    mark_content_missing,
+)
+from app.assets.services.asset_management import update_asset_metadata
+from app.assets.services.tagging import apply_tags
+
+STALE = datetime(2020, 1, 1, 0, 0, 0)
+RACED = "raced"
+UNRELATED = "unrelated"
+
+
+def _file_backed_engine(db_path):
+    engine = create_engine(
+        f"sqlite:///{db_path}",
+        connect_args={"check_same_thread": False, "timeout": 0.2},
+    )
+    Base.metadata.create_all(engine)
+    return engine
+
+
+def _seed_record(session, path: str, tags=None) -> str:
+    content = create_content(session, path)
+    record = create_record(session, content.id, "fixture", tags=tags)
+    session.commit()
+    session.execute(update(Asset).where(Asset.id == record.id).values(updated_at=STALE))
+    session.commit()
+    return record.id
+
+
+def _updated_at(session, record_id: str) -> datetime:
+    session.expire_all()
+    return session.scalar(select(Asset.updated_at).where(Asset.id == record_id))
+
+
+def _tag_names(session, record_id: str) -> list[str]:
+    return sorted(
+        session.scalars(select(AssetTag.tag_name).where(AssetTag.asset_id == record_id)).all()
+    )
+
+
+def test_apply_tags_loses_a_tag_race_without_raising_and_reports_it_honestly(tmp_path):
+    engine = _file_backed_engine(tmp_path / "tag_race.db")
+    with SASession(engine) as seed_session:
+        record_id = _seed_record(seed_session, "/tmp/tag-race-fixture", tags=[UNRELATED])
+
+    def connection_a_commits_the_raced_tag() -> None:
+        with SASession(engine) as connection_a:
+            connection_a.add(Tag(name=RACED))
+            connection_a.flush()
+            connection_a.add(
+                AssetTag(asset_id=record_id, tag_name=RACED, origin="manual")
+            )
+            connection_a.commit()
+
+    fired: list[bool] = []
+
+    @contextmanager
+    def racing_session_factory():
+        with SASession(engine) as session_b:
+            real_add = session_b.add
+
+            def add_racing_the_winner(instance, *args, **kwargs):
+                if isinstance(instance, Tag) and instance.name == RACED and not fired:
+                    fired.append(True)
+                    connection_a_commits_the_raced_tag()
+                return real_add(instance, *args, **kwargs)
+
+            session_b.add = add_racing_the_winner
+            yield session_b
+
+    with patch("app.assets.services.tagging.create_session", racing_session_factory):
+        result = apply_tags(record_id, [RACED])
+
+    assert fired, "the interleave never fired; the test proves nothing"
+    assert result.added == [], (
+        "session B lost the race; it inserted nothing and must not claim it did"
+    )
+    assert result.already_present == [RACED], (
+        "already_present reports the REQUESTED tags that were already there — never "
+        "unrelated pre-existing tags the caller did not ask about"
+    )
+    assert sorted(result.total_tags) == [RACED, UNRELATED]
+
+    with SASession(engine) as check:
+        assert _tag_names(check, record_id) == [RACED, UNRELATED]
+        assert _updated_at(check, record_id) == STALE, (
+            "a race loser changed no link, so it is not an edit and must not move updated_at"
+        )
+
+
+def test_ensure_tag_link_reraises_when_the_parent_asset_is_missing(db_engine_fk):
+    with SASession(db_engine_fk) as session:
+        session.add(Tag(name="orphan-link"))
+        session.flush()
+
+        with pytest.raises(IntegrityError):
+            records_module.ensure_tag_link(
+                session,
+                asset_id="no-such-asset",
+                tag_name="orphan-link",
+                origin="manual",
+            )
+
+
+def _drive_create_record(session, record_id):
+    content = create_content(session, "/tmp/four-sites-create-record")
+    create_record(session, content.id, "created", tags=["spied"])
+
+
+def _drive_mark_content_missing(session, record_id):
+    content_id = session.scalar(select(Asset.content_id).where(Asset.id == record_id))
+    mark_content_missing(session, content_id)
+
+
+def _drive_update_asset_metadata(session, record_id):
+    update_asset_metadata(record_id, tags=["spied"])
+
+
+def _drive_apply_tags(session, record_id):
+    apply_tags(record_id, ["spied"])
+
+
+@pytest.mark.parametrize(
+    ("target_module", "drive"),
+    [
+        (records_module, _drive_create_record),
+        (records_module, _drive_mark_content_missing),
+        (asset_management_module, _drive_update_asset_metadata),
+        (tagging_module, _drive_apply_tags),
+    ],
+    ids=["create_record", "mark_content_missing", "update_asset_metadata", "apply_tags"],
+)
+def test_every_tag_write_site_routes_through_the_conflict_safe_helper(
+    session, mock_create_session, monkeypatch, target_module, drive
+):
+    record_id = _seed_record(session, "/tmp/four-sites-fixture")
+    calls: list[str] = []
+    real_ensure_tag_link = records_module.ensure_tag_link
+
+    def spying_ensure_tag_link(*args, **kwargs):
+        calls.append(kwargs["tag_name"])
+        return real_ensure_tag_link(*args, **kwargs)
+
+    monkeypatch.setattr(target_module, "ensure_tag_link", spying_ensure_tag_link)
+
+    drive(session, record_id)
+
+    assert calls, (
+        "this site still writes asset_tags with a bare check-then-insert; a concurrent "
+        "writer inserting the same link makes it raise instead of settling"
+    )

--- a/tests-unit/assets_test/services/test_transition_drain.py
+++ b/tests-unit/assets_test/services/test_transition_drain.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 
 import folder_paths
@@ -311,3 +312,110 @@ def test_transition_drain_skips_out_of_root_path(session, temp_dir, monkeypatch,
     assert session.get(AssetContent, old_content_id).is_missing is False
     assert hash_mode_state.pending_transition_count() == 0
     assert any("orphan.bin" in record.getMessage() for record in caplog.records)
+
+
+def _seed_hashed_row(session, path: Path, payload: bytes) -> tuple[str, str]:
+    path.write_bytes(payload)
+    stat = path.stat()
+    stored = to_stored_hash(blake3(payload).hexdigest())
+    content = create_content(session, str(path), stored, stat.st_size, stat.st_mtime_ns)
+    create_record(session, content.id, path.name)
+    return content.id, stored
+
+
+def test_transition_drain_clears_an_unverifiable_hash_only_on_the_third_attempt(
+    session, temp_dir, monkeypatch, caplog
+):
+    path = temp_dir / "permanently-unreadable.bin"
+    content_id, original_hash = _seed_hashed_row(session, path, b"bytes nobody can read")
+    write_stored_mode(session, "off")
+    monkeypatch.setattr(hash_mode_state._mode, "hashing_enabled", lambda: True)
+
+    def always_denied(_candidate_path: str):
+        raise PermissionError("denied")
+
+    monkeypatch.setattr(hash_mode_state, "snapshot_hash", always_denied)
+
+    transition = record_transition_intent(session)
+    enqueue_transition_work(session, transition)
+
+    def warnings_naming_the_path() -> list[str]:
+        return [r.getMessage() for r in caplog.records if str(path) in r.getMessage()]
+
+    with caplog.at_level(logging.WARNING):
+        for attempt in (1, 2):
+            drain_transition_queue(session)
+            session.commit()
+            session.expire_all()
+            assert hash_mode_state.pending_transition_count() == 1, (
+                f"attempt {attempt} of 3 must requeue the entry, not retire it"
+            )
+            assert read_stored_mode(session) == "off", (
+                f"the mode must not flip while attempt {attempt} is still pending"
+            )
+            assert session.get(AssetContent, content_id).hash == original_hash, (
+                f"a transient failure on attempt {attempt} must not clear a good hash"
+            )
+            assert warnings_naming_the_path() == [], (
+                f"attempt {attempt} is a retry, not a terminal outcome; it must stay quiet"
+            )
+
+        drain_transition_queue(session)
+        session.commit()
+
+    session.expire_all()
+    assert hash_mode_state.pending_transition_count() == 0, (
+        "the third failure retires the entry so the queue can empty"
+    )
+    assert read_stored_mode(session) == "on", (
+        "an unreadable file must not wedge the mode flip for the process lifetime"
+    )
+    retired = session.get(AssetContent, content_id)
+    assert retired.is_missing is False, (
+        "the file is unreadable, not gone; retiring its hash must not mark the row missing"
+    )
+    assert retired.hash is None, (
+        "an unverifiable digest must not survive into persisted 'on'"
+    )
+    assert len(warnings_naming_the_path()) == 1, (
+        "the terminal outcome is announced exactly once, naming the path"
+    )
+
+
+def test_transition_drain_retires_only_the_unreadable_path_and_hashes_the_healthy_one(
+    session, temp_dir, monkeypatch
+):
+    unreadable_path = temp_dir / "unreadable.bin"
+    healthy_path = temp_dir / "healthy.bin"
+    healthy_payload = b"a file that reads fine"
+    unreadable_id, _ = _seed_hashed_row(session, unreadable_path, b"a file that does not")
+    healthy_path.write_bytes(healthy_payload)
+    healthy_stat = healthy_path.stat()
+    healthy_content = create_content(
+        session, str(healthy_path), size_bytes=healthy_stat.st_size, mtime_ns=healthy_stat.st_mtime_ns
+    )
+    healthy_id = healthy_content.id
+    create_record(session, healthy_id, healthy_path.name)
+    write_stored_mode(session, "off")
+    monkeypatch.setattr(hash_mode_state._mode, "hashing_enabled", lambda: True)
+
+    def denied_for_the_unreadable_path(candidate_path: str):
+        if candidate_path == str(unreadable_path):
+            raise PermissionError("denied")
+        return snapshot_hash(candidate_path)
+
+    monkeypatch.setattr(hash_mode_state, "snapshot_hash", denied_for_the_unreadable_path)
+
+    transition = record_transition_intent(session)
+    enqueue_transition_work(session, transition)
+    for _ in range(3):
+        drain_transition_queue(session)
+        session.commit()
+
+    session.expire_all()
+    assert session.get(AssetContent, healthy_id).hash == _stored_hash(healthy_path), (
+        "one unreadable path must not cost the healthy paths behind it their hashes"
+    )
+    assert session.get(AssetContent, unreadable_id).hash is None
+    assert hash_mode_state.pending_transition_count() == 0
+    assert read_stored_mode(session) == "on"

--- a/tests-unit/assets_test/services/test_transition_settle.py
+++ b/tests-unit/assets_test/services/test_transition_settle.py
@@ -1,0 +1,108 @@
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.orm import Session as SASession
+
+from app.assets import scanner, seeder as seeder_module
+from app.assets.database.models import AssetContent
+from app.assets.database.queries.records import create_content, create_record
+from app.assets.helpers import to_stored_hash
+from app.assets.services import hash_mode_state
+from app.assets.services.hash_mode_state import (
+    clear_transition_queue,
+    enqueue_transition_work,
+    read_stored_mode,
+    record_transition_intent,
+    write_stored_mode,
+)
+
+_ATTEMPT_BUDGET = 5
+
+
+class _AttemptBudgetExhausted(BaseException):
+    # BaseException, not Exception: enrich_assets_batch's blanket except would swallow it.
+    pass
+
+
+@pytest.fixture(autouse=True)
+def transition_queue():
+    clear_transition_queue()
+    yield
+    clear_transition_queue()
+
+
+def _denied(_candidate_path: str):
+    raise PermissionError("denied")
+
+
+def test_enrich_phase_settles_an_unreadable_transition_without_looping(
+    session, db_engine, temp_dir: Path, monkeypatch
+):
+    path = temp_dir / "unreadable.safetensors"
+    payload = b"bytes that can be stat'd but never hashed"
+    path.write_bytes(payload)
+    stat = path.stat()
+    content = create_content(
+        session, str(path), to_stored_hash("seed-digest"), stat.st_size, stat.st_mtime_ns
+    )
+    content_id = content.id
+    record = create_record(session, content_id, path.name)
+    record_id = record.id
+    write_stored_mode(session, "off")
+    monkeypatch.setattr(hash_mode_state._mode, "hashing_enabled", lambda: True)
+
+    transition = record_transition_intent(session)
+    enqueue_transition_work(session, transition)
+    session.commit()
+
+    @contextmanager
+    def _create_session():
+        with SASession(db_engine) as sess:
+            yield sess
+
+    attempts: list[str] = []
+    real_enrich_asset = scanner.enrich_asset
+
+    def counting_enrich_asset(*args, **kwargs):
+        attempts.append(kwargs["record_id"])
+        if len(attempts) > _ATTEMPT_BUDGET:
+            raise _AttemptBudgetExhausted
+        return real_enrich_asset(*args, **kwargs)
+
+    seeder = seeder_module._AssetSeeder()
+    seeder._compute_hashes = True
+    seeder._run_gate.set()
+    seeder._cancel_event.clear()
+
+    monkeypatch.setattr("folder_paths.get_input_directory", lambda: str(temp_dir))
+    monkeypatch.setattr(hash_mode_state, "snapshot_hash", _denied)
+    monkeypatch.setattr(scanner, "snapshot_hash", _denied)
+    monkeypatch.setattr(scanner, "enrich_asset", counting_enrich_asset)
+
+    with patch("app.assets.seeder.create_session", _create_session), \
+         patch("app.assets.scanner.create_session", _create_session):
+        try:
+            cancelled, _enriched = seeder._run_enrich_phase(("input",))
+        except _AttemptBudgetExhausted:
+            pytest.fail(
+                f"the enrich phase re-selected the same record more than {_ATTEMPT_BUDGET} "
+                "times: a terminally-cleared row stays hash-eligible, so counting its "
+                "metadata as progress keeps it out of failed_ids and the pass never ends"
+            )
+
+    assert cancelled is False
+    session.expire_all()
+    assert read_stored_mode(session) == "on", (
+        "one background scan must settle the transition on its own; waiting for a future "
+        "prompt to queue another enrich pass leaves a quiet server wedged at 'off'"
+    )
+    settled = session.get(AssetContent, content_id)
+    assert settled.is_missing is False, (
+        "an unreadable file is not a deleted one; settling must not mark its row missing"
+    )
+    assert settled.hash is None
+    assert attempts == [record_id], (
+        "the record is attempted once, then excluded from the rest of the pass"
+    )

--- a/tests-unit/assets_test/services/test_updated_at_semantics.py
+++ b/tests-unit/assets_test/services/test_updated_at_semantics.py
@@ -28,7 +28,7 @@ STALE = datetime(2020, 1, 1, 0, 0, 0)
 
 
 def _seed_record(session: Session, path: str, name: str = "fixture", tags=None, hash=None) -> Asset:
-    content = create_content(session, path, hash=hash)
+    content = create_content(session, path, hash=hash, size_bytes=os.stat(path).st_size)
     record = create_record(session, content.id, name, tags=tags)
     session.commit()
     _force_stale(session, record.id)

--- a/tests-unit/assets_test/services/test_upload_b.py
+++ b/tests-unit/assets_test/services/test_upload_b.py
@@ -1132,3 +1132,229 @@ def test_off_mode_upload_calls_content_lookup(mock_create_session, hashing_off):
     finally:
         if os.path.exists(temp):
             os.unlink(temp)
+
+
+def _tag_names(session, record_id: str) -> list[str]:
+    return sorted(
+        session.scalars(select(AssetTag.tag_name).where(AssetTag.asset_id == record_id)).all()
+    )
+
+
+def test_upload_round_trips_its_own_served_tags(mock_create_session, hashing_on):
+    temp = _write_temp(b"round-trip-served-tags")
+    try:
+        result = upload_from_temp_path(
+            temp_path=temp,
+            name="served.bin",
+            tags=["output", "uploaded"],
+            client_filename="served.bin",
+        )
+
+        with mock_create_session() as session:
+            assert _tag_names(session, result.ref.id) == ["output", "uploaded"], (
+                "re-uploading a file with the tags the API served for it must succeed; "
+                "'uploaded' is appended unconditionally, so a request already carrying it "
+                "double-adds the same composite PK"
+            )
+    finally:
+        if os.path.exists(temp):
+            os.unlink(temp)
+
+
+def test_upload_accepts_a_repeated_custom_tag(mock_create_session, hashing_on):
+    temp = _write_temp(b"repeated-custom-tag")
+    try:
+        result = upload_from_temp_path(
+            temp_path=temp,
+            name="repeat.bin",
+            tags=["output", "x", "x"],
+            client_filename="repeat.bin",
+        )
+
+        with mock_create_session() as session:
+            assert _tag_names(session, result.ref.id) == ["output", "uploaded", "x"]
+    finally:
+        if os.path.exists(temp):
+            os.unlink(temp)
+
+
+def test_upload_normalizes_tags_before_they_reach_the_query_layer(
+    mock_create_session, hashing_on, monkeypatch
+):
+    captured: list[list[str]] = []
+    real_create_upload_record = ingest_module._create_upload_record
+
+    def capturing_create_upload_record(*args, **kwargs):
+        captured.append(list(args[4]))
+        return real_create_upload_record(*args, **kwargs)
+
+    monkeypatch.setattr(
+        ingest_module, "_create_upload_record", capturing_create_upload_record
+    )
+
+    payload = b"seam-assertion-bytes"
+    new_content_temp = _write_temp(payload)
+    reused_content_temp = _write_temp(payload)
+    try:
+        upload_from_temp_path(
+            temp_path=new_content_temp,
+            name="seam.bin",
+            tags=["output", "uploaded"],
+            client_filename="seam.bin",
+        )
+        upload_from_temp_path(
+            temp_path=reused_content_temp,
+            name="seam.bin",
+            tags=["output", "uploaded"],
+            client_filename="seam.bin",
+        )
+
+        assert len(captured) == 2, (
+            "expected one new-content upload and one reused-content upload"
+        )
+        for tags in captured:
+            assert len(tags) == len(set(tags)), (
+                f"{tags!r} reached the query layer with duplicates; normalization belongs "
+                "at the build site, not as a side effect of create_record's dedup"
+            )
+            assert tags.count("uploaded") == 1
+    finally:
+        for path in (new_content_temp, reused_content_temp):
+            if os.path.exists(path):
+                os.unlink(path)
+
+
+def _stat_pair(path: str) -> tuple[int, int]:
+    stat_result = os.stat(path)
+    return stat_result.st_size, stat_result.st_mtime_ns
+
+
+def _mutating_snapshot_hash(path_to_mutate: str, new_bytes: bytes):
+    real_snapshot_hash = ingest_module.snapshot_hash
+
+    def _mutate_then_hash(candidate_path: str):
+        if candidate_path == path_to_mutate:
+            with open(path_to_mutate, "wb") as file:
+                file.write(new_bytes)
+            os.utime(path_to_mutate, ns=(_LATER_NS, _LATER_NS))
+        return real_snapshot_hash(candidate_path)
+
+    return _mutate_then_hash
+
+
+_LATER_NS = 2_000_000_000_000_000_000
+
+
+def test_incumbent_reconciliation_persists_the_stat_hashing_verified(
+    mock_create_session, hashing_on, monkeypatch
+):
+    output_dir = folder_paths.get_output_directory()
+    os.makedirs(output_dir, exist_ok=True)
+    dest_abs = os.path.join(output_dir, "incumbent_stat.bin")
+    original = b"the original incumbent bytes"
+    rewritten = b"REWRITTEN incumbent bytes!!!"
+    assert len(rewritten) == len(original), (
+        "same length keeps reconciliation on its adopt-the-hash branch, so this test "
+        "isolates stat pairing instead of the size-contradiction retirement"
+    )
+    with open(dest_abs, "wb") as file:
+        file.write(original)
+    try:
+        with mock_create_session() as session:
+            stale_size, stale_mtime = _stat_pair(dest_abs)
+            create_content(session, dest_abs, None, stale_size, stale_mtime)
+            session.commit()
+
+        monkeypatch.setattr(
+            ingest_module,
+            "snapshot_hash",
+            _mutating_snapshot_hash(dest_abs, rewritten),
+        )
+
+        with mock_create_session() as session:
+            ingest_module._settle_destination_before_write(session, dest_abs)
+            session.commit()
+
+        verified_size, verified_mtime = _stat_pair(dest_abs)
+        with mock_create_session() as session:
+            live = session.scalar(
+                select(AssetContent).where(
+                    AssetContent.path == dest_abs, AssetContent.is_missing.is_(False)
+                )
+            )
+            assert live is not None
+            assert (live.size_bytes, live.mtime_ns) == (verified_size, verified_mtime), (
+                "the row's hash describes the bytes hashing actually read, so its size and "
+                "mtime must describe those same bytes; a pre-hash stat makes the row "
+                "stat-inconsistent and therefore unservable by hash"
+            )
+            assert lookup_for_view(session, live.hash) is not None
+    finally:
+        if os.path.exists(dest_abs):
+            os.unlink(dest_abs)
+
+
+def test_in_place_registration_persists_the_stat_hashing_verified(
+    mock_create_session, hashing_on, monkeypatch
+):
+    output_dir = folder_paths.get_output_directory()
+    os.makedirs(output_dir, exist_ok=True)
+    locator = os.path.join(output_dir, "in_place_stat.bin")
+    with open(locator, "wb") as file:
+        file.write(b"in-place original bytes")
+    try:
+        monkeypatch.setattr(
+            ingest_module,
+            "snapshot_hash",
+            _mutating_snapshot_hash(locator, b"in-place bytes rewritten mid-hash"),
+        )
+
+        result = register_file_in_place(
+            abs_path=locator, name="in_place_stat.bin", tags=["output"]
+        )
+
+        verified_size, verified_mtime = _stat_pair(locator)
+        with mock_create_session() as session:
+            record = session.get(Asset, result.ref.id)
+            content = session.get(AssetContent, record.content_id)
+            assert (content.size_bytes, content.mtime_ns) == (verified_size, verified_mtime)
+            assert lookup_for_view(session, content.hash) is not None
+    finally:
+        if os.path.exists(locator):
+            os.unlink(locator)
+
+
+def test_multipart_upload_persists_the_stat_hashing_verified(
+    mock_create_session, hashing_on, monkeypatch
+):
+    payload = b"multipart bytes whose destination stat goes stale"
+    temp = _write_temp(payload)
+    real_digest = snapshot_hash(temp)[0]
+
+    def _stale_stat(_path: str, follow_symlinks: bool = True) -> tuple[int, int]:
+        return 1, 1
+
+    monkeypatch.setattr(ingest_module, "get_size_and_mtime_ns", _stale_stat)
+
+    result = upload_from_temp_path(
+        temp_path=temp,
+        name="multipart_stat.bin",
+        tags=["output"],
+        client_filename="multipart_stat.bin",
+    )
+
+    with mock_create_session() as session:
+        record = session.get(Asset, result.ref.id)
+        content = session.get(AssetContent, record.content_id)
+        assert (content.size_bytes, content.mtime_ns) != (1, 1), (
+            "a stat read separately from hashing can be stale; the verified stat that "
+            "hashing proved describes these bytes is the one to persist"
+        )
+        assert (content.size_bytes, content.mtime_ns) == _stat_pair(content.path)
+        assert content.hash == to_stored_hash(real_digest), (
+            "the digest, not the (digest, stat) pair, feeds to_stored_hash"
+        )
+        assert real_digest[:8] in os.path.basename(content.path), (
+            "the digest, not the pair, feeds hash-mode destination naming"
+        )
+        assert lookup_for_view(session, content.hash) is not None

--- a/tests-unit/assets_test/test_import_isolation.py
+++ b/tests-unit/assets_test/test_import_isolation.py
@@ -1,0 +1,110 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from app.assets import manager
+from utils.install_util import get_missing_requirements_message
+
+
+def test_no_assets_imports_without_database_dependencies() -> None:
+    code = """
+import importlib.abc
+import sys
+from aiohttp import web
+
+class MissingDatabaseDependencyFinder(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname in {"sqlalchemy", "alembic"}:
+            raise ImportError(f"blocked dependency: {fullname}")
+        return None
+
+sys.meta_path.insert(0, MissingDatabaseDependencyFinder())
+import app.assets.manager as manager
+
+assert manager._IMPORT_ERROR is not None
+manager.NoAssets(manager.args).register_routes(web.Application(), None)
+manager.args.enable_assets = False
+assert isinstance(manager.default_asset_manager(), manager.NoAssets)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=Path(__file__).resolve().parents[2],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize(
+    ("import_error", "database_dependencies_available"),
+    [(ImportError("sqlalchemy"), True), (None, False)],
+)
+def test_enabled_assets_exits_without_database_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    import_error: ImportError | None,
+    database_dependencies_available: bool,
+) -> None:
+    monkeypatch.setattr(manager.args, "enable_assets", True)
+    monkeypatch.setattr(manager, "_IMPORT_ERROR", import_error)
+    monkeypatch.setattr(
+        manager,
+        "dependencies_available",
+        lambda: database_dependencies_available,
+        raising=False,
+    )
+
+    with pytest.raises(SystemExit):
+        manager.default_asset_manager()
+
+    assert "--enable-assets" in caplog.text
+    assert get_missing_requirements_message() in caplog.text
+    if import_error is not None:
+        assert str(import_error) in caplog.text
+
+
+def test_disabled_assets_do_not_consult_database_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unavailable_dependencies() -> bool:
+        raise AssertionError("disabled assets must not check database dependencies")
+
+    monkeypatch.setattr(manager.args, "enable_assets", False)
+    monkeypatch.setattr(
+        manager, "dependencies_available", unavailable_dependencies, raising=False
+    )
+
+    assert isinstance(manager.default_asset_manager(), manager.NoAssets)
+
+
+def test_enabled_asset_hashing_exits_without_blake3(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(manager.args, "enable_assets", True)
+    monkeypatch.setattr(manager.args, "enable_asset_hashing", True)
+    monkeypatch.setattr(manager, "_IMPORT_ERROR", None)
+    monkeypatch.setattr(manager, "dependencies_available", lambda: True)
+    monkeypatch.setitem(sys.modules, "blake3", None)
+
+    with pytest.raises(SystemExit):
+        manager.default_asset_manager()
+
+    assert "blake3" in caplog.text
+    assert "--enable-asset-hashing" in caplog.text
+
+
+def test_enabled_assets_without_hashing_do_not_consult_blake3(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(manager.args, "enable_assets", True)
+    monkeypatch.setattr(manager.args, "enable_asset_hashing", False)
+    monkeypatch.setattr(manager, "_IMPORT_ERROR", None)
+    monkeypatch.setattr(manager, "dependencies_available", lambda: True)
+    monkeypatch.setitem(sys.modules, "blake3", None)
+
+    assert isinstance(manager.default_asset_manager(), manager.AssetsEnabled)

--- a/tests-unit/assets_test/test_intended_behaviour.py
+++ b/tests-unit/assets_test/test_intended_behaviour.py
@@ -136,7 +136,7 @@ def _writer_lands_mid_hash(path: Path, replacement: bytes):
         def hexdigest(self) -> str:
             return self._inner.hexdigest()
 
-    with patch("app.assets.services.snapshot_hash.blake3", _WriterHasher):
+    with patch("blake3.blake3", _WriterHasher):
         yield _WriterHasher
 
 

--- a/tests-unit/assets_test/test_tags_api.py
+++ b/tests-unit/assets_test/test_tags_api.py
@@ -21,3 +21,48 @@ def test_tag_refine_rejects_metadata_filter(http, api_base):
             "details": {},
         }
     }
+
+
+def _expected_system_tag_envelope() -> dict:
+    return {
+        "error": {
+            "code": "SYSTEM_TAG_FORBIDDEN",
+            "message": "Tag 'missing' is system-managed and cannot be modified via the API",
+            "details": {"tag": "missing"},
+        }
+    }
+
+
+def test_add_system_tag_returns_the_error_envelope(
+    http, api_base, asset_factory, make_asset_bytes
+):
+    record = asset_factory("sys-add.png", ["output"], {}, make_asset_bytes("sys-add"))
+
+    response = http.post(
+        f"{api_base}/api/assets/{record['id']}/tags",
+        json={"tags": ["missing"]},
+        timeout=120,
+    )
+
+    assert response.status_code == 400
+    assert response.headers["Content-Type"].startswith("application/json"), (
+        "a rejection clients must parse cannot be text/plain while every neighbouring "
+        "error on this route is the JSON envelope"
+    )
+    assert response.json() == _expected_system_tag_envelope()
+
+
+def test_delete_system_tag_returns_the_error_envelope(
+    http, api_base, asset_factory, make_asset_bytes
+):
+    record = asset_factory("sys-del.png", ["output"], {}, make_asset_bytes("sys-del"))
+
+    response = http.delete(
+        f"{api_base}/api/assets/{record['id']}/tags",
+        json={"tags": ["missing"]},
+        timeout=120,
+    )
+
+    assert response.status_code == 400
+    assert response.headers["Content-Type"].startswith("application/json")
+    assert response.json() == _expected_system_tag_envelope()


### PR DESCRIPTION
Layer 8/8, top of the review-and-land stack continuing #15915–#16030. Full collapse procedure: `~/adocs/review-stack.md`.

**Question for this layer:** are the new dependency semantics right — missing asset-system dependencies invisible without the flag, fatal with it?

**This supersedes base commit `7efdd1d7`** (not ported in layer 7). That fix degraded routes to 503 when database dependencies were missing even under `--enable-assets`. Owner-specified semantics instead:

- **Without `--enable-assets`:** asset-system deps (sqlalchemy/alembic) are *never imported*. A broken install boots normally; asset routes still answer the standard 503 envelope.
- **With `--enable-assets`:** missing deps are **fatal at startup** with an actionable error (reuses the house `get_missing_requirements_message()` remedy, matching the existing `database is locked` exit precedent).
- **blake3 symmetric:** imported only when hashing runs; `--enable-assets --enable-asset-hashing` with blake3 missing is fatal, hashing off means blake3 is never required.

Three commits on `synap5e/feat/assets-di-v2` (`68418810..6aac53ac`):

1. `13e6f462` **import isolation** (mechanical, no behavior change): `AssetsEnabled` moves to `app/assets/manager_enabled.py` behind a lazy import; `cleanup_temp_filesystem` + the excluded-scan-roots registry move to dependency-free `app/assets/temp_paths.py`; `routes.py` and `server.py` defer their sqlalchemy-reaching imports to handler bodies (the 503 gate answers before any of them run). Before this commit, a bare `from sqlalchemy import select` in `lifecycle.py` made missing sqlalchemy fatal for *everyone*, flag or no flag — the promise in the old docs was structurally unkeepable.
2. `01287d18` **the semantics**: `default_asset_manager()` enabled path checks imports + `dependencies_available()` and exits with the remedy message; flag-off path consults nothing. `main.py`'s temp-cleanup condition simplifies (`enabled` now implies deps). Rewrites the one docs sentence layer 7 carried for `7efdd1d7`.
3. `6aac53ac` **blake3**: lazy import in `snapshot_hash.py` + fatal check keyed on `args.enable_asset_hashing`.

Locked by subprocess import-poison tests (block sqlalchemy/alembic at the finder level, boot the NoAssets path, register routes — exit 0) plus fatal-path tests asserting the SystemExit and the remedy text: `test_import_isolation.py` (4 new tests). Suite: **1345 passed, 1 skipped, 0 failed**. The `AssetManager` protocol is unchanged — still exactly 12 members.

**Top of the stack.** Once approved, merge this into #16030 (ordinary "Merge" — always a fast-forward). The squash into `master` happens once, at #15915, after the full top-down collapse 8→7→6→5→4→3→2→1.

**Stack:**
1. #15915 `code` — Is the logic change right?
2. #15916 `tests-removed` — For each dropped assertion: obsolete by a ruling, or covered by a tests-new test?
3. #15917 `tests-changed` — Did the edits weaken an existing check?
4. #15918 `tests-new` — Is the code layer well covered?
5. #16008 `code` — Is the logic change right?
6. #16009 `tests` — Is the code layer well covered, and did any edit weaken an existing check?
7. #16030 `ported-fixes` — Was each base fix ported faithfully?
8. (this PR) `deps-semantics` — Are the new dependency semantics right?

**Files (20, +394/−256).**