### PR TITLE
[Partner Nodes] feat(Anthropic): add Claude Fable 5.1 to the Claude node

### DIFF
--- a/comfy_api_nodes/apis/anthropic.py
+++ b/comfy_api_nodes/apis/anthropic.py
@@ -45,7 +45,7 @@ class AnthropicThinkingConfig(BaseModel):
 
 class AnthropicOutputConfig(BaseModel):
     """Used with `thinking.type='adaptive'` on models like Opus 4.7."""
-    effort: Literal["low", "medium", "high"] | None = Field(None)
+    effort: Literal["low", "medium", "high", "xhigh", "max"] | None = Field(None)
 
 
 class AnthropicMessagesRequest(BaseModel):

--- a/comfy_api_nodes/nodes_anthropic.py
+++ b/comfy_api_nodes/nodes_anthropic.py
@@ -30,6 +30,7 @@ CLAUDE_MAX_IMAGES = 20
 CLAUDE_MODELS: dict[str, str] = {
     "Opus 5": "claude-opus-5",
     "Opus 4.8": "claude-opus-4-8",
+    "Fable 5.1": "claude-fable-5-1",
     "Fable 5": "claude-fable-5",
     "Sonnet 5": "claude-sonnet-5",
     "Opus 4.7": "claude-opus-4-7",
@@ -43,9 +44,9 @@ _THINKING_UNSUPPORTED = {"Haiku 4.5"}
 # Models that use the newer "adaptive" thinking mode (Opus 4.7+ require it; older models keep the explicit budget API).
 # Anthropic decides the actual budget when adaptive is used, based on the `output_config.effort` hint.
 _ADAPTIVE_THINKING_MODELS = {"Opus 4.8", "Sonnet 5", "Opus 4.7", "Opus 4.6", "Sonnet 4.6"}
-_ALWAYS_THINKING_MODELS = {"Opus 5", "Fable 5"}
+_ALWAYS_THINKING_MODELS = {"Opus 5", "Fable 5.1", "Fable 5"}
 _EXPLICIT_THINKING_OFF_MODELS = {"Sonnet 5"}
-_NO_TEMPERATURE_MODELS = {"Opus 5", "Opus 4.8", "Fable 5", "Sonnet 5"}
+_NO_TEMPERATURE_MODELS = {"Opus 5", "Opus 4.8", "Fable 5.1", "Fable 5", "Sonnet 5"}
 
 # Budget mode (Sonnet 4.5): effort -> reasoning budget in tokens. Must be < max_tokens.
 # Sized so even the "high" budget fits comfortably under the default max_tokens=32768.

--- a/comfy_api_nodes/nodes_anthropic.py
+++ b/comfy_api_nodes/nodes_anthropic.py
@@ -45,6 +45,8 @@ _THINKING_UNSUPPORTED = {"Haiku 4.5"}
 # Anthropic decides the actual budget when adaptive is used, based on the `output_config.effort` hint.
 _ADAPTIVE_THINKING_MODELS = {"Opus 4.8", "Sonnet 5", "Opus 4.7", "Opus 4.6", "Sonnet 4.6"}
 _ALWAYS_THINKING_MODELS = {"Opus 5", "Fable 5.1", "Fable 5"}
+_XHIGH_EFFORT_MODELS = {"Opus 5", "Opus 4.8", "Fable 5.1", "Fable 5", "Sonnet 5", "Opus 4.7"}
+_MAX_EFFORT_MODELS = _XHIGH_EFFORT_MODELS | {"Opus 4.6", "Sonnet 4.6"}
 _EXPLICIT_THINKING_OFF_MODELS = {"Sonnet 5"}
 _NO_TEMPERATURE_MODELS = {"Opus 5", "Opus 4.8", "Fable 5.1", "Fable 5", "Sonnet 5"}
 
@@ -56,6 +58,17 @@ _REASONING_BUDGET: dict[str, int] = {
     "high": 16384,
 }
 _REASONING_EFFORTS = ["off", "low", "medium", "high"]
+
+
+def _reasoning_effort_options(model_label: str) -> list[str]:
+    options = list(_REASONING_EFFORTS)
+    if model_label in _ALWAYS_THINKING_MODELS:
+        options.remove("off")
+    if model_label in _XHIGH_EFFORT_MODELS:
+        options.append("xhigh")
+    if model_label in _MAX_EFFORT_MODELS:
+        options.append("max")
+    return options
 
 
 def _claude_model_inputs(model_label: str):
@@ -88,7 +101,7 @@ def _claude_model_inputs(model_label: str):
         inputs.append(
             IO.Combo.Input(
                 "reasoning_effort",
-                options=[e for e in _REASONING_EFFORTS if e != "off"],
+                options=_reasoning_effort_options(model_label),
                 default="high",
                 tooltip="Extended thinking effort. Reasoning is always enabled for this model.",
                 advanced=True,
@@ -98,7 +111,7 @@ def _claude_model_inputs(model_label: str):
         inputs.append(
             IO.Combo.Input(
                 "reasoning_effort",
-                options=_REASONING_EFFORTS,
+                options=_reasoning_effort_options(model_label),
                 default="off",
                 tooltip="Extended thinking effort. 'off' disables reasoning.",
                 advanced=True,


### PR DESCRIPTION
Additionally we add `xhigh` and `max` reasoning levels to the models that supports this.

<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [x] **Is API Node Change**

### Pricing & Billing
- [x] **Need pricing update**
- [ ] **No pricing update**

If **Need pricing update**:
- [x] Metronome rate cards updated
- [x] Auto‑billing tests updated and passing

### QA
- [x] **QA done**
- [ ] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**

