### PR TITLE
Allow disconnected Switch inputs

### DIFF
--- a/comfy_extras/nodes_logic.py
+++ b/comfy_extras/nodes_logic.py
@@ -95,8 +95,8 @@ class SwitchNode(io.ComfyNode):
             is_experimental=True,
             inputs=[
                 io.Boolean.Input("switch"),
-                io.MatchType.Input("on_false", template=template, lazy=True),
-                io.MatchType.Input("on_true", template=template, lazy=True),
+                io.MatchType.Input("on_false", template=template, lazy=True, optional=True),
+                io.MatchType.Input("on_true", template=template, lazy=True, optional=True),
             ],
             outputs=[
                 io.MatchType.Output(template=template, display_name="output"),
@@ -104,15 +104,16 @@ class SwitchNode(io.ComfyNode):
         )
 
     @classmethod
-    def check_lazy_status(cls, switch, on_false=None, on_true=None):
+    def check_lazy_status(cls, switch, on_false=MISSING, on_true=MISSING):
         if switch and on_true is None:
             return ["on_true"]
         if not switch and on_false is None:
             return ["on_false"]
 
     @classmethod
-    def execute(cls, switch, on_true, on_false) -> io.NodeOutput:
-        return io.NodeOutput(on_true if switch else on_false)
+    def execute(cls, switch, on_true=MISSING, on_false=MISSING) -> io.NodeOutput:
+        selected = on_true if switch else on_false
+        return io.NodeOutput(None if selected is MISSING else selected)
 
 
 class SoftSwitchNode(io.ComfyNode):


### PR DESCRIPTION
Kinda useful for optional inputs with reasonable none behavior.

The classic case is an optional first image to switch between I2V and T2V.

Requested by @comfyui-wiki and @drozbay 

Example use case:

<img width="1320" height="613" alt="image" src="https://github.com/user-attachments/assets/d3e0d198-cb0e-4933-b68a-408f72dd8980" />



