### PR TITLE
Make start/end_percent for timestep scheduling choose steps more predictably across nodes

### DIFF
--- a/comfy/ldm/sensenova/sampling.py
+++ b/comfy/ldm/sensenova/sampling.py
@@ -57,7 +57,7 @@ class SenseNovaModelSampling(
             return 1.0
         if percent >= 1.0:
             return 0.0
-        return torch.tensor(time_snr_shift(self.shift, 1.0 - percent), dtype=torch.float32).item()
+        return self.sigma(torch.tensor(percent * self.multiplier, dtype=torch.float32)).item()
 
     def noise_scaling(self, sigma, noise, latent_image, max_denoise=False):
         sigma = comfy.model_sampling.reshape_sigma(sigma, noise.ndim)

--- a/comfy/ldm/sensenova/sampling.py
+++ b/comfy/ldm/sensenova/sampling.py
@@ -57,7 +57,7 @@ class SenseNovaModelSampling(
             return 1.0
         if percent >= 1.0:
             return 0.0
-        return float(time_snr_shift(self.shift, 1.0 - percent))
+        return torch.tensor(time_snr_shift(self.shift, 1.0 - percent), dtype=torch.float32).item()
 
     def noise_scaling(self, sigma, noise, latent_image, max_denoise=False):
         sigma = comfy.model_sampling.reshape_sigma(sigma, noise.ndim)

--- a/comfy/model_sampling.py
+++ b/comfy/model_sampling.py
@@ -265,7 +265,7 @@ class ModelSamplingContinuousEDM(torch.nn.Module):
         percent = 1.0 - percent
 
         log_sigma_min = math.log(self.sigma_min)
-        return math.exp((math.log(self.sigma_max) - log_sigma_min) * percent + log_sigma_min)
+        return torch.tensor(math.exp((math.log(self.sigma_max) - log_sigma_min) * percent + log_sigma_min)).item()
 
 
 class ModelSamplingContinuousV(ModelSamplingContinuousEDM):
@@ -323,7 +323,7 @@ class ModelSamplingDiscreteFlow(torch.nn.Module):
             return 1.0
         if percent >= 1.0:
             return 0.0
-        return time_snr_shift(self.shift, 1.0 - percent)
+        return torch.tensor(time_snr_shift(self.shift, 1.0 - percent)).item()
 
 class ModelSamplingAV(ModelSamplingDiscreteFlow):
     """Flow sampling for packed audio-video latents whose audio stream has its own flow shift.
@@ -437,7 +437,7 @@ class ModelSamplingFlux(torch.nn.Module):
             return 1.0
         if percent >= 1.0:
             return 0.0
-        return flux_time_shift(self.shift, 1.0, 1.0 - percent)
+        return torch.tensor(flux_time_shift(self.shift, 1.0, 1.0 - percent)).item()
 
 
 class ModelSamplingCosmosRFlow(ModelSamplingContinuousEDM):

--- a/comfy/model_sampling.py
+++ b/comfy/model_sampling.py
@@ -323,7 +323,7 @@ class ModelSamplingDiscreteFlow(torch.nn.Module):
             return 1.0
         if percent >= 1.0:
             return 0.0
-        return torch.tensor(time_snr_shift(self.shift, 1.0 - percent), dtype=torch.float32).item()
+        return self.sigma(torch.tensor((1.0 - percent) * self.multiplier, dtype=torch.float32)).item()
 
 class ModelSamplingAV(ModelSamplingDiscreteFlow):
     """Flow sampling for packed audio-video latents whose audio stream has its own flow shift.
@@ -437,7 +437,7 @@ class ModelSamplingFlux(torch.nn.Module):
             return 1.0
         if percent >= 1.0:
             return 0.0
-        return torch.tensor(flux_time_shift(self.shift, 1.0, 1.0 - percent), dtype=torch.float32).item()
+        return self.sigma(torch.tensor(1.0 - percent, dtype=torch.float32)).item()
 
 
 class ModelSamplingCosmosRFlow(ModelSamplingContinuousEDM):

--- a/comfy/model_sampling.py
+++ b/comfy/model_sampling.py
@@ -265,7 +265,7 @@ class ModelSamplingContinuousEDM(torch.nn.Module):
         percent = 1.0 - percent
 
         log_sigma_min = math.log(self.sigma_min)
-        return torch.tensor(math.exp((math.log(self.sigma_max) - log_sigma_min) * percent + log_sigma_min)).item()
+        return torch.tensor(math.exp((math.log(self.sigma_max) - log_sigma_min) * percent + log_sigma_min), dtype=torch.float32).item()
 
 
 class ModelSamplingContinuousV(ModelSamplingContinuousEDM):
@@ -323,7 +323,7 @@ class ModelSamplingDiscreteFlow(torch.nn.Module):
             return 1.0
         if percent >= 1.0:
             return 0.0
-        return torch.tensor(time_snr_shift(self.shift, 1.0 - percent)).item()
+        return torch.tensor(time_snr_shift(self.shift, 1.0 - percent), dtype=torch.float32).item()
 
 class ModelSamplingAV(ModelSamplingDiscreteFlow):
     """Flow sampling for packed audio-video latents whose audio stream has its own flow shift.
@@ -437,7 +437,7 @@ class ModelSamplingFlux(torch.nn.Module):
             return 1.0
         if percent >= 1.0:
             return 0.0
-        return torch.tensor(flux_time_shift(self.shift, 1.0, 1.0 - percent)).item()
+        return torch.tensor(flux_time_shift(self.shift, 1.0, 1.0 - percent), dtype=torch.float32).item()
 
 
 class ModelSamplingCosmosRFlow(ModelSamplingContinuousEDM):

--- a/comfy_extras/nodes_easycache.py
+++ b/comfy_extras/nodes_easycache.py
@@ -227,7 +227,7 @@ class EasyCacheHolder:
         self.output_channels = output_channels
 
     def is_past_end_timestep(self, timestep: float) -> bool:
-        return not (timestep[0] > self.end_t).item()
+        return not (timestep[0] >= self.end_t).item()
 
     def should_do_easycache(self, timestep: float) -> bool:
         return (timestep[0] <= self.start_t).item()
@@ -418,7 +418,7 @@ class LazyCacheHolder:
         return self.cache_diff is not None
 
     def is_past_end_timestep(self, timestep: float) -> bool:
-        return not (timestep[0] > self.end_t).item()
+        return not (timestep[0] >= self.end_t).item()
 
     def should_do_easycache(self, timestep: float) -> bool:
         return (timestep[0] <= self.start_t).item()

--- a/comfy_extras/nodes_hidream_o1.py
+++ b/comfy_extras/nodes_hidream_o1.py
@@ -200,9 +200,8 @@ class HiDreamO1PatchSeamSmoothing(io.ComfyNode):
 
         m = model.clone()
         model_sampling = m.get_model_object("model_sampling")
-        multiplier = float(model_sampling.multiplier)
-        start_t = float(model_sampling.percent_to_sigma(start_percent)) * multiplier
-        end_t = float(model_sampling.percent_to_sigma(end_percent)) * multiplier
+        start_sigma = model_sampling.percent_to_sigma(start_percent)
+        end_sigma = model_sampling.percent_to_sigma(end_percent)
 
         edge_ramp_cache: dict = {}
 
@@ -224,15 +223,15 @@ class HiDreamO1PatchSeamSmoothing(io.ComfyNode):
 
         def smoothing_wrapper(executor, *args, **kwargs):
             x = args[0]
-            t = float(args[1][0])
+            sigma = float(args[3]["sigmas"][0])
             pred = executor(*args, **kwargs)
-            if not (end_t <= t <= start_t):
+            if not (end_sigma <= sigma <= start_sigma):
                 return pred
             # Pick shift-level by sigma phase across the gated range.
             if len(shift_levels) == 1:
                 level_idx = 0
             else:
-                phase = (start_t - t) / max(start_t - end_t, 1e-8)
+                phase = (start_sigma - sigma) / max(start_sigma - end_sigma, 1e-8)
                 level_idx = min(int(phase * len(shift_levels)), len(shift_levels) - 1)
             shifts = shift_levels[level_idx]
             window_tiles = window_tile_levels[level_idx]


### PR DESCRIPTION
### Problem:
When setting up timestep scheduling, `start_percent` evaluates to different steps depending on the node and model setup.

Every node that uses `start_percent` converts with `percent_to_sigma`, but ControlNet, ConditioningSetTimestepRange and hooks compare the float32 sigma tensor directly, while SLG, the LTX guidance nodes, Uni3C and SparseAttention call .item() first and compare in float64. This can result in the evaluations either including or excluding steps that evaluate to the bound exactly (which is pretty common).

Here's a very common setup where it fails often:
Flow model, shift 8, simple scheduler, 8 steps, start_percent 0.5.
ControlNet runs 4 steps, SparseAttention runs 3.
(see top part of image below)

Many models have step-distill versions at 4 or 8 steps so one step is a big chunk of the effect, and which shifts hit it is a rounding coin flip (6, 8, 10, 12 do, 5, 7, 9 don't). It also makes more sense if someone sets the start_percent to 0.5 for half of the steps to be include. Right now only some nodes and shift settings may result in that outcome.

The fix in this PR is to round the result of `percent_to_sigma` through float32 so every site compares the same two numbers.

<img width="510" height="340" alt="percent_8steps_B" src="https://github.com/user-attachments/assets/f7a27073-7313-4ccc-bb94-66e7b3a3ef34" />

The PR also makes EasyCache's end bound inclusive to match every other site, and switches HiDream O1's seam smoothing node to gate on the raw sigma instead of the x1000 timestep, which was scaling the two sides in different precisions.

### Note:

This only really applies to the **simple** scheduler, which matches the expected timesteps of the model modified by shift. ComfyUI has no awareness of the actual sigmas being used so any other schedule may not conform to this mechanism but this change does make every node behave in the same way so one could predict the exact percentage needed reliably with prior knowledge of the schedule.

---
### Test workflow

It's hard to come up with a good test for this since it's subtle to see the effects of 1 or 2 steps difference even in low-step workflows. I had Claude come up with a test that showed clearly that the STG and ConditioningSetTimestepRange nodes behave differently before the PR and the same after the PR, and that setting the exact fraction value for the steps only works as expected after the PR. See the workflow below and look through the provided note to understand what you're seeing.


[percent_to_sigma_step_boundary_B.json](https://github.com/user-attachments/files/31932793/percent_to_sigma_step_boundary_B.json)

