### PR TITLE
Fix stale WebSocket reconnect cleanup

### DIFF
--- a/comfy_api/feature_flags.py
+++ b/comfy_api/feature_flags.py
@@ -118,6 +118,20 @@ _cli_flags = {k: v for k, v in _parse_cli_feature_flags().items() if k not in _C
 SERVER_FEATURE_FLAGS: dict[str, Any] = {**_CORE_FEATURE_FLAGS, **_cli_flags}
 
 
+def try_set_connection_feature_flags(
+    sockets_metadata: dict[str, dict[str, Any]],
+    sid: str,
+    connection_metadata: dict[str, Any],
+    client_flags: dict[str, Any],
+) -> bool:
+    """Store feature flags if the metadata still belongs to this connection."""
+    if sockets_metadata.get(sid) is not connection_metadata:
+        return False
+
+    connection_metadata["feature_flags"] = client_flags
+    return True
+
+
 def get_connection_feature(
     sockets_metadata: dict[str, dict[str, Any]],
     sid: str,

--- a/server.py
+++ b/server.py
@@ -280,7 +280,8 @@ class PromptServer():
             # Store WebSocket for backward compatibility
             self.sockets[sid] = ws
             # Store metadata separately
-            self.sockets_metadata[sid] = {"feature_flags": {}}
+            connection_metadata = {"feature_flags": {}}
+            self.sockets_metadata[sid] = connection_metadata
 
             try:
                 if old_socket is not None:
@@ -311,7 +312,13 @@ class PromptServer():
                             if first_message and data.get("type") == "feature_flags":
                                 # Store client feature flags
                                 client_flags = data.get("data", {})
-                                self.sockets_metadata[sid]["feature_flags"] = client_flags
+                                if not feature_flags.try_set_connection_feature_flags(
+                                    self.sockets_metadata,
+                                    sid,
+                                    connection_metadata,
+                                    client_flags,
+                                ):
+                                    break
 
                                 # Send server feature flags in response
                                 await self.send(

--- a/server.py
+++ b/server.py
@@ -272,10 +272,10 @@ class PromptServer():
             await ws.prepare(request)
             sid = request.rel_url.query.get('clientId', '')
             if sid:
-                # Reusing existing session, remove old
-                self.sockets.pop(sid, None)
+                old_socket = self.sockets.get(sid)
             else:
                 sid = uuid.uuid4().hex
+                old_socket = None
 
             # Store WebSocket for backward compatibility
             self.sockets[sid] = ws
@@ -283,6 +283,12 @@ class PromptServer():
             self.sockets_metadata[sid] = {"feature_flags": {}}
 
             try:
+                if old_socket is not None:
+                    await old_socket.close()
+
+                if self.sockets.get(sid) is not ws:
+                    return ws
+
                 # Send initial state to the new client
                 await self.send("status", {"status": self.get_queue_info(), "sid": sid}, sid)
                 # On reconnect if we are the currently executing client send the current node
@@ -293,6 +299,9 @@ class PromptServer():
                 first_message = True
 
                 async for msg in ws:
+                    if self.sockets.get(sid) is not ws:
+                        break
+
                     if msg.type == aiohttp.WSMsgType.ERROR:
                         logging.warning('ws connection closed with exception %s' % ws.exception())
                     elif msg.type == aiohttp.WSMsgType.TEXT:
@@ -322,8 +331,9 @@ class PromptServer():
                         except Exception as e:
                             logging.error(f"Error processing WebSocket message: {e}")
             finally:
-                self.sockets.pop(sid, None)
-                self.sockets_metadata.pop(sid, None)
+                if self.sockets.get(sid) is ws:
+                    self.sockets.pop(sid, None)
+                    self.sockets_metadata.pop(sid, None)
             return ws
 
         @routes.get("/")

--- a/tests-unit/websocket_feature_flags_test.py
+++ b/tests-unit/websocket_feature_flags_test.py
@@ -51,6 +51,30 @@ class TestWebSocketFeatureFlags:
             sockets_metadata, "legacy_client", "supports_preview_metadata"
         ) is False
 
+    def test_stale_connection_cannot_overwrite_replacement_features(self):
+        """Test that feature negotiation only updates the current connection."""
+        client_id = "reconnecting_client"
+        stale_metadata = {"feature_flags": {}}
+        replacement_metadata = {"feature_flags": {}}
+        sockets_metadata = {client_id: replacement_metadata}
+
+        assert feature_flags.try_set_connection_feature_flags(
+            sockets_metadata,
+            client_id,
+            replacement_metadata,
+            {"supports_preview_metadata": True},
+        ) is True
+        assert feature_flags.try_set_connection_feature_flags(
+            sockets_metadata,
+            client_id,
+            stale_metadata,
+            {"supports_preview_metadata": False},
+        ) is False
+        assert sockets_metadata[client_id] is replacement_metadata
+        assert sockets_metadata[client_id]["feature_flags"] == {
+            "supports_preview_metadata": True
+        }
+
     def test_feature_negotiation_message_format(self):
         """Test the format of feature negotiation messages."""
         # Client message format

--- a/tests/execution/test_websocket_reconnect.py
+++ b/tests/execution/test_websocket_reconnect.py
@@ -1,0 +1,75 @@
+import json
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+import pytest
+import websocket
+
+
+@pytest.fixture(scope="module", autouse=True)
+def server(args_pytest):
+    process = subprocess.Popen([
+        sys.executable,
+        "main.py",
+        "--output-directory", args_pytest["output_dir"],
+        "--listen", args_pytest["listen"],
+        "--port", str(args_pytest["port"]),
+        "--extra-model-paths-config", "tests/execution/extra_model_paths.yaml",
+        "--cpu",
+    ])
+
+    try:
+        server_url = f"http://{args_pytest['listen']}:{args_pytest['port']}/system_stats"
+        for _ in range(90):
+            try:
+                with urllib.request.urlopen(server_url, timeout=1):
+                    break
+            except (OSError, urllib.error.URLError):
+                if process.poll() is not None:
+                    raise RuntimeError("ComfyUI exited before accepting connections")
+                time.sleep(1)
+        else:
+            raise RuntimeError("ComfyUI did not accept connections within 90 seconds")
+
+        yield
+    finally:
+        if process.poll() is None:
+            process.kill()
+        process.wait(timeout=10)
+
+
+def connect(args_pytest, client_id):
+    ws = websocket.WebSocket()
+    ws.settimeout(5)
+    ws.connect(f"ws://{args_pytest['listen']}:{args_pytest['port']}/ws?clientId={client_id}")
+    return ws
+
+
+def receive_message(ws, expected_type):
+    message = json.loads(ws.recv())
+    assert message["type"] == expected_type
+    return message
+
+
+@pytest.mark.execution
+def test_reconnect_retires_stale_socket_and_keeps_replacement(args_pytest):
+    client_id = "reconnecting-client"
+    first = connect(args_pytest, client_id)
+    receive_message(first, "status")
+
+    second = connect(args_pytest, client_id)
+    assert first.recv() == ""
+    assert not first.connected
+    receive_message(second, "status")
+
+    second.send(json.dumps({
+        "type": "feature_flags",
+        "data": {"supports_preview_metadata": True},
+    }))
+    response = receive_message(second, "feature_flags")
+    assert response["data"]["supports_preview_metadata"] is True
+
+    second.close()


### PR DESCRIPTION
## Summary

- make a replacement socket the active owner before retiring the prior connection
- prevent displaced handlers from processing messages or clearing the replacement socket metadata
- add live regression coverage for reconnect cleanup and feature-flag negotiation

## Testing

- python -m pytest tests/execution/test_websocket_reconnect.py -v --skip-timing-checks
- ruff check .
- python -m py_compile server.py tests/execution/test_websocket_reconnect.py

Fixes #16010