### PR TITLE
Fix Get Image Size Description

### DIFF
--- a/comfy_extras/nodes_images.py
+++ b/comfy_extras/nodes_images.py
@@ -720,7 +720,7 @@ class GetImageSize(IO.ComfyNode):
             node_id="GetImageSize",
             search_aliases=["dimensions", "resolution", "image info"],
             display_name="Get Image Size",
-            description="Returns width and height of the image, and passes it through unchanged.",
+            description="Returns the width, height, and batch size of the image.",
             category="image",
             inputs=[
                 IO.Image.Input("image"),


### PR DESCRIPTION
There is no passthrough

<img width="454" height="236" alt="image" src="https://github.com/user-attachments/assets/580820d4-872d-4797-9d4f-2d3135075da2" />
