### PR TITLE
Fix Trellis2 sparse RoPE shape for accelerated backends

### DIFF
--- a/comfy/ldm/trellis2/model.py
+++ b/comfy/ldm/trellis2/model.py
@@ -118,15 +118,27 @@ class SparseRotaryPositionEmbedder(nn.Module):
             freqs_cis = self._get_freqs_cis(coords)
             q.register_spatial_cache(cache_name, freqs_cis)
 
-        if q.feats.ndim == 3:
-            f_cis = freqs_cis.unsqueeze(1)
+        # Sparse feats are [N, heads, head_dim] with no explicit batch axis (batch
+        # is folded into N via coords). Accelerated RoPE backends (e.g. the
+        # comfy_kitchen triton kernel) require a 4-D (batch, dim1, dim2, head_dim)
+        # input, so add a size-1 batch dim here and mirror it on freqs_cis, the
+        # same way the dense path does for its [B, L, H, head_dim] tensors.
+        is_sparse_feats = q.feats.ndim == 3
+        if is_sparse_feats:
+            f_cis = freqs_cis.unsqueeze(0).unsqueeze(2)
         else:
             f_cis = freqs_cis
 
         if k is None:
-            return q.replace(apply_rope1(q.feats, f_cis))
+            q_feats = q.feats.unsqueeze(0) if is_sparse_feats else q.feats
+            out = apply_rope1(q_feats, f_cis)
+            return q.replace(out.squeeze(0) if is_sparse_feats else out)
 
-        q_feats, k_feats = apply_rope(q.feats, k.feats, f_cis)
+        q_feats = q.feats.unsqueeze(0) if is_sparse_feats else q.feats
+        k_feats = k.feats.unsqueeze(0) if is_sparse_feats else k.feats
+        q_feats, k_feats = apply_rope(q_feats, k_feats, f_cis)
+        if is_sparse_feats:
+            q_feats, k_feats = q_feats.squeeze(0), k_feats.squeeze(0)
         return q.replace(q_feats), k.replace(k_feats)
 
 

--- a/tests-unit/comfy_test/test_trellis2_rope.py
+++ b/tests-unit/comfy_test/test_trellis2_rope.py
@@ -1,0 +1,78 @@
+"""Regression test for SparseRotaryPositionEmbedder RoPE shape handling.
+
+Accelerated RoPE backends (e.g. comfy-kitchen's triton kernel, which every
+ComfyUI install depends on via requirements.txt) unpack their input tensor as
+exactly (batch, dim1, dim2, head_dim) -- see comfy_kitchen/backends/triton/rope.py.
+Trellis2's sparse attention path (shape/texture generation) feeds it
+[N, heads, head_dim], 3-D with no explicit batch axis, which used to raise
+"ValueError: not enough values to unpack (expected 4, got 3)" (issue #16028).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import torch
+
+from comfy.cli_args import args
+
+if not torch.cuda.is_available():
+    args.cpu = True
+
+import comfy.quant_ops as quant_ops  # noqa: E402
+from comfy.ldm.flux.math import _apply_rope1  # noqa: E402
+from comfy.ldm.trellis2.model import SparseRotaryPositionEmbedder  # noqa: E402
+from comfy.ldm.trellis2.vae import SparseTensor  # noqa: E402
+
+
+class _StrictCK:
+    """Stand-in for comfy_kitchen's triton backend: requires 4-D tensors."""
+
+    @staticmethod
+    def apply_rope1(x, freqs_cis):
+        _batch, _dim1, _dim2, _head_dim = x.shape  # raises ValueError if x isn't 4-D
+        return _apply_rope1(x, freqs_cis)
+
+    @staticmethod
+    def apply_rope(xq, xk, freqs_cis):
+        return _StrictCK.apply_rope1(xq, freqs_cis), _StrictCK.apply_rope1(xk, freqs_cis)
+
+
+def _make_sparse_qk(num_tokens: int, heads: int, head_dim: int, resolution: int = 4):
+    coords = torch.stack(
+        [
+            torch.zeros(num_tokens, dtype=torch.int32),
+            torch.randint(0, resolution, (num_tokens,), dtype=torch.int32),
+            torch.randint(0, resolution, (num_tokens,), dtype=torch.int32),
+            torch.randint(0, resolution, (num_tokens,), dtype=torch.int32),
+        ],
+        dim=1,
+    )
+    q_feats = torch.randn(num_tokens, heads, head_dim)
+    k_feats = torch.randn(num_tokens, heads, head_dim)
+    q = SparseTensor(feats=q_feats, coords=coords, shape=torch.Size([1, heads, head_dim]))
+    k = SparseTensor(feats=k_feats, coords=coords, shape=torch.Size([1, heads, head_dim]))
+    return q, k
+
+
+def test_sparse_rope_works_with_4d_only_backend():
+    heads, head_dim, num_tokens = 3, 16, 5
+    rope = SparseRotaryPositionEmbedder(head_dim=head_dim, dim=3)
+    q, k = _make_sparse_qk(num_tokens=num_tokens, heads=heads, head_dim=head_dim)
+
+    with patch.object(quant_ops, "ck", _StrictCK(), create=True):
+        q_out, k_out = rope(q, k)
+
+    assert q_out.feats.shape == (num_tokens, heads, head_dim)
+    assert k_out.feats.shape == (num_tokens, heads, head_dim)
+
+
+def test_sparse_rope_single_input_works_with_4d_only_backend():
+    heads, head_dim, num_tokens = 2, 8, 4
+    rope = SparseRotaryPositionEmbedder(head_dim=head_dim, dim=3)
+    q, _ = _make_sparse_qk(num_tokens=num_tokens, heads=heads, head_dim=head_dim)
+
+    with patch.object(quant_ops, "ck", _StrictCK(), create=True):
+        q_out = rope(q)
+
+    assert q_out.feats.shape == (num_tokens, heads, head_dim)


### PR DESCRIPTION
## Problem

Fixes #16028.

Trellis2's Shape Generation stage crashes at KSampler with:

```
ValueError: not enough values to unpack (expected 4, got 3)
```

The traceback (from the reporter's log) bottoms out in comfy-kitchen's triton
`apply_rope` kernel, which unpacks its query/key tensor as exactly
`(batch, dim1, dim2, head_dim) = x.shape`. `comfy-kitchen` is a hard
dependency (`requirements.txt`), and `apply_rope`/`apply_rope1` in
`comfy/ldm/flux/math.py` dispatch to it whenever `comfy.model_management.in_training`
is `False` (the default at inference), so every install hits this path.

`SparseRotaryPositionEmbedder.forward` in `comfy/ldm/trellis2/model.py`
(used by Trellis2's sparse shape/texture attention) passes it query/key
tensors shaped `[N, heads, head_dim]` — 3-D, since the sparse-token batch
dimension is folded into `N` via `coords` rather than kept as a separate
axis. That 3-D shape fails the kernel's 4-D unpack. The dense
(`SparseStructureFlowModel`) path already avoids this by keeping
`freqs_cis` 6-D (`[1, L, 1, head_dim/2, 2, 2]`) to match its dense
`[B, L, H, head_dim]` q/k tensors; the sparse path never got the equivalent
treatment.

## Fix

Add a size-1 batch dim to the sparse `q`/`k` feats before calling
`apply_rope`/`apply_rope1`, and shape `freqs_cis` to match (mirroring what
the dense path already does), then drop the added dim from the result.
This only changes tensor layout going into/out of the shared RoPE helper —
the math is unchanged.

## Test plan

Added `tests-unit/comfy_test/test_trellis2_rope.py`, which stands in a
minimal fake for comfy-kitchen's triton backend (same strict 4-D unpack)
and drives `SparseRotaryPositionEmbedder` with sparse-shaped q/k, matching
the KSampler crash path from the issue.

Confirmed the test reproduces the reported crash before the fix
(`git stash` the fix, rerun):

```
$ python -m pytest tests-unit/comfy_test/test_trellis2_rope.py -v
...
E       ValueError: not enough values to unpack (expected 4, got 3)
tests-unit/comfy_test/test_trellis2_rope.py:33: ValueError
FAILED tests-unit/comfy_test/test_trellis2_rope.py::test_sparse_rope_works_with_4d_only_backend
FAILED tests-unit/comfy_test/test_trellis2_rope.py::test_sparse_rope_single_input_works_with_4d_only_backend
2 failed in 2.76s
```

And passes with the fix:

```
$ python -m pytest tests-unit/comfy_test/test_trellis2_rope.py -v
tests-unit/comfy_test/test_trellis2_rope.py::test_sparse_rope_works_with_4d_only_backend PASSED
tests-unit/comfy_test/test_trellis2_rope.py::test_sparse_rope_single_input_works_with_4d_only_backend PASSED
2 passed in 2.73s
```

Also ran the broader unit suite (`tests-unit/comfy_test`, `tests-unit/comfy_quant`,
149 tests) with the fix applied — all pass. `ruff check` on the changed files
passes clean.

- [x] I have tested this fix locally (unit test above; no GPU/comfy-kitchen
  triton backend available in this environment, so the test mocks the
  backend's documented 4-D shape contract rather than running the real
  kernel)

---
This PR was prepared with AI assistance (Claude).
