### PR TITLE
Fix MiniMax H3 FinalLayer.forward four-arg calling contract

### DIFF
--- a/comfy/ldm/minimax/model.py
+++ b/comfy/ldm/minimax/model.py
@@ -309,7 +309,7 @@ class FinalLayer(nn.Module):
         self.video_out = operations.Linear(hidden, video_dim, bias=True, dtype=torch.float32, device=device)
         self.audio_out = operations.Linear(hidden, audio_dim, bias=True, dtype=torch.float32, device=device)
 
-    def forward(self, x, t_emb, video_seg, audio_seg, sigma, sample_sigmas, shifts):
+    def forward(self, x, t_emb, video_seg, audio_seg, sigma=None, sample_sigmas=None, shifts=None):
         # video_seg / audio_seg: (start, stop, row) of the target streams, where row
         # is a mod-row index or a per-token blend (see _mod_row)
         shift, scale = self.adaln_proj(t_emb)
@@ -769,7 +769,11 @@ class MiniMaxH3Model(nn.Module):
             audio_seg = (aa, ab, rows_to_mod_index(audio_rows_t, 0) // 3)
         else:
             audio_seg = (aa, ab, t_row[seg_t["audio"]])
-        v, a = self.final_layer(h, t_emb, video_seg, audio_seg, sigma_v, transformer_options.get("sample_sigmas"), (shift_v, shift_a))
+        n = self.final_layer.video_out.weight.shape[0] // self.final_layer.video_out.out_features
+        if n == 1:
+            v, a = self.final_layer(h, t_emb, video_seg, audio_seg)
+        else:
+            v, a = self.final_layer(h, t_emb, video_seg, audio_seg, sigma_v, transformer_options.get("sample_sigmas"), (shift_v, shift_a))
 
         video_out = unpatchify_video(v, latent_t, lat_h // 2, lat_w // 2, self.latents_dim, self.patch_size)
         video_out = video_out[:, :, :orig_t, :orig_h, :orig_w]

--- a/tests-unit/comfy_test/test_minimax_final_layer.py
+++ b/tests-unit/comfy_test/test_minimax_final_layer.py
@@ -1,0 +1,87 @@
+from comfy.cli_args import args
+
+import pytest
+import torch
+from torch import nn
+
+if not torch.cuda.is_available():
+    args.cpu = True
+
+import comfy.ops as comfy_ops
+from comfy.ldm.minimax.model import FinalLayer, MiniMaxH3Model
+
+
+def _final_layer(heads=1, hidden=8, t_dim=8, video_dim=16, audio_dim=8):
+    layer = FinalLayer(
+        hidden, t_dim, video_dim, audio_dim, 1e-5,
+        dtype=torch.float32, device="cpu", operations=comfy_ops.disable_weight_init,
+    )
+    with torch.no_grad():
+        for p in layer.parameters():
+            p.normal_()
+    if heads > 1:
+        layer.video_out.weight = nn.Parameter(torch.randn(heads * video_dim, hidden, dtype=torch.float32))
+        layer.video_out.bias = nn.Parameter(torch.randn(heads * video_dim, dtype=torch.float32))
+        layer.audio_out.weight = nn.Parameter(torch.randn(heads * audio_dim, hidden, dtype=torch.float32))
+        layer.audio_out.bias = nn.Parameter(torch.randn(heads * audio_dim, dtype=torch.float32))
+    return layer, hidden, t_dim, video_dim, audio_dim
+
+
+def _layer_inputs(hidden, t_dim):
+    x = torch.randn(4, hidden)
+    t_emb = torch.randn(1, t_dim)
+    return x, t_emb, (0, 2, 0), (2, 4, 0)
+
+
+def test_final_layer_four_arg_call_works_when_n_is_1():
+    layer, hidden, t_dim, video_dim, audio_dim = _final_layer()
+    v, a = layer(*_layer_inputs(hidden, t_dim))
+    assert tuple(v.shape) == (2, video_dim)
+    assert tuple(a.shape) == (2, audio_dim)
+
+
+def test_final_layer_pdd_heads_without_schedule_raise():
+    layer, hidden, t_dim, _, _ = _final_layer(heads=2)
+    with pytest.raises(ValueError, match="PDD heads need the sampler's sigma schedule"):
+        layer(*_layer_inputs(hidden, t_dim))
+
+
+def test_final_layer_pdd_heads_with_schedule_return_output():
+    layer, hidden, t_dim, video_dim, audio_dim = _final_layer(heads=2)
+    x, t_emb, video_seg, audio_seg = _layer_inputs(hidden, t_dim)
+    v, a = layer(
+        x, t_emb, video_seg, audio_seg,
+        torch.tensor(0.5), torch.tensor([1.0, 0.5, 0.0]), (12.0, 3.0),
+    )
+    assert tuple(v.shape) == (2, video_dim)
+    assert tuple(a.shape) == (2, audio_dim)
+
+
+def test_h3_forward_four_arg_wrapper_when_n_is_1():
+    model = MiniMaxH3Model(
+        hidden_size=8, num_layers=0, token_refiner_num_layers=0,
+        num_attention_heads=1, attention_head_dim=8, ffn_hidden_size=16,
+        latents_dim=24, audio_latents_dim=32, patch_size=(1, 2, 2), text_dim=8,
+        timestep_input_dim=8, time_embed_hidden_size=8, time_embed_dim=8,
+        rope_inv_freq_len=16, dtype=torch.float32, device="cpu",
+        operations=comfy_ops.disable_weight_init,
+    )
+    with torch.no_grad():
+        for p in model.parameters():
+            p.normal_()
+        model.rope.inv_freq.copy_(torch.ones_like(model.rope.inv_freq))
+
+    orig = model.final_layer.forward
+
+    def forward(x, t_emb, video_seg, audio_seg):
+        return orig(x, t_emb, video_seg, audio_seg)
+
+    model.final_layer.forward = forward
+    video, audio = model._forward(
+        [torch.randn(1, 24, 1, 2, 2), torch.randn(1, 32, 2, 1)],
+        torch.tensor([500.0]),
+        torch.randn(1, 2, 8),
+        {},
+    )
+    assert tuple(video.shape) == (1, 24, 1, 2, 2)
+    assert tuple(audio.shape) == (1, 32, 2, 1)


### PR DESCRIPTION
Fixes https://github.com/Comfy-Org/ComfyUI/issues/15960

#15908 made `sigma`, `sample_sigmas`, and `shifts` required on MiniMax H3 `FinalLayer.forward`, and `MiniMaxH3Model._forward` always passes them. A wrapper that implements the old four-arg contract raises `TypeError: forward() takes 4 positional arguments but 7 were given`. The n==1 path never reads those three values.

This defaults the three PDD args to None and has `_forward` call `FinalLayer` with the original four args when the output head bank has one head. The n>1 path still passes them. I did not pass them as kwargs on every call because a four-arg wrapper still TypeErrors on unexpected keywords.

Tested with `.venv/bin/python -m pytest tests-unit/comfy_test/test_minimax_final_layer.py -q --tb=short`: 4 passed. With the defaults and the n==1 branch reverted: 3 failed, 1 passed. The two direct `FinalLayer` tests fail with TypeError missing 3 required positional arguments, and the four-arg wrapper test through `_forward` (CPU stand-in, `num_layers=0`) fails with the 4-vs-7 TypeError. Fix restored: 4 passed. No GPU run.
