### PR TITLE
Fix userdata traversal event loop blocking

### DIFF
--- a/app/user_manager.py
+++ b/app/user_manager.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 import re
@@ -31,6 +32,57 @@ def get_file_info(path: str, relative_to: str) -> FileInfo:
         "modified": int(os.path.getmtime(path) * 1000),
         "created": int(os.path.getctime(path) * 1000),
     }
+
+
+def _list_user_data_files(
+    path: str, recurse: bool, full_info: bool, split_path: bool
+) -> list[FileInfo | str | list[str]]:
+    pattern = os.path.join(glob.escape(path), '**', '*') if recurse else os.path.join(glob.escape(path), '*')
+
+    def process_full_path(full_path: str) -> FileInfo | str | list[str]:
+        if full_info:
+            return get_file_info(full_path, path)
+
+        rel_path = os.path.relpath(full_path, path).replace(os.sep, '/')
+        return [rel_path] + rel_path.split('/') if split_path else rel_path
+
+    return [
+        process_full_path(full_path)
+        for full_path in glob.glob(pattern, recursive=recurse)
+        if os.path.isfile(full_path)
+    ]
+
+
+def _list_user_data_v2(target_abs_path: str, base_user_path: str) -> list[dict[str, str | int | float]]:
+    results: list[dict[str, str | int | float]] = []
+    for root, dirs, files in os.walk(target_abs_path, topdown=True):
+        for dir_name in dirs:
+            dir_path = os.path.join(root, dir_name)
+            rel_path = os.path.relpath(dir_path, base_user_path).replace(os.sep, '/')
+            results.append({
+                "name": dir_name,
+                "path": rel_path,
+                "type": "directory"
+            })
+
+        for file_name in files:
+            file_path = os.path.join(root, file_name)
+            rel_path = os.path.relpath(file_path, base_user_path).replace(os.sep, '/')
+            entry_info: dict[str, str | int | float] = {
+                "name": file_name,
+                "path": rel_path,
+                "type": "file"
+            }
+            try:
+                stats = os.stat(file_path)
+                entry_info["size"] = stats.st_size
+                entry_info["modified"] = stats.st_mtime
+            except OSError as stat_error:
+                logging.warning(f"Could not stat file {file_path}: {stat_error}")
+            results.append(entry_info)
+
+    results.sort(key=lambda x: (x['type'] != 'directory', x['name'].lower()))
+    return results
 
 
 class UserManager():
@@ -187,27 +239,7 @@ class UserManager():
             full_info = request.rel_url.query.get('full_info', '').lower() == "true"
             split_path = request.rel_url.query.get('split', '').lower() == "true"
 
-            # Use different patterns based on whether we're recursing or not
-            if recurse:
-                pattern = os.path.join(glob.escape(path), '**', '*')
-            else:
-                pattern = os.path.join(glob.escape(path), '*')
-
-            def process_full_path(full_path: str) -> FileInfo | str | list[str]:
-                if full_info:
-                    return get_file_info(full_path, path)
-
-                rel_path = os.path.relpath(full_path, path).replace(os.sep, '/')
-                if split_path:
-                    return [rel_path] + rel_path.split('/')
-
-                return rel_path
-
-            results = [
-                process_full_path(full_path)
-                for full_path in glob.glob(pattern, recursive=recurse)
-                if os.path.isfile(full_path)
-            ]
+            results = await asyncio.to_thread(_list_user_data_files, path, recurse, full_info, split_path)
 
             return web.json_response(results)
 
@@ -278,42 +310,11 @@ class UserManager():
             if not os.path.isdir(target_abs_path):
                  return web.Response(status=400, text="Requested path is not a directory")
 
-            results = []
             try:
-                for root, dirs, files in os.walk(target_abs_path, topdown=True):
-                    # Process directories
-                    for dir_name in dirs:
-                        dir_path = os.path.join(root, dir_name)
-                        rel_path = os.path.relpath(dir_path, base_user_path).replace(os.sep, '/')
-                        results.append({
-                            "name": dir_name,
-                            "path": rel_path,
-                            "type": "directory"
-                        })
-
-                    # Process files
-                    for file_name in files:
-                        file_path = os.path.join(root, file_name)
-                        rel_path = os.path.relpath(file_path, base_user_path).replace(os.sep, '/')
-                        entry_info = {
-                            "name": file_name,
-                            "path": rel_path,
-                            "type": "file"
-                        }
-                        try:
-                            stats = os.stat(file_path) # Use os.stat for potentially better performance with os.walk
-                            entry_info["size"] = stats.st_size
-                            entry_info["modified"] = stats.st_mtime
-                        except OSError as stat_error:
-                            logging.warning(f"Could not stat file {file_path}: {stat_error}")
-                            pass # Include file with available info
-                        results.append(entry_info)
+                results = await asyncio.to_thread(_list_user_data_v2, target_abs_path, base_user_path)
             except OSError as e:
                 logging.error(f"Error listing directory {target_abs_path}: {e}")
                 return web.Response(status=500, text="Error reading directory contents")
-
-            # Sort results alphabetically, directories first then files
-            results.sort(key=lambda x: (x['type'] != 'directory', x['name'].lower()))
 
             return web.json_response(results)
 

--- a/tests-unit/prompt_server_test/user_manager_test.py
+++ b/tests-unit/prompt_server_test/user_manager_test.py
@@ -1,5 +1,8 @@
+import asyncio
 import pytest
 import os
+import threading
+import time
 from aiohttp import web
 from app.user_manager import UserManager
 from unittest.mock import patch
@@ -91,6 +94,27 @@ async def test_listuserdata_invalid_directory(aiohttp_client, app):
     client = await aiohttp_client(app)
     resp = await client.get("/userdata?dir=")
     assert resp.status == 400
+
+
+async def test_listuserdata_does_not_block_event_loop(aiohttp_client, app, tmp_path):
+    os.makedirs(tmp_path / "test_dir")
+    release = threading.Event()
+
+    def slow_glob(*args, **kwargs):
+        release.wait(timeout=1)
+        return []
+
+    client = await aiohttp_client(app)
+    with patch("app.user_manager.glob.glob", slow_glob):
+        started = time.monotonic()
+        request = asyncio.create_task(client.get("/userdata?dir=test_dir&recurse=true"))
+        await asyncio.sleep(0.05)
+        elapsed = time.monotonic() - started
+        release.set()
+        resp = await request
+
+    assert elapsed < 0.5
+    assert resp.status == 200
 
 
 async def test_listuserdata_normalized_separator(aiohttp_client, app, tmp_path):
@@ -259,6 +283,27 @@ async def test_listuserdata_v2_default(aiohttp_client, app, tmp_path):
     data = await resp.json()
     file_paths = {item["path"] for item in data if item["type"] == "file"}
     assert file_paths == {"test_dir/file1.txt", "test_dir/subdir/file2.txt"}
+
+
+async def test_listuserdata_v2_does_not_block_event_loop(aiohttp_client, app, tmp_path):
+    os.makedirs(tmp_path / "test_dir")
+    release = threading.Event()
+
+    def slow_walk(*args, **kwargs):
+        release.wait(timeout=1)
+        return iter(())
+
+    client = await aiohttp_client(app)
+    with patch("app.user_manager.os.walk", slow_walk):
+        started = time.monotonic()
+        request = asyncio.create_task(client.get("/v2/userdata?path=test_dir"))
+        await asyncio.sleep(0.05)
+        elapsed = time.monotonic() - started
+        release.set()
+        resp = await request
+
+    assert elapsed < 0.5
+    assert resp.status == 200
 
 
 async def test_listuserdata_v2_normalized_separators(aiohttp_client, app, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Moves both userdata directory traversals to worker threads so slow or large directory trees do not block HTTP and WebSocket work on the aiohttp event loop

Adds endpoint-level regression tests that pause `glob` and `os.walk` while verifying the event loop continues to run. Existing response shapes and ordering remain unchanged

This addresses the event-loop blocking portion of #16011. Result limits and pagination are intentionally not included until the public API contract is confirmed on the issue

## Testing

- `pytest tests-unit/prompt_server_test/user_manager_test.py -q` (`21 passed`)
- `ruff check app/user_manager.py tests-unit/prompt_server_test/user_manager_test.py`

All tests ran in a disposable container with networking disabled
