### PR TITLE
Fix inherited ComfyNode schema caches

### DIFF
--- a/comfy_api/latest/_io.py
+++ b/comfy_api/latest/_io.py
@@ -2103,7 +2103,7 @@ class _ComfyNodeBaseInternal(_ComfyNodeInternal):
     @final
     @classproperty
     def DESCRIPTION(cls):  # noqa
-        if cls._DESCRIPTION is None:
+        if cls.__dict__.get("_DESCRIPTION") is None:
             cls.GET_SCHEMA()
         return cls._DESCRIPTION
 
@@ -2111,7 +2111,7 @@ class _ComfyNodeBaseInternal(_ComfyNodeInternal):
     @final
     @classproperty
     def CATEGORY(cls):  # noqa
-        if cls._CATEGORY is None:
+        if cls.__dict__.get("_CATEGORY") is None:
             cls.GET_SCHEMA()
         return cls._CATEGORY
 
@@ -2119,7 +2119,7 @@ class _ComfyNodeBaseInternal(_ComfyNodeInternal):
     @final
     @classproperty
     def EXPERIMENTAL(cls):  # noqa
-        if cls._EXPERIMENTAL is None:
+        if cls.__dict__.get("_EXPERIMENTAL") is None:
             cls.GET_SCHEMA()
         return cls._EXPERIMENTAL
 
@@ -2127,7 +2127,7 @@ class _ComfyNodeBaseInternal(_ComfyNodeInternal):
     @final
     @classproperty
     def DEPRECATED(cls):  # noqa
-        if cls._DEPRECATED is None:
+        if cls.__dict__.get("_DEPRECATED") is None:
             cls.GET_SCHEMA()
         return cls._DEPRECATED
 
@@ -2135,7 +2135,7 @@ class _ComfyNodeBaseInternal(_ComfyNodeInternal):
     @final
     @classproperty
     def DEV_ONLY(cls):  # noqa
-        if cls._DEV_ONLY is None:
+        if cls.__dict__.get("_DEV_ONLY") is None:
             cls.GET_SCHEMA()
         return cls._DEV_ONLY
 
@@ -2143,7 +2143,7 @@ class _ComfyNodeBaseInternal(_ComfyNodeInternal):
     @final
     @classproperty
     def API_NODE(cls):  # noqa
-        if cls._API_NODE is None:
+        if cls.__dict__.get("_API_NODE") is None:
             cls.GET_SCHEMA()
         return cls._API_NODE
 
@@ -2151,7 +2151,7 @@ class _ComfyNodeBaseInternal(_ComfyNodeInternal):
     @final
     @classproperty
     def OUTPUT_NODE(cls):  # noqa
-        if cls._OUTPUT_NODE is None:
+        if cls.__dict__.get("_OUTPUT_NODE") is None:
             cls.GET_SCHEMA()
         return cls._OUTPUT_NODE
 
@@ -2159,7 +2159,7 @@ class _ComfyNodeBaseInternal(_ComfyNodeInternal):
     @final
     @classproperty
     def HAS_INTERMEDIATE_OUTPUT(cls):  # noqa
-        if cls._HAS_INTERMEDIATE_OUTPUT is None:
+        if cls.__dict__.get("_HAS_INTERMEDIATE_OUTPUT") is None:
             cls.GET_SCHEMA()
         return cls._HAS_INTERMEDIATE_OUTPUT
 
@@ -2167,7 +2167,7 @@ class _ComfyNodeBaseInternal(_ComfyNodeInternal):
     @final
     @classproperty
     def INPUT_IS_LIST(cls):  # noqa
-        if cls._INPUT_IS_LIST is None:
+        if cls.__dict__.get("_INPUT_IS_LIST") is None:
             cls.GET_SCHEMA()
         return cls._INPUT_IS_LIST
     _OUTPUT_IS_LIST = None
@@ -2175,7 +2175,7 @@ class _ComfyNodeBaseInternal(_ComfyNodeInternal):
     @final
     @classproperty
     def OUTPUT_IS_LIST(cls):  # noqa
-        if cls._OUTPUT_IS_LIST is None:
+        if cls.__dict__.get("_OUTPUT_IS_LIST") is None:
             cls.GET_SCHEMA()
         return cls._OUTPUT_IS_LIST
 
@@ -2183,7 +2183,7 @@ class _ComfyNodeBaseInternal(_ComfyNodeInternal):
     @final
     @classproperty
     def RETURN_TYPES(cls):  # noqa
-        if cls._RETURN_TYPES is None:
+        if cls.__dict__.get("_RETURN_TYPES") is None:
             cls.GET_SCHEMA()
         return cls._RETURN_TYPES
 
@@ -2191,7 +2191,7 @@ class _ComfyNodeBaseInternal(_ComfyNodeInternal):
     @final
     @classproperty
     def RETURN_NAMES(cls):  # noqa
-        if cls._RETURN_NAMES is None:
+        if cls.__dict__.get("_RETURN_NAMES") is None:
             cls.GET_SCHEMA()
         return cls._RETURN_NAMES
 
@@ -2199,7 +2199,7 @@ class _ComfyNodeBaseInternal(_ComfyNodeInternal):
     @final
     @classproperty
     def OUTPUT_TOOLTIPS(cls):  # noqa
-        if cls._OUTPUT_TOOLTIPS is None:
+        if cls.__dict__.get("_OUTPUT_TOOLTIPS") is None:
             cls.GET_SCHEMA()
         return cls._OUTPUT_TOOLTIPS
 
@@ -2207,7 +2207,7 @@ class _ComfyNodeBaseInternal(_ComfyNodeInternal):
     @final
     @classproperty
     def NOT_IDEMPOTENT(cls):  # noqa
-        if cls._NOT_IDEMPOTENT is None:
+        if cls.__dict__.get("_NOT_IDEMPOTENT") is None:
             cls.GET_SCHEMA()
         return cls._NOT_IDEMPOTENT
 
@@ -2215,7 +2215,7 @@ class _ComfyNodeBaseInternal(_ComfyNodeInternal):
     @final
     @classproperty
     def ACCEPT_ALL_INPUTS(cls):  # noqa
-        if cls._ACCEPT_ALL_INPUTS is None:
+        if cls.__dict__.get("_ACCEPT_ALL_INPUTS") is None:
             cls.GET_SCHEMA()
         return cls._ACCEPT_ALL_INPUTS
 
@@ -2241,30 +2241,30 @@ class _ComfyNodeBaseInternal(_ComfyNodeInternal):
         cls.VALIDATE_CLASS()
         schema = cls.FINALIZE_SCHEMA()
         schema.validate()
-        if cls._DESCRIPTION is None:
+        if cls.__dict__.get("_DESCRIPTION") is None:
             cls._DESCRIPTION = schema.description
-        if cls._CATEGORY is None:
+        if cls.__dict__.get("_CATEGORY") is None:
             cls._CATEGORY = schema.category
-        if cls._EXPERIMENTAL is None:
+        if cls.__dict__.get("_EXPERIMENTAL") is None:
             cls._EXPERIMENTAL = schema.is_experimental
-        if cls._DEPRECATED is None:
+        if cls.__dict__.get("_DEPRECATED") is None:
             cls._DEPRECATED = schema.is_deprecated
-        if cls._DEV_ONLY is None:
+        if cls.__dict__.get("_DEV_ONLY") is None:
             cls._DEV_ONLY = schema.is_dev_only
-        if cls._API_NODE is None:
+        if cls.__dict__.get("_API_NODE") is None:
             cls._API_NODE = schema.is_api_node
-        if cls._OUTPUT_NODE is None:
+        if cls.__dict__.get("_OUTPUT_NODE") is None:
             cls._OUTPUT_NODE = schema.is_output_node
-        if cls._HAS_INTERMEDIATE_OUTPUT is None:
+        if cls.__dict__.get("_HAS_INTERMEDIATE_OUTPUT") is None:
             cls._HAS_INTERMEDIATE_OUTPUT = schema.has_intermediate_output
-        if cls._INPUT_IS_LIST is None:
+        if cls.__dict__.get("_INPUT_IS_LIST") is None:
             cls._INPUT_IS_LIST = schema.is_input_list
-        if cls._NOT_IDEMPOTENT is None:
+        if cls.__dict__.get("_NOT_IDEMPOTENT") is None:
             cls._NOT_IDEMPOTENT = schema.not_idempotent
-        if cls._ACCEPT_ALL_INPUTS is None:
+        if cls.__dict__.get("_ACCEPT_ALL_INPUTS") is None:
             cls._ACCEPT_ALL_INPUTS = schema.accept_all_inputs
 
-        if cls._RETURN_TYPES is None:
+        if cls.__dict__.get("_RETURN_TYPES") is None:
             output = []
             output_name = []
             output_is_list = []

--- a/tests-unit/comfy_api_test/node_schema_cache_test.py
+++ b/tests-unit/comfy_api_test/node_schema_cache_test.py
@@ -1,0 +1,32 @@
+from comfy_api.latest import io
+
+
+class ParentNode(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(node_id="ParentNode", outputs=[io.String.Output()])
+
+    @classmethod
+    def execute(cls):
+        return io.NodeOutput("parent")
+
+
+class ChildNode(ParentNode):
+    @classmethod
+    def define_schema(cls):
+        schema = super().define_schema()
+        schema.node_id = "ChildNode"
+        schema.outputs[0].is_output_list = True
+        return schema
+
+    @classmethod
+    def execute(cls):
+        return io.NodeOutput(["child"])
+
+
+def test_schema_cache_is_isolated_per_subclass():
+    ParentNode.GET_SCHEMA()
+    ChildNode.GET_SCHEMA()
+
+    assert ParentNode.OUTPUT_IS_LIST == [False]
+    assert ChildNode.OUTPUT_IS_LIST == [True]


### PR DESCRIPTION
## Summary
- make schema-derived compatibility caches class-local instead of inheriting populated parent values
- ensure subclasses call `GET_SCHEMA()` when their own cached property has not been initialized
- add a regression test for parent-first initialization with different `OUTPUT_IS_LIST` values

Fixes #16026

## Testing
- `python -m pytest -q tests-unit/comfy_api_test/node_schema_cache_test.py` — 1 passed
- `python -m pytest -q tests-unit/comfy_api_test --ignore=tests-unit/comfy_api_test/preview_ui_3d_test.py` — 141 passed
- `ruff check comfy_api/latest/_io.py tests-unit/comfy_api_test/node_schema_cache_test.py` — passed
- `git diff --check` — passed

The excluded 3D preview test requires CUDA during collection; this contribution was verified with CPU-only PyTorch.
