### PR TITLE
comfy_api: regenerate the sync stubs

### DIFF
--- a/comfy_api/latest/generated/ComfyAPISyncStub.pyi
+++ b/comfy_api/latest/generated/ComfyAPISyncStub.pyi
@@ -1,9 +1,39 @@
 from typing import Any, Dict, List, Optional, Tuple, Union, Set, Sequence, cast, NamedTuple
 from comfy_api.latest import ComfyAPI_latest
 from PIL.Image import Image
+from comfy_api.latest._caching import CacheProvider
+from comfy_api.latest._io import NodeReplace
 from torch import Tensor
 class ComfyAPISyncStub:
     def __init__(self) -> None: ...
+
+    class CachingSync:
+        """
+        External cache provider API for sharing cached node outputs
+        across ComfyUI instances.
+
+        Example::
+
+            from comfy_api.latest import Caching
+
+            class MyCacheProvider(Caching.CacheProvider):
+                async def on_lookup(self, context):
+                    ...  # check external storage
+
+                async def on_store(self, context, value):
+                    ...  # store to external storage
+
+            Caching.register_provider(MyCacheProvider())
+        """
+        def __init__(self) -> None: ...
+        """
+        Register an external cache provider. Providers are called in registration order.
+        """
+        def register_provider(self, provider: CacheProvider) -> None: ...
+        """
+        Unregister a previously registered cache provider.
+        """
+        def unregister_provider(self, provider: CacheProvider) -> None: ...
 
     class ExecutionSync:
         def __init__(self) -> None: ...
@@ -17,4 +47,13 @@ class ComfyAPISyncStub:
         """
         def set_progress(self, value: float, max_value: float, node_id: Union[str, None] = None, preview_image: Union[Image, Tensor, None] = None, ignore_size_limit: bool = False) -> None: ...
 
-    execution: ExecutionSync
+    class NodeReplacementSync:
+        def __init__(self) -> None: ...
+        """
+        Register a node replacement mapping.
+        """
+        def register(self, node_replace: NodeReplace) -> None: ...
+
+    Caching: CachingSync
+    Execution: ExecutionSync
+    NodeReplacement: NodeReplacementSync

--- a/comfy_api/v0_0_1/generated/ComfyAPISyncStub.pyi
+++ b/comfy_api/v0_0_1/generated/ComfyAPISyncStub.pyi
@@ -1,9 +1,39 @@
 from typing import Any, Dict, List, Optional, Tuple, Union, Set, Sequence, cast, NamedTuple
 from comfy_api.v0_0_1 import ComfyAPIAdapter_v0_0_1
 from PIL.Image import Image
+from comfy_api.latest._caching import CacheProvider
+from comfy_api.latest._io import NodeReplace
 from torch import Tensor
 class ComfyAPISyncStub:
     def __init__(self) -> None: ...
+
+    class CachingSync:
+        """
+        External cache provider API for sharing cached node outputs
+        across ComfyUI instances.
+
+        Example::
+
+            from comfy_api.latest import Caching
+
+            class MyCacheProvider(Caching.CacheProvider):
+                async def on_lookup(self, context):
+                    ...  # check external storage
+
+                async def on_store(self, context, value):
+                    ...  # store to external storage
+
+            Caching.register_provider(MyCacheProvider())
+        """
+        def __init__(self) -> None: ...
+        """
+        Register an external cache provider. Providers are called in registration order.
+        """
+        def register_provider(self, provider: CacheProvider) -> None: ...
+        """
+        Unregister a previously registered cache provider.
+        """
+        def unregister_provider(self, provider: CacheProvider) -> None: ...
 
     class ExecutionSync:
         def __init__(self) -> None: ...
@@ -17,4 +47,13 @@ class ComfyAPISyncStub:
         """
         def set_progress(self, value: float, max_value: float, node_id: Union[str, None] = None, preview_image: Union[Image, Tensor, None] = None, ignore_size_limit: bool = False) -> None: ...
 
-    execution: ExecutionSync
+    class NodeReplacementSync:
+        def __init__(self) -> None: ...
+        """
+        Register a node replacement mapping.
+        """
+        def register(self, node_replace: NodeReplace) -> None: ...
+
+    Caching: CachingSync
+    Execution: ExecutionSync
+    NodeReplacement: NodeReplacementSync

--- a/comfy_api/v0_0_2/generated/ComfyAPISyncStub.pyi
+++ b/comfy_api/v0_0_2/generated/ComfyAPISyncStub.pyi
@@ -1,9 +1,39 @@
 from typing import Any, Dict, List, Optional, Tuple, Union, Set, Sequence, cast, NamedTuple
 from comfy_api.v0_0_2 import ComfyAPIAdapter_v0_0_2
 from PIL.Image import Image
+from comfy_api.latest._caching import CacheProvider
+from comfy_api.latest._io import NodeReplace
 from torch import Tensor
 class ComfyAPISyncStub:
     def __init__(self) -> None: ...
+
+    class CachingSync:
+        """
+        External cache provider API for sharing cached node outputs
+        across ComfyUI instances.
+
+        Example::
+
+            from comfy_api.latest import Caching
+
+            class MyCacheProvider(Caching.CacheProvider):
+                async def on_lookup(self, context):
+                    ...  # check external storage
+
+                async def on_store(self, context, value):
+                    ...  # store to external storage
+
+            Caching.register_provider(MyCacheProvider())
+        """
+        def __init__(self) -> None: ...
+        """
+        Register an external cache provider. Providers are called in registration order.
+        """
+        def register_provider(self, provider: CacheProvider) -> None: ...
+        """
+        Unregister a previously registered cache provider.
+        """
+        def unregister_provider(self, provider: CacheProvider) -> None: ...
 
     class ExecutionSync:
         def __init__(self) -> None: ...
@@ -17,4 +47,13 @@ class ComfyAPISyncStub:
         """
         def set_progress(self, value: float, max_value: float, node_id: Union[str, None] = None, preview_image: Union[Image, Tensor, None] = None, ignore_size_limit: bool = False) -> None: ...
 
-    execution: ExecutionSync
+    class NodeReplacementSync:
+        def __init__(self) -> None: ...
+        """
+        Register a node replacement mapping.
+        """
+        def register(self, node_replace: NodeReplace) -> None: ...
+
+    Caching: CachingSync
+    Execution: ExecutionSync
+    NodeReplacement: NodeReplacementSync


### PR DESCRIPTION
The checked in `ComfyAPISyncStub.pyi` files do not match what `comfy_api/generate_api_stubs.py` produces from the current API. `CachingSync` and `NodeReplacementSync` are missing from all three, along with the two imports they need, so anything reading the stubs for the sync surface (an editor, a type checker) does not see them.

This is the generator's output against current master, no hand edits:

```
$ python comfy_api/generate_api_stubs.py
$ git diff --stat
 comfy_api/latest/generated/ComfyAPISyncStub.pyi | 41 ++++++++++++++++++++-
 comfy_api/v0_0_1/generated/ComfyAPISyncStub.pyi | 41 ++++++++++++++++++++-
 comfy_api/v0_0_2/generated/ComfyAPISyncStub.pyi | 41 ++++++++++++++++++++-
```

`pytest tests-unit` is 1599 passed before and after.
