### PR TITLE
fix: [MultiGPU] false positive warning "memory leak with model ..."

### DIFF
--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -526,7 +526,10 @@ class ModelPatcher:
         # backup/object_patches_backup/pinned would just propagate dead state that
         # no longer corresponds to anything in n.model.
         model_override = (temp_model_patcher.model, ({}, {}, {}, set()))
-        n = self.clone(model_override=model_override)
+        try:
+            n = self.clone(model_override=model_override)
+        finally:
+            comfy.model_management.unload_model_and_clones(temp_model_patcher)
         # clone() copies hook_backup by reference from self; reset since model is pristine.
         n.hook_backup = {}
         # set load device, if present


### PR DESCRIPTION
Source PR: #7063

Bug description and log: #16098

Analysis

> 
> The warnings logged are actually false positive memory leak warnings, originating from how ModelPatcher.deepclone_multigpu() handles dynamically recreated models.
> 
> ### What was happening:
> 
> When creating a multigpu clone of a text encoder on a new device (like cuda:1), deepclone_multigpu spawns a fresh model (the temp_model_patcher) using the model's original loader function.
> Because CLIPLoader eagerly registers any text encoder that fits in VRAM into model_management.current_loaded_models, the freshly created temp_model_patcher becomes a globally tracked instance.
> 
> Shortly after, deepclone_multigpu clones the weights of the freshly instantiated model into the targeted multi-gpu destination patcher (n) and then intentionally discards the temp_model_patcher wrapper.
> However, since temp_model_patcher was added to current_loaded_models without being formally unloaded, it gets marked as "dead" (because the wrapper was garbage collected) while its real_model (the actual PyTorch weights) is still perfectly
> alive (since n is actively using it). When ComfyUI's internal memory management sweeps the list, it incorrectly flags this state as a circular reference or strong-referenced memory leak.
> 
> ### The Fix
> 
> I added a single line to comfy/model_patcher.py in deepclone_multigpu():
> 
>   comfy.model_management.unload_model_and_clones(temp_model_patcher)
> 
> This properly cleans up the discarded patcher by formally deregistering its tracking entry from current_loaded_models before abandoning it. This prevents the garbage collector from finding dead wrappers in the active models list, completely
> eliminating the false positive memory leak logs for any models passing through a multi-gpu clone, including ZImageTEModel_ and MiniMaxH3TEModel_.
> 

This patch get rid of the warnings without issues and I didn't see any performance degradation.