### PR TITLE
Add per-image MiniMax H3 text encoder references

### DIFF
--- a/comfy/ldm/minimax/model.py
+++ b/comfy/ldm/minimax/model.py
@@ -359,8 +359,15 @@ class PackedLayout:
 
         target_audio_w = (float(w_grid[0]), float(w_grid[-1]))
         # refs pack between text and the targets, so the target timeline starts after their spans
+        ref_positions = []
         cursor = float(text_len)
+        next_picture_index = 0
         for blk in refs or ():
+            if blk["kind"] == "image":
+                picture_index = blk.get("picture_index", next_picture_index)
+                cursor += picture_index - next_picture_index
+                next_picture_index = picture_index + 1
+            ref_positions.append((blk, cursor))
             cursor += _ref_t_span(blk)
 
         if keyframes:
@@ -386,31 +393,28 @@ class PackedLayout:
                     audio_update.append(torch.zeros(rt * 2, dtype=torch.bool))
                     row += rt * 2
 
-        if refs:
-            cursor = float(text_len)
-            for blk in refs:
+        if ref_positions:
+            for blk, ref_cursor in ref_positions:
                 kind = blk["kind"]
                 if kind == "image":
                     r_frame, _ = _frame_grid(blk["latent_h"], blk["latent_w"])
                     n = r_frame.shape[0]
                     g = torch.empty(n, 3, dtype=torch.float64)
-                    g[:, 0] = cursor
+                    g[:, 0] = ref_cursor
                     g[:, 1:] = r_frame
                     segments.append(("ref_img", n))
                     pos.append(g)
                     img_pos.append(torch.arange(row, row + n))
                     img_update.append(torch.zeros(n, dtype=torch.bool))
                     row += n
-                    cursor += 1.0
                 elif kind == "audio":
                     rt = blk["ref_audio_t"]
                     if rt > 0:
                         segments.append(("ref_audio", rt * 2))
-                        pos.append(_audio_grid(cursor, rt, *target_audio_w))
+                        pos.append(_audio_grid(ref_cursor, rt, *target_audio_w))
                         audio_pos.append(torch.arange(row, row + rt * 2))
                         audio_update.append(torch.zeros(rt * 2, dtype=torch.bool))
                         row += rt * 2
-                    cursor += float(rt)
                 elif kind in ("video", "video_audio"):
                     # the block's audio rows pack immediately before its video
                     # rows, both sharing the cursor origin
@@ -419,17 +423,16 @@ class PackedLayout:
                     r_frame, r_w_grid = _frame_grid(blk["latent_h"], blk["latent_w"])
                     if rt > 0:
                         segments.append(("ref_audio", rt * 2))
-                        pos.append(_audio_grid(cursor, rt, float(r_w_grid[0]), float(r_w_grid[-1])))
+                        pos.append(_audio_grid(ref_cursor, rt, float(r_w_grid[0]), float(r_w_grid[-1])))
                         audio_pos.append(torch.arange(row, row + rt * 2))
                         audio_update.append(torch.zeros(rt * 2, dtype=torch.bool))
                         row += rt * 2
                     n = vt * r_frame.shape[0]
                     segments.append(("ref_img", n))
-                    pos.append(_video_grid(vt, r_frame, cursor))
+                    pos.append(_video_grid(vt, r_frame, ref_cursor))
                     img_pos.append(torch.arange(row, row + n))
                     img_update.append(torch.zeros(n, dtype=torch.bool))
                     row += n
-                    cursor += max(float(rt), sum(_video_t_spans(vt)))
 
         # target audio then target video, always the last two segments
         segments.append(("audio", audio_t * 2))

--- a/comfy_extras/nodes_minimax_h3.py
+++ b/comfy_extras/nodes_minimax_h3.py
@@ -32,6 +32,8 @@ REF_IMAGE_SHORT_EDGE = 2048
 FPS = 24
 AUDIO_LATENT_FPS = 40
 
+MiniMaxH3ReferenceImage = io.Custom("MINIMAX_H3_REFERENCE_IMAGE")
+
 
 def align_frame_count(n):
     while n % 17 != 5:
@@ -238,6 +240,23 @@ class MiniMaxH3AddGuide(io.ComfyNode):
         return io.NodeOutput(positive)
 
 
+class MiniMaxH3TextEncoderOnlyReference(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="MiniMaxH3TextEncoderOnlyReference",
+            display_name="MiniMax H3 Text Encoder Only Reference",
+            description="Mark a reference image to condition the MiniMax H3 text encoder without VAE encoding it for the diffusion model.",
+            category="model/conditioning/minimax",
+            inputs=[io.Image.Input("image")],
+            outputs=[MiniMaxH3ReferenceImage.Output(display_name="reference_image")],
+        )
+
+    @classmethod
+    def execute(cls, image) -> io.NodeOutput:
+        return io.NodeOutput({"image": image})
+
+
 class MiniMaxH3ReferenceToVideo(io.ComfyNode):
     """ref2va: prompt + reference images / videos / audio -> conditioning + AV latent.
 
@@ -266,7 +285,9 @@ class MiniMaxH3ReferenceToVideo(io.ComfyNode):
                     tooltip="Reference image sizing. 'match' scales each ref (down only, keeping aspect) to the generation's pixel area; 'max' uses the reference pipeline's 2048px short edge for best identity fidelity. Reference tokens ride through every sampling step, so 'max' can be several times slower."),
                 io.Autogrow.Input("ref_images", optional=True,
                     template=io.Autogrow.TemplatePrefix(
-                        input=io.Image.Input("ref_image", tooltip="Reference image (downscaled to 2048 short edge if larger, never upscaled)"),
+                        input=io.MultiType.Input(
+                            io.Image.Input("ref_image", tooltip="Reference image (downscaled to 2048 short edge if larger, never upscaled)"),
+                            types=[MiniMaxH3ReferenceImage]),
                         prefix="ref_image_", min=0, max=9)),
                 io.Autogrow.Input("ref_videos", optional=True,
                     template=io.Autogrow.TemplatePrefix(
@@ -290,11 +311,13 @@ class MiniMaxH3ReferenceToVideo(io.ComfyNode):
         latent, frame_count = _empty_av_latent(width, height, length)
 
         ref_items = []   # for the tokenizer presentation, in request order
-        ref_blocks = []  # for the DiT payload, same order
+        ref_blocks = []  # VAE-enabled subset for the DiT payload, in request order
 
-        for img in (ref_images or {}).values():
-            if img is None:
+        for ref_image in (ref_images or {}).values():
+            if ref_image is None:
                 continue
+            text_encoder_only = isinstance(ref_image, dict)
+            img = ref_image["image"] if text_encoder_only else ref_image
             h, w = img.shape[1], img.shape[2]
             if ref_image_size == "match":
                 # aspect-preserving scale (down only) to the generation's pixel area
@@ -305,7 +328,7 @@ class MiniMaxH3ReferenceToVideo(io.ComfyNode):
             th = max(CANVAS_MULTIPLE, round(h * scale / CANVAS_MULTIPLE) * CANVAS_MULTIPLE)
             resized = _resize(img[:1], tw, th, "disabled")
             ref_items.append({"type": "image", "data": resized})
-            if vae is not None:
+            if vae is not None and not text_encoder_only:
                 z = vae.encode(resized)
                 ref_blocks.append({"kind": "image", "latent_h": th // 16, "latent_w": tw // 16, "latent": z})
 
@@ -616,6 +639,7 @@ class MiniMaxH3Extension(ComfyExtension):
             EmptyMiniMaxH3LatentAV,
             MiniMaxH3ImageToVideo,
             MiniMaxH3AddGuide,
+            MiniMaxH3TextEncoderOnlyReference,
             MiniMaxH3ReferenceToVideo,
             MiniMaxH3SigmaShift,
             MiniMaxH3FunControlNetApply,

--- a/comfy_extras/nodes_minimax_h3.py
+++ b/comfy_extras/nodes_minimax_h3.py
@@ -312,6 +312,7 @@ class MiniMaxH3ReferenceToVideo(io.ComfyNode):
 
         ref_items = []   # for the tokenizer presentation, in request order
         ref_blocks = []  # VAE-enabled subset for the DiT payload, in request order
+        picture_index = 0
 
         for ref_image in (ref_images or {}).values():
             if ref_image is None:
@@ -330,7 +331,9 @@ class MiniMaxH3ReferenceToVideo(io.ComfyNode):
             ref_items.append({"type": "image", "data": resized})
             if vae is not None and not text_encoder_only:
                 z = vae.encode(resized)
-                ref_blocks.append({"kind": "image", "latent_h": th // 16, "latent_w": tw // 16, "latent": z})
+                ref_blocks.append({"kind": "image", "picture_index": picture_index,
+                                   "latent_h": th // 16, "latent_w": tw // 16, "latent": z})
+            picture_index += 1
 
         ref_video_audios = ref_video_audios or {}
         for name, video_frames in (ref_videos or {}).items():

--- a/tests-unit/comfy_extras_test/test_nodes_minimax_h3.py
+++ b/tests-unit/comfy_extras_test/test_nodes_minimax_h3.py
@@ -4,6 +4,7 @@ from comfy.cli_args import args
 
 args.cpu = True
 
+from comfy.ldm.minimax.model import PackedLayout
 from comfy_extras import nodes_minimax_h3
 
 
@@ -61,18 +62,28 @@ def test_marked_reference_skips_vae_but_still_reaches_text_encoder(monkeypatch):
         width=32,
         height=32,
         length=5,
-        ref_images={"ref_image_0": plain_image, "ref_image_1": marked_reference},
+        ref_images={"ref_image_0": marked_reference, "ref_image_1": plain_image},
     )
 
     assert clip.prompt == "test"
     assert len(clip.ref_items) == 2
-    assert torch.equal(clip.ref_items[0]["data"], plain_image)
-    assert torch.equal(clip.ref_items[1]["data"], marked_image)
+    assert torch.equal(clip.ref_items[0]["data"], marked_image)
+    assert torch.equal(clip.ref_items[1]["data"], plain_image)
     assert len(vae.images) == 1
     assert torch.equal(vae.images[0], plain_image)
     refs = output.result[0][0][1]["minimax_refs"]
     assert len(refs) == 1
     assert refs[0]["kind"] == "image"
+    assert refs[0]["picture_index"] == 1
+
+
+def test_vae_reference_keeps_position_after_marked_reference():
+    refs = [{"kind": "image", "picture_index": 1, "latent_h": 2, "latent_w": 2}]
+
+    layout = PackedLayout(text_len=8, latent_t=1, latent_h=2, latent_w=2, audio_t=1, refs=refs)
+
+    ref_start = next(start for start, _, kind in layout.segments if kind == "ref_img")
+    assert layout.position_ids[ref_start, 0] == 9
 
 
 def test_no_vae_keeps_all_references_text_encoder_only(monkeypatch):

--- a/tests-unit/comfy_extras_test/test_nodes_minimax_h3.py
+++ b/tests-unit/comfy_extras_test/test_nodes_minimax_h3.py
@@ -1,0 +1,98 @@
+import torch
+
+from comfy.cli_args import args
+
+args.cpu = True
+
+from comfy_extras import nodes_minimax_h3
+
+
+class FakeClip:
+    def tokenize(self, prompt, minimax_ref_items=None):
+        self.prompt = prompt
+        self.ref_items = minimax_ref_items
+        return {}
+
+    def encode_from_tokens_scheduled(self, tokens):
+        return [[torch.empty(1), {}]]
+
+
+class FakeVAE:
+    def __init__(self):
+        self.images = []
+
+    def encode(self, image):
+        self.images.append(image)
+        return torch.empty(1, 24, 1, 2, 2)
+
+
+def test_text_encoder_only_reference_wraps_image():
+    image = torch.rand(1, 32, 32, 3)
+
+    reference = nodes_minimax_h3.MiniMaxH3TextEncoderOnlyReference.execute(image).result[0]
+
+    assert list(reference) == ["image"]
+    assert reference["image"] is image
+
+
+def test_reference_input_accepts_images_and_marked_references():
+    schema = nodes_minimax_h3.MiniMaxH3ReferenceToVideo.define_schema()
+    schema.finalize()
+    schema.validate()
+    ref_images = schema.get_v1_info(nodes_minimax_h3.MiniMaxH3ReferenceToVideo).input["optional"]["ref_images"]
+
+    assert ref_images[1]["template"]["input"]["required"]["ref_image"][0] == "IMAGE,MINIMAX_H3_REFERENCE_IMAGE"
+
+
+def test_marked_reference_skips_vae_but_still_reaches_text_encoder(monkeypatch):
+    monkeypatch.setattr(nodes_minimax_h3, "_empty_av_latent", lambda width, height, length: ({"samples": torch.empty(0)}, 5))
+    monkeypatch.setattr(nodes_minimax_h3, "_resize", lambda image, width, height, crop: image)
+    plain_image = torch.rand(1, 32, 32, 3)
+    marked_image = torch.rand(1, 32, 32, 3)
+    marked_reference = nodes_minimax_h3.MiniMaxH3TextEncoderOnlyReference.execute(marked_image).result[0]
+    clip = FakeClip()
+    vae = FakeVAE()
+
+    output = nodes_minimax_h3.MiniMaxH3ReferenceToVideo.execute(
+        clip=clip,
+        vae=vae,
+        audio_vae=None,
+        prompt="test",
+        width=32,
+        height=32,
+        length=5,
+        ref_images={"ref_image_0": plain_image, "ref_image_1": marked_reference},
+    )
+
+    assert clip.prompt == "test"
+    assert len(clip.ref_items) == 2
+    assert torch.equal(clip.ref_items[0]["data"], plain_image)
+    assert torch.equal(clip.ref_items[1]["data"], marked_image)
+    assert len(vae.images) == 1
+    assert torch.equal(vae.images[0], plain_image)
+    refs = output.result[0][0][1]["minimax_refs"]
+    assert len(refs) == 1
+    assert refs[0]["kind"] == "image"
+
+
+def test_no_vae_keeps_all_references_text_encoder_only(monkeypatch):
+    monkeypatch.setattr(nodes_minimax_h3, "_empty_av_latent", lambda width, height, length: ({"samples": torch.empty(0)}, 5))
+    monkeypatch.setattr(nodes_minimax_h3, "_resize", lambda image, width, height, crop: image)
+    plain_image = torch.rand(1, 32, 32, 3)
+    marked_image = torch.rand(1, 32, 32, 3)
+    marked_reference = nodes_minimax_h3.MiniMaxH3TextEncoderOnlyReference.execute(marked_image).result[0]
+    clip = FakeClip()
+
+    output = nodes_minimax_h3.MiniMaxH3ReferenceToVideo.execute(
+        clip=clip,
+        vae=None,
+        audio_vae=None,
+        prompt="test",
+        width=32,
+        height=32,
+        length=5,
+        ref_images={"ref_image_0": plain_image, "ref_image_1": marked_reference},
+    )
+
+    assert len(clip.ref_items) == 2
+    assert "minimax_refs" not in output.result[0][0][1]


### PR DESCRIPTION
## Summary

- Add a `MiniMax H3 Text Encoder Only Reference` marker node.
- Allow each `MiniMax H3 Reference to Video` image input to accept either a regular image or a marked reference.
- Keep marked images in the Qwen3-VL presentation while excluding them from VAE encoding and the DiT reference-latent payload.
- Preserve each VAE-backed image's original `<Picture n>` position when marked and regular references are mixed.
- Preserve the existing behavior for ordinary image references and workflows without a VAE.

This builds on #16065, which made the VAE optional for all references, by allowing text-encoder-only and VAE-backed image references to be mixed in the same workflow.

## Demo

The comparison uses the same FL2VA model, prompt, noise, and sampling settings for three outputs:

1. Text-described identities without image references.
2. The same images marked as Qwen3-VL-only references.
3. The same images used as regular VAE-backed references.

### Follow-up suggestion

Qwen3-VL-only references do not enter the VAE/DiT reference payload, so they could eventually be allowed to exceed the current nine-image UI limit. This PR intentionally keeps the existing limit unchanged.

## Tests

- `225 passed` in `tests-unit/comfy_extras_test`
- `ruff check comfy_extras/nodes_minimax_h3.py tests-unit/comfy_extras_test/test_nodes_minimax_h3.py`
- Manual MiniMax H3 FL2VA comparison with two Qwen-only references and two regular references, including generated audio

<img width="256" alt="tim_burton_1989_batmobile" src="https://github.com/user-attachments/assets/71aa53e6-2a42-4970-9bc7-8ac43b99e4ab" /> <img width="256" alt="scooby_doo_mystery_machine" src="https://github.com/user-attachments/assets/de16e425-229f-4558-b437-fc976a4a2fc5" />
[minimax-h3-text-encoder-only-reference-demo.json](https://github.com/user-attachments/files/31812679/minimax-h3-text-encoder-only-reference-demo.json) 

https://github.com/user-attachments/assets/a10c66f8-e6b6-4a99-88d7-130402e50eb1



