### PR TITLE
chore: update frontend to v1.52.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-comfyui-frontend-package==1.51.9
+comfyui-frontend-package==1.52.6
 comfyui-workflow-templates==0.11.55
 comfyui-embedded-docs==0.5.10
 torch


### PR DESCRIPTION
Bumps `comfyui-frontend-package` from 1.51.9 to 1.52.6.

## Note before merging

At the time of opening, **1.52.6 is not published to PyPI** — the latest release is 1.51.9 and there are no 1.52.x releases yet. Installs and CI will fail until it publishes. Kept as a draft for that reason; ready to mark for review once the package is out.

## Checklist
- [x] Single-line dependency pin change, no code changes
- [ ] Blocked: 1.52.6 available on PyPI