### PR TITLE
Pause comfy compiler for long lived sparse allocations

### DIFF
--- a/comfy/model_prefetch.py
+++ b/comfy/model_prefetch.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 import threading
 import warnings
@@ -27,6 +28,17 @@ def _malloc_graph_break():
 
 def malloc_graph_enabled(device):
     return not args.disable_comfy_compiler and comfy.memory_management.aimdo_enabled and comfy.model_management.is_device_cuda(device)
+
+@contextlib.contextmanager
+def pause_malloc_graph(sync=False):
+    graph = ACTIVE_MALLOC_GRAPHS.get(threading.get_ident())
+    if graph is not None:
+        graph.pause(sync=sync)
+    try:
+        yield
+    finally:
+        if graph is not None:
+            graph.resume(sync=sync)
 
 def malloc_graph_begin(module, device):
     global MALLOC_GRAPH_USED

--- a/comfy_extras/nodes_sparse_attention.py
+++ b/comfy_extras/nodes_sparse_attention.py
@@ -10,6 +10,7 @@ import comfy_kitchen as ck
 import torch
 
 import comfy.model_management
+import comfy.model_prefetch
 import comfy.patcher_extension
 from comfy.ldm.minimax.model import MiniMaxH3Model
 from comfy_api.latest import ComfyExtension, io
@@ -252,9 +253,22 @@ def h3_sparse_attention(attn, x, rope_freqs, transformer_options, patch: SparseA
     kw = comfy.model_management.cast_to(attn.k_norm.weight, device=x.device)
     extra, plan, gate = {}, None, None
     n, freqs = n_tokens, rope_freqs
+    with comfy.model_prefetch.pause_malloc_graph():
+        if patch.vsa:
+            plan = patch.vsa_plan(transformer_options["minimax_h3_layout"], x.device)
+            n = plan["n"]
+
+        key = (block_index, n, tuple(transformer_options.get("uuids", ())))   # statistics per conditioning branch
+        pooled = patch.pooled.get(key)
+        first = pooled is None
+        if first:
+            pooled = (
+                torch.empty((heads, head_dim), dtype=torch.float32, device=x.device),
+                torch.empty((heads, head_dim), dtype=torch.float32, device=x.device),
+            )
+
     if patch.vsa:
-        plan = patch.vsa_plan(transformer_options["minimax_h3_layout"], x.device)
-        n, freqs = plan["n"], patch.vsa_rope_freqs(rope_freqs, plan)
+        freqs = patch.vsa_rope_freqs(rope_freqs, plan)
         sink = sink_q = (0, plan["n_prefix"])
         extra = {"tail": False, "block_len": plan["block_len"]}
         gate = attn.to_gate_compress
@@ -274,16 +288,16 @@ def h3_sparse_attention(attn, x, rope_freqs, transformer_options, patch: SparseA
                 extra["coarse_gate"].view(n, heads * head_dim)[i:i + xc.shape[0]] = gate(xc)
             yield attn.qkv_proj(xc)
 
-    key = (block_index, n, tuple(transformer_options.get("uuids", ())))   # statistics per conditioning branch
-    pooled = patch.pooled.get(key)
     out, kmean, vscale = ck.sol_attn_chunked(
         chunks, n, heads, freqs, (qw, kw),
-        kmean=None if pooled is None else pooled[0],
-        vscale=None if pooled is None else pooled[1],
+        kmean=None if first else pooled[0],
+        vscale=None if first else pooled[1],
         tau=patch.tau, topk_ratio=patch.topk_ratio, token_aug=patch.extra_tokens,
         sink_blocks=list(sink), sink_q=list(sink_q),
         rope_eps=attn.q_norm.eps, **extra)
-    patch.pooled[key] = (kmean, vscale)
+    pooled[0].copy_(kmean)
+    pooled[1].copy_(vscale)
+    patch.pooled[key] = pooled
     mode = f"VSA tiles ({n} padded rows, {sink[1]} prefix tiles)" if plan is not None else f"sinks {sink}/{sink_q}"
     patch.log_once(("producer", n), f"sparse producer path: {n_tokens} tokens, {mode}")
     out = out.view(n, heads * head_dim)


### PR DESCRIPTION
https://github.com/Comfy-Org/ComfyUI/issues/16144

There are some memory allocations in sparse attention that live across attention blocks or steps that don't get freed during the lifetime of the transformer. These need to be severed from the comfy compiler graph as rogue allocations.

In the case of the tiny pooled this cost a full Aimdo page per sever, one every block which caused a fast VRAM leak.

Aimdo can handle this better with improved dereffing and earlier free of rogue pages while the graph is live, but this fix is better as it avoids the flood of graph breaks in the first place.

There is still a low volume of graph breaks due to comfy-kitchen caching however the flood and huge VRAM leak should fix with this.

Example test conditions:

Windows, RTX5080, 32GB RAM
Minimax H3 + topk sparse attention, I2V, 0.4MP

<img width="1721" height="705" alt="image" src="https://github.com/user-attachments/assets/b03e5672-7990-4df7-81a9-dca2390d16b0" />

Before:

VRAM leaks over the course of sampling (see model load level going down)

[Screencast from 2026-09-07 01-55-26.webm](https://github.com/user-attachments/assets/a2a70b15-f0b7-4ab1-98d3-04261437e59b)


```
[INFO] got prompt
[INFO] Requested to load MiniMaxH3
[INFO] 0 models unloaded.
[INFO] Model MiniMaxH3 prepared for dynamic VRAM loading. 19995MB Staged. 0 patches attached. Force pre-loaded 210 weights: 1175 KB.
100%|##########| 20/20 [00:33<00:00,  1.67s/it]
[INFO] Comfy model compiler graph breaks: 752
[INFO] Model MiniMaxH3AudioVAE prepared for dynamic VRAM loading. 576MB Staged. 0 patches attached. Force pre-loaded 401 weights: 539 KB.
[INFO] Model MiniMaxH3VideoVAE prepared for dynamic VRAM loading. 4965MB Staged. 0 patches attached. Force pre-loaded 128 weights: 348 KB.
[INFO] Prompt executed in 40.43 seconds
```

After:

[Screencast from 2026-09-07 02-02-47.webm](https://github.com/user-attachments/assets/b0775cba-8b31-4fbc-ad9d-11ee15a8c93f)


```
[INFO] got prompt
[INFO] Requested to load MiniMaxH3
[INFO] 0 models unloaded.
[INFO] Model MiniMaxH3 prepared for dynamic VRAM loading. 19995MB Staged. 0 patches attached. Force pre-loaded 210 weights: 1175 KB.
100%|##########| 20/20 [00:29<00:00,  1.45s/it]                                  
[INFO] Comfy model compiler graph breaks: 32
[INFO] Model MiniMaxH3AudioVAE prepared for dynamic VRAM loading. 576MB Staged. 0 patches attached. Force pre-loaded 401 weights: 539 KB.
[INFO] 0 models unloaded.
[INFO] Model MiniMaxH3VideoVAE prepared for dynamic VRAM loading. 4965MB Staged. 0 patches attached. Force pre-loaded 128 weights: 348 KB.
[INFO] Prompt executed in 35.99 seconds
```