### PR TITLE
Add nodes to get Latent Geometries

### DIFF
--- a/comfy_extras/nodes_audio.py
+++ b/comfy_extras/nodes_audio.py
@@ -9,6 +9,7 @@ import node_helpers
 import logging
 from typing_extensions import override
 from comfy_api.latest import ComfyExtension, IO, UI
+from server import PromptServer
 
 class EmptyLatentAudio(IO.ComfyNode):
     @classmethod
@@ -132,6 +133,44 @@ class VAEDecodeAudio(IO.ComfyNode):
         return IO.NodeOutput(vae_decode_audio(vae, samples))
 
     decode = execute  # TODO: remove
+
+
+class GetAudioLatentSize(IO.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return IO.Schema(
+            node_id="GetAudioLatentSize",
+            search_aliases=["dimensions", "audio latent info", "audio latent length"],
+            display_name="Get Audio Latent Size",
+            description="Returns the length, audio channel count, and batch size of an audio latent.",
+            category="model/latent",
+            inputs=[
+                IO.Latent.Input("latent", tooltip="The audio or audio/video latent to inspect."),
+            ],
+            outputs=[
+                IO.Int.Output(display_name="length", tooltip="The audio latent length."),
+                IO.Int.Output(display_name="audio_channels", tooltip="The number of audio channels. Latents without an audio channel dimension have one channel."),
+                IO.Int.Output(display_name="batch_size", tooltip="The number of latents in the batch."),
+            ],
+            hidden=[IO.Hidden.unique_id],
+        )
+
+    @classmethod
+    def execute(cls, latent) -> IO.NodeOutput:
+        samples = latent["samples"]
+        if samples.is_nested:
+            samples = samples.unbind()[-1]
+
+        if samples.ndim == 4:
+            batch_size, _, audio_channels, length = samples.shape
+        else:
+            batch_size, _, length = samples.shape
+            audio_channels = 1
+
+        if cls.hidden.unique_id:
+            PromptServer.instance.send_progress_text(f"length: {length}, audio channels: {audio_channels}\n batch size: {batch_size}", cls.hidden.unique_id)
+
+        return IO.NodeOutput(length, audio_channels, batch_size)
 
 
 class VAEDecodeAudioTiled(IO.ComfyNode):
@@ -873,6 +912,7 @@ class AudioExtension(ComfyExtension):
             EmptyLatentAudio,
             VAEEncodeAudio,
             VAEDecodeAudio,
+            GetAudioLatentSize,
             VAEDecodeAudioTiled,
             SaveAudio,
             SaveAudioMP3,

--- a/comfy_extras/nodes_images.py
+++ b/comfy_extras/nodes_images.py
@@ -748,6 +748,45 @@ class GetImageSize(IO.ComfyNode):
     get_size = execute  # TODO: remove
 
 
+class GetLatentSize(IO.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return IO.Schema(
+            node_id="GetLatentSize",
+            search_aliases=["dimensions", "resolution", "latent info", "video latent size"],
+            display_name="Get Image/Video Latent Size",
+            description="Returns the width, height, frame count, and batch size of an image or video latent.",
+            category="latent",
+            inputs=[
+                IO.Latent.Input("latent", tooltip="The image or video latent to inspect."),
+            ],
+            outputs=[
+                IO.Int.Output(display_name="width", tooltip="The latent width."),
+                IO.Int.Output(display_name="height", tooltip="The latent height."),
+                IO.Int.Output(display_name="frames", tooltip="The latent frame count. Image latents have one frame."),
+                IO.Int.Output(display_name="batch_size", tooltip="The number of latents in the batch."),
+            ],
+            hidden=[IO.Hidden.unique_id],
+        )
+
+    @classmethod
+    def execute(cls, latent) -> IO.NodeOutput:
+        samples = latent["samples"]
+        if samples.is_nested:
+            samples = samples.unbind()[0]
+
+        if samples.ndim == 5:
+            batch_size, _, frames, height, width = samples.shape
+        else:
+            batch_size, _, height, width = samples.shape
+            frames = 1
+
+        if cls.hidden.unique_id:
+            PromptServer.instance.send_progress_text(f"width: {width}, height: {height}\n frames: {frames}, batch size: {batch_size}", cls.hidden.unique_id)
+
+        return IO.NodeOutput(width, height, frames, batch_size)
+
+
 class ImageRotate(IO.ComfyNode):
     @classmethod
     def define_schema(cls):
@@ -1775,6 +1814,7 @@ class ImagesExtension(ComfyExtension):
             ImageStitch,
             ResizeAndPadImage,
             GetImageSize,
+            GetLatentSize,
             ImageRotate,
             ImageFlip,
             ImageScaleToMaxDimension,


### PR DESCRIPTION
There are a lot of useful things you can do with latent sizes including things like overlap calculations and noise mask geometry setups. Add the nodes.

Based on a similar node from KJNodes but with some changes:

- No passthrough (to match Get Image Size)
- Add preview text (same as Get Image Size)
- Remove latent channels - this is a simplfication and matches Get Image Size where we dont get the number of channels there either

We also split between video and audio latent explicitly with two nodes for two reasons.

- The actual latent primitive is indistinguishable between audio and image/video in a workflow so we do need the user to tell us which so we can label things properly.
- The new semantics where we implicitly unbind nested tensors can be used to avoid extra nodes to split audio from video and it makes it super clear what its going to do with a nested tensor

<img width="1210" height="820" alt="image" src="https://github.com/user-attachments/assets/7ba7fac6-8acf-46ef-9f7a-7aba2e9dca62" />
