### PR TITLE
[review-stack 8/8] defensive-parity — synap5e/feat/assets-di-v2

### DIFF
--- a/app/assets/manager.py
+++ b/app/assets/manager.py
@@ -14,6 +14,7 @@ from app.assets.services.ingest import (
 )
 from app.assets.services.path_utils import get_known_subfolder_tags
 from app.assets.services.schemas import RegisteredAsset, UploadAssetView
+from app.database.db import dependencies_available
 from app.user_manager import UserManager
 from comfy.cli_args import args
 
@@ -214,4 +215,10 @@ class AssetsEnabled:
 
 
 def default_asset_manager() -> AssetManager:
+    if args.enable_assets and not dependencies_available():
+        logging.warning(
+            "Assets requested but database dependencies unavailable; asset endpoints "
+            "will answer 503. Please install the updated requirements.txt file."
+        )
+        return NoAssets(args)
     return AssetsEnabled(args) if args.enable_assets else NoAssets(args)

--- a/app/database/db.py
+++ b/app/database/db.py
@@ -21,6 +21,7 @@ try:
 
     from app.database.models import Base
     import app.assets.database.models  # noqa: F401 — register models with Base.metadata
+    import blake3  # noqa: F401 — verify the hard dependency is importable at startup
 
     _DB_AVAILABLE = True
 except ImportError as e:

--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ console_log_level = get_console_log_level(args.verbose)
 file_log_outputs = get_file_log_outputs(args.verbose)
 setup_logger(log_level=console_log_level, file_outputs=file_log_outputs, use_stdout=args.log_stdout)
 
+from app.database.db import dependencies_available, init_db
 from app.assets.lifecycle import cleanup_temp_filesystem
 from app.assets.manager import AssetManager, default_asset_manager
 import itertools
@@ -34,7 +35,6 @@ import sys
 from comfy_execution.progress import get_progress_state
 from comfy_execution.utils import get_executing_context
 from comfy_api import feature_flags
-from app.database.db import dependencies_available, init_db
 
 if __name__ == "__main__":
     #NOTE: These do not do anything on core ComfyUI, they are for custom nodes.
@@ -488,7 +488,7 @@ def start_comfyui(asyncio_loop=None):
         folder_paths.set_temp_directory(temp_dir)
 
     asset_manager: AssetManager = default_asset_manager()
-    if not (asset_manager.enabled and dependencies_available()):
+    if not asset_manager.enabled:
         cleanup_temp_filesystem()
 
     if not asyncio_loop:

--- a/tests-unit/assets_test/services/test_noassets_parity.py
+++ b/tests-unit/assets_test/services/test_noassets_parity.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable
 from contextlib import AbstractContextManager
+import logging
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -13,7 +14,8 @@ from app.assets import lifecycle
 from app.assets.api import routes
 from app.assets.database.models import Asset, AssetContent
 from app.assets.database.queries.records import create_content, create_record
-from app.assets.manager import NoAssets
+from app.assets import manager
+from app.assets.manager import AssetsEnabled, NoAssets
 from app.assets.mode import hashing_enabled
 from app.assets.seeder import asset_seeder
 from app.assets.services.hash_mode_state import read_stored_mode
@@ -175,3 +177,26 @@ def test_noassets_registration_methods_return_none() -> None:
 
 def test_noassets_is_disabled() -> None:
     assert _no_assets().enabled is False
+
+
+def test_default_asset_manager_disables_assets_when_dependencies_are_unavailable(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setattr(manager.args, "enable_assets", True)
+    monkeypatch.setattr(manager, "dependencies_available", lambda: False)
+
+    with caplog.at_level(logging.WARNING):
+        asset_manager = manager.default_asset_manager()
+
+    assert isinstance(asset_manager, NoAssets)
+    assert "asset endpoints will answer 503" in caplog.text
+    assert "requirements.txt" in caplog.text
+
+
+def test_default_asset_manager_enables_assets_when_dependencies_are_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(manager.args, "enable_assets", True)
+    monkeypatch.setattr(manager, "dependencies_available", lambda: True)
+
+    assert isinstance(manager.default_asset_manager(), AssetsEnabled)


### PR DESCRIPTION
Layer 8/8, top of the review-and-land stack continuing #15915–#16030. Replaces the withdrawn #16031 after an audit of how `master` actually defends against blake3/alembic/sqlalchemy being absent or broken. Full collapse procedure: `~/adocs/review-stack.md`.

**Question for this layer:** does each degradation path now match or improve master's behavior?

**The audit** (each scenario tested against master's real code paths, not its comments):

| scenario | master | this stack |
|---|---|---|
| sqlalchemy missing | boot crash; the friendly `db.py` requirements warning never prints (assets imports run first) | boot crash **after** the requirements warning (commit 2) |
| alembic missing | boots + warns; `--enable-assets` registers real routes that **500** per request | boots + warns; factory selects `NoAssets` → **503 SERVICE_DISABLED** envelope (commit 1) |
| blake3 missing | soft warning, per-op failures | **hard fail at boot — owner ruling**: blake3 is a hard dependency of this codepath; a missing package is a broken install. Deliberately NOT softened. Commit 3 lists it in `db.py`'s guarded imports so the actionable requirements warning prints before the failing traceback |
| database locked | fatal exit | identical |
| migration drift | rebuild + backup | improved in layer 7 (`0482426a` names the backup) |
| runtime hash failures | can wedge | improved in layer 7 (`dd1412c2` bounded retries, `818c511c` batch isolation) |

**Commit 1** — `fix(assets): select NoAssets when database dependencies are unavailable`. This is base commit `7efdd1d7`'s outcome (excluded from layer 7) delivered through the DI seam: instead of resurrecting `disable_assets_routes()` mutating route globals, `default_asset_manager()` returns `NoAssets` with a warning when `--enable-assets` is set but `dependencies_available()` is false. Same observable 503 envelope, non-fatal, zero new machinery. Also simplifies `main.py`'s temp-cleanup condition (the factory now guarantees `enabled` implies dependencies).

**Commit 2** — `fix(assets): print the database requirements warning before assets imports can crash the boot`. One import moved. Master has this bug too: its `main.py` imports the seeder (→ sqlalchemy, bare) before anything imports `app.database.db`, so the actionable warning is unreachable exactly when it's needed.

**Commit 3** — `fix(assets): include blake3 in the guarded dependency imports`. One line: the boot still hard-fails (`snapshot_hash.py` imports blake3 bare, per the ruling above), but the failure is now announced by the same requirements warning the database dependencies get, instead of a bare traceback.

Suite: **1343 passed, 1 skipped, 0 failed**. AssetManager protocol untouched (12 members). Net: 4 files, +36/−3.

**Top of the stack.** Once approved, merge this into #16030 (ordinary "Merge" — always a fast-forward). The squash into `master` happens once, at #15915, after the full top-down collapse 8→7→6→5→4→3→2→1.

**Stack:**
1. #15915 `code` — Is the logic change right?
2. #15916 `tests-removed` — For each dropped assertion: obsolete by a ruling, or covered by a tests-new test?
3. #15917 `tests-changed` — Did the edits weaken an existing check?
4. #15918 `tests-new` — Is the code layer well covered?
5. #16008 `code` — Is the logic change right?
6. #16009 `tests` — Is the code layer well covered, and did any edit weaken an existing check?
7. #16030 `ported-fixes` — Was each base fix ported faithfully?
8. (this PR) `defensive-parity` — Does each degradation path match or improve master?
