### PR TITLE
[review-stack 9/9] fixes

### DIFF
--- a/app/assets/api/routes.py
+++ b/app/assets/api/routes.py
@@ -736,6 +736,10 @@ async def upload_asset(request: web.Request) -> web.Response:
 
     try:
         if not parsed.file_present and spec.hash:
+            if not mode.hashing_enabled():
+                return _build_error_response(
+                    400, "FEATURE_DISABLED", "Asset hashing is disabled."
+                )
             result = create_from_hash(
                 hash_str=spec.hash,
                 name=spec.name or (spec.hash.split(":", 1)[1]),

--- a/app/assets/database/queries/__init__.py
+++ b/app/assets/database/queries/__init__.py
@@ -8,6 +8,7 @@ from importlib import import_module
 
 from app.assets.database.queries.records import (
     create_content,
+    create_content_reporting_insert,
     create_record,
     delete_record,
     fetch_record_tags,
@@ -21,6 +22,7 @@ from app.assets.database.queries.records import (
 
 __all__ = [
     "create_content",
+    "create_content_reporting_insert",
     "create_record",
     "delete_record",
     "fetch_record_tags",

--- a/app/assets/database/queries/records.py
+++ b/app/assets/database/queries/records.py
@@ -55,7 +55,7 @@ def _is_live_path_conflict(error: IntegrityError) -> bool:
     return postgres_names_the_index or sqlite_names_the_column
 
 
-def create_content(session: Session, path: str, hash: str | None = None, size_bytes: int = 0, mtime_ns: int | None = None) -> AssetContent:
+def create_content_reporting_insert(session: Session, path: str, hash: str | None = None, size_bytes: int = 0, mtime_ns: int | None = None) -> tuple[AssetContent, bool]:
     # The sole writer of asset_contents.path, which is what makes the raw-column SQL prefix
     # predicates sound — lifecycle's temp wipe HARD-DELETES every row its predicate admits.
     path = os.path.abspath(path)
@@ -64,12 +64,17 @@ def create_content(session: Session, path: str, hash: str | None = None, size_by
         with session.begin_nested():
             session.add(content)
             session.flush()
-            return content
+            return content, True
     except IntegrityError as error:
         if not _is_live_path_conflict(error):
             raise
         winner = session.execute(sa.select(AssetContent).where(AssetContent.path == path, AssetContent.is_missing.is_(False))).scalar_one()
-        return winner
+        return winner, False
+
+
+def create_content(session: Session, path: str, hash: str | None = None, size_bytes: int = 0, mtime_ns: int | None = None) -> AssetContent:
+    content, _ = create_content_reporting_insert(session, path, hash, size_bytes, mtime_ns)
+    return content
 
 
 def ensure_tag(session: Session, name: str) -> None:

--- a/app/assets/manager.py
+++ b/app/assets/manager.py
@@ -6,7 +6,7 @@ from aiohttp import web
 from app.assets import mode
 from app.assets.api.routes import register_assets_routes
 from app.assets.lifecycle import record_hash_mode_transition_intent, run_shutdown, run_startup
-from app.assets.seeder import asset_seeder
+from app.assets.seeder import ScanPhase, asset_seeder
 from app.assets.services.ingest import (
     register_cached_output as ingest_register_cached_output,
     register_executed_output as ingest_register_executed_output,
@@ -35,7 +35,7 @@ class AssetManager(Protocol):
 
     def pause_background_scan(self) -> None: ...
 
-    def queue_output_enrichment(self) -> None: ...
+    def queue_output_scan(self) -> None: ...
 
     def resume_background_scan(self) -> None: ...
 
@@ -98,7 +98,7 @@ class NoAssets:
     def pause_background_scan(self) -> None:
         return None
 
-    def queue_output_enrichment(self) -> None:
+    def queue_output_scan(self) -> None:
         return None
 
     def resume_background_scan(self) -> None:
@@ -156,10 +156,12 @@ class AssetsEnabled:
     def pause_background_scan(self) -> None:
         asset_seeder.pause()
 
-    def queue_output_enrichment(self) -> None:
+    def queue_output_scan(self) -> None:
         if not asset_seeder.is_disabled():
-            asset_seeder.enqueue_enrich(
-                roots=("output",), compute_hashes=self._args.enable_asset_hashing
+            asset_seeder.enqueue_scan(
+                roots=("output",),
+                phase=ScanPhase.FULL,
+                compute_hashes=self._args.enable_asset_hashing,
             )
 
     def resume_background_scan(self) -> None:

--- a/app/assets/manager.py
+++ b/app/assets/manager.py
@@ -157,6 +157,12 @@ class AssetsEnabled:
         asset_seeder.pause()
 
     def queue_output_scan(self) -> None:
+        # ScanPhase.FULL, not ENRICH, is deliberate: only a walk discovers output
+        # files a custom node wrote without declaring them, so they become assets
+        # shortly after generation instead of at the next restart or page load.
+        # The cost is one output-root walk per ~10s of activity - the same walk
+        # every frontend page load already triggers, minus the models roots.
+        # Do not downgrade this to ENRICH without revisiting that trade.
         if not asset_seeder.is_disabled():
             asset_seeder.enqueue_scan(
                 roots=("output",),

--- a/app/assets/manager.py
+++ b/app/assets/manager.py
@@ -157,13 +157,8 @@ class AssetsEnabled:
         asset_seeder.pause()
 
     def queue_output_scan(self) -> None:
-        # ScanPhase.FULL, not ENRICH, is deliberate: only a walk discovers output
-        # files a custom node wrote without declaring them, so they become assets
-        # shortly after generation instead of at the next restart or page load.
-        # The cost is one output-root walk per ~10s of activity - the same walk
-        # every frontend page load already triggers, minus the models roots.
-        # Do not downgrade this to ENRICH without revisiting that trade.
         if not asset_seeder.is_disabled():
+            # FULL, not ENRICH: only a walk finds outputs a node never declared. Do not downgrade without re-weighing the cost.
             asset_seeder.enqueue_scan(
                 roots=("output",),
                 phase=ScanPhase.FULL,

--- a/app/assets/scanner.py
+++ b/app/assets/scanner.py
@@ -19,11 +19,11 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from app.assets import mode
 from app.assets.database.queries import (
+    create_content_reporting_insert,
     mark_content_missing,
     create_record,
 )
 from app.assets.database.models import Asset, AssetContent
-from app.assets.database.queries.records import create_content_reporting_insert
 from app.assets.helpers import sql_path_under_prefix, to_stored_hash
 from app.assets.lifecycle import get_excluded_scan_roots
 from app.assets.scanner_changes import (
@@ -69,6 +69,7 @@ RootType = Literal["models", "input", "output"]
 class SeedAssetSpec(TypedDict):
 
     abs_path: str
+    # Walk-time diagnostics only: seeding persists the seed-time restat instead.
     size_bytes: int
     mtime_ns: int
     info_name: str

--- a/app/assets/scanner.py
+++ b/app/assets/scanner.py
@@ -347,8 +347,8 @@ def seed_asset_specs(session: Session, specs: list[SeedAssetSpec]) -> int:
                         session,
                         path=path,
                         hash=None,
-                        size_bytes=spec["size_bytes"],
-                        mtime_ns=spec["mtime_ns"],
+                        size_bytes=stat_result.st_size,
+                        mtime_ns=get_mtime_ns(stat_result),
                     )
                     if inserted:
                         created_content_ids.append(content.id)

--- a/app/assets/scanner.py
+++ b/app/assets/scanner.py
@@ -20,10 +20,10 @@ from sqlalchemy.orm import Session
 from app.assets import mode
 from app.assets.database.queries import (
     mark_content_missing,
-    create_content,
     create_record,
 )
 from app.assets.database.models import Asset, AssetContent
+from app.assets.database.queries.records import create_content_reporting_insert
 from app.assets.helpers import sql_path_under_prefix, to_stored_hash
 from app.assets.lifecycle import get_excluded_scan_roots
 from app.assets.scanner_changes import (
@@ -343,14 +343,15 @@ def seed_asset_specs(session: Session, specs: list[SeedAssetSpec]) -> int:
                         continue
                     if recovery != "no_match":
                         continue
-                    content = create_content(
+                    content, inserted = create_content_reporting_insert(
                         session,
                         path=path,
                         hash=None,
                         size_bytes=spec["size_bytes"],
                         mtime_ns=spec["mtime_ns"],
                     )
-                    created_content_ids.append(content.id)
+                    if inserted:
+                        created_content_ids.append(content.id)
                     existing_record = session.scalar(
                         sa.select(Asset.id).where(Asset.content_id == content.id).limit(1)
                     )

--- a/app/assets/scanner_changes.py
+++ b/app/assets/scanner_changes.py
@@ -21,7 +21,7 @@ from app.assets.database.queries.records import (
     mark_content_missing,
     unset_content_missing,
 )
-from app.assets.helpers import to_stored_hash
+from app.assets.helpers import sql_path_under_prefix, to_stored_hash
 from app.assets.services.path_utils import compute_loader_path, get_name_and_tags_from_asset_path
 from app.assets.services.snapshot_hash import snapshot_hash
 
@@ -193,7 +193,13 @@ def drain_pending_verifications(session: Session, limit: int | None = None) -> i
 
 
 def live_contents_under_prefixes(session: Session, prefixes: list[str]) -> list[AssetContent]:
-    contents = session.scalars(
-        sa.select(AssetContent).where(AssetContent.is_missing.is_(False))
+    if not prefixes:
+        return []
+    return list(
+        session.scalars(
+            sa.select(AssetContent).where(
+                AssetContent.is_missing.is_(False),
+                sa.or_(*(sql_path_under_prefix(AssetContent.path, prefix) for prefix in prefixes)),
+            )
+        )
     )
-    return [content for content in contents if is_path_under_prefixes(content.path, prefixes)]

--- a/app/assets/seeder.py
+++ b/app/assets/seeder.py
@@ -394,7 +394,7 @@ class _AssetSeeder:
         joined = self.wait(timeout=timeout)
         if not joined:
             logging.warning(
-                "Asset seeder thread did not exit within %ss; skipping temp cleanup",
+                "Asset seeder thread did not exit within %ss",
                 timeout,
             )
         with self._lock:

--- a/app/assets/seeder.py
+++ b/app/assets/seeder.py
@@ -12,7 +12,7 @@ import threading
 import time
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable
+from typing import Any, Callable, TypedDict
 
 from app.assets.scanner import (
     RootType,
@@ -52,6 +52,12 @@ class ScanPhase(Enum):
     FAST = "fast"  # Phase 1: filesystem only (stubs)
     ENRICH = "enrich"  # Phase 2: metadata + hash
     FULL = "full"  # Both phases sequentially
+
+
+class PendingScan(TypedDict):
+    roots: tuple[RootType, ...]
+    phase: ScanPhase
+    compute_hashes: bool
 
 
 @dataclass
@@ -103,7 +109,7 @@ class _AssetSeeder:
         self._progress_callback: ProgressCallback | None = None
         self._event_sink: Callable[[str, dict[str, Any]], None] | None = None
         self._disabled: bool = False
-        self._pending_enrich: dict | None = None
+        self._pending_scan: PendingScan | None = None
 
     def set_event_sink(self, sink: Callable[[str, dict[str, Any]], None] | None) -> None:
         self._event_sink = sink
@@ -229,22 +235,47 @@ class _AssetSeeder:
         Returns:
             True if started immediately, False if queued for later
         """
+        return self.enqueue_scan(
+            roots=roots,
+            phase=ScanPhase.ENRICH,
+            compute_hashes=compute_hashes,
+        )
+
+    def enqueue_scan(
+        self,
+        roots: tuple[RootType, ...],
+        phase: ScanPhase,
+        compute_hashes: bool = False,
+    ) -> bool:
+        """Start a scan now, or coalesce it with work pending after this scan."""
         with self._lock:
-            if self.start_enrich(roots=roots, compute_hashes=compute_hashes):
+            if self.start(
+                roots=roots,
+                phase=phase,
+                prune_first=False,
+                compute_hashes=compute_hashes,
+            ):
                 return True
-            if self._pending_enrich is not None:
-                existing_roots = set(self._pending_enrich["roots"])
+            if self._pending_scan is not None:
+                existing_roots = set(self._pending_scan["roots"])
                 existing_roots.update(roots)
-                self._pending_enrich["roots"] = tuple(existing_roots)
-                self._pending_enrich["compute_hashes"] = (
-                    self._pending_enrich["compute_hashes"] or compute_hashes
+                self._pending_scan["roots"] = tuple(existing_roots)
+                self._pending_scan["compute_hashes"] = (
+                    self._pending_scan["compute_hashes"] or compute_hashes
                 )
+                if self._pending_scan["phase"] is not phase:
+                    self._pending_scan["phase"] = ScanPhase.FULL
             else:
-                self._pending_enrich = {
+                self._pending_scan = {
                     "roots": roots,
+                    "phase": phase,
                     "compute_hashes": compute_hashes,
                 }
-            logging.info("Enrich scan queued (roots=%s)", self._pending_enrich["roots"])
+            logging.info(
+                "Scan queued (roots=%s, phase=%s)",
+                self._pending_scan["roots"],
+                self._pending_scan["phase"].value,
+            )
         return False
 
     def cancel(self) -> bool:
@@ -659,16 +690,19 @@ class _AssetSeeder:
                 )
             with self._lock:
                 self._reset_to_idle()
-                pending = self._pending_enrich
+                pending = self._pending_scan
                 if pending is not None:
-                    self._pending_enrich = None
-                    if not self.start_enrich(
+                    self._pending_scan = None
+                    if not self.start(
                         roots=pending["roots"],
+                        phase=pending["phase"],
+                        prune_first=False,
                         compute_hashes=pending["compute_hashes"],
                     ):
                         logging.warning(
-                            "Pending enrich scan could not start (roots=%s)",
+                            "Pending scan could not start (roots=%s, phase=%s)",
                             pending["roots"],
+                            pending["phase"].value,
                         )
 
     def _run_fast_phase(self, roots: tuple[RootType, ...]) -> tuple[int, int, int]:

--- a/app/assets/seeder.py
+++ b/app/assets/seeder.py
@@ -199,7 +199,6 @@ class _AssetSeeder:
         phase: ScanPhase,
         compute_hashes: bool = False,
     ) -> bool:
-        """Start a scan now, or coalesce it with work pending after this scan."""
         with self._lock:
             if self.start(
                 roots=roots,

--- a/app/assets/seeder.py
+++ b/app/assets/seeder.py
@@ -193,54 +193,6 @@ class _AssetSeeder:
             compute_hashes=False,
         )
 
-    def start_enrich(
-        self,
-        roots: tuple[RootType, ...] = ("models", "input", "output"),
-        progress_callback: ProgressCallback | None = None,
-        compute_hashes: bool = False,
-    ) -> bool:
-        """Start an enrichment scan (phase 2 only) - extracts metadata and hashes.
-
-        Args:
-            roots: Tuple of root types to scan
-            progress_callback: Optional callback for progress updates
-            compute_hashes: If True, compute blake3 hashes
-
-        Returns:
-            True if scan was started, False if already running
-        """
-        return self.start(
-            roots=roots,
-            phase=ScanPhase.ENRICH,
-            progress_callback=progress_callback,
-            prune_first=False,
-            compute_hashes=compute_hashes,
-        )
-
-    def enqueue_enrich(
-        self,
-        roots: tuple[RootType, ...] = ("models", "input", "output"),
-        compute_hashes: bool = False,
-    ) -> bool:
-        """Start an enrichment scan now, or queue it for after the current scan.
-
-        If the seeder is idle, starts immediately. Otherwise, the enrich
-        request is stored and will run automatically when the current scan
-        finishes.
-
-        Args:
-            roots: Tuple of root types to scan
-            compute_hashes: If True, compute blake3 hashes
-
-        Returns:
-            True if started immediately, False if queued for later
-        """
-        return self.enqueue_scan(
-            roots=roots,
-            phase=ScanPhase.ENRICH,
-            compute_hashes=compute_hashes,
-        )
-
     def enqueue_scan(
         self,
         roots: tuple[RootType, ...],

--- a/app/assets/seeder.py
+++ b/app/assets/seeder.py
@@ -130,6 +130,8 @@ class _AssetSeeder:
         progress_callback: ProgressCallback | None = None,
         prune_first: bool = False,
         compute_hashes: bool = False,
+        *,
+        _start_paused: bool = False,
     ) -> bool:
         """Start a background scan for the given roots.
 
@@ -139,6 +141,7 @@ class _AssetSeeder:
             progress_callback: Optional callback called with progress updates
             prune_first: If True, prune orphaned assets before scanning
             compute_hashes: If True, compute blake3 hashes (slow)
+            _start_paused: Start with phase work blocked until resume()
 
         Returns:
             True if scan was started, False if already running
@@ -151,7 +154,7 @@ class _AssetSeeder:
             if self._state != State.IDLE:
                 logging.info("Asset seeder already running, skipping start")
                 return False
-            self._state = State.RUNNING
+            self._state = State.PAUSED if _start_paused else State.RUNNING
             self._progress = Progress()
             self._errors = []
             self._roots = roots
@@ -160,7 +163,10 @@ class _AssetSeeder:
             self._compute_hashes = compute_hashes
             self._progress_callback = progress_callback
             self._cancel_event.clear()
-            self._run_gate.set()  # Ensure unpaused when starting
+            if _start_paused:
+                self._run_gate.clear()
+            else:
+                self._run_gate.set()
             self._thread = threading.Thread(
                 target=self._run_scan,
                 name="_AssetSeeder",
@@ -640,6 +646,7 @@ class _AssetSeeder:
                     },
                 )
             with self._lock:
+                start_paused = self._state is State.PAUSED
                 self._reset_to_idle()
                 pending = self._pending_scan
                 if pending is not None:
@@ -649,6 +656,7 @@ class _AssetSeeder:
                         phase=pending["phase"],
                         prune_first=False,
                         compute_hashes=pending["compute_hashes"],
+                        _start_paused=start_paused,
                     ):
                         logging.warning(
                             "Pending scan could not start (roots=%s, phase=%s)",

--- a/app/assets/services/ingest.py
+++ b/app/assets/services/ingest.py
@@ -18,7 +18,11 @@ from sqlalchemy.orm import Session
 
 from app.assets import mode
 from app.assets.database.models import Asset, AssetContent, AssetTag
-from app.assets.database.queries.records import create_content, create_record, mark_content_missing
+from app.assets.database.queries.records import (
+    create_content_reporting_insert,
+    create_record,
+    mark_content_missing,
+)
 from app.assets.helpers import normalize_tags, to_stored_hash
 from app.assets.services.file_utils import get_mtime_ns, get_size_and_mtime_ns
 from app.assets.services.image_dimensions import extract_image_dimensions
@@ -485,10 +489,10 @@ def upload_from_temp_path(
             _ContentFacts(stored_hash, size_bytes, mtime_ns),
             content_written=True,
         )
-        content = create_content(
+        content, inserted = create_content_reporting_insert(
             session, dest_abs, stored_hash, size_bytes, mtime_ns
         )
-        created_content_id = content.id
+        created_content_id = content.id if inserted else None
         try:
             record = _create_upload_record(
                 session,
@@ -503,7 +507,8 @@ def upload_from_temp_path(
             session.commit()
         except Exception:
             session.rollback()
-            _discard_unreferenced_content(session, created_content_id)
+            if created_content_id is not None:
+                _discard_unreferenced_content(session, created_content_id)
             raise
         return _record_to_upload_result(session, record, created_new=True)
 
@@ -565,10 +570,10 @@ def register_file_in_place(
         session.commit()
 
     with create_session() as session:
-        content = create_content(
+        content, inserted = create_content_reporting_insert(
             session, locator, stored_hash, size_bytes, mtime_ns
         )
-        created_content_id = content.id
+        created_content_id = content.id if inserted else None
         try:
             record = _create_upload_record(
                 session,
@@ -583,7 +588,8 @@ def register_file_in_place(
             session.commit()
         except Exception:
             session.rollback()
-            _discard_unreferenced_content(session, created_content_id)
+            if created_content_id is not None:
+                _discard_unreferenced_content(session, created_content_id)
             raise
         return _record_to_upload_result(session, record, created_new=True)
 
@@ -724,8 +730,11 @@ def register_executed_output(
                 ).first()
                 if existing is not None:
                     mark_content_missing(session, existing.id)
-                content = create_content(session, locator, None, size_bytes, mtime_ns)
-                created_content_id = content.id
+                content, inserted = create_content_reporting_insert(
+                    session, locator, None, size_bytes, mtime_ns
+                )
+                if inserted:
+                    created_content_id = content.id
                 record = create_record(
                     session,
                     content.id,

--- a/main.py
+++ b/main.py
@@ -405,7 +405,7 @@ def prompt_worker(q, server_instance, asset_manager):
                 need_gc = False
                 hook_breaker_ac10a0.restore_functions()
 
-                asset_manager.queue_output_enrichment()
+                asset_manager.queue_output_scan()
                 asset_manager.resume_background_scan()
 
 

--- a/main.py
+++ b/main.py
@@ -457,13 +457,22 @@ def setup_database(asset_manager):
         init_db()
         asset_manager.startup()
     except Exception as e:
-        if "database is locked" in str(e) or "Could not acquire lock on database" in str(e):
+        if "database is locked" in str(e):
             logging.error(
                 "Database is locked. Another ComfyUI process is already using this database.\n"
                 "To resolve this, specify a separate database file for this instance:\n"
                 "  --database-url sqlite:///path/to/another.db"
             )
             sys.exit(1)
+        if "Could not acquire lock on database" in str(e):
+            logging.error(
+                "Database is locked. Another ComfyUI process is already using this database.\n"
+                "To resolve this, specify a separate database file for this instance:\n"
+                "  --database-url sqlite:///path/to/another.db"
+            )
+            if args.enable_assets:
+                sys.exit(1)
+            return
         if args.enable_assets:
             logging.error(
                 f"Failed to initialize database: {e}\n"

--- a/main.py
+++ b/main.py
@@ -457,7 +457,7 @@ def setup_database(asset_manager):
         init_db()
         asset_manager.startup()
     except Exception as e:
-        if "database is locked" in str(e):
+        if "database is locked" in str(e) or "Could not acquire lock on database" in str(e):
             logging.error(
                 "Database is locked. Another ComfyUI process is already using this database.\n"
                 "To resolve this, specify a separate database file for this instance:\n"

--- a/tests-unit/app_test/test_db_init_locking.py
+++ b/tests-unit/app_test/test_db_init_locking.py
@@ -1,12 +1,20 @@
+import logging
 import os
 import sqlite3
 
 import pytest
+import torch
 from alembic import command
 from alembic.config import Config
 from filelock import FileLock, Timeout
 
 from app.database import db as db_module
+from comfy.cli_args import args as cli_args
+
+if not torch.cuda.is_available():
+    cli_args.cpu = True
+
+import main  # noqa: E402
 
 _PRE_HEAD = "0006_add_loader_path"
 
@@ -87,3 +95,24 @@ def test_held_lock_blocks_before_any_migration_work(stale_db):
         assert db_module.Session is None
     finally:
         holder.release()
+
+
+def test_setup_database_routes_file_lock_to_lock_guidance(monkeypatch, caplog):
+    monkeypatch.setattr(main, "dependencies_available", lambda: True)
+
+    def _raise_file_lock():
+        raise RuntimeError(
+            "Could not acquire lock on database '/some/path.db'. "
+            "Another ComfyUI process may already be using it. "
+            "Use --database-url to specify a separate database file."
+        )
+
+    monkeypatch.setattr(main, "init_db", _raise_file_lock)
+    monkeypatch.setattr(main.args, "enable_assets", False)
+
+    with caplog.at_level(logging.ERROR), pytest.raises(SystemExit) as error:
+        main.setup_database(None)
+
+    assert error.value.code == 1
+    assert "Database is locked. Another ComfyUI process is already using this database." in caplog.text
+    assert "Failed to initialize database." not in caplog.text

--- a/tests-unit/app_test/test_db_init_locking.py
+++ b/tests-unit/app_test/test_db_init_locking.py
@@ -102,7 +102,7 @@ def test_setup_database_routes_file_lock_to_lock_guidance(monkeypatch, caplog):
 
     def _raise_file_lock():
         raise RuntimeError(
-            "Could not acquire lock on database '/some/path.db'. "
+            "Could not acquire lock on database 'x.db'. "
             "Another ComfyUI process may already be using it. "
             "Use --database-url to specify a separate database file."
         )
@@ -110,9 +110,46 @@ def test_setup_database_routes_file_lock_to_lock_guidance(monkeypatch, caplog):
     monkeypatch.setattr(main, "init_db", _raise_file_lock)
     monkeypatch.setattr(main.args, "enable_assets", False)
 
+    with caplog.at_level(logging.ERROR):
+        result = main.setup_database(None)
+
+    assert result is None
+    assert "Database is locked. Another ComfyUI process is already using this database." in caplog.text
+    assert "Failed to initialize database." not in caplog.text
+
+
+def test_setup_database_exits_for_file_lock_when_assets_are_enabled(monkeypatch, caplog):
+    monkeypatch.setattr(main, "dependencies_available", lambda: True)
+
+    def _raise_file_lock():
+        raise RuntimeError(
+            "Could not acquire lock on database 'x.db'. "
+            "Another ComfyUI process may already be using it. "
+            "Use --database-url to specify a separate database file."
+        )
+
+    monkeypatch.setattr(main, "init_db", _raise_file_lock)
+    monkeypatch.setattr(main.args, "enable_assets", True)
+
     with caplog.at_level(logging.ERROR), pytest.raises(SystemExit) as error:
         main.setup_database(None)
 
     assert error.value.code == 1
     assert "Database is locked. Another ComfyUI process is already using this database." in caplog.text
-    assert "Failed to initialize database." not in caplog.text
+    assert "The --enable-assets flag requires a working database connection." not in caplog.text
+
+
+def test_setup_database_exits_for_driver_lock_when_assets_are_disabled(monkeypatch, caplog):
+    monkeypatch.setattr(main, "dependencies_available", lambda: True)
+
+    def _raise_driver_lock():
+        raise Exception("sqlite3.OperationalError: database is locked")
+
+    monkeypatch.setattr(main, "init_db", _raise_driver_lock)
+    monkeypatch.setattr(main.args, "enable_assets", False)
+
+    with caplog.at_level(logging.ERROR), pytest.raises(SystemExit) as error:
+        main.setup_database(None)
+
+    assert error.value.code == 1
+    assert "Database is locked. Another ComfyUI process is already using this database." in caplog.text

--- a/tests-unit/assets_test/services/test_enrichment_predicate.py
+++ b/tests-unit/assets_test/services/test_enrichment_predicate.py
@@ -9,9 +9,12 @@ from unittest.mock import patch
 import sqlalchemy as sa
 from sqlalchemy.orm import Session
 
-from app.assets.database.queries import create_content, create_record
+from app.assets.database.queries import create_content, create_record, mark_content_missing
 from app.assets.scanner import get_unenriched_assets_for_roots
-from app.assets.scanner_changes import is_path_under_prefixes
+from app.assets.scanner_changes import (
+    is_path_under_prefixes,
+    live_contents_under_prefixes,
+)
 
 from .path_prefix_cases import prefix_case_paths
 
@@ -205,3 +208,100 @@ def test_prefix_holding_metacharacters_matches_only_literal_children(
 
     assert is_path_under_prefixes(decoy_path, [root]) is False
     assert returned == {inside_path}
+
+
+# --- live_contents_under_prefixes direct pins ---
+# These pins exercise live_contents_under_prefixes directly, not the enrichment predicate.
+
+
+def test_live_contents_under_prefixes_returns_empty_for_empty_prefixes(
+    session: Session, temp_dir: Path
+) -> None:
+    _ = create_content(session, str(temp_dir / "seed.safetensors"))
+
+    returned = {content.path for content in live_contents_under_prefixes(session, [])}
+
+    assert returned == set()
+
+
+def test_live_contents_under_prefixes_matches_directory_and_exact_path_prefixes(
+    session: Session, temp_dir: Path
+) -> None:
+    content = create_content(session, str(temp_dir / "root" / "model.safetensors"))
+
+    under_directory = {candidate.path for candidate in live_contents_under_prefixes(session, [str(temp_dir / "root")])}
+    exact_path = {candidate.path for candidate in live_contents_under_prefixes(session, [content.path])}
+
+    assert under_directory == {content.path}
+    assert exact_path == {content.path}
+
+
+def test_live_contents_under_prefixes_respects_sibling_boundary(
+    session: Session, temp_dir: Path
+) -> None:
+    sibling_path = str(temp_dir / "a" / "bc" / "model.safetensors")
+    _ = create_content(session, sibling_path)
+
+    returned = {content.path for content in live_contents_under_prefixes(session, [str(temp_dir / "a" / "b")])}
+
+    assert returned == set()
+
+
+def test_live_contents_under_prefixes_is_case_sensitive(
+    session: Session, temp_dir: Path
+) -> None:
+    case_different_path = str(temp_dir / "data" / "TEMP" / "model.safetensors")
+    _ = create_content(session, case_different_path)
+
+    returned = {content.path for content in live_contents_under_prefixes(session, [str(temp_dir / "data" / "temp")])}
+
+    assert returned == set()
+
+
+def test_live_contents_under_prefixes_treats_metacharacters_literally(
+    session: Session, temp_dir: Path
+) -> None:
+    prefix = temp_dir / "a_b%c*d?e[f"
+    literal_child = create_content(session, str(prefix / "child.safetensors"))
+    decoy_path = str(temp_dir / "aXbYc*d?e[f" / "keep.safetensors")
+    _ = create_content(session, decoy_path)
+
+    returned = {content.path for content in live_contents_under_prefixes(session, [str(prefix)])}
+
+    assert returned == {literal_child.path}
+
+
+def test_live_contents_under_prefixes_matches_any_prefix(
+    session: Session, temp_dir: Path
+) -> None:
+    content = create_content(session, str(temp_dir / "second" / "model.safetensors"))
+    prefixes = [str(temp_dir / "first"), str(temp_dir / "second")]
+
+    returned = {candidate.path for candidate in live_contents_under_prefixes(session, prefixes)}
+
+    assert returned == {content.path}
+
+
+def test_live_contents_under_prefixes_excludes_missing_content(
+    session: Session, temp_dir: Path
+) -> None:
+    content = create_content(session, str(temp_dir / "root" / "missing.safetensors"))
+    mark_content_missing(session, content.id)
+
+    returned = {candidate.path for candidate in live_contents_under_prefixes(session, [str(temp_dir / "root")])}
+
+    assert returned == set()
+
+
+def test_live_contents_under_prefixes_equals_python_predicate_for_corpus(
+    session: Session, temp_dir: Path
+) -> None:
+    root = str(temp_dir / "root")
+    corpus = prefix_case_paths(root)
+    stored_paths = {create_content(session, path).path for path in corpus}
+    prefixes = [root]
+
+    returned = {content.path for content in live_contents_under_prefixes(session, prefixes)}
+    expected = {path for path in stored_paths if is_path_under_prefixes(path, prefixes)}
+
+    assert returned == expected

--- a/tests-unit/assets_test/services/test_ingest_orphan_content.py
+++ b/tests-unit/assets_test/services/test_ingest_orphan_content.py
@@ -47,7 +47,7 @@ def _live_content_count(session: Session) -> int:
     )
 
 
-def test_upload_from_temp_path_discards_content_on_record_failure(
+def test_upload_record_failure_discards_newly_inserted_content(
     mock_create_session, hashing_off, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     content = b"orphan-upload-" + uuid.uuid4().bytes

--- a/tests-unit/assets_test/services/test_lifecycle.py
+++ b/tests-unit/assets_test/services/test_lifecycle.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import tempfile
 from contextlib import contextmanager
@@ -212,6 +213,14 @@ def test_shutdown_skips_cleanup_when_seeder_join_times_out(session, comfy_dirs, 
 
     wipe_mock.assert_not_called()
     assert session.get(Asset, record_id) is not None
+
+
+def test_seeder_shutdown_logs_only_when_thread_does_not_exit(caplog: pytest.LogCaptureFixture) -> None:
+    seeder = type(asset_seeder)()
+    with patch.object(seeder, "cancel"), patch.object(seeder, "wait", return_value=False), caplog.at_level(logging.WARNING):
+        assert seeder.shutdown(timeout=2.5) is False
+    assert caplog.messages == ["Asset seeder thread did not exit within 2.5s"]
+    assert "skipping temp cleanup" not in caplog.text
 
 
 def test_shutdown_cleanup_wipes_rows_then_rmtree(session, comfy_dirs, mock_create_session):

--- a/tests-unit/assets_test/services/test_manager_isolated.py
+++ b/tests-unit/assets_test/services/test_manager_isolated.py
@@ -18,7 +18,7 @@ from app.assets import scanner, seeder as seeder_module
 from app.assets.database.models import Asset, AssetContent
 from app.assets.database.queries.records import create_content, create_record
 from app.assets.manager import AssetsEnabled
-from app.assets.seeder import asset_seeder
+from app.assets.seeder import ScanStatus, asset_seeder
 from app.database.models import Base
 from app.assets.services.schemas import RegisteredAsset, UploadAssetView
 
@@ -30,6 +30,8 @@ class _ArgsStub:
 
 class _OutputSeeder(Protocol):
     def wait(self, timeout: float | None = None) -> bool: ...
+
+    def get_status(self) -> ScanStatus: ...
 
     def shutdown(self, timeout: float = 5.0) -> bool: ...
 
@@ -123,9 +125,12 @@ def test_queue_output_scan_does_not_duplicate_declared_output(
         str(output_path), job_id="declared-job"
     )
     assert registered is not None
+    undeclared_path = output_dir / "alongside.bin"
+    undeclared_path.write_bytes(b"undeclared custom node output")
 
     enabled_manager.queue_output_scan()
     assert output_seeder.wait(timeout=5)
+    assert output_seeder.get_status().errors == []
 
     with threaded_create_session() as session:
         rows = list(
@@ -135,7 +140,17 @@ def test_queue_output_scan_does_not_duplicate_declared_output(
                 .where(AssetContent.path == str(output_path.resolve()))
             )
         )
+        undeclared_rows = list(
+            session.scalars(
+                select(Asset)
+                .join(AssetContent, Asset.content_id == AssetContent.id)
+                .where(AssetContent.path == str(undeclared_path.resolve()))
+            )
+        )
     assert len(rows) == 1
+    assert len(undeclared_rows) == 1, (
+        "the undeclared sibling proves the walk ran, so the declared row's count of 1 is a real skip rather than a silently-failed scan"
+    )
 
 
 def test_executed_and_cached_outputs_share_unhashed_content(

--- a/tests-unit/assets_test/services/test_manager_isolated.py
+++ b/tests-unit/assets_test/services/test_manager_isolated.py
@@ -109,6 +109,7 @@ def test_queue_output_scan_registers_undeclared_output(
                 .where(AssetContent.path == str(output_path.resolve()))
             )
         )
+        assert rows[0].job_id is None
     assert len(rows) == 1
 
 
@@ -147,6 +148,8 @@ def test_queue_output_scan_does_not_duplicate_declared_output(
                 .where(AssetContent.path == str(undeclared_path.resolve()))
             )
         )
+        assert rows[0].job_id == "declared-job"
+        assert undeclared_rows[0].job_id is None
     assert len(rows) == 1
     assert len(undeclared_rows) == 1, (
         "the undeclared sibling proves the walk ran, so the declared row's count of 1 is a real skip rather than a silently-failed scan"

--- a/tests-unit/assets_test/services/test_manager_isolated.py
+++ b/tests-unit/assets_test/services/test_manager_isolated.py
@@ -1,26 +1,37 @@
 import dataclasses
 import threading
-from collections.abc import Callable
-from contextlib import AbstractContextManager
+from collections.abc import Callable, Generator, Iterator
+from contextlib import AbstractContextManager, contextmanager
 from pathlib import Path
+from typing import Protocol
 from unittest.mock import MagicMock, Mock, call
 
 import folder_paths
 import pytest
-from sqlalchemy.orm import Session
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, Session as SASession
+from sqlalchemy.pool import StaticPool
 
 from app.assets import lifecycle
 from app.assets import manager as manager_module
+from app.assets import scanner, seeder as seeder_module
 from app.assets.database.models import Asset, AssetContent
 from app.assets.database.queries.records import create_content, create_record
 from app.assets.manager import AssetsEnabled
 from app.assets.seeder import asset_seeder
+from app.database.models import Base
 from app.assets.services.schemas import RegisteredAsset, UploadAssetView
 
 
 class _ArgsStub:
     enable_assets = True
     enable_asset_hashing = False
+
+
+class _OutputSeeder(Protocol):
+    def wait(self, timeout: float | None = None) -> bool: ...
+
+    def shutdown(self, timeout: float = 5.0) -> bool: ...
 
 
 @pytest.fixture
@@ -42,6 +53,89 @@ def asset_roots(
     monkeypatch.setattr(folder_paths, "get_input_directory", lambda: str(input_dir))
     monkeypatch.setattr(folder_paths, "get_temp_directory", lambda: str(temp_dir))
     return output_dir, input_dir, temp_dir
+
+
+@pytest.fixture
+def threaded_create_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[Callable[[], AbstractContextManager[Session]]]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+
+    @contextmanager
+    def _create_session() -> Generator[SASession, None, None]:
+        with SASession(engine) as session:
+            yield session
+
+    monkeypatch.setattr(seeder_module, "create_session", _create_session)
+    monkeypatch.setattr(scanner, "create_session", _create_session)
+    monkeypatch.setattr("app.assets.services.ingest.create_session", _create_session)
+    yield _create_session
+    engine.dispose()
+
+
+@pytest.fixture
+def output_seeder(monkeypatch: pytest.MonkeyPatch) -> Iterator[_OutputSeeder]:
+    seeder = asset_seeder.__class__()
+    monkeypatch.setattr(manager_module, "asset_seeder", seeder)
+    yield seeder
+    _ = seeder.shutdown()
+
+
+def test_queue_output_scan_registers_undeclared_output(
+    enabled_manager: AssetsEnabled,
+    asset_roots: tuple[Path, Path, Path],
+    threaded_create_session: Callable[[], AbstractContextManager[Session]],
+    output_seeder: _OutputSeeder,
+) -> None:
+    output_dir, _, _ = asset_roots
+    output_path = output_dir / "undeclared.bin"
+    output_path.write_bytes(b"custom node output")
+
+    enabled_manager.queue_output_scan()
+    assert output_seeder.wait(timeout=5)
+
+    with threaded_create_session() as session:
+        rows = list(
+            session.scalars(
+                select(Asset)
+                .join(AssetContent, Asset.content_id == AssetContent.id)
+                .where(AssetContent.path == str(output_path.resolve()))
+            )
+        )
+    assert len(rows) == 1
+
+
+def test_queue_output_scan_does_not_duplicate_declared_output(
+    enabled_manager: AssetsEnabled,
+    asset_roots: tuple[Path, Path, Path],
+    threaded_create_session: Callable[[], AbstractContextManager[Session]],
+    output_seeder: _OutputSeeder,
+) -> None:
+    output_dir, _, _ = asset_roots
+    output_path = output_dir / "declared.bin"
+    output_path.write_bytes(b"declared custom node output")
+    registered = enabled_manager.register_executed_output(
+        str(output_path), job_id="declared-job"
+    )
+    assert registered is not None
+
+    enabled_manager.queue_output_scan()
+    assert output_seeder.wait(timeout=5)
+
+    with threaded_create_session() as session:
+        rows = list(
+            session.scalars(
+                select(Asset)
+                .join(AssetContent, Asset.content_id == AssetContent.id)
+                .where(AssetContent.path == str(output_path.resolve()))
+            )
+        )
+    assert len(rows) == 1
 
 
 def test_executed_and_cached_outputs_share_unhashed_content(

--- a/tests-unit/assets_test/services/test_noassets_parity.py
+++ b/tests-unit/assets_test/services/test_noassets_parity.py
@@ -148,19 +148,19 @@ def test_noassets_callbacks_are_noops_without_seeder_side_effects() -> None:
     with (
         patch.object(asset_seeder, "start") as start,
         patch.object(asset_seeder, "pause") as pause,
-        patch.object(asset_seeder, "enqueue_enrich") as enqueue_enrich,
+        patch.object(asset_seeder, "enqueue_scan") as enqueue_scan,
         patch.object(asset_seeder, "resume") as resume,
         patch.object(asset_seeder, "set_event_sink") as set_event_sink,
     ):
         assert manager.ensure_scan_started() is None
         assert manager.pause_background_scan() is None
-        assert manager.queue_output_enrichment() is None
+        assert manager.queue_output_scan() is None
         assert manager.resume_background_scan() is None
         assert manager.set_event_sink(Mock()) is None
 
     start.assert_not_called()
     pause.assert_not_called()
-    enqueue_enrich.assert_not_called()
+    enqueue_scan.assert_not_called()
     resume.assert_not_called()
     set_event_sink.assert_not_called()
 

--- a/tests-unit/assets_test/services/test_scanner_seed_resilience.py
+++ b/tests-unit/assets_test/services/test_scanner_seed_resilience.py
@@ -1,9 +1,11 @@
+import os
 from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.assets.database.models import Asset, AssetContent
@@ -114,10 +116,33 @@ def test_seed_logs_once_for_each_vanished_path(
 
 
 def test_seed_isolates_a_poisoned_spec_and_persists_the_specs_around_it(
-    session: Session, temp_dir: Path
+    session: Session, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     specs, poisoned_path = _specs_with_vanished_path(temp_dir)
-    specs[1]["size_bytes"] = -1
+
+    def _create_record_or_raise(
+        session_arg: Session,
+        *,
+        content_id: str,
+        name: str,
+        mime_type: str | None,
+        job_id: str | None,
+        loader_path: str | None,
+        tags: list[str],
+    ) -> Asset:
+        if name == poisoned_path.name:
+            raise IntegrityError("forced record creation failure", {}, ValueError())
+        return create_record(
+            session_arg,
+            content_id,
+            name,
+            mime_type,
+            job_id,
+            loader_path,
+            tags,
+        )
+
+    monkeypatch.setattr("app.assets.scanner.create_record", _create_record_or_raise)
 
     created = seed_asset_specs(session, specs)
     session.commit()
@@ -131,6 +156,32 @@ def test_seed_isolates_a_poisoned_spec_and_persists_the_specs_around_it(
         "the batch shares one transaction, so a bare rollback would erase the spec BEFORE "
         f"the poisoned one; both neighbours of {poisoned_path.name} must survive"
     )
+
+
+def test_seed_persists_fresh_stat_after_spec_was_built(
+    session: Session, temp_dir: Path
+) -> None:
+    path = temp_dir / "changed-after-walk.bin"
+    path.write_bytes(b"walk-time")
+    spec = _spec(path)
+
+    path.write_bytes(b"fresh-seed-time-content")
+    fresh_mtime_ns = spec["mtime_ns"] + 1_000_000
+    os.utime(path, ns=(fresh_mtime_ns, fresh_mtime_ns))
+    fresh_stat = path.stat()
+
+    created = seed_asset_specs(session, [spec])
+    session.commit()
+
+    persisted = session.scalar(
+        select(AssetContent).where(AssetContent.path == str(path))
+    )
+    assert created == 1
+    assert fresh_stat.st_size != spec["size_bytes"]
+    assert fresh_stat.st_mtime_ns != spec["mtime_ns"]
+    assert persisted is not None
+    assert persisted.size_bytes == fresh_stat.st_size
+    assert persisted.mtime_ns == fresh_stat.st_mtime_ns
 
 
 def test_seed_record_failure_preserves_retained_live_content(

--- a/tests-unit/assets_test/services/test_scanner_seed_resilience.py
+++ b/tests-unit/assets_test/services/test_scanner_seed_resilience.py
@@ -6,7 +6,8 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.assets.database.models import Asset
+from app.assets.database.models import Asset, AssetContent
+from app.assets.database.queries import create_content, create_record, delete_record
 from app.assets.scanner import SeedAssetSpec, seed_asset_specs
 from app.assets.services.snapshot_hash import snapshot_hash
 
@@ -130,3 +131,33 @@ def test_seed_isolates_a_poisoned_spec_and_persists_the_specs_around_it(
         "the batch shares one transaction, so a bare rollback would erase the spec BEFORE "
         f"the poisoned one; both neighbours of {poisoned_path.name} must survive"
     )
+
+
+def test_seed_record_failure_preserves_retained_live_content(
+    session: Session, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = temp_dir / "retained.bin"
+    path.write_bytes(b"retained-live-content")
+    spec = _spec(path)
+    content = create_content(
+        session,
+        path=str(path),
+        size_bytes=spec["size_bytes"],
+        mtime_ns=spec["mtime_ns"],
+    )
+    record = create_record(session, content.id, path.name)
+    session.commit()
+    retained_content_id = content.id
+    delete_record(session, record.id)
+    session.commit()
+
+    def _raise_record_creation(*_args, **_kwargs):
+        raise RuntimeError("forced record creation failure")
+
+    monkeypatch.setattr("app.assets.scanner.create_record", _raise_record_creation)
+
+    with pytest.raises(RuntimeError, match="forced record creation failure"):
+        seed_asset_specs(session, [spec])
+    session.rollback()
+
+    assert session.get(AssetContent, retained_content_id) is not None

--- a/tests-unit/assets_test/services/test_upload_b.py
+++ b/tests-unit/assets_test/services/test_upload_b.py
@@ -18,6 +18,7 @@ from app.assets.database.queries.records import (
     mark_content_missing,
 )
 from app.assets.helpers import to_stored_hash
+from app.assets.services.asset_management import delete_asset_reference
 from app.assets.services.file_utils import get_size_and_mtime_ns
 from app.assets.services.ingest import (
     UploadUnstableError,
@@ -380,6 +381,47 @@ def _seed_live_content(session, path: str, stored_hash: str | None) -> tuple[str
     )
     session.commit()
     return content.id, record.id
+
+
+def test_register_file_in_place_record_failure_preserves_retained_live_content(
+    mock_create_session, hashing_off, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output_dir = folder_paths.get_output_directory()
+    os.makedirs(output_dir, exist_ok=True)
+    path = os.path.join(output_dir, f"retained_{uuid.uuid4().hex}.bin")
+    with open(path, "wb") as file:
+        file.write(b"retained-live-content")
+
+    try:
+        original = register_file_in_place(
+            abs_path=path,
+            name="retained.bin",
+            tags=["output"],
+        )
+        retained_content_id = original.content_id
+        assert delete_asset_reference(original.ref.id) is True
+
+        def _raise_record_creation(*_args, **_kwargs):
+            raise RuntimeError("forced record creation failure")
+
+        monkeypatch.setattr(
+            ingest_module,
+            "_create_upload_record",
+            _raise_record_creation,
+        )
+
+        with pytest.raises(RuntimeError, match="forced record creation failure"):
+            register_file_in_place(
+                abs_path=path,
+                name="retained.bin",
+                tags=["output"],
+            )
+
+        with mock_create_session() as session:
+            assert session.get(AssetContent, retained_content_id) is not None
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
 
 
 def _is_missing_tagged(session, record_id: str) -> bool:

--- a/tests-unit/assets_test/test_upload_hashing_modes.py
+++ b/tests-unit/assets_test/test_upload_hashing_modes.py
@@ -7,15 +7,19 @@ import time
 import uuid
 from contextlib import contextmanager
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 import requests
+from aiohttp import web
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session as SASession
 
 import app.assets.mode as mode_module
 import folder_paths
+from app.assets.api import routes, schemas_in
 from app.assets.database.models import AssetContent, Base
 from app.assets.services.ingest import register_executed_output
 
@@ -89,6 +93,40 @@ def _upload_via_image(
 
 def _unique_bytes(seed: str, size: int = 4096) -> bytes:
     return uuid.uuid4().bytes + seed.encode("utf-8").ljust(size, b"\0")[: size - 16]
+
+
+@pytest.mark.asyncio
+async def test_hash_only_multipart_upload_off_mode_returns_400(monkeypatch):
+    hash_value = f"blake3:{'a' * 64}"
+    parsed = schemas_in.ParsedUpload(
+        file_present=False,
+        file_written=0,
+        file_client_name=None,
+        tmp_path=None,
+        tags_raw=[],
+        provided_name=None,
+        user_metadata_raw=None,
+        provided_hash=hash_value,
+        provided_hash_exists=True,
+    )
+    monkeypatch.setattr(mode_module, "hashing_enabled", lambda: False)
+    monkeypatch.setattr(routes, "_ASSETS_ENABLED", True)
+    monkeypatch.setattr(
+        routes, "parse_multipart_upload", AsyncMock(return_value=parsed)
+    )
+    monkeypatch.setattr(
+        routes,
+        "USER_MANAGER",
+        SimpleNamespace(get_request_user_id=lambda _request: "test-user"),
+    )
+
+    response = await routes.upload_asset(AsyncMock(spec=web.Request))
+
+    assert isinstance(response, web.Response)
+    assert response.status == 400
+    response_body = response.body
+    assert isinstance(response_body, bytes | bytearray)
+    assert json.loads(response_body)["error"]["code"] == "FEATURE_DISABLED"
 
 
 @pytest.fixture(scope="session")

--- a/tests-unit/execution_test/test_enrich_output.py
+++ b/tests-unit/execution_test/test_enrich_output.py
@@ -95,6 +95,95 @@ def test_executed_new_path_gets_fresh_id(output_path_environment) -> None:
     ]
 
 
+def test_executed_multiple_entries_register_each_output(output_path_environment) -> None:
+    manager = InMemoryAssets()
+    filenames = ["first.png", "second.png", "third.png"]
+    output_ui = {
+        "images": [
+            {"filename": filename, "subfolder": "batch", "type": "output"}
+            for filename in filenames
+        ]
+    }
+
+    register_executed_outputs(output_ui, "job-list", manager)
+
+    expected_paths = [os.path.join(_BASE, "batch", filename) for filename in filenames]
+    assert manager.calls == [
+        AssetCall("register_executed_output", (path, "job-list"))
+        for path in expected_paths
+    ]
+    assert [
+        (delivery.abs_path, delivery.asset.job_id, delivery.superseded)
+        for path in expected_paths
+        for delivery in manager.deliveries_by_path[path]
+    ] == [(path, "job-list", False) for path in expected_paths]
+
+
+def test_executed_mixed_types_use_their_own_roots(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = InMemoryAssets()
+    output_root = f"{_BASE}-output"
+    temp_root = f"{_BASE}-temp"
+    roots = {"output": output_root, "temp": temp_root}
+    monkeypatch.setattr(
+        folder_paths,
+        "get_directory_by_type",
+        lambda output_type: roots[output_type],
+    )
+    monkeypatch.setattr(os.path, "isfile", lambda _path: True)
+    output_ui = {
+        "images": [
+            {"filename": "kept.png", "subfolder": "saved", "type": "output"},
+            {"filename": "preview.png", "subfolder": "staged", "type": "temp"},
+        ]
+    }
+
+    register_executed_outputs(output_ui, "job-mixed", manager)
+
+    assert manager.calls == [
+        AssetCall(
+            "register_executed_output",
+            (os.path.join(output_root, "saved", "kept.png"), "job-mixed"),
+        ),
+        AssetCall(
+            "register_executed_output",
+            (os.path.join(temp_root, "staged", "preview.png"), "job-mixed"),
+        ),
+    ]
+
+
+def test_executed_repeated_calls_keep_distinct_path_deliveries(
+    output_path_environment,
+) -> None:
+    manager = InMemoryAssets()
+    filenames = ["iteration-1.png", "iteration-2.png", "iteration-3.png"]
+
+    for filename in filenames:
+        register_executed_outputs(_output(filename), "loop-job", manager)
+
+    expected_paths = [os.path.join(_BASE, filename) for filename in filenames]
+    assert manager.calls == [
+        AssetCall("register_executed_output", (path, "loop-job"))
+        for path in expected_paths
+    ]
+    assert [
+        (delivery.abs_path, delivery.asset.job_id, delivery.superseded)
+        for path in expected_paths
+        for delivery in manager.deliveries_by_path[path]
+    ] == [(path, "loop-job", False) for path in expected_paths]
+
+
+def test_executed_empty_entry_list_is_noop(output_path_environment) -> None:
+    manager = InMemoryAssets()
+
+    enriched = register_executed_outputs({"images": []}, "job", manager)
+
+    assert enriched == {"images": []}
+    assert manager.calls == []
+    assert manager.deliveries_by_path == {}
+
+
 def test_executed_over_existing_path_gets_new_id_and_marks_old_missing(output_path_environment) -> None:
     manager = InMemoryAssets()
 

--- a/tests-unit/execution_test/test_inmemory_assets.py
+++ b/tests-unit/execution_test/test_inmemory_assets.py
@@ -59,7 +59,7 @@ class InMemoryAssets:
     def pause_background_scan(self) -> None:
         return None
 
-    def queue_output_enrichment(self) -> None:
+    def queue_output_scan(self) -> None:
         return None
 
     def resume_background_scan(self) -> None:
@@ -135,7 +135,7 @@ def test_conforms() -> None:
     manager.register_routes(web.Application(), None)
     manager.ensure_scan_started()
     manager.pause_background_scan()
-    manager.queue_output_enrichment()
+    manager.queue_output_scan()
     manager.resume_background_scan()
     assert (
         manager.register_upload(

--- a/tests/execution/test_execution.py
+++ b/tests/execution/test_execution.py
@@ -13,7 +13,303 @@ import uuid
 import urllib.request
 import urllib.parse
 import urllib.error
+import os
+from pathlib import PurePosixPath
 from comfy_execution.graph_utils import GraphBuilder, Node
+from app.assets.scanner_admission import _should_skip_extension
+from app.assets.services.file_utils import list_files_recursively
+
+
+ASSET_HEALTH_TIMEOUT_SECONDS = 120
+ASSET_SEED_RETRY_ATTEMPTS = 10
+ASSET_SEED_RETRY_DELAY_SECONDS = 3
+ASSET_STATUS_POLL_DELAY_SECONDS = 1
+ASSET_CAPTURE_TAIL_LINES = 80
+
+# Static prefixes of app/assets exception-path messages; re-diff against logging.exception sites when the assets logging PR lands.
+ASSET_FATAL_LOG_PREFIXES = (
+    "get_asset failed for reference_id=",
+    "upload_asset failed for tenant_id=",
+    "update_asset failed for reference_id=",
+    "delete_asset_reference failed for reference_id=",
+    "add_tags_to_asset failed for reference_id=",
+    "remove_tags_from_asset failed for reference_id=",
+    "check_hash_exists failed for hash=",
+    "Temp DB row wipe failed; skipping filesystem cleanup",
+    "Asset startup maintenance failed",
+    "Temp DB row wipe failed during shutdown",
+    "Asset shutdown cleanup failed",
+    "fast DB scan failed for ",
+    "temp reference sync failed: ",
+    "marking missing assets failed: ",
+    "Failed to enrich ",
+    "Asset scan failed",
+    "Batch insert failed at offset ",
+    "Failed to discard orphan content ",
+    "Failed to register cached output: ",
+    "Failed to register executed output: ",
+    "Failed to register uploaded image as asset",
+    "WARNING: blake3 package not installed",
+)
+
+
+def _asset_json_request(url, deadline, data=None):
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise AssertionError(
+            f"Asset health check failure (i): deadline/transport failure before requesting {url}"
+        )
+
+    request = urllib.request.Request(url, data=data)
+    if data is not None:
+        request.add_header("Content-Type", "application/json")
+
+    try:
+        with urllib.request.urlopen(request, timeout=max(0.01, remaining)) as response:
+            status = response.status
+            raw_payload = response.read()
+    except urllib.error.HTTPError as error:
+        status = error.code
+        raw_payload = error.read()
+    except (TimeoutError, ConnectionError, urllib.error.URLError) as error:
+        raise AssertionError(
+            f"Asset health check failure (i): deadline/transport failure requesting {url}: {error!r}"
+        ) from error
+
+    try:
+        payload = json.loads(raw_payload)
+    except (json.JSONDecodeError, UnicodeDecodeError) as error:
+        rendered_payload = raw_payload.decode("utf-8", errors="replace")
+        raise AssertionError(
+            "Asset health check failure (iv): malformed JSON/schema "
+            f"from {url}: status={status}, payload={rendered_payload!r}"
+        ) from error
+    if not isinstance(payload, dict):
+        raise AssertionError(
+            "Asset health check failure (iv): malformed JSON/schema "
+            f"from {url}: status={status}, payload={payload!r}"
+        )
+    return status, payload
+
+
+def _seed_output_assets(base_url, deadline):
+    request_data = json.dumps({"roots": ["output"]}).encode("utf-8")
+    last_conflict_payload = None
+    for attempt in range(1, ASSET_SEED_RETRY_ATTEMPTS + 1):
+        if last_conflict_payload is not None and deadline - time.monotonic() <= 0:
+            raise AssertionError(
+                "Asset health check failure (ii): 409-retries-exhausted before the deadline; "
+                f"last payload={last_conflict_payload!r}"
+            )
+
+        url = f"{base_url}/api/assets/seed?wait=true"
+        status, payload = _asset_json_request(url, deadline, request_data)
+        if status == 409:
+            if payload.get("status") != "already_running":
+                raise AssertionError(
+                    "Asset health check failure (iv): malformed JSON/schema "
+                    f"from {url}: status={status}, payload={payload!r}"
+                )
+            last_conflict_payload = payload
+            if attempt == ASSET_SEED_RETRY_ATTEMPTS:
+                raise AssertionError(
+                    "Asset health check failure (ii): 409-retries-exhausted after "
+                    f"{attempt} attempts; last payload={payload!r}"
+                )
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise AssertionError(
+                    "Asset health check failure (ii): 409-retries-exhausted before the deadline; "
+                    f"last payload={payload!r}"
+                )
+            time.sleep(min(ASSET_SEED_RETRY_DELAY_SECONDS, remaining))
+            continue
+        if status != 200:
+            raise AssertionError(
+                "Asset health check failure (iv): unexpected-HTTP-status "
+                f"from {url}: status={status}, payload={payload!r}"
+            )
+
+        progress = payload.get("progress")
+        errors = payload.get("errors")
+        progress_fields = ("scanned", "total", "created", "skipped")
+        if (
+            payload.get("status") != "completed"
+            or not isinstance(progress, dict)
+            or any(type(progress.get(field)) is not int for field in progress_fields)
+            or not isinstance(errors, list)
+        ):
+            raise AssertionError(
+                "Asset health check failure (iv): malformed JSON/schema "
+                f"from {url}: status={status}, payload={payload!r}"
+            )
+        if errors:
+            raise AssertionError(
+                f"Asset health check failure (iii): scan-completed-with-errors: errors={errors!r}"
+            )
+        return
+
+
+def _wait_for_stable_asset_idle(base_url, deadline):
+    stable_reads = 0
+    last_payload = None
+    url = f"{base_url}/api/assets/seed/status"
+    while True:
+        if deadline - time.monotonic() <= 0:
+            raise AssertionError(
+                "Asset health check failure (v): idle-stability-exhaustion; "
+                f"last payload={last_payload!r}"
+            )
+        status, payload = _asset_json_request(url, deadline)
+        progress = payload.get("progress")
+        errors = payload.get("errors")
+        if (
+            status != 200
+            or not isinstance(payload.get("state"), str)
+            or not isinstance(errors, list)
+            or (progress is not None and not isinstance(progress, dict))
+        ):
+            failure = "unexpected-HTTP-status" if status != 200 else "malformed JSON/schema"
+            raise AssertionError(
+                f"Asset health check failure (iv): {failure} from {url}: "
+                f"status={status}, payload={payload!r}"
+            )
+
+        last_payload = payload
+        if payload["state"].lower() == "idle" and errors == []:
+            stable_reads += 1
+            if stable_reads == 2:
+                return
+        else:
+            stable_reads = 0
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise AssertionError(
+                "Asset health check failure (v): idle-stability-exhaustion; "
+                f"last payload={last_payload!r}"
+            )
+        time.sleep(min(ASSET_STATUS_POLL_DELAY_SECONDS, remaining))
+
+
+def _normalize_asset_path(path):
+    return PurePosixPath(path.replace("\\", "/")).as_posix()
+
+
+def _fetch_output_asset_paths(base_url, deadline):
+    asset_paths = set()
+    after = None
+    previous_cursor = None
+    while True:
+        query = {"tags_all": "output", "limit": "100"}
+        if after is not None:
+            query["after"] = after
+        url = f"{base_url}/api/assets?{urllib.parse.urlencode(query)}"
+        status, payload = _asset_json_request(url, deadline)
+        assets = payload.get("assets")
+        next_cursor = payload.get("next_cursor")
+        if (
+            status != 200
+            or not isinstance(assets, list)
+            or type(payload.get("total")) is not int
+            or not isinstance(payload.get("has_more"), bool)
+            or (next_cursor is not None and not isinstance(next_cursor, str))
+        ):
+            failure = "unexpected-HTTP-status" if status != 200 else "malformed JSON/schema"
+            raise AssertionError(
+                f"Asset health check failure (iv): {failure} from {url}: "
+                f"status={status}, payload={payload!r}"
+            )
+
+        for asset in assets:
+            if not isinstance(asset, dict):
+                raise AssertionError(
+                    "Asset health check failure (iv): malformed JSON/schema "
+                    f"from {url}: asset={asset!r}, payload={payload!r}"
+                )
+            loader_path = asset.get("loader_path")
+            if not isinstance(loader_path, str):
+                raise AssertionError(
+                    "Asset health check reconcile failure: asset has missing/non-string "
+                    f"loader_path: asset={asset!r}"
+                )
+            asset_paths.add(_normalize_asset_path(loader_path))
+
+        if next_cursor is None:
+            if payload["has_more"]:
+                raise AssertionError(
+                    "Asset health check failure (iv): malformed JSON/schema "
+                    f"from {url}: has_more=true without next_cursor, payload={payload!r}"
+                )
+            return asset_paths
+        if next_cursor == previous_cursor:
+            raise AssertionError(
+                "Asset health check reconcile failure: pagination cursor made no progress: "
+                f"cursor={next_cursor!r}, payload={payload!r}"
+            )
+        previous_cursor = next_cursor
+        after = next_cursor
+
+
+def _list_output_files_on_disk(output_dir):
+    output_root = os.path.abspath(output_dir)
+    disk_paths = set()
+    for file_path in list_files_recursively(output_root):
+        if _should_skip_extension(file_path):
+            continue
+        try:
+            stat_result = os.stat(file_path, follow_symlinks=True)
+        except OSError:
+            continue
+        if not stat_result.st_size:
+            continue
+        relative_path = os.path.relpath(file_path, output_root)
+        disk_paths.add(_normalize_asset_path(relative_path))
+    return disk_paths
+
+
+def _assert_no_fatal_asset_logs(capture_path):
+    server_output = capture_path.read_text(encoding="utf-8", errors="replace")
+    matched_prefixes = [
+        prefix for prefix in ASSET_FATAL_LOG_PREFIXES if prefix in server_output
+    ]
+    if matched_prefixes:
+        raise AssertionError(
+            "Asset health check fatal-log failure: "
+            f"matched prefixes={matched_prefixes!r}"
+        )
+
+
+def _assert_assets_healthy(listen, port, output_dir, capture_path):
+    deadline = time.monotonic() + ASSET_HEALTH_TIMEOUT_SECONDS
+    base_url = f"http://{listen}:{port}"
+    _seed_output_assets(base_url, deadline)
+    _wait_for_stable_asset_idle(base_url, deadline)
+
+    api_paths = _fetch_output_asset_paths(base_url, deadline)
+    disk_paths = _list_output_files_on_disk(output_dir)
+    if not api_paths or not disk_paths:
+        raise AssertionError(
+            "Asset health check reconcile failure: expected non-empty sets: "
+            f"api_paths={sorted(api_paths)!r}, disk_paths={sorted(disk_paths)!r}"
+        )
+    disk_only = disk_paths - api_paths
+    api_only = api_paths - disk_paths
+    if disk_only or api_only:
+        raise AssertionError(
+            "Asset health check reconcile failure: "
+            f"disk-has-but-API-lacks={sorted(disk_only)!r}, "
+            f"API-has-but-disk-lacks={sorted(api_only)!r}"
+        )
+    _assert_no_fatal_asset_logs(capture_path)
+
+
+def _capture_tail(capture_path):
+    try:
+        lines = capture_path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError as error:
+        return f"<unable to read capture file: {error!r}>"
+    return "\n".join(lines[-ASSET_CAPTURE_TAIL_LINES:])
 
 def run_warmup(client, prefix="warmup"):
     """Run a simple workflow to warm up the server."""
@@ -186,9 +482,11 @@ class TestExecution:
         { "extra_args" : ["--cache-classic"], "should_cache_results" : True },
         { "extra_args" : ["--cache-lru", 100], "should_cache_results" : True },
         { "extra_args" : ["--cache-none"], "should_cache_results" : False },
+        {"extra_args": ["--enable-assets"], "should_cache_results": True, "assets": True},
     ])
-    def server(self, args_pytest, request):
+    def server(self, args_pytest, request, tmp_path_factory):
         # Start server
+        assets_enabled = request.param.get("assets")
         pargs = [
             'python','main.py',
             '--output-directory', args_pytest["output_dir"],
@@ -198,7 +496,67 @@ class TestExecution:
             '--cpu',
         ]
         pargs += [ str(param) for param in request.param["extra_args"] ]
+        if assets_enabled:
+            assets_tmp_dir = tmp_path_factory.mktemp("execution-assets")
+            database_path = assets_tmp_dir / "assets.db"
+            capture_path = assets_tmp_dir / "server.log"
+            pargs += ["--database-url", f"sqlite:///{database_path}"]
         print("Running server with args:", pargs)  # noqa: T201
+        if assets_enabled:
+            capture_file = capture_path.open("a", encoding="utf-8")
+            try:
+                p = subprocess.Popen(
+                    pargs, stdout=capture_file, stderr=subprocess.STDOUT
+                )
+            except OSError:
+                capture_file.close()
+                raise
+
+            health_failure = None
+            cleanup_failures = []
+            try:
+                yield request.param
+                exit_code = p.poll()
+                if exit_code is not None:
+                    raise AssertionError(
+                        "Asset health check server-dead failure: "
+                        f"exit code={exit_code}"
+                    )
+                _assert_assets_healthy(
+                    args_pytest["listen"],
+                    args_pytest["port"],
+                    args_pytest["output_dir"],
+                    capture_path,
+                )
+            except AssertionError as error:
+                health_failure = error
+            finally:
+                try:
+                    p.kill()
+                except OSError as error:
+                    cleanup_failures.append(f"kill failed: {error!r}")
+                finally:
+                    try:
+                        p.wait(timeout=10)
+                    except (OSError, subprocess.TimeoutExpired) as error:
+                        cleanup_failures.append(f"bounded reap failed: {error!r}")
+                    finally:
+                        try:
+                            capture_file.close()
+                        except OSError as error:
+                            cleanup_failures.append(f"capture close failed: {error!r}")
+                        finally:
+                            torch.cuda.empty_cache()
+
+            if cleanup_failures:
+                print("Asset server cleanup warnings:", cleanup_failures)  # noqa: T201
+            if health_failure is not None:
+                capture_tail = _capture_tail(capture_path)
+                raise AssertionError(
+                    f"{health_failure}\nServer output tail:\n{capture_tail}"
+                ) from health_failure
+            return
+
         p = subprocess.Popen(pargs)
         yield request.param
         p.kill()

--- a/tests/test_asset_seeder.py
+++ b/tests/test_asset_seeder.py
@@ -1,12 +1,10 @@
-"""Tests for app.assets.seeder – enqueue_enrich and pending-queue behaviour."""
-
 import threading
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
 
-from app.assets.seeder import Progress, _AssetSeeder, State
+from app.assets.seeder import Progress, ScanPhase, _AssetSeeder, State
 
 
 @pytest.fixture()
@@ -81,16 +79,19 @@ class TestResetToIdle:
 
 class TestEnqueueEnrichStartsImmediately:
     def test_starts_when_idle(self, seeder):
-        """enqueue_enrich should delegate to start_enrich and return True when idle."""
-        with patch.object(seeder, "start_enrich", return_value=True) as mock:
+        with patch.object(seeder, "start", return_value=True) as mock:
             assert seeder.enqueue_enrich(roots=("output",), compute_hashes=True) is True
-            mock.assert_called_once_with(roots=("output",), compute_hashes=True)
+            mock.assert_called_once_with(
+                roots=("output",),
+                phase=ScanPhase.ENRICH,
+                prune_first=False,
+                compute_hashes=True,
+            )
 
     def test_no_pending_when_started_immediately(self, seeder):
-        """No pending request should be stored when start_enrich succeeds."""
-        with patch.object(seeder, "start_enrich", return_value=True):
+        with patch.object(seeder, "start", return_value=True):
             seeder.enqueue_enrich(roots=("output",))
-        assert seeder._pending_enrich is None
+        assert seeder._pending_scan is None
 
 
 # ---------------------------------------------------------------------------
@@ -101,20 +102,21 @@ class TestEnqueueEnrichStartsImmediately:
 class TestEnqueueEnrichQueuesWhenBusy:
     def test_queues_when_busy(self, seeder):
         """enqueue_enrich should store a pending request when seeder is busy."""
-        with patch.object(seeder, "start_enrich", return_value=False):
+        with patch.object(seeder, "start", return_value=False):
             result = seeder.enqueue_enrich(roots=("models",), compute_hashes=False)
 
         assert result is False
-        assert seeder._pending_enrich == {
+        assert seeder._pending_scan == {
             "roots": ("models",),
+            "phase": ScanPhase.ENRICH,
             "compute_hashes": False,
         }
 
     def test_queues_preserves_compute_hashes_true(self, seeder):
-        with patch.object(seeder, "start_enrich", return_value=False):
+        with patch.object(seeder, "start", return_value=False):
             seeder.enqueue_enrich(roots=("input",), compute_hashes=True)
 
-        assert seeder._pending_enrich["compute_hashes"] is True
+        assert seeder._pending_scan["compute_hashes"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -124,17 +126,17 @@ class TestEnqueueEnrichQueuesWhenBusy:
 
 class TestEnqueueEnrichMergesPending:
     def _make_busy(self, seeder):
-        """Patch start_enrich to always return False (seeder busy)."""
-        return patch.object(seeder, "start_enrich", return_value=False)
+        return patch.object(seeder, "start", return_value=False)
 
     def test_merges_roots(self, seeder):
         """A second enqueue should merge roots with the existing pending request."""
         with self._make_busy(seeder):
             seeder.enqueue_enrich(roots=("models",))
-            seeder.enqueue_enrich(roots=("output",))
+            seeder.enqueue_scan(roots=("output",), phase=ScanPhase.FAST)
 
-        merged = set(seeder._pending_enrich["roots"])
+        merged = set(seeder._pending_scan["roots"])
         assert merged == {"models", "output"}
+        assert seeder._pending_scan["phase"] is ScanPhase.FULL
 
     def test_merges_overlapping_roots(self, seeder):
         """Duplicate roots should be deduplicated."""
@@ -142,7 +144,7 @@ class TestEnqueueEnrichMergesPending:
             seeder.enqueue_enrich(roots=("models", "input"))
             seeder.enqueue_enrich(roots=("input", "output"))
 
-        merged = set(seeder._pending_enrich["roots"])
+        merged = set(seeder._pending_scan["roots"])
         assert merged == {"models", "input", "output"}
 
     def test_compute_hashes_sticky_true(self, seeder):
@@ -151,7 +153,7 @@ class TestEnqueueEnrichMergesPending:
             seeder.enqueue_enrich(roots=("models",), compute_hashes=True)
             seeder.enqueue_enrich(roots=("output",), compute_hashes=False)
 
-        assert seeder._pending_enrich["compute_hashes"] is True
+        assert seeder._pending_scan["compute_hashes"] is True
 
     def test_compute_hashes_upgrades_to_true(self, seeder):
         """A later enqueue with compute_hashes=True should upgrade the pending request."""
@@ -159,7 +161,7 @@ class TestEnqueueEnrichMergesPending:
             seeder.enqueue_enrich(roots=("models",), compute_hashes=False)
             seeder.enqueue_enrich(roots=("output",), compute_hashes=True)
 
-        assert seeder._pending_enrich["compute_hashes"] is True
+        assert seeder._pending_scan["compute_hashes"] is True
 
     def test_compute_hashes_stays_false(self, seeder):
         """If both enqueues have compute_hashes=False it stays False."""
@@ -167,7 +169,7 @@ class TestEnqueueEnrichMergesPending:
             seeder.enqueue_enrich(roots=("models",), compute_hashes=False)
             seeder.enqueue_enrich(roots=("output",), compute_hashes=False)
 
-        assert seeder._pending_enrich["compute_hashes"] is False
+        assert seeder._pending_scan["compute_hashes"] is False
 
     def test_triple_merge(self, seeder):
         """Three successive enqueues should all merge correctly."""
@@ -176,43 +178,41 @@ class TestEnqueueEnrichMergesPending:
             seeder.enqueue_enrich(roots=("input",), compute_hashes=False)
             seeder.enqueue_enrich(roots=("output",), compute_hashes=True)
 
-        merged = set(seeder._pending_enrich["roots"])
+        merged = set(seeder._pending_scan["roots"])
         assert merged == {"models", "input", "output"}
-        assert seeder._pending_enrich["compute_hashes"] is True
+        assert seeder._pending_scan["compute_hashes"] is True
 
 
-# ---------------------------------------------------------------------------
-# Pending enrich drains after scan completes
-# ---------------------------------------------------------------------------
-
-
-class TestPendingEnrichDrain:
-    """Verify that _run_scan drains _pending_enrich via start_enrich."""
+class TestPendingScanDrain:
 
     @patch("app.assets.seeder.dependencies_available", return_value=True)
     @patch("app.assets.seeder.get_owned_prefixes", return_value=[])
     @patch("app.assets.seeder.sync_root_safely", return_value=set())
     @patch("app.assets.seeder.collect_paths_for_roots", return_value=[])
     @patch("app.assets.seeder.build_asset_specs", return_value=([], {}, 0))
-    def test_pending_enrich_starts_after_scan(self, *_mocks):
-        """After a fast scan finishes, the pending enrich should be started."""
+    def test_pending_scan_starts_after_scan(self, *_mocks):
         seeder = _AssetSeeder()
 
-        seeder._pending_enrich = {
+        seeder._pending_scan = {
             "roots": ("output",),
+            "phase": ScanPhase.FULL,
             "compute_hashes": True,
         }
 
-        with patch.object(seeder, "start_enrich", return_value=True) as mock_start:
+        real_start = seeder.start
+        with patch.object(seeder, "start", wraps=real_start) as mock_start:
             seeder.start_fast(roots=("models",))
             seeder.wait(timeout=5)
+            seeder.wait(timeout=5)
 
-            mock_start.assert_called_once_with(
+            assert mock_start.call_args_list[-1] == call(
                 roots=("output",),
+                phase=ScanPhase.FULL,
+                prune_first=False,
                 compute_hashes=True,
             )
 
-        assert seeder._pending_enrich is None
+        assert seeder._pending_scan is None
 
     @patch("app.assets.seeder.dependencies_available", return_value=True)
     @patch("app.assets.seeder.get_owned_prefixes", return_value=[])
@@ -220,18 +220,25 @@ class TestPendingEnrichDrain:
     @patch("app.assets.seeder.collect_paths_for_roots", return_value=[])
     @patch("app.assets.seeder.build_asset_specs", return_value=([], {}, 0))
     def test_pending_cleared_even_when_start_fails(self, *_mocks):
-        """_pending_enrich should be cleared even if start_enrich returns False."""
         seeder = _AssetSeeder()
-        seeder._pending_enrich = {
+        seeder._pending_scan = {
             "roots": ("output",),
+            "phase": ScanPhase.ENRICH,
             "compute_hashes": False,
         }
 
-        with patch.object(seeder, "start_enrich", return_value=False):
+        real_start = seeder.start
+
+        def start_initial_scan_only(**kwargs):
+            if kwargs["roots"] == ("models",):
+                return real_start(**kwargs)
+            return False
+
+        with patch.object(seeder, "start", side_effect=start_initial_scan_only):
             seeder.start_fast(roots=("models",))
             seeder.wait(timeout=5)
 
-        assert seeder._pending_enrich is None
+        assert seeder._pending_scan is None
 
     @patch("app.assets.seeder.dependencies_available", return_value=True)
     @patch("app.assets.seeder.get_owned_prefixes", return_value=[])
@@ -239,15 +246,15 @@ class TestPendingEnrichDrain:
     @patch("app.assets.seeder.collect_paths_for_roots", return_value=[])
     @patch("app.assets.seeder.build_asset_specs", return_value=([], {}, 0))
     def test_no_drain_when_no_pending(self, *_mocks):
-        """start_enrich should not be called when there is no pending request."""
         seeder = _AssetSeeder()
-        assert seeder._pending_enrich is None
+        assert seeder._pending_scan is None
 
-        with patch.object(seeder, "start_enrich", return_value=True) as mock_start:
+        real_start = seeder.start
+        with patch.object(seeder, "start", wraps=real_start) as mock_start:
             seeder.start_fast(roots=("models",))
             seeder.wait(timeout=5)
 
-            mock_start.assert_not_called()
+            assert mock_start.call_count == 1
 
 
 # ---------------------------------------------------------------------------
@@ -258,7 +265,7 @@ class TestPendingEnrichDrain:
 class TestEnqueueEnrichThreadSafety:
     def test_concurrent_enqueues(self, seeder):
         """Multiple threads enqueuing should not lose roots."""
-        with patch.object(seeder, "start_enrich", return_value=False):
+        with patch.object(seeder, "start", return_value=False):
             barrier = threading.Barrier(3)
 
             def enqueue(root):
@@ -274,5 +281,5 @@ class TestEnqueueEnrichThreadSafety:
             for t in threads:
                 t.join(timeout=5)
 
-        merged = set(seeder._pending_enrich["roots"])
+        merged = set(seeder._pending_scan["roots"])
         assert merged == {"models", "input", "output"}

--- a/tests/test_asset_seeder.py
+++ b/tests/test_asset_seeder.py
@@ -1,4 +1,3 @@
-"""Covers the seeder's event sink, idle reset, and ``enqueue_scan``'s start-now-or-queue-and-merge behaviour."""
 
 import threading
 from typing import Any
@@ -108,7 +107,6 @@ class TestEnqueueScanStartsImmediately:
 
 class TestEnqueueScanQueuesWhenBusy:
     def test_queues_when_busy(self, seeder):
-        """enqueue_scan should store a pending request when seeder is busy."""
         with patch.object(seeder, "start", return_value=False):
             result = seeder.enqueue_scan(
                 roots=("models",), phase=ScanPhase.ENRICH, compute_hashes=False

--- a/tests/test_asset_seeder.py
+++ b/tests/test_asset_seeder.py
@@ -236,9 +236,100 @@ class TestPendingScanDrain:
                 phase=ScanPhase.FULL,
                 prune_first=False,
                 compute_hashes=True,
+                _start_paused=False,
             )
 
         assert seeder._pending_scan is None
+
+    @patch("app.assets.seeder.dependencies_available", return_value=True)
+    def test_pause_is_preserved_when_pending_scan_drains(self, _dependencies):
+        seeder = _AssetSeeder()
+        phase_ready = threading.Event()
+        allow_phase_return = threading.Event()
+        drained_phase_calls: list[tuple[str, ...]] = []
+
+        def gated_enrich(roots):
+            if roots == ("models",):
+                phase_ready.set()
+                allow_phase_return.wait(timeout=5)
+                allow_phase_return.clear()
+            else:
+                drained_phase_calls.append(roots)
+                phase_ready.set()
+                allow_phase_return.wait(timeout=5)
+            return False, 0
+
+        seeder._pending_scan = {
+            "roots": ("output",),
+            "phase": ScanPhase.ENRICH,
+            "compute_hashes": False,
+        }
+        real_start = seeder.start
+
+        def start_and_signal(**kwargs):
+            started = real_start(**kwargs)
+            if started and kwargs["roots"] == ("output",):
+                if seeder._state is State.PAUSED:
+                    phase_ready.set()
+                else:
+                    phase_ready.wait(timeout=5)
+            return started
+
+        observed = {}
+        with (
+            patch.object(seeder, "_log_scan_config"),
+            patch.object(seeder, "_run_enrich_phase", side_effect=gated_enrich),
+            patch.object(seeder, "start", side_effect=start_and_signal),
+        ):
+            try:
+                assert seeder.start(
+                    roots=("models",), phase=ScanPhase.ENRICH
+                ) is True
+                assert phase_ready.wait(timeout=5)
+                assert seeder.pause() is True
+                phase_ready.clear()
+                allow_phase_return.set()
+                assert phase_ready.wait(timeout=5)
+
+                with seeder._lock:
+                    state_before_resume = seeder._state
+                    gate_set_before_resume = seeder._run_gate.is_set()
+                    calls_before_resume = len(drained_phase_calls)
+
+                phase_ready.clear()
+                resume_return = seeder.resume()
+                if calls_before_resume == 0:
+                    assert phase_ready.wait(timeout=5)
+                allow_phase_return.set()
+                assert seeder.wait(timeout=5)
+
+                observed = {
+                    "state_before_resume": state_before_resume,
+                    "gate_set_before_resume": gate_set_before_resume,
+                    "resume_return": resume_return,
+                    "drained_phase_calls_before_resume": calls_before_resume,
+                    "drained_phase_calls_after_resume": len(drained_phase_calls),
+                }
+            finally:
+                allow_phase_return.set()
+                seeder.resume()
+                seeder.wait(timeout=5)
+
+        assert observed == {
+            "state_before_resume": State.PAUSED,
+            "gate_set_before_resume": False,
+            "resume_return": True,
+            "drained_phase_calls_before_resume": 0,
+            "drained_phase_calls_after_resume": 1,
+        }, (
+            f"state_before_resume={observed['state_before_resume']!r}, "
+            f"gate_set_before_resume={observed['gate_set_before_resume']!r}, "
+            f"resume_return={observed['resume_return']!r}, "
+            "drained_phase_calls_before_resume="
+            f"{observed['drained_phase_calls_before_resume']!r}, "
+            "drained_phase_calls_after_resume="
+            f"{observed['drained_phase_calls_after_resume']!r}"
+        )
 
     @patch("app.assets.seeder.dependencies_available", return_value=True)
     @patch("app.assets.seeder.get_owned_prefixes", return_value=[])

--- a/tests/test_asset_seeder.py
+++ b/tests/test_asset_seeder.py
@@ -1,3 +1,5 @@
+"""Covers the seeder's event sink, idle reset, and ``enqueue_scan``'s start-now-or-queue-and-merge behaviour."""
+
 import threading
 from typing import Any
 from unittest.mock import call, patch
@@ -73,14 +75,19 @@ class TestResetToIdle:
 
 
 # ---------------------------------------------------------------------------
-# enqueue_enrich – immediate start when idle
+# enqueue_scan – immediate start when idle
 # ---------------------------------------------------------------------------
 
 
-class TestEnqueueEnrichStartsImmediately:
+class TestEnqueueScanStartsImmediately:
     def test_starts_when_idle(self, seeder):
         with patch.object(seeder, "start", return_value=True) as mock:
-            assert seeder.enqueue_enrich(roots=("output",), compute_hashes=True) is True
+            assert (
+                seeder.enqueue_scan(
+                    roots=("output",), phase=ScanPhase.ENRICH, compute_hashes=True
+                )
+                is True
+            )
             mock.assert_called_once_with(
                 roots=("output",),
                 phase=ScanPhase.ENRICH,
@@ -90,20 +97,22 @@ class TestEnqueueEnrichStartsImmediately:
 
     def test_no_pending_when_started_immediately(self, seeder):
         with patch.object(seeder, "start", return_value=True):
-            seeder.enqueue_enrich(roots=("output",))
+            seeder.enqueue_scan(roots=("output",), phase=ScanPhase.ENRICH)
         assert seeder._pending_scan is None
 
 
 # ---------------------------------------------------------------------------
-# enqueue_enrich – queuing when busy
+# enqueue_scan – queuing when busy
 # ---------------------------------------------------------------------------
 
 
-class TestEnqueueEnrichQueuesWhenBusy:
+class TestEnqueueScanQueuesWhenBusy:
     def test_queues_when_busy(self, seeder):
-        """enqueue_enrich should store a pending request when seeder is busy."""
+        """enqueue_scan should store a pending request when seeder is busy."""
         with patch.object(seeder, "start", return_value=False):
-            result = seeder.enqueue_enrich(roots=("models",), compute_hashes=False)
+            result = seeder.enqueue_scan(
+                roots=("models",), phase=ScanPhase.ENRICH, compute_hashes=False
+            )
 
         assert result is False
         assert seeder._pending_scan == {
@@ -114,24 +123,26 @@ class TestEnqueueEnrichQueuesWhenBusy:
 
     def test_queues_preserves_compute_hashes_true(self, seeder):
         with patch.object(seeder, "start", return_value=False):
-            seeder.enqueue_enrich(roots=("input",), compute_hashes=True)
+            seeder.enqueue_scan(
+                roots=("input",), phase=ScanPhase.ENRICH, compute_hashes=True
+            )
 
         assert seeder._pending_scan["compute_hashes"] is True
 
 
 # ---------------------------------------------------------------------------
-# enqueue_enrich – merging when a pending request already exists
+# enqueue_scan – merging when a pending request already exists
 # ---------------------------------------------------------------------------
 
 
-class TestEnqueueEnrichMergesPending:
+class TestEnqueueScanMergesPending:
     def _make_busy(self, seeder):
         return patch.object(seeder, "start", return_value=False)
 
     def test_merges_roots(self, seeder):
         """A second enqueue should merge roots with the existing pending request."""
         with self._make_busy(seeder):
-            seeder.enqueue_enrich(roots=("models",))
+            seeder.enqueue_scan(roots=("models",), phase=ScanPhase.ENRICH)
             seeder.enqueue_scan(roots=("output",), phase=ScanPhase.FAST)
 
         merged = set(seeder._pending_scan["roots"])
@@ -141,8 +152,8 @@ class TestEnqueueEnrichMergesPending:
     def test_merges_overlapping_roots(self, seeder):
         """Duplicate roots should be deduplicated."""
         with self._make_busy(seeder):
-            seeder.enqueue_enrich(roots=("models", "input"))
-            seeder.enqueue_enrich(roots=("input", "output"))
+            seeder.enqueue_scan(roots=("models", "input"), phase=ScanPhase.ENRICH)
+            seeder.enqueue_scan(roots=("input", "output"), phase=ScanPhase.ENRICH)
 
         merged = set(seeder._pending_scan["roots"])
         assert merged == {"models", "input", "output"}
@@ -150,33 +161,51 @@ class TestEnqueueEnrichMergesPending:
     def test_compute_hashes_sticky_true(self, seeder):
         """Once compute_hashes is True it should stay True after merging."""
         with self._make_busy(seeder):
-            seeder.enqueue_enrich(roots=("models",), compute_hashes=True)
-            seeder.enqueue_enrich(roots=("output",), compute_hashes=False)
+            seeder.enqueue_scan(
+                roots=("models",), phase=ScanPhase.ENRICH, compute_hashes=True
+            )
+            seeder.enqueue_scan(
+                roots=("output",), phase=ScanPhase.ENRICH, compute_hashes=False
+            )
 
         assert seeder._pending_scan["compute_hashes"] is True
 
     def test_compute_hashes_upgrades_to_true(self, seeder):
         """A later enqueue with compute_hashes=True should upgrade the pending request."""
         with self._make_busy(seeder):
-            seeder.enqueue_enrich(roots=("models",), compute_hashes=False)
-            seeder.enqueue_enrich(roots=("output",), compute_hashes=True)
+            seeder.enqueue_scan(
+                roots=("models",), phase=ScanPhase.ENRICH, compute_hashes=False
+            )
+            seeder.enqueue_scan(
+                roots=("output",), phase=ScanPhase.ENRICH, compute_hashes=True
+            )
 
         assert seeder._pending_scan["compute_hashes"] is True
 
     def test_compute_hashes_stays_false(self, seeder):
         """If both enqueues have compute_hashes=False it stays False."""
         with self._make_busy(seeder):
-            seeder.enqueue_enrich(roots=("models",), compute_hashes=False)
-            seeder.enqueue_enrich(roots=("output",), compute_hashes=False)
+            seeder.enqueue_scan(
+                roots=("models",), phase=ScanPhase.ENRICH, compute_hashes=False
+            )
+            seeder.enqueue_scan(
+                roots=("output",), phase=ScanPhase.ENRICH, compute_hashes=False
+            )
 
         assert seeder._pending_scan["compute_hashes"] is False
 
     def test_triple_merge(self, seeder):
         """Three successive enqueues should all merge correctly."""
         with self._make_busy(seeder):
-            seeder.enqueue_enrich(roots=("models",), compute_hashes=False)
-            seeder.enqueue_enrich(roots=("input",), compute_hashes=False)
-            seeder.enqueue_enrich(roots=("output",), compute_hashes=True)
+            seeder.enqueue_scan(
+                roots=("models",), phase=ScanPhase.ENRICH, compute_hashes=False
+            )
+            seeder.enqueue_scan(
+                roots=("input",), phase=ScanPhase.ENRICH, compute_hashes=False
+            )
+            seeder.enqueue_scan(
+                roots=("output",), phase=ScanPhase.ENRICH, compute_hashes=True
+            )
 
         merged = set(seeder._pending_scan["roots"])
         assert merged == {"models", "input", "output"}
@@ -184,7 +213,6 @@ class TestEnqueueEnrichMergesPending:
 
 
 class TestPendingScanDrain:
-
     @patch("app.assets.seeder.dependencies_available", return_value=True)
     @patch("app.assets.seeder.get_owned_prefixes", return_value=[])
     @patch("app.assets.seeder.sync_root_safely", return_value=set())
@@ -258,11 +286,11 @@ class TestPendingScanDrain:
 
 
 # ---------------------------------------------------------------------------
-# Thread-safety of enqueue_enrich
+# Thread-safety of enqueue_scan
 # ---------------------------------------------------------------------------
 
 
-class TestEnqueueEnrichThreadSafety:
+class TestEnqueueScanThreadSafety:
     def test_concurrent_enqueues(self, seeder):
         """Multiple threads enqueuing should not lose roots."""
         with patch.object(seeder, "start", return_value=False):
@@ -270,7 +298,9 @@ class TestEnqueueEnrichThreadSafety:
 
             def enqueue(root):
                 barrier.wait()
-                seeder.enqueue_enrich(roots=(root,), compute_hashes=False)
+                seeder.enqueue_scan(
+                    roots=(root,), phase=ScanPhase.ENRICH, compute_hashes=False
+                )
 
             threads = [
                 threading.Thread(target=enqueue, args=(r,))


### PR DESCRIPTION
Layer 9/9 of the review-and-land stack #15915–#16036, hand-built (`review-stack.py` is frozen while layers 1–8 await review). **Stays draft until layers 1–8 are approved; blocks nothing.**

**Rule:** post-review fixes — the accepted CodeRabbit findings from #15915, plus one detection-gap fix.
**Question for this layer:** does each fix do only what its finding needs?

**Headline (commit 6) — `fix(assets): walk the output root after execution so undeclared outputs register promptly`.** Files written to `output/` without an `output_ui` declaration were only discovered by a frontend page load or a restart — for headless/API sessions, never. The debounced (~10s) post-execution hook now runs a fast+enrich scan of the output root instead of enrich-only. Declared outputs aren't double-registered, temp stays excluded, and the cost is one output-root walk per active window — the same walk every page load already triggers, minus the models root.

**`fix(assets): only discard content rows this operation actually inserted`** (CR-9, commit 1). On a path conflict `create_content` returned a pre-existing live row with no signal it hadn't inserted, so failure cleanup could delete the retained row that makes API deletes durable — letting the next scan re-mint a deleted asset. New `create_content_reporting_insert` returns `(row, inserted)`; the four cleanup sites track the id only when `inserted`.

**`fix(assets): reject hash-only uploads with FEATURE_DISABLED when hashing is off`** (CR-2, commit 2). Was a misleading 404 ASSET_NOT_FOUND; now pre-checks `mode.hashing_enabled()` and mirrors the sibling route's 400 gate.

**`fix(assets): seed persists the stat it verified`** (CR-7, commit 3). Persist the seed-time restat the loop already computed, not the stale walk-time values.

**`fix(assets): route database lock failures to the lock guidance`** (CR-16, commit 4). `main.py` now also matches `db.py`'s file-lock message, so a second-instance lock conflict gets the `--database-url` guidance instead of the generic error. Detection only.

**`fix(assets): drop the inaccurate temp-cleanup claim from the shutdown warning`** (CR-10, commit 5). Cleanup runs whether or not the thread joined; the warning now says only that it didn't exit in time.

Commits 7–8 are review-round cleanup: dead `start_enrich`/`enqueue_enrich` removed (their tests retargeted to the new `enqueue_scan`), the two deliberate choices documented in-code, the new query helper exported via the package façade, the dedup test hardened against vacuous passes — then a comment-gate pass over this layer's additions.

Suite: **1351 passed, 1 skipped**. `ruff` and `comment-gate check` clean. Net: 18 files, +519/−165.

**Files (18, +519/-165):**

| +/- | path |
|---|---|
| +4/-0 | `app/assets/api/routes.py` |
| +2/-0 | `app/assets/database/queries/__init__.py` |
| +8/-3 | `app/assets/database/queries/records.py` |
| +9/-6 | `app/assets/manager.py` |
| +7/-5 | `app/assets/scanner.py` |
| +39/-54 | `app/assets/seeder.py` |
| +18/-9 | `app/assets/services/ingest.py` |
| +2/-2 | `main.py` |
| +29/-0 | `tests-unit/app_test/test_db_init_locking.py` |
| +1/-1 | `tests-unit/assets_test/services/test_ingest_orphan_content.py` |
| +9/-0 | `tests-unit/assets_test/services/test_lifecycle.py` |
| +113/-4 | `tests-unit/assets_test/services/test_manager_isolated.py` |
| +3/-3 | `tests-unit/assets_test/services/test_noassets_parity.py` |
| +85/-3 | `tests-unit/assets_test/services/test_scanner_seed_resilience.py` |
| +42/-0 | `tests-unit/assets_test/services/test_upload_b.py` |
| +38/-0 | `tests-unit/assets_test/test_upload_hashing_modes.py` |
| +2/-2 | `tests-unit/execution_test/test_inmemory_assets.py` |
| +108/-73 | `tests/test_asset_seeder.py` |

**Stack:**
1. #15915 `code` — Is the logic change right?
2. #15916 `tests-removed` — For each dropped assertion: obsolete by a ruling, or covered by a tests-new test?
3. #15917 `tests-changed` — Did the edits weaken an existing check?
4. #15918 `tests-new` — Is the code layer well covered?
5. #16008 `code` — Is the logic change right?
6. #16009 `tests` — Is the code layer well covered, and did any edit weaken an existing check?
7. #16030 `ported-fixes` — Was each base fix ported faithfully?
8. #16036 `defensive-parity` — Does each degradation path match or improve master?
9. (this PR) `fixes` — Does each fix do only what its finding needs?
