### PR TITLE
Annotate temp paths in Preview3DAdvanced / PreviewGaussianSplat / PreviewPointCloud outputs

### DIFF
--- a/comfy_api/latest/_ui.py
+++ b/comfy_api/latest/_ui.py
@@ -457,13 +457,17 @@ class PreviewUI3D(_UIOutput):
 
 
 class PreviewUI3DAdvanced(_UIOutput):
-    def __init__(self, model_file, camera_info, model_3d_info):
+    def __init__(self, model_file, camera_info, model_3d_info, folder_type: FolderType | None = None):
         self.model_file = model_file
         self.camera_info = camera_info
         self.model_3d_info = model_3d_info
+        self.folder_type = folder_type
 
     def as_dict(self):
-        return {"result": [self.model_file, self.camera_info, self.model_3d_info]}
+        model_file = self.model_file
+        if self.folder_type is not None:
+            model_file = f"{model_file} [{FolderType(self.folder_type).value}]"
+        return {"result": [model_file, self.camera_info, self.model_3d_info]}
 
 
 class PreviewText(_UIOutput):

--- a/comfy_extras/nodes_load_3d.py
+++ b/comfy_extras/nodes_load_3d.py
@@ -185,7 +185,7 @@ class Preview3DAdvanced(IO.ComfyNode):
             camera_info,
             width,
             height,
-            ui=UI.PreviewUI3DAdvanced(filename, camera_info, model_3d_info),
+            ui=UI.PreviewUI3DAdvanced(filename, camera_info, model_3d_info, folder_type=IO.FolderType.temp),
         )
 
 
@@ -255,7 +255,7 @@ class PreviewGaussianSplat(IO.ComfyNode):
             camera_info,
             width,
             height,
-            ui=UI.PreviewUI3DAdvanced(filename, camera_info, model_3d_info),
+            ui=UI.PreviewUI3DAdvanced(filename, camera_info, model_3d_info, folder_type=IO.FolderType.temp),
         )
 
 
@@ -316,7 +316,7 @@ class PreviewPointCloud(IO.ComfyNode):
             camera_info,
             width,
             height,
-            ui=UI.PreviewUI3DAdvanced(filename, camera_info, model_3d_info),
+            ui=UI.PreviewUI3DAdvanced(filename, camera_info, model_3d_info, folder_type=IO.FolderType.temp),
         )
 
 

--- a/tests-unit/comfy_api_test/preview_ui_3d_test.py
+++ b/tests-unit/comfy_api_test/preview_ui_3d_test.py
@@ -1,0 +1,50 @@
+import os
+from io import BytesIO
+from unittest.mock import patch
+
+import pytest
+
+import folder_paths
+from comfy_api.latest import IO, UI, Types
+from comfy_extras.nodes_load_3d import Preview3DAdvanced, PreviewGaussianSplat, PreviewPointCloud
+
+
+def test_preview_ui_3d_advanced_keeps_bare_path_by_default():
+    ui = UI.PreviewUI3DAdvanced("3d/model.glb", {"fov": 35}, [])
+
+    assert ui.as_dict() == {"result": ["3d/model.glb", {"fov": 35}, []]}
+
+
+@pytest.mark.parametrize("folder_type", [IO.FolderType.temp, "temp"])
+def test_preview_ui_3d_advanced_annotates_folder_type(folder_type):
+    ui = UI.PreviewUI3DAdvanced("preview.glb", None, [], folder_type=folder_type)
+
+    result = ui.as_dict()["result"]
+
+    assert result[0] == "preview.glb [temp]"
+    name, base_dir = folder_paths.annotated_filepath(result[0])
+    assert name == "preview.glb"
+    assert base_dir == folder_paths.get_temp_directory()
+
+
+@pytest.mark.parametrize(
+    ("node_cls", "file_format", "prefix"),
+    [
+        (Preview3DAdvanced, "glb", "preview3d_advanced_"),
+        (Preview3DAdvanced, "obj", "preview3d_advanced_"),
+        (PreviewGaussianSplat, "spz", "preview_splat_"),
+        (PreviewPointCloud, "ply", "preview_pointcloud_"),
+    ],
+)
+def test_preview_nodes_report_where_they_wrote_the_file(tmp_path, node_cls, file_format, prefix):
+    model = Types.File3D(BytesIO(b"model-bytes"), file_format)
+
+    with patch.object(folder_paths, "get_temp_directory", return_value=str(tmp_path)):
+        output = node_cls.execute(model, viewport_state={}, width=1, height=1)
+        reported = output.ui.as_dict()["result"][0]
+        name, base_dir = folder_paths.annotated_filepath(reported)
+
+    assert reported.endswith(f".{file_format} [temp]")
+    assert name.startswith(prefix)
+    assert base_dir == str(tmp_path)
+    assert os.path.isfile(os.path.join(tmp_path, name))


### PR DESCRIPTION
These nodes save the model under the temp directory but report it in ui.result as a bare filename. Anything that has to locate the file from that value (the frontend, Comfy Cloud's output upload) had to know these particular nodes are special and assume temp/, and Cloud assumed output/ instead, so the previews stayed empty there.

PreviewUI3DAdvanced now takes an optional folder_type and appends the standard "[temp]" / "[output]" annotation, the same convention every other file reference in prompts and outputs already uses. The three preview nodes pass FolderType.temp. Save3DAdvanced and the other callers pass nothing and keep emitting the bare path.