### PR TITLE
Warn when --use-ck-attention is enabled for TRELLIS.2

### DIFF
--- a/comfy/model_base.py
+++ b/comfy/model_base.py
@@ -1927,6 +1927,8 @@ class WAN22(WAN21):
 class Trellis2(BaseModel):
     def __init__(self, model_config, model_type=ModelType.FLOW, device=None, unet_model=comfy.ldm.trellis2.model.Trellis2):
         super().__init__(model_config, model_type, device, unet_model)
+        if comfy.model_management.comfy_kitchen_attention_enabled():
+            logging.warning("TRELLIS.2 produces corrupted meshes with --use-ck-attention; run without that flag for correct results.")
 
     def extra_conds(self, **kwargs):
         out = super().extra_conds(**kwargs)

--- a/tests-unit/comfy_test/test_trellis2_attention_warning.py
+++ b/tests-unit/comfy_test/test_trellis2_attention_warning.py
@@ -1,0 +1,38 @@
+import logging
+from types import SimpleNamespace
+
+from comfy.cli_args import args
+
+args.cpu = True
+
+from comfy import model_base, model_management
+
+
+def _model_config():
+    return SimpleNamespace(
+        unet_config={"disable_unet_model_creation": True},
+        latent_format=None,
+        manual_cast_dtype=None,
+        custom_operations=None,
+        optimizations={},
+        memory_usage_factor=1.0,
+        sampling_settings={},
+    )
+
+
+def test_trellis2_warns_when_ck_attention_is_enabled(monkeypatch, caplog):
+    monkeypatch.setattr(model_management, "comfy_kitchen_attention_enabled", lambda: True)
+
+    with caplog.at_level(logging.WARNING):
+        model_base.Trellis2(_model_config())
+
+    assert any("use-ck-attention" in record.message for record in caplog.records)
+
+
+def test_trellis2_does_not_warn_when_ck_attention_is_disabled(monkeypatch, caplog):
+    monkeypatch.setattr(model_management, "comfy_kitchen_attention_enabled", lambda: False)
+
+    with caplog.at_level(logging.WARNING):
+        model_base.Trellis2(_model_config())
+
+    assert not any("use-ck-attention" in record.message for record in caplog.records)

--- a/tests-unit/comfy_test/test_trellis2_attention_warning.py
+++ b/tests-unit/comfy_test/test_trellis2_attention_warning.py
@@ -1,11 +1,26 @@
 import logging
 from types import SimpleNamespace
 
+import pytest
+import torch
+
 from comfy.cli_args import args
 
-args.cpu = True
+# comfy.model_management probes the CUDA device at import time, so the CPU
+# override must be in place before the import below runs (a per-test
+# monkeypatch fixture would apply too late). Scope it to this module instead
+# of leaving it mutated for the rest of the pytest process.
+_original_cpu_flag = args.cpu
+if not torch.cuda.is_available():
+    args.cpu = True
 
 from comfy import model_base, model_management
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _restore_cli_cpu_flag():
+    yield
+    args.cpu = _original_cpu_flag
 
 
 def _model_config():


### PR DESCRIPTION
## Summary

Fixes #16027.

`--use-ck-attention` (comfy-kitchen INT8 attention) is a global switch with no
per-model guard. The issue shows that TRELLIS.2's shape/upsample stages
(`Trellis2ShapeStage` → KSampler → `Trellis2UpsampleStage` → KSampler →
`VaeDecodeShapeTrellis`) silently collapse into a degenerate mesh (~1/15 the
expected vertex/face count) when this flag is active — the run still reports
`execution_success`, so a user just concludes "TRELLIS.2 gives bad meshes"
with no indication the flag is the cause.

Per `AGENTS.md`, model code must use whatever optimized attention backend
ComfyUI selected and must not branch on which backend was chosen, so this
does not force a different attention path for TRELLIS.2. Instead it logs a
one-time warning when the `Trellis2` model is loaded with `--use-ck-attention`
active, so the corrupted output can be attributed to the flag.

## Test plan

Added `tests-unit/comfy_test/test_trellis2_attention_warning.py`, which
constructs a `Trellis2` model with unet construction disabled and asserts the
warning is logged only when `comfy_kitchen_attention_enabled()` is true.

Verified the added test fails without the fix (`git checkout HEAD~1 --
comfy/model_base.py`, rerun, restore):

```
$ python -m pytest tests-unit/comfy_test/test_trellis2_attention_warning.py -v
...
tests-unit/comfy_test/test_trellis2_attention_warning.py::test_trellis2_warns_when_ck_attention_is_enabled FAILED
tests-unit/comfy_test/test_trellis2_attention_warning.py::test_trellis2_does_not_warn_when_ck_attention_is_disabled PASSED
```

With the fix:

```
$ python -m pytest tests-unit/comfy_test/test_trellis2_attention_warning.py -v
...
tests-unit/comfy_test/test_trellis2_attention_warning.py::test_trellis2_warns_when_ck_attention_is_enabled PASSED
tests-unit/comfy_test/test_trellis2_attention_warning.py::test_trellis2_does_not_warn_when_ck_attention_is_disabled PASSED
2 passed in 5.05s
```

Full suite, no regressions:

```
$ python -m pytest tests-unit -q
1535 passed, 10 skipped, 12 warnings in 47.87s
```

`ruff check comfy/model_base.py tests-unit/comfy_test/test_trellis2_attention_warning.py` — all checks passed.

---
This change was drafted with AI assistance (Claude) and reviewed before submission.
