### PR TITLE
Fix BerniniConditioning crash when reference_images is a raw tensor

### DIFF
--- a/comfy_extras/nodes_bernini.py
+++ b/comfy_extras/nodes_bernini.py
@@ -80,15 +80,22 @@ class BerniniConditioning(io.ComfyNode):
             ref_vid = _resize_long_edge(reference_video[:length], ref_max_size)  # moving content, native aspect
             context.append(vae.encode(ref_vid[:, :, :, :3]))
 
-        # reference_images is an autogrow dict {reference_image_0: IMAGE, ...}; each slot is a
-        # separate stream at its own native aspect (a multi-image batch in one slot -> one stream per frame).
-        if reference_images:
-            for name in sorted(reference_images):
-                imgs = reference_images[name]
-                if imgs is None:
-                    continue
-                for i in range(imgs.shape[0]):
-                    img = _resize_long_edge(imgs[i:i + 1], ref_max_size)  # native aspect per ref
+        # reference_images is normally an autogrow dict {reference_image_0: IMAGE, ...}; each slot is
+        # a separate stream at its own native aspect (a multi-image batch in one slot -> one stream per
+        # frame). It can also arrive as a raw IMAGE batch tensor when wired directly (e.g. via the API),
+        # in which case each frame of the batch becomes its own stream.
+        if reference_images is not None:
+            if isinstance(reference_images, dict):
+                for name in sorted(reference_images):
+                    imgs = reference_images[name]
+                    if imgs is None:
+                        continue
+                    for i in range(imgs.shape[0]):
+                        img = _resize_long_edge(imgs[i:i + 1], ref_max_size)  # native aspect per ref
+                        context.append(vae.encode(img[:, :, :, :3]))
+            else:
+                for i in range(reference_images.shape[0]):
+                    img = _resize_long_edge(reference_images[i:i + 1], ref_max_size)
                     context.append(vae.encode(img[:, :, :, :3]))
 
         if context:

--- a/tests-unit/comfy_extras_test/nodes_bernini_test.py
+++ b/tests-unit/comfy_extras_test/nodes_bernini_test.py
@@ -1,0 +1,51 @@
+from unittest.mock import MagicMock
+
+import torch
+
+from comfy.cli_args import args as cli_args
+
+if not torch.cuda.is_available():
+    cli_args.cpu = True
+
+from comfy_extras.nodes_bernini import BerniniConditioning
+
+
+def _run(reference_images):
+    vae = MagicMock()
+    vae.encode.side_effect = lambda pixels: pixels.sum()
+    positive = [[torch.zeros(1, 1), {}]]
+    negative = [[torch.zeros(1, 1), {}]]
+
+    out = BerniniConditioning.execute(
+        positive, negative, vae,
+        width=16, height=16, length=1, batch_size=1,
+        reference_images=reference_images,
+    )
+    return out, vae
+
+
+def test_reference_images_as_tensor_batch():
+    """A raw IMAGE batch (e.g. wired directly instead of through the autogrow dict)
+    must not crash on the ambiguous multi-element tensor boolean check."""
+    images = torch.zeros(3, 16, 16, 3)
+
+    (positive, _negative, _latent), vae = _run(images)
+
+    assert vae.encode.call_count == 3
+    assert len(positive[0][1]["context_latents"]) == 3
+
+
+def test_reference_images_as_dict():
+    images = {"reference_image_0": torch.zeros(2, 16, 16, 3)}
+
+    (positive, _negative, _latent), vae = _run(images)
+
+    assert vae.encode.call_count == 2
+    assert len(positive[0][1]["context_latents"]) == 2
+
+
+def test_reference_images_none():
+    (positive, _negative, _latent), vae = _run(None)
+
+    assert vae.encode.call_count == 0
+    assert "context_latents" not in positive[0][1]


### PR DESCRIPTION
Fixes #16050

## Problem

`BerniniConditioning.execute` (comfy_extras/nodes_bernini.py) assumed
`reference_images` is always the autogrow dict `{reference_image_0: IMAGE, ...}`
that the UI produces. When a raw IMAGE batch tensor is wired directly into
that input instead (e.g. via a hand-built API workflow), the node crashed:

```
RuntimeError: Boolean value of Tensor with more than one value is ambiguous
```

raised by `if reference_images:` (and `sorted(reference_images)` would have
failed the same way right after).

## Fix

Explicitly check `reference_images is not None`, then branch on whether it's
a `dict` (autogrow case, unchanged behavior) or a raw tensor (new case: treat
each frame of the batch as its own reference stream, same as a single autogrow
slot containing a multi-frame batch already does).

## Testing

Added `tests-unit/comfy_extras_test/nodes_bernini_test.py` covering the
tensor-batch, dict, and `None` cases.

Confirmed the new tensor-batch test fails against the pre-fix code:

```
$ git checkout HEAD~1 -- comfy_extras/nodes_bernini.py   # (pre-fix version)
$ python -m pytest tests-unit/comfy_extras_test/nodes_bernini_test.py -v
...
FAILED tests-unit/comfy_extras_test/nodes_bernini_test.py::test_reference_images_as_tensor_batch
RuntimeError: Boolean value of Tensor with more than one value is ambiguous
1 failed, 2 passed in 2.62s

$ git checkout HEAD -- comfy_extras/nodes_bernini.py     # (restore the fix)
$ python -m pytest tests-unit/comfy_extras_test/nodes_bernini_test.py -v
tests-unit/comfy_extras_test/nodes_bernini_test.py::test_reference_images_as_tensor_batch PASSED
tests-unit/comfy_extras_test/nodes_bernini_test.py::test_reference_images_as_dict PASSED
tests-unit/comfy_extras_test/nodes_bernini_test.py::test_reference_images_none PASSED
3 passed in 2.59s
```

Also ran `ruff check` on the changed files (clean) and the full `tests-unit`
suite; the only failures/errors present are pre-existing environment issues
unrelated to this change (a `torchvision`/`torch` build mismatch in this
sandbox, and a couple of unrelated `comfy_quant`/`seedvr2` tests) — none of
which touch `nodes_bernini.py`.

## AI assistance disclosure

This change was written with the assistance of an AI coding agent (Claude).
