### PR TITLE
tests: let every tests-unit directory run on a CPU only install

### DIFF
--- a/tests-unit/conftest.py
+++ b/tests-unit/conftest.py
@@ -1,0 +1,33 @@
+import pytest  # noqa: F401
+import torch
+
+from comfy.cli_args import args
+
+
+def _has_accelerator():
+    """Whether torch can reach any device comfy.model_management would pick.
+
+    Mirrors the detection in comfy/model_management.py, guarded the same way,
+    so a machine with MPS or XPU is not pushed onto the CPU path.
+    """
+    if torch.cuda.is_available():
+        return True
+    try:
+        if torch.xpu.is_available():
+            return True
+    except Exception:
+        pass
+    try:
+        if torch.backends.mps.is_available():
+            return True
+    except Exception:
+        pass
+    return False
+
+
+# Several test modules import comfy.model_management, directly or through a
+# node module, and it picks a torch device at import time. Without this, those
+# modules fail at collection with "Torch not compiled with CUDA enabled" on a
+# CPU only install, and take their whole directory with them.
+if not _has_accelerator():
+    args.cpu = True


### PR DESCRIPTION
`pytest tests-unit/execution_test` and `pytest tests-unit/comfy_api_test` both fail at collection with `AssertionError: Torch not compiled with CUDA enabled`, and run nothing:

```
$ python -m pytest tests-unit/execution_test
ERROR tests-unit/execution_test/preview_method_override_test.py - AssertionError: Torch not compiled with CUDA enabled
!!! Interrupted: 1 error during collection !!!
```

Two modules reach `comfy.model_management` through an import (`latent_preview`, and `nodes_load_3d`), and it picks a torch device at import time.

CI does not see this, and I do not think it is a CI bug: the full `pytest tests-unit` run passes because another test module sets `args.cpu` before either of these is imported, and the flag is process wide. It only bites when a directory or a single file is run on its own, which is the normal way to work on one area.

This guards both the way `tests-unit/comfy_test/test_seedvr2_vae_decode.py` already does.

| | before | after |
|---|---|---|
| `pytest tests-unit/execution_test` | collection error, 0 tests | 104 passed |
| `pytest tests-unit/comfy_api_test` | collection error, 0 tests | 147 passed |
| `pytest tests-unit` | 1599 passed | 1599 passed |

Tested on Linux, CPU only torch 2.11.0. No behaviour change outside the two test modules.
