### PR TITLE
Support Ascend NPU MultiGPU execution

### DIFF
--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -291,27 +291,33 @@ def resolve_gpu_device_option(option: str):
 
 @contextmanager
 def cuda_device_context(device):
-    """Context manager that sets torch.cuda.current_device to match *device*.
+    """Context manager that sets the current accelerator to match *device*.
 
-    Used when running operations on a non-default CUDA device so that custom
-    CUDA kernels (e.g. comfy_kitchen fp8 quantization) pick up the correct
-    device index.  The previous device is restored on exit.
+    Used when running operations on a non-default CUDA or NPU device so that
+    custom kernels pick up the correct device index. The previous device is
+    restored on exit.
 
-    No-op when *device* is not CUDA, has no explicit index, or already matches
-    the current device.
+    No-op for other device types, when *device* has no explicit index, or when
+    the requested device is already current.
     """
+    device_module = None
+    if device.type == "cuda":
+        device_module = torch.cuda
+    elif device.type == "npu":
+        device_module = torch.npu
+
     prev = None
-    if device.type == "cuda" and device.index is not None:
-        prev = torch.cuda.current_device()
+    if device_module is not None and device.index is not None:
+        prev = device_module.current_device()
         if prev != device.index:
-            torch.cuda.set_device(device)
+            device_module.set_device(device)
         else:
             prev = None
     try:
         yield
     finally:
         if prev is not None:
-            torch.cuda.set_device(prev)
+            device_module.set_device(prev)
 
 def get_total_memory(dev=None, torch_total_too=False):
     global directml_enabled
@@ -1822,12 +1828,17 @@ def is_device_xpu(device):
 def is_device_cuda(device):
     return is_device_type(device, 'cuda')
 
+def is_device_npu(device):
+    return is_device_type(device, 'npu')
+
 def set_torch_device(device):
-    """Set the current device for the given torch device. Supports CUDA and XPU."""
+    """Set the current device for the given torch accelerator."""
     if is_device_cuda(device):
         torch.cuda.set_device(device)
     elif is_device_xpu(device):
         torch.xpu.set_device(device)
+    elif is_device_npu(device):
+        torch.npu.set_device(device)
 
 def is_directml_enabled():
     global directml_enabled

--- a/comfy/samplers.py
+++ b/comfy/samplers.py
@@ -461,6 +461,7 @@ def _calc_cond_batch_multigpu(model: BaseModel, conds: list[list[dict]], x_in: t
         area: Any
         batch_chunks: int
         cond_or_uncond: Any
+        copy_event: Any = None
         error: Exception = None
 
     def _handle_batch(device: torch.device, batch_tuple: tuple[comfy.hooks.HookGroup, tuple], results: list[thread_result]):
@@ -524,13 +525,16 @@ def _calc_cond_batch_multigpu(model: BaseModel, conds: list[list[dict]], x_in: t
                         output = model_options['model_function_wrapper'](model_current.apply_model, {"input": input_x, "timestep": timestep_, "c": c, "cond_or_uncond": cond_or_uncond}).to(output_device).chunk(batch_chunks)
                     else:
                         output = model_current.apply_model(input_x, timestep_, **c).to(output_device).chunk(batch_chunks)
-                    # TODO: non-NVIDIA support -- the `.to(output_device)` copies
-                    # above are async on CUDA, so the main thread's aggregation
-                    # could race with in-flight transfers. CUDA-only QA has not
-                    # surfaced this in practice, but before extending multigpu
-                    # beyond NVIDIA add a `torch.cuda.synchronize(output_device)`
-                    # here (guarded by `output_device.type == "cuda"`).
-                    results.append(thread_result(output, mult, area, batch_chunks, cond_or_uncond))
+                    copy_event = None
+                    if device.type == "npu" and device != output_device:
+                        # Cross-NPU copies are queued on the source device's
+                        # current stream. Record completion there and let the
+                        # output stream wait before aggregating the result.
+                        # This preserves asynchronous execution without a
+                        # device-wide synchronize on every diffusion step.
+                        copy_event = torch.npu.Event()
+                        copy_event.record(torch.npu.current_stream(device))
+                    results.append(thread_result(output, mult, area, batch_chunks, cond_or_uncond, copy_event))
         except Exception as e:
             results.append(thread_result(None, None, None, None, None, error=e))
             raise
@@ -561,9 +565,11 @@ def _calc_cond_batch_multigpu(model: BaseModel, conds: list[list[dict]], x_in: t
             raise error
         results.extend(worker_results)
 
-    for output, mult, area, batch_chunks, cond_or_uncond, error in results:
+    for output, mult, area, batch_chunks, cond_or_uncond, copy_event, error in results:
         if error is not None:
             raise error
+        if copy_event is not None:
+            torch.npu.current_stream(output_device).wait_event(copy_event)
         for o in range(batch_chunks):
             cond_index = cond_or_uncond[o]
             a = area[o]

--- a/tests/test_multigpu_npu.py
+++ b/tests/test_multigpu_npu.py
@@ -1,0 +1,99 @@
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+import comfy.model_management as model_management
+from comfy.multigpu import MultiGPUThreadPool
+
+
+class FakeAccelerator:
+    def __init__(self, current=0):
+        self.current = current
+        self.set_calls = []
+
+    def current_device(self):
+        return self.current
+
+    def set_device(self, device):
+        self.set_calls.append(device)
+        self.current = device.index if hasattr(device, "index") else device
+
+
+def fake_device(device_type, index=None):
+    return SimpleNamespace(type=device_type, index=index)
+
+
+@pytest.mark.parametrize("device_type", ["cuda", "npu"])
+def test_device_context_switches_and_restores(monkeypatch, device_type):
+    accelerator = FakeAccelerator(current=0)
+    monkeypatch.setattr(model_management.torch, device_type, accelerator, raising=False)
+    device = fake_device(device_type, 2)
+
+    with model_management.cuda_device_context(device):
+        assert accelerator.current_device() == 2
+
+    assert accelerator.current_device() == 0
+    assert accelerator.set_calls == [device, 0]
+
+
+@pytest.mark.parametrize("device_type", ["cuda", "npu"])
+def test_device_context_is_noop_for_current_device(monkeypatch, device_type):
+    accelerator = FakeAccelerator(current=1)
+    monkeypatch.setattr(model_management.torch, device_type, accelerator, raising=False)
+
+    with model_management.cuda_device_context(fake_device(device_type, 1)):
+        assert accelerator.current_device() == 1
+
+    assert accelerator.set_calls == []
+
+
+def test_set_torch_device_supports_npu(monkeypatch):
+    accelerator = FakeAccelerator()
+    monkeypatch.setattr(model_management.torch, "npu", accelerator, raising=False)
+    device = fake_device("npu", 1)
+
+    model_management.set_torch_device(device)
+
+    assert accelerator.set_calls == [device]
+
+
+def test_multigpu_thread_pool_binds_each_worker(monkeypatch):
+    worker_state = threading.local()
+    devices = ["npu:0", "npu:1", "npu:2"]
+    monkeypatch.setattr(
+        model_management,
+        "set_torch_device",
+        lambda device: setattr(worker_state, "device", device),
+    )
+    pool = MultiGPUThreadPool(devices)
+    try:
+        for device in devices:
+            pool.submit(device, lambda: worker_state.device)
+        for device in devices:
+            result, error = pool.get_result(device)
+            assert error is None
+            assert result == device
+    finally:
+        pool.shutdown()
+
+
+def test_multigpu_thread_pool_reports_error_and_keeps_worker_alive(monkeypatch):
+    monkeypatch.setattr(model_management, "set_torch_device", lambda device: None)
+    pool = MultiGPUThreadPool(["npu:0"])
+    try:
+        def fail():
+            raise RuntimeError("expected failure")
+
+        pool.submit("npu:0", fail)
+        result, error = pool.get_result("npu:0")
+        assert result is None
+        assert isinstance(error, RuntimeError)
+        assert str(error) == "expected failure"
+
+        pool.submit("npu:0", lambda: "recovered")
+        result, error = pool.get_result("npu:0")
+        assert error is None
+        assert result == "recovered"
+    finally:
+        pool.shutdown()

--- a/tests/test_multigpu_npu.py
+++ b/tests/test_multigpu_npu.py
@@ -1,9 +1,10 @@
 import threading
-from types import SimpleNamespace
+from typing import NamedTuple
 
 import pytest
 
 import comfy.model_management as model_management
+import comfy.samplers as samplers
 from comfy.multigpu import MultiGPUThreadPool
 
 
@@ -20,8 +21,13 @@ class FakeAccelerator:
         self.current = device.index if hasattr(device, "index") else device
 
 
+class FakeDevice(NamedTuple):
+    type: str
+    index: int
+
+
 def fake_device(device_type, index=None):
-    return SimpleNamespace(type=device_type, index=index)
+    return FakeDevice(device_type, index)
 
 
 @pytest.mark.parametrize("device_type", ["cuda", "npu"])
@@ -48,6 +54,20 @@ def test_device_context_is_noop_for_current_device(monkeypatch, device_type):
     assert accelerator.set_calls == []
 
 
+def test_npu_device_context_restores_after_exception(monkeypatch):
+    accelerator = FakeAccelerator(current=0)
+    monkeypatch.setattr(model_management.torch, "npu", accelerator, raising=False)
+    device = fake_device("npu", 2)
+
+    with pytest.raises(RuntimeError, match="expected failure"):
+        with model_management.cuda_device_context(device):
+            assert accelerator.current_device() == 2
+            raise RuntimeError("expected failure")
+
+    assert accelerator.current_device() == 0
+    assert accelerator.set_calls == [device, 0]
+
+
 def test_set_torch_device_supports_npu(monkeypatch):
     accelerator = FakeAccelerator()
     monkeypatch.setattr(model_management.torch, "npu", accelerator, raising=False)
@@ -56,6 +76,82 @@ def test_set_torch_device_supports_npu(monkeypatch):
     model_management.set_torch_device(device)
 
     assert accelerator.set_calls == [device]
+
+
+def test_multigpu_aggregation_waits_for_copy_events(monkeypatch):
+    operations = []
+    stream_devices = []
+
+    class FakeEvent:
+        def __init__(self, name):
+            self.name = name
+
+    class FakeStream:
+        def wait_event(self, event):
+            operations.append(("wait", event.name))
+
+    class FakeNPU:
+        def current_stream(self, device):
+            stream_devices.append(device)
+            return FakeStream()
+
+    class FakeOutput:
+        def __init__(self, event_name):
+            self.event_name = event_name
+
+        def __mul__(self, other):
+            assert operations[-1] == ("wait", self.event_name)
+            operations.append(("consume", self.event_name))
+            return model_management.torch.ones_like(other)
+
+    class FakeThreadPool:
+        def __init__(self, responses):
+            self.responses = responses
+
+        def submit(self, device, fn, *args):
+            pass
+
+        def get_result(self, device):
+            return self.responses[device], None
+
+    class FakePatcher:
+        def prepare_state(self, timestep, model_options):
+            pass
+
+    class FakeModel:
+        current_patcher = FakePatcher()
+
+        def memory_required(self, input_shape, cond_shapes):
+            return 1
+
+    devices = [fake_device("npu", 0), fake_device("npu", 1)]
+    x_in = model_management.torch.zeros((1, 1, 1, 1))
+    multiplier = model_management.torch.ones_like(x_in)
+    events = [FakeEvent("event-0"), FakeEvent("event-1")]
+    responses = {
+        device: [([FakeOutput(event.name)], [multiplier], [None], 1, [index], event, None)]
+        for index, (device, event) in enumerate(zip(devices, events))
+    }
+    model_options = {
+        "multigpu_clones": {device: object() for device in devices},
+        "multigpu_thread_pool": FakeThreadPool(responses),
+    }
+    conds = [[{"model_conds": {}, "uuid": f"cond-{index}"}] for index in range(2)]
+
+    monkeypatch.setattr(samplers.comfy.model_management, "get_free_memory", lambda device: 1024)
+    monkeypatch.setattr(samplers.torch, "npu", FakeNPU(), raising=False)
+
+    samplers._calc_cond_batch_multigpu(
+        FakeModel(), conds, x_in, model_management.torch.ones(1), model_options
+    )
+
+    assert operations == [
+        ("wait", "event-0"),
+        ("consume", "event-0"),
+        ("wait", "event-1"),
+        ("consume", "event-1"),
+    ]
+    assert stream_devices == [x_in.device, x_in.device]
 
 
 def test_multigpu_thread_pool_binds_each_worker(monkeypatch):


### PR DESCRIPTION
## Summary

- Set and restore the current Ascend NPU for each MultiGPU worker thread.
- Wait on cross-NPU copy events before aggregating sampler outputs on the main device.
- Add regression coverage for CUDA/NPU device contexts and MultiGPU worker behavior.

Without this change, `set_torch_device()` is a no-op for NPU, so worker threads can submit operations to the wrong device. Cross-NPU outputs can also be consumed before their asynchronous copy completes. The event-based wait preserves asynchronous execution and avoids a device-wide synchronization on every diffusion step.

## Testing

- `pytest -q tests/test_multigpu_npu.py`: 9 passed
- `ruff check comfy/model_management.py comfy/samplers.py tests/test_multigpu_npu.py`: passed
- Broader suite excluding model/inference tests: 294 passed, 7 skipped. One unrelated asset-seeder test failure reproduces on unmodified `master` in the same environment.
- Ascend 910B3: 20 consecutive dual-NPU runs, interruption recovery, and fixed-seed restart reproducibility passed.
- Z-Image Turbo true-CFG, 1920x1088, 8 steps, five hot runs: 17.736 s mean on one NPU versus 8.748 s on two NPUs (50.7% lower server execution time).

## Related work

#16057 also introduces the small `is_device_npu()` helper for a separate NPU offload change. This PR keeps the helper so the MultiGPU implementation is independently testable; it can be trivially rebased if that PR lands first.
