### PR TITLE
Fix TypeError when saving checkpoints with dynamic VRAM loading (FakeDevice)

### DIFF
--- a/comfy/diffusers_convert.py
+++ b/comfy/diffusers_convert.py
@@ -117,6 +117,10 @@ code2idx = {"q": 0, "k": 1, "v": 2}
 
 # This function exists because at the time of writing torch.cat can't do fp8 with cuda
 def cat_tensors(tensors):
+    # Materialize lazy-casting weights (e.g. comfy.model_patcher.LazyCastingParam) whose
+    # .device property returns a placeholder object instead of a real torch.device.
+    tensors = [t.to(t.device) for t in tensors]
+
     x = 0
     for t in tensors:
         x += t.shape[0]

--- a/tests-unit/comfy_test/diffusers_convert_test.py
+++ b/tests-unit/comfy_test/diffusers_convert_test.py
@@ -28,6 +28,8 @@ def test_cat_tensors_with_lazy_casting_param():
     fake = LazyCastingLikeTensor(real)
 
     out = cat_tensors([fake, fake])
+    regular_out = cat_tensors([real, real])
 
     assert out.device.type == "cpu"
     assert torch.equal(out, torch.cat([real, real], dim=0))
+    assert torch.equal(regular_out, torch.cat([real, real], dim=0))

--- a/tests-unit/comfy_test/diffusers_convert_test.py
+++ b/tests-unit/comfy_test/diffusers_convert_test.py
@@ -1,0 +1,33 @@
+import collections
+
+import torch
+
+from comfy.diffusers_convert import cat_tensors
+
+FakeDevice = collections.namedtuple("FakeDevice", ["type", "index"])("comfy-lazy-caster", 0)
+
+
+class LazyCastingLikeTensor(torch.Tensor):
+    """Mimics comfy.model_patcher.LazyCastingParam: its .device property lies
+    (returns a non-torch.device object) but .to() materializes the real tensor."""
+
+    @staticmethod
+    def __new__(cls, tensor):
+        return super().__new__(cls, tensor)
+
+    @property
+    def device(self):
+        return FakeDevice
+
+    def to(self, *args, **kwargs):
+        return torch.Tensor(self).to("cpu")
+
+
+def test_cat_tensors_with_lazy_casting_param():
+    real = torch.randn(3, 4)
+    fake = LazyCastingLikeTensor(real)
+
+    out = cat_tensors([fake, fake])
+
+    assert out.device.type == "cpu"
+    assert torch.equal(out, torch.cat([real, real], dim=0))


### PR DESCRIPTION
## Problem

Fixes #16070.

Saving a SDXL/SD2 checkpoint with dynamic VRAM loading enabled (`CheckpointSave`
after `Load Checkpoint` + `Load Dual CLIP` + `Load VAE`) crashes with:

```
TypeError: empty(): argument 'device' must be torch.device, not FakeDevice
  File "comfy/diffusers_convert.py", line 125, in cat_tensors
    out = torch.empty(shape, device=tensors[0].device, dtype=tensors[0].dtype)
```

## Root cause

`comfy.model_patcher.LazyCastingParam` (used to cast/patch weights on demand
while a checkpoint is being written, so the whole model doesn't need to be
materialized in memory up front) overrides `.device` to return a placeholder
`namedtuple` instead of a real `torch.device`, and only produces the real
tensor once `.to()` is called.

`cat_tensors()`, used by `convert_text_enc_state_dict_v20()` to merge the
CLIP text encoder's q/k/v projection weights for saving, reads
`tensors[0].device` directly to allocate its output buffer with
`torch.empty(...)`. `torch.empty` rejects the placeholder device object,
so the save fails for any model whose CLIP state dict goes through this
lazy-casting path (e.g. SDXL/SD2.x models with dynamic VRAM loading).

## Fix

Materialize each tensor via `.to(t.device)` before concatenating. For a
`LazyCastingParam` this resolves the real, correctly patched weight on a
real device (its `.to()` override ignores the passed device/args and always
returns the properly patched CPU tensor); for an ordinary tensor this is a
no-op that preserves its existing device, so the unrelated
"`torch.cat` can't do fp8 with cuda" behavior this function exists for is
unchanged.

## Test plan

Added `tests-unit/comfy_test/diffusers_convert_test.py`, which reproduces the
crash with a minimal stand-in for `LazyCastingParam` (a tensor subclass whose
`.device` returns a placeholder object but whose `.to()` materializes the
real tensor).

Before the fix (verified by temporarily reverting `comfy/diffusers_convert.py`
only, via `git stash`):

```
$ python -m pytest tests-unit/comfy_test/diffusers_convert_test.py -v
...
TypeError: empty(): argument 'device' must be torch.device, not FakeDevice
FAILED tests-unit/comfy_test/diffusers_convert_test.py::test_cat_tensors_with_lazy_casting_param
```

After the fix:

```
$ python -m pytest tests-unit/comfy_test/diffusers_convert_test.py -v
tests-unit/comfy_test/diffusers_convert_test.py::test_cat_tensors_with_lazy_casting_param PASSED
1 passed, 1 warning in 0.87s
```

Also ran the rest of the collectible `tests-unit/comfy_test` suite (some
files fail to collect in this sandbox due to missing unrelated optional
dependencies — `einops`, `PIL`, `comfy_aimdo` — confirmed pre-existing on
unmodified `master`, unrelated to this change):

```
$ python -m pytest tests-unit/comfy_test -q <ignoring the pre-existing collection errors above>
15 passed, 1 warning in 0.89s
```

`ruff check comfy/diffusers_convert.py tests-unit/comfy_test/diffusers_convert_test.py` passes with no issues.

## AI assistance disclosure

This change was prepared with AI assistance (Claude).
