### PR TITLE
Enable SageAttention key smoothing for diffusion-model attention

### DIFF
--- a/comfy/ldm/modules/attention.py
+++ b/comfy/ldm/modules/attention.py
@@ -22,6 +22,7 @@ if model_management.xformers_enabled():
     import xformers.ops
 
 SAGE_ATTENTION_IS_AVAILABLE = False
+SAGE_SMOOTH_K_MIN_SEQ = 1024  # smooth keys only for long sequences (the diffusion model), not the text encoder
 SAGE_ATTENTION_SUPPORTS_MASK = False
 try:
     from sageattention import sageattn
@@ -671,7 +672,15 @@ def attention_sage(q, k, v, heads, mask=None, attn_precision=None, skip_reshape=
         if mask.ndim == 3:
             mask = mask.unsqueeze(1)
 
-    sage_kwargs = {"is_causal": False, "tensor_layout": tensor_layout, "sm_scale": kwargs.get("scale", None), "smooth_k": False}
+    # Key smoothing subtracts the per-head key mean before SageAttention quantizes K to int8. It is
+    # exact (softmax ignores a per-row constant) and recovers most of the int8 accuracy loss on
+    # diffusion transformers, but it hurts on short key sequences such as the text encoder's, where
+    # the mean is the signal. sageattention 1.x subtracts the mean in place, so pass a copy of k.
+    seq_len = k.shape[2] if tensor_layout == "HND" else k.shape[1]
+    smooth_k = seq_len >= SAGE_SMOOTH_K_MIN_SEQ
+    if smooth_k:
+        k = k.clone()
+    sage_kwargs = {"is_causal": False, "tensor_layout": tensor_layout, "sm_scale": kwargs.get("scale", None), "smooth_k": smooth_k}
     if mask is not None:
         sage_kwargs["attn_mask"] = mask
 

--- a/comfy/ldm/modules/attention.py
+++ b/comfy/ldm/modules/attention.py
@@ -22,7 +22,29 @@ if model_management.xformers_enabled():
     import xformers.ops
 
 SAGE_ATTENTION_IS_AVAILABLE = False
-SAGE_SMOOTH_K_MIN_SEQ = 1024  # smooth keys only for long sequences (the diffusion model), not the text encoder
+SAGE_SMOOTH_K_MIN_SEQ = 1024   # never smooth short key sequences (text encoder, cross-attention)
+SAGE_SMOOTH_K_MIN_MEAN_RATIO = 0.8   # smooth only when the shared key component dominates the keys
+
+
+def _sage_should_smooth_k(k, tensor_layout):
+    """SageAttention key smoothing subtracts the per-head key mean before quantizing K to int8.
+    It is exact (softmax ignores a per-row constant) and matters when the keys share a large
+    common component that would otherwise consume the int8 range. It is useless or slightly
+    harmful when they do not, and harmful on short sequences where the mean is the signal.
+    Gate on both: sequence length, and the size of the key mean relative to the keys."""
+    seq_dim = 2 if tensor_layout == "HND" else 1
+    seq_len = k.shape[seq_dim]
+    if seq_len < SAGE_SMOOTH_K_MIN_SEQ:
+        return False
+    # A global statistic: a strided token subsample is plenty, and fp32 accumulation
+    # without materialising an fp32 copy keeps this well under a millisecond.
+    step = max(1, seq_len // 512)
+    ks = k[(slice(None),) * seq_dim + (slice(0, None, step),)]
+    mean_norm = torch.linalg.vector_norm(ks.mean(dim=seq_dim, dtype=torch.float32), dim=-1).mean()
+    key_norm = torch.linalg.vector_norm(ks, dim=-1, dtype=torch.float32).mean()
+    return bool(mean_norm > SAGE_SMOOTH_K_MIN_MEAN_RATIO * key_norm)
+
+
 SAGE_ATTENTION_SUPPORTS_MASK = False
 try:
     from sageattention import sageattn
@@ -672,14 +694,9 @@ def attention_sage(q, k, v, heads, mask=None, attn_precision=None, skip_reshape=
         if mask.ndim == 3:
             mask = mask.unsqueeze(1)
 
-    # Key smoothing subtracts the per-head key mean before SageAttention quantizes K to int8. It is
-    # exact (softmax ignores a per-row constant) and recovers most of the int8 accuracy loss on
-    # diffusion transformers, but it hurts on short key sequences such as the text encoder's, where
-    # the mean is the signal. sageattention 1.x subtracts the mean in place, so pass a copy of k.
-    seq_len = k.shape[2] if tensor_layout == "HND" else k.shape[1]
-    smooth_k = seq_len >= SAGE_SMOOTH_K_MIN_SEQ
+    smooth_k = _sage_should_smooth_k(k, tensor_layout)
     if smooth_k:
-        k = k.clone()
+        k = k.clone()  # sageattention 1.x subtracts the key mean in place
     sage_kwargs = {"is_causal": False, "tensor_layout": tensor_layout, "sm_scale": kwargs.get("scale", None), "smooth_k": smooth_k}
     if mask is not None:
         sage_kwargs["attn_mask"] = mask

--- a/tests-unit/comfy_test/test_sage_smooth_k_gate.py
+++ b/tests-unit/comfy_test/test_sage_smooth_k_gate.py
@@ -1,0 +1,53 @@
+import pytest
+import torch
+
+from comfy.ldm.modules.attention import (
+    SAGE_SMOOTH_K_MIN_MEAN_RATIO,
+    SAGE_SMOOTH_K_MIN_SEQ,
+    _sage_should_smooth_k,
+)
+
+
+def _keys(seq_len, layout, shared_component):
+    """Random keys with a controllable common component.
+
+    shared_component=0 gives zero-mean keys (mean norm << key norm);
+    shared_component=30 makes one direction dominate every key (mean norm ~0.97 x key norm).
+    """
+    torch.manual_seed(0)
+    heads, dim = 4, 64
+    shape = (1, heads, seq_len, dim) if layout == "HND" else (1, seq_len, heads, dim)
+    k = torch.randn(shape, dtype=torch.float16)
+    if shared_component:
+        direction = torch.zeros(dim, dtype=torch.float16)
+        direction[0] = shared_component
+        k = k + direction
+    return k
+
+
+@pytest.mark.parametrize("layout", ["HND", "NHD"])
+@pytest.mark.parametrize("seq_len", [SAGE_SMOOTH_K_MIN_SEQ - 1, SAGE_SMOOTH_K_MIN_SEQ, SAGE_SMOOTH_K_MIN_SEQ + 1])
+def test_sequence_length_gate(layout, seq_len):
+    # Keys with a dominant shared component: smoothing is worthwhile, but only at or above the minimum length.
+    k = _keys(seq_len, layout, shared_component=30)
+    expected = seq_len >= SAGE_SMOOTH_K_MIN_SEQ
+    assert _sage_should_smooth_k(k, layout) is expected
+
+
+@pytest.mark.parametrize("layout", ["HND", "NHD"])
+def test_mean_ratio_gate(layout):
+    seq_len = SAGE_SMOOTH_K_MIN_SEQ + 1
+    assert _sage_should_smooth_k(_keys(seq_len, layout, shared_component=30), layout) is True
+    assert _sage_should_smooth_k(_keys(seq_len, layout, shared_component=0), layout) is False
+
+
+def test_gate_does_not_modify_keys():
+    layout = "HND"
+    k = _keys(SAGE_SMOOTH_K_MIN_SEQ + 1, layout, shared_component=30)
+    before = k.clone()
+    _sage_should_smooth_k(k, layout)
+    assert torch.equal(k, before)
+
+
+def test_ratio_threshold_is_sane():
+    assert 0.0 < SAGE_SMOOTH_K_MIN_MEAN_RATIO < 1.0


### PR DESCRIPTION
## Summary

`attention_sage` passes `smooth_k=False` to SageAttention unconditionally. Key smoothing (subtracting the per-head key mean before the int8 quantization of K) is SageAttention's main accuracy mechanism, and it is mathematically free: it shifts every score in a row by the same constant, which softmax ignores. On some diffusion transformers turning it off costs a lot of accuracy; on others it does nothing; on short key sequences it hurts. This PR enables it only where the data says it helps: long key sequences whose keys share a dominant common component. Both conditions are checked per call, cheaply.

## Why it was off, and why a plain flip is wrong twice over

`smooth_k=False` arrived with #14772. The likely reason is real: SageAttention 1.x subtracts the mean **in place** (`k -= km` in `sageattention/core.py`), which corrupts a caller-owned `k` (verified on 1.0.6: `max |Δk| = 596` after one call). The 2.x CUDA paths and the ROCm gfx12 path compute the mean without touching `k`. A `k.clone()` removes the hazard on 1.x for the cost of one fp16 copy of K.

Two things stop this from being a one-line `smooth_k=True`:

1. **The text encoder goes through the same function.** On a Krea2 run the DiT makes 224 calls at `(1, 48, 8771, 128)`, and the text encoder makes 32 calls at `(476, 20, 12, 128)` and `(1, 20, 476, 128)`. Subtracting a 12-token mean on those removes most of the signal, and the damaged conditioning propagates into every block. Enabling smoothing everywhere is *worse* than the status quo (table below).
2. **Whether smoothing helps at all depends on the model.** It helps when the keys share a large common component that would otherwise consume the int8 range. Krea2's block-0 keys are 99 % common direction (`‖mean k‖ / mean ‖k‖ = 0.989`); Flux2 Klein's are 0.49, int8 attention is already near-lossless there, and smoothing is neutral at the attention level and slightly worse in images.

So the gate is: key sequence ≥ 1024 (rules out text-encoder and cross-attention calls) **and** `‖mean k‖ > 0.8 · mean ‖k‖` (rules out models where there is nothing to smooth). The ratio is computed on a strided token subsample with fp32 accumulation; 0.29 ms at the Krea2 shape against ~16 ms for the attention call.

## Evidence

Hardware: RX 9070 XT (gfx1201), ROCm 7.15, sageattention 1.0.6 (Triton). Attention-level reference is fp32 `scaled_dot_product_attention` on real q/k/v captured from the models — not synthetic inputs, which give cos 0.9999 for every variant and hide all of this. Image-level numbers are the mean |Δ| (RGB, 0–255) between the generated image and the one produced with `--use-pytorch-cross-attention` (exact attention), same seed, 4 seeds.

**Krea2 Turbo fp8, 2 MP.** Attention level, DiT block 0, vs fp32:

| | cos | rel-L2 | KL(exact ‖ quant) of attention probs |
|---|---|---|---|
| `smooth_k=False` (today) | 0.831 | 55.6 % | 0.808 |
| `smooth_k=True` | 0.937 | 40.1 % | 0.090 |

Later blocks (5, 14, 20, 27) are lossless under both (KL ≤ 0.0006); the damage lives in the early blocks, where the key mean is 99 % of the key norm. Image level:

| | 1-step | 8-step |
|---|---|---|
| `smooth_k=False` (today) | 10.18 | 21.75 |
| `smooth_k=True` on every call | 17.52 | 33.90 |
| `smooth_k=True` on the DiT only | 7.22 | 21.21 |
| this PR (adaptive gate) | 7.31 | — |

The DiT-only setting wins on 4/4 seeds at 1-step (7.76 / 7.17 / 6.69 / 7.27 vs 8.64 / 8.44 / 11.89 / 11.74). The "every call" row is what a plain `smooth_k=True` would have shipped.

**Flux2 Klein 9B, 1280², 4-step turbo** (int8 checkpoint via a third-party int8 loader; the attention path is the same). Block-0 keys: `‖mean k‖ / mean ‖k‖ = 0.485`; attention-level cos vs fp32 is 0.999900 with smoothing off and 0.999899 with it on — there is nothing to recover. Image level:

| | 1-step | 4-step |
|---|---|---|
| `smooth_k=False` (today) | 1.20 | 3.75 |
| `smooth_k=True` on the DiT (seq gate only) | 1.32 | 4.36 |
| this PR (adaptive gate) | 1.20 (gate off → identical to today) | 3.75 (identical) |

That Klein row is the reason for the ratio check: a length-only gate would smooth Klein and make it marginally worse for no gain.

## Change

```python
SAGE_SMOOTH_K_MIN_SEQ = 1024
SAGE_SMOOTH_K_MIN_MEAN_RATIO = 0.8

def _sage_should_smooth_k(k, tensor_layout):
    # seq_len >= 1024 and ‖mean k‖ > 0.8 · mean ‖k‖, on a strided subsample with fp32 accumulation
    ...

# in attention_sage:
smooth_k = _sage_should_smooth_k(k, tensor_layout)
if smooth_k:
    k = k.clone()   # sageattention 1.x subtracts the key mean in place
sage_kwargs = {..., "smooth_k": smooth_k}
```

Applies to every SageAttention backend, since only the kwarg and a clone change. Unit tests cover the length boundary (1023 / 1024 / 1025, HND and NHD), the ratio gate in both directions, and that the gate does not modify the caller's tensor.

## Testing

- Krea2 Turbo 2 MP, 1 step and 8 steps, 4 seeds; Flux2 Klein 1280², 1 step and 4 steps, 4 seeds; RX 9070 XT / ROCm.
- Verified on sageattention 1.0.6 that the clone keeps the caller's `k` bit-identical across the call.
- The attention-level attribution was reproduced in pure PyTorch (int8 per-block quantization of the captured q/k, fp32 PV) so the effect is the quantization, not the kernel.
- `pytest tests-unit/comfy_test/test_sage_smooth_k_gate.py` passes on CPU.

I only have AMD hardware. The mechanism is not AMD-specific — it is the int8 quantization of K, which is the same on CUDA — but I'd welcome a check on an NVIDIA card with sageattention 2.x, and numbers from other model families: the ratio gate is there precisely because this is model-dependent.
