### PR TITLE
Fix hipBLAS alloc failure in UnwrapMesh's LSCM batch solve on ROCm

### DIFF
--- a/comfy_extras/mesh3d/uv_unwrap/parameterize.py
+++ b/comfy_extras/mesh3d/uv_unwrap/parameterize.py
@@ -10,9 +10,19 @@ import scipy.sparse.linalg as spla
 import torch
 from torch import Tensor
 
+import comfy.model_management
 from . import mesh as _mesh
 
 LSCM_BATCH_MAX_VERTS = 256      # charts above this solve per-chart sparse (lscm_chart)
+
+
+def _lscm_solve_on_gpu(device: "torch.device | None") -> bool:
+    """True if the dense batched normal-equations solve should run on device rather
+    than CPU. Excludes ROCm: hipBLAS's batched getrf (torch.linalg.solve's backing
+    call) raises HIPBLAS_STATUS_ALLOC_FAILED on these chart batches even with plenty
+    of free VRAM, and PyTorch reports a ROCm device's .type as "cuda", so the type
+    check alone can't tell AMD and NVIDIA apart."""
+    return device is not None and device.type == "cuda" and not comfy.model_management.is_amd()
 
 
 def solve_least_squares(A: sp.csr_matrix, b: np.ndarray) -> np.ndarray:
@@ -319,7 +329,7 @@ def lscm_charts_batch(
         np.put_along_axis(cval, pin_cols, pin_vals, axis=1)
 
         # normal equations + batched solve; the fp64 dense algebra goes to the GPU when available
-        use_gpu = device is not None and device.type == "cuda"
+        use_gpu = _lscm_solve_on_gpu(device)
         if use_gpu:
             A_t = torch.from_numpy(A).to(device)
             At = A_t.transpose(1, 2)

--- a/tests-unit/comfy_extras_test/mesh3d_uv_unwrap_parameterize_test.py
+++ b/tests-unit/comfy_extras_test/mesh3d_uv_unwrap_parameterize_test.py
@@ -1,0 +1,65 @@
+"""lscm_charts_batch must not run the dense solve on the GPU on AMD/ROCm (issue #16124).
+
+ROCm's hipBLAS backing call for torch.linalg.solve (hipblasDgetrfBatched) raises
+HIPBLAS_STATUS_ALLOC_FAILED on these chart-solve batches even with ample free VRAM.
+PyTorch reports a ROCm device's .type as "cuda", so the GPU-solve decision must also
+check comfy.model_management.is_amd() and fall back to the CPU (numpy/LAPACK) path.
+"""
+
+import numpy as np
+import torch
+
+from comfy.cli_args import args as cli_args
+
+if not torch.cuda.is_available():
+    cli_args.cpu = True
+
+import comfy.model_management
+from comfy_extras.mesh3d.uv_unwrap import parameterize
+
+
+def test_solve_on_gpu_false_for_amd_cuda_type_device(monkeypatch):
+    monkeypatch.setattr(comfy.model_management, "is_amd", lambda: True)
+
+    assert parameterize._lscm_solve_on_gpu(torch.device("cuda")) is False
+
+
+def test_solve_on_gpu_true_for_non_amd_cuda_type_device(monkeypatch):
+    monkeypatch.setattr(comfy.model_management, "is_amd", lambda: False)
+
+    assert parameterize._lscm_solve_on_gpu(torch.device("cuda")) is True
+
+
+def test_solve_on_gpu_false_for_cpu_device(monkeypatch):
+    monkeypatch.setattr(comfy.model_management, "is_amd", lambda: False)
+
+    assert parameterize._lscm_solve_on_gpu(torch.device("cpu")) is False
+
+
+def _one_triangle_chart():
+    verts = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float64)
+    uv_pins = np.zeros((3, 2), dtype=np.float64)
+    faces_gl = np.array([[0, 1, 2]], dtype=np.int64)
+    face_pos = np.array([0], dtype=np.int64)
+    chart_of_face = np.array([0], dtype=np.int64)
+    chart_of_vert = np.array([0, 0, 0], dtype=np.int64)
+    vert_offsets = np.array([0, 3], dtype=np.int64)
+    chart_ids = np.array([0], dtype=np.int64)
+    return verts, uv_pins, faces_gl, face_pos, chart_of_face, chart_of_vert, vert_offsets, chart_ids
+
+
+def test_lscm_charts_batch_completes_on_amd_with_cuda_type_device(monkeypatch):
+    """End-to-end: on a machine reporting an AMD/ROCm "cuda"-type device, the batch
+    solve must not attempt any GPU tensor transfer (which would otherwise be the
+    first operation to fail/hang on real ROCm hardware per issue #16124)."""
+    monkeypatch.setattr(comfy.model_management, "is_amd", lambda: True)
+
+    (verts, uv_pins, faces_gl, face_pos, chart_of_face, chart_of_vert,
+     vert_offsets, chart_ids) = _one_triangle_chart()
+
+    out = parameterize.lscm_charts_batch(
+        verts, uv_pins, faces_gl, face_pos, chart_of_face, chart_of_vert,
+        vert_offsets, chart_ids, n_charts=1, device=torch.device("cuda"))
+
+    assert 0 in out
+    assert out[0].shape == (3, 2)


### PR DESCRIPTION
Fixes #16124.

## Problem

On ROCm (AMD), `UnwrapMesh`'s LSCM parameterization path crashes with:

```
RuntimeError: CUDA error: HIPBLAS_STATUS_ALLOC_FAILED when calling
`hipblasDgetrfBatched( handle, n, dA_array, ldda, ipiv_array, info_array, batchsize)`
```

`lscm_charts_batch()` in `comfy_extras/mesh3d/uv_unwrap/parameterize.py`
solves the dense per-chunk normal equations with `torch.linalg.solve` on
the GPU whenever `device.type == "cuda"`. On ROCm builds of PyTorch, a HIP
device also reports `device.type == "cuda"`, so this check can't tell AMD
and NVIDIA apart. `torch.linalg.solve`'s ROCm backing call
(`hipblasDgetrfBatched`, a batched LU factorization) fails with
`HIPBLAS_STATUS_ALLOC_FAILED` on these chart batches even with plenty of
free VRAM (the reporter confirmed disabling dynamic memory made no
difference), so every mesh whose UnwrapMesh run reaches this branch
crashes on AMD GPUs.

## Fix

Extract the GPU/CPU decision into `_lscm_solve_on_gpu(device)` and add an
`is_amd()` check (`comfy.model_management.is_amd()`, the repo's existing
way to distinguish ROCm from CUDA), so AMD falls back to the existing
CPU/numpy (`np.linalg.solve`) path instead of the CUDA-only branch,
matching how other backend-specific workarounds are handled in this
codebase (e.g. `device_supports_non_blocking` for MPS).

## Test

Added `tests-unit/comfy_extras_test/mesh3d_uv_unwrap_parameterize_test.py`:
- `_lscm_solve_on_gpu` returns `False` for an AMD "cuda"-type device, `True`
  for a non-AMD "cuda"-type device, and `False` for a CPU device.
- An end-to-end `lscm_charts_batch` call with `is_amd()` mocked `True` and
  `device=torch.device("cuda")` completes without attempting any GPU
  tensor transfer (which is otherwise the first operation to fail on a
  machine without real CUDA/ROCm hardware — reproducing the shape of the
  reported crash).

Verified the new test fails against the pre-fix code (reverted
`parameterize.py` to its pre-fix state via `git checkout HEAD~1 --
comfy_extras/mesh3d/uv_unwrap/parameterize.py`, confirming
`AttributeError: ... has no attribute '_lscm_solve_on_gpu'` and
`AssertionError: Torch not compiled with CUDA enabled` from the
unconditional `.to(cuda)` call), then restored the fix and re-ran:

```
$ python -m pytest tests-unit/comfy_extras_test/mesh3d_uv_unwrap_parameterize_test.py -v
tests-unit/comfy_extras_test/mesh3d_uv_unwrap_parameterize_test.py::test_solve_on_gpu_false_for_amd_cuda_type_device PASSED
tests-unit/comfy_extras_test/mesh3d_uv_unwrap_parameterize_test.py::test_solve_on_gpu_true_for_non_amd_cuda_type_device PASSED
tests-unit/comfy_extras_test/mesh3d_uv_unwrap_parameterize_test.py::test_solve_on_gpu_false_for_cpu_device PASSED
tests-unit/comfy_extras_test/mesh3d_uv_unwrap_parameterize_test.py::test_lscm_charts_batch_completes_on_amd_with_cuda_type_device PASSED

4 passed in 1.96s
```

Also ran `ruff check` on the changed files: all checks passed.

## AI-assistance disclosure

This PR was prepared with the assistance of an AI coding agent
(Claude), reviewed and pushed by a human maintainer of this fork.
