### PR TITLE
Ask registered memory holders to release from unload_all_models

### DIFF
--- a/comfy/memory_management.py
+++ b/comfy/memory_management.py
@@ -1,4 +1,5 @@
 import math
+import logging
 import ctypes
 import dataclasses
 import torch
@@ -185,3 +186,25 @@ def extra_ram_release(target, free_active=False):
     if extra_ram_release_callback is None:
         return 0
     return extra_ram_release_callback(target, free_active=free_active)
+
+
+# Software outside ComfyUI holding memory on the same device: another
+# framework in this process, a sibling process, an external cache. A holder is
+# asked to release when ComfyUI releases its own models. Nothing is registered
+# by default and none of this runs while the list is empty.
+memory_holders = []
+
+def register_memory_holder(holder):
+    if holder not in memory_holders:
+        memory_holders.append(holder)
+
+def unregister_memory_holder(holder):
+    if holder in memory_holders:
+        memory_holders.remove(holder)
+
+def holders_release_memory(device):
+    for holder in memory_holders:
+        try:
+            holder.release_memory(device)
+        except Exception as e:
+            logging.warning("Memory holder {} failed release_memory on {}: {}".format(holder.__class__.__name__, device, e))

--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -2070,8 +2070,13 @@ def soft_empty_cache(force=False):
         torch.cuda.ipc_collect()
 
 def unload_all_models():
-    for device in get_all_torch_devices():
+    devices = get_all_torch_devices()
+    for device in devices:
         free_memory(1e30, device)
+    if comfy.memory_management.memory_holders:
+        for device in devices:
+            comfy.memory_management.holders_release_memory(device)
+        soft_empty_cache()
 
 def unload_model_and_clones(model: ModelPatcher, unload_additional_models=True, all_devices=False):
     'Unload only model and its clones - primarily for multigpu cloning purposes.'


### PR DESCRIPTION
`unload_all_models()` frees every model ComfyUI loaded. Anything not in `current_loaded_models` is never asked to leave and stays resident: another framework in this process, or a sibling process, holding memory on the same device.

It has three callers: the Unload Models button (`main.py:426`), the OOM handler (`execution.py:645`), and `--disable-smart-memory` at prompt end (`execution.py:837`).

This adds a registry beside `extra_ram_release_callback`, and asks each holder after ComfyUI's own models are gone:

```python
comfy.memory_management.register_memory_holder(holder)   # holder.release_memory(device)
```

Same shape as `set_ram_cache_release_state` (`comfy/memory_management.py:174-187`), which already does this for the RAM cache.

**Two packs currently monkeypatch `unload_all_models` to get this notification.** `hidream_sampler` wraps it to call its own `cleanup_models()` (`hidreamsampler.py:1569-1578`), under a comment reading "Check if we can register a cleanup callback". `llama-cpp_vllm` keeps a backup and wraps it to clear its llama.cpp models (`nodes.py:340-345`). `hook_breaker_ac10a0.py` exists to undo exactly this, and its list is one entry today.

**Holders are asked from `unload_all_models` only.** Not from `free_memory`: `unload_model_and_clones` passes the same `1e30` sentinel on every multigpu controlnet prep (`sampler_helpers.py:141`), and under DynamicVRAM the shortfall is a virtual figure, so a holder would be drained on ordinary loads.

Related: #3192 (VRAM not freed between tools), #8600 (process isolation, where the child is a holder core cannot reach).

**Measured**, RTX 3090, SDXL, holder releases 6 GiB from a separate process:

| | DynamicVRAM | `--disable-dynamic-vram` |
|---|---|---|
| Unload Models | 14117 to 1377 MiB | 14433 to 1335 MiB |
| release calls | 1 per device | 1 per device |
| full prompt, sibling holding 6 GiB | 0 calls | |

`pytest tests-unit`: 1599 passed before and after. With nothing registered, `unload_all_models` is unchanged.
