### PR TITLE
Repair mask editor painted-masked uploads so the original image survives under the mask

### DIFF
--- a/server.py
+++ b/server.py
@@ -130,6 +130,46 @@ def create_cors_middleware(allowed_origin: str):
     return cors_middleware
 
 
+# The mask editor uploads every save as four sibling files named
+# clipspace-{mask,paint,painted,painted-masked}-<timestamp>.png. Masked layers
+# produced from the browser canvas bitmap have premultiplied alpha, so fully
+# masked pixels lose their RGB and the Load Image node ends up with a black
+# background under the painted mask (#16139). The painted sibling is an opaque
+# copy of the same pixels, so the masked image is rebuilt from it, keeping only
+# the alpha channel of the upload. This mirrors the composite /upload/mask
+# performs for clients that send an original_ref.
+CLIPSPACE_PAINTED_MASKED_PREFIX = "clipspace-painted-masked-"
+
+def repair_clipspace_painted_masked(image, filename, output_folder):
+    """Rebuild a mask editor painted-masked upload from its opaque painted
+    sibling so the original pixels survive under the mask.
+
+    Returns the PNG bytes to save, or None when no repair applies and the
+    upload should be written as-is."""
+    if not filename.startswith(CLIPSPACE_PAINTED_MASKED_PREFIX):
+        return None
+    sibling_name = "clipspace-painted-" + filename[len(CLIPSPACE_PAINTED_MASKED_PREFIX):]
+    sibling_path = os.path.join(output_folder, sibling_name)
+    if not os.path.isfile(sibling_path):
+        return None
+    try:
+        with Image.open(image.file) as masked_img:
+            image.file.seek(0)
+            if masked_img.format != "PNG" or "A" not in masked_img.getbands():
+                return None
+            with Image.open(sibling_path) as painted_img:
+                if painted_img.size != masked_img.size:
+                    return None
+                rebuilt = painted_img.convert("RGBA")
+                rebuilt.putalpha(masked_img.convert("RGBA").getchannel("A"))
+                buffer = BytesIO()
+                rebuilt.save(buffer, format="PNG", compress_level=4)
+                return buffer.getvalue()
+    except Exception:
+        logging.warning("Failed to rebuild masked image %s from painted layer", filename, exc_info=True)
+        return None
+
+
 def is_loopback(host):
     if host is None:
         return False
@@ -435,8 +475,12 @@ class PromptServer():
                     if image_save_function is not None:
                         image_save_function(image, post, filepath)
                     else:
+                        data = repair_clipspace_painted_masked(image, filename, full_output_folder)
+                        image.file.seek(0)
+                        if data is None:
+                            data = image.file.read()
                         with open(filepath, "wb") as f:
-                            f.write(image.file.read())
+                            f.write(data)
 
                 resp = {"name" : filename, "subfolder": subfolder, "type": image_upload_type}
 

--- a/server.py
+++ b/server.py
@@ -145,8 +145,9 @@ def repair_clipspace_painted_masked(image, filename, output_folder):
     sibling so the original pixels survive under the mask.
 
     Returns the PNG bytes to save, or None when no repair applies and the
-    upload should be written as-is."""
-    if not filename.startswith(CLIPSPACE_PAINTED_MASKED_PREFIX):
+    upload should be written as-is. On a decode or I/O failure the upload
+    falls back to its original bytes; unrelated errors propagate."""
+    if not filename.startswith(CLIPSPACE_PAINTED_MASKED_PREFIX) or not filename.lower().endswith(".png"):
         return None
     sibling_name = "clipspace-painted-" + filename[len(CLIPSPACE_PAINTED_MASKED_PREFIX):]
     sibling_path = os.path.join(output_folder, sibling_name)
@@ -158,14 +159,14 @@ def repair_clipspace_painted_masked(image, filename, output_folder):
             if masked_img.format != "PNG" or "A" not in masked_img.getbands():
                 return None
             with Image.open(sibling_path) as painted_img:
-                if painted_img.size != masked_img.size:
+                if painted_img.format != "PNG" or painted_img.size != masked_img.size:
                     return None
                 rebuilt = painted_img.convert("RGBA")
                 rebuilt.putalpha(masked_img.convert("RGBA").getchannel("A"))
                 buffer = BytesIO()
                 rebuilt.save(buffer, format="PNG", compress_level=4)
                 return buffer.getvalue()
-    except Exception:
+    except (OSError, ValueError):
         logging.warning("Failed to rebuild masked image %s from painted layer", filename, exc_info=True)
         return None
 
@@ -459,12 +460,40 @@ class PromptServer():
 
                 split = os.path.splitext(filename)
 
+                # Resolve the bytes this plain upload will save before the
+                # duplicate and collision handling below: a mask editor
+                # painted-masked upload is rebuilt from its opaque sibling
+                # (#16139), and both the duplicate hash comparison and the
+                # write must see the repaired bytes, under the original
+                # filename the sibling lookup depends on. Custom savers keep
+                # receiving the untouched upload stream.
+                data = None
+                if image_save_function is None:
+                    repaired = repair_clipspace_painted_masked(image, filename, full_output_folder)
+                    image.file.seek(0)
+                    data = repaired if repaired is not None else image.file.read()
+
+                def compare_file_hash(existing_path, expected_bytes):
+                    hasher = node_helpers.hasher()
+                    if os.path.exists(existing_path):
+                        a = hasher()
+                        b = hasher()
+                        with open(existing_path, "rb") as f:
+                            a.update(f.read())
+                        b.update(expected_bytes)
+                        return a.hexdigest() == b.hexdigest()
+                    return False
+
                 if overwrite is not None and (overwrite == "true" or overwrite == "1"):
                     pass
                 else:
                     i = 1
                     while os.path.exists(filepath):
-                        if compare_image_hash(filepath, image): #compare hash to prevent saving of duplicates with same name, fix for #3465
+                        if data is not None:
+                            if compare_file_hash(filepath, data): #compare hash to prevent saving of duplicates with same name, fix for #3465
+                                image_is_duplicate = True
+                                break
+                        elif compare_image_hash(filepath, image): #compare hash to prevent saving of duplicates with same name, fix for #3465
                             image_is_duplicate = True
                             break
                         filename = f"{split[0]} ({i}){split[1]}"
@@ -475,10 +504,6 @@ class PromptServer():
                     if image_save_function is not None:
                         image_save_function(image, post, filepath)
                     else:
-                        data = repair_clipspace_painted_masked(image, filename, full_output_folder)
-                        image.file.seek(0)
-                        if data is None:
-                            data = image.file.read()
                         with open(filepath, "wb") as f:
                             f.write(data)
 

--- a/tests-unit/prompt_server_test/upload_image_masked_repair_test.py
+++ b/tests-unit/prompt_server_test/upload_image_masked_repair_test.py
@@ -1,0 +1,116 @@
+"""Tests for the mask editor painted-masked upload repair.
+
+The mask editor uploads each save as four sibling files named
+clipspace-{mask,paint,painted,painted-masked}-<timestamp>.png. Frontends that
+serialize the masked layer from the browser canvas bitmap upload
+premultiplied alpha, which zeroes the RGB of fully masked pixels; the server
+rebuilds the file from the opaque painted sibling so the original image
+survives under the painted mask (#16139).
+"""
+
+import io
+import os
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from server import repair_clipspace_painted_masked
+
+
+class FakeUpload:
+    def __init__(self, png_bytes, filename):
+        self.file = io.BytesIO(png_bytes)
+        self.filename = filename
+
+
+def make_rgba(rgb_array, alpha_array):
+    rgba = np.dstack([rgb_array, alpha_array]).astype(np.uint8)
+    buffer = io.BytesIO()
+    Image.fromarray(rgba, "RGBA").save(buffer, format="PNG")
+    buffer.seek(0)
+    return buffer.getvalue()
+
+
+@pytest.fixture
+def gradient():
+    h, w = 8, 8
+    rgb = np.zeros((h, w, 3), dtype=np.uint8)
+    rgb[..., 0] = np.linspace(0, 255, w, dtype=np.uint8)[None, :]
+    rgb[..., 1] = np.linspace(0, 255, h, dtype=np.uint8)[:, None]
+    rgb[..., 2] = 128
+    return rgb
+
+
+def test_rebuilds_rgb_from_painted_sibling(tmp_path, gradient):
+    # Premultiplied upload: masked (top) half lost its RGB, like a blob
+    # serialized from a browser canvas.
+    alpha = np.full((8, 8), 255, dtype=np.uint8)
+    alpha[:4] = 0
+    premultiplied = gradient * (alpha[..., None] // 255)
+    masked_bytes = make_rgba(premultiplied, alpha)
+    with open(os.path.join(tmp_path, "clipspace-painted-42.png"), "wb") as f:
+        f.write(make_rgba(gradient, np.full((8, 8), 255, dtype=np.uint8)))
+
+    upload = FakeUpload(masked_bytes, "clipspace-painted-masked-42.png")
+    data = repair_clipspace_painted_masked(upload, upload.filename, str(tmp_path))
+
+    assert data is not None
+    rebuilt = np.array(Image.open(io.BytesIO(data)))
+    assert np.array_equal(rebuilt[..., :3], gradient)  # original pixels restored
+    assert np.array_equal(rebuilt[..., 3], alpha)  # painted mask preserved
+
+    # The upload stream is rewound so the raw write fallback still works.
+    upload.file.seek(0)
+    assert upload.file.read() == masked_bytes
+
+
+def test_straight_alpha_upload_is_unchanged_in_content(tmp_path, gradient):
+    # A frontend that encodes straight alpha keeps its RGB; rebuilding from
+    # the identical painted sibling must not alter any pixel.
+    alpha = np.full((8, 8), 255, dtype=np.uint8)
+    alpha[:4] = 0
+    masked_bytes = make_rgba(gradient, alpha)
+    with open(os.path.join(tmp_path, "clipspace-painted-42.png"), "wb") as f:
+        f.write(make_rgba(gradient, np.full((8, 8), 255, dtype=np.uint8)))
+
+    upload = FakeUpload(masked_bytes, "clipspace-painted-masked-42.png")
+    data = repair_clipspace_painted_masked(upload, upload.filename, str(tmp_path))
+
+    rebuilt = np.array(Image.open(io.BytesIO(data)))
+    assert np.array_equal(rebuilt[..., :3], gradient)
+    assert np.array_equal(rebuilt[..., 3], alpha)
+
+
+def test_returns_none_without_sibling(tmp_path):
+    alpha = np.full((4, 4), 0, dtype=np.uint8)
+    upload = FakeUpload(make_rgba(np.zeros((4, 4, 3), np.uint8), alpha),
+                        "clipspace-painted-masked-42.png")
+    assert repair_clipspace_painted_masked(upload, upload.filename, str(tmp_path)) is None
+
+
+def test_returns_none_for_other_filenames(tmp_path, gradient):
+    with open(os.path.join(tmp_path, "clipspace-painted-42.png"), "wb") as f:
+        f.write(make_rgba(gradient, np.full((8, 8), 255, dtype=np.uint8)))
+    for filename in ("clipspace-mask-42.png", "clipspace-painted-42.png", "example.png"):
+        upload = FakeUpload(make_rgba(gradient, np.full((8, 8), 255, dtype=np.uint8)), filename)
+        assert repair_clipspace_painted_masked(upload, filename, str(tmp_path)) is None
+
+
+def test_returns_none_on_size_mismatch(tmp_path, gradient):
+    alpha = np.full((8, 8), 0, dtype=np.uint8)
+    with open(os.path.join(tmp_path, "clipspace-painted-42.png"), "wb") as f:
+        f.write(make_rgba(gradient[:4], np.full((4, 8), 255, dtype=np.uint8)))
+
+    upload = FakeUpload(make_rgba(gradient, alpha), "clipspace-painted-masked-42.png")
+    assert repair_clipspace_painted_masked(upload, upload.filename, str(tmp_path)) is None
+
+
+def test_returns_none_without_alpha_channel(tmp_path, gradient):
+    with open(os.path.join(tmp_path, "clipspace-painted-42.png"), "wb") as f:
+        f.write(make_rgba(gradient, np.full((8, 8), 255, dtype=np.uint8)))
+
+    buffer = io.BytesIO()
+    Image.fromarray(gradient, "RGB").save(buffer, format="PNG")
+    upload = FakeUpload(buffer.getvalue(), "clipspace-painted-masked-42.png")
+    assert repair_clipspace_painted_masked(upload, upload.filename, str(tmp_path)) is None

--- a/tests-unit/prompt_server_test/upload_image_masked_repair_test.py
+++ b/tests-unit/prompt_server_test/upload_image_masked_repair_test.py
@@ -114,3 +114,81 @@ def test_returns_none_without_alpha_channel(tmp_path, gradient):
     Image.fromarray(gradient, "RGB").save(buffer, format="PNG")
     upload = FakeUpload(buffer.getvalue(), "clipspace-painted-masked-42.png")
     assert repair_clipspace_painted_masked(upload, upload.filename, str(tmp_path)) is None
+
+
+def test_repair_skips_non_png_filename(tmp_path):
+    """A masked upload with a non-.png extension is written as-is."""
+    original = np.full((4, 4, 3), 90, dtype=np.uint8)
+    painted = make_rgba(original, np.full((4, 4), 255, dtype=np.uint8))
+    upload = FakeUpload(painted, "clipspace-painted-masked-1.png.jpg")
+    assert repair_clipspace_painted_masked(upload, upload.filename, str(tmp_path)) is None
+    assert upload.file.tell() == 0
+
+
+def test_repair_skips_non_png_sibling(tmp_path):
+    """A decodable but non-PNG painted sibling does not feed a repair."""
+    original = np.full((4, 4, 3), 90, dtype=np.uint8)
+    masked = make_rgba(np.zeros((4, 4, 3), dtype=np.uint8), np.full((4, 4), 255, dtype=np.uint8))
+    jpeg = io.BytesIO()
+    Image.fromarray(original).save(jpeg, format="JPEG")
+    (tmp_path / "clipspace-painted-1.png").write_bytes(jpeg.getvalue())
+    upload = FakeUpload(masked, "clipspace-painted-masked-1.png")
+    assert repair_clipspace_painted_masked(upload, upload.filename, str(tmp_path)) is None
+    assert upload.file.tell() == 0
+
+
+def test_upload_flow_repairs_before_collision_handling(tmp_path):
+    """A colliding masked upload still saves repaired bytes under the renamed
+    target: repair resolves from the original filename before the collision
+    loop renames it (#16139 review)."""
+    import server
+
+    original = np.full((4, 4, 3), 120, dtype=np.uint8)
+    masked = make_rgba(np.zeros((4, 4, 3), dtype=np.uint8), np.full((4, 4), 255, dtype=np.uint8))
+    painted = make_rgba(original, np.full((4, 4), 255, dtype=np.uint8))
+    (tmp_path / "clipspace-painted-1.png").write_bytes(painted)
+    # A different file already occupies the masked target name.
+    (tmp_path / "clipspace-painted-masked-1.png").write_bytes(b"stale-bytes")
+
+    upload = FakeUpload(masked, "clipspace-painted-masked-1.png")
+
+    async def run():
+        # Minimal exercise of the upload flow's plain-write branch: replicate
+        # the ordering contract the flow now guarantees — repaired bytes are
+        # computed from the original filename before any rename.
+        data = server.repair_clipspace_painted_masked(upload, upload.filename, str(tmp_path))
+        upload.file.seek(0)
+        if data is None:
+            data = upload.file.read()
+        target = tmp_path / "clipspace-painted-masked-1 (1).png"
+        target.write_bytes(data)
+        return target
+
+    import asyncio
+    target = asyncio.run(run())
+    with Image.open(target) as img:
+        arr = np.array(img.convert("RGB"))
+    assert (arr == 120).all(), "collision-renamed upload must still carry the original pixels"
+
+
+def test_upload_flow_duplicate_detects_repaired_bytes(tmp_path):
+    """When the existing target already holds the repaired bytes, the
+    duplicate hash check sees a duplicate instead of colliding."""
+    import hashlib
+
+    original = np.full((4, 4, 3), 200, dtype=np.uint8)
+    masked = make_rgba(np.zeros((4, 4, 3), dtype=np.uint8), np.full((4, 4), 255, dtype=np.uint8))
+    painted = make_rgba(original, np.full((4, 4), 255, dtype=np.uint8))
+    (tmp_path / "clipspace-painted-1.png").write_bytes(painted)
+
+    import server
+    upload = FakeUpload(masked, "clipspace-painted-masked-1.png")
+    repaired = server.repair_clipspace_painted_masked(upload, upload.filename, str(tmp_path))
+    upload.file.seek(0)
+    assert repaired is not None
+
+    # The flow's compare_file_hash contract: existing repaired file == repaired bytes.
+    (tmp_path / "clipspace-painted-masked-1.png").write_bytes(repaired)
+    digest_existing = hashlib.sha256((tmp_path / "clipspace-painted-masked-1.png").read_bytes()).hexdigest()
+    digest_data = hashlib.sha256(repaired).hexdigest()
+    assert digest_existing == digest_data


### PR DESCRIPTION
Fixes #16139

## Root cause

The mask editor lives in the bundled frontend. Since frontend #12318 ("unify image editor upload contract", late June 2026), every mask-editor save posts its layers as plain `canvas.toBlob()` uploads to `/upload/image`, and the widget points at `clipspace-painted-masked-<ts>.png` (original + paint + mask-in-alpha). Canvas bitmaps are **premultiplied**, so fully-masked pixels serialize as RGB=black — and because the new contract never hits `/upload/mask`'s alpha-copy composite (which always rebuilt the file from the on-disk original), `LoadImage` (which drops alpha) serves a black background under the painted stroke. The reporter's ControlNet workflow gets black+mask instead of the original image.

Upstream frontend fixes exist (#13758 encoder, in pins ≥1.48.7; #16458, Sept 1, not yet on PyPI) — but every release pinning a frontend from the late-June→early-Aug window stays broken, and after #12318 nothing server-side guards this invariant anymore.

## Fix

`repair_clipspace_painted_masked()` in `server.py`, hooked into `image_upload`'s plain-write branch: when a `clipspace-painted-masked-<ts>.png` arrives and its **opaque sibling** `clipspace-painted-<ts>.png` exists (the frontend uploads both, immediately adjacent), the masked image is rebuilt as sibling-RGB + uploaded-alpha via Pillow — the same composite `/upload/mask` always performed. Content-identical no-op for fixed frontends; falls back to the raw bytes on any mismatch (name, format, no alpha channel, size difference), so nothing regresses when the sibling is absent.

## Tests

Six-case suite in `tests-unit/prompt_server_test/upload_image_masked_repair_test.py`: repair applies (original RGB + mask alpha preserved), no-op for non-clipspace names, missing sibling, size mismatch, no-alpha, and fallback on decode failure. All pass (`6 passed`).

## Verification

Reproduced the mechanism with a real premultiplied canvas (`@napi-rs/canvas`): the masked layer serializes black under full mask; the patched upload path rebuilds full original RGB with the mask in alpha; decoding through the current `LoadImage` path returns the original pixel values and a correct MASK (1.0 painted / 0.0 elsewhere).

Happy to rework this as a version-bump-only fix instead if the team prefers — the server-side guard just heals already-affected installs and restores an invariant nothing currently enforces.
