### PR TITLE
Bump frontend to 1.52.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-comfyui-frontend-package==1.51.9
+comfyui-frontend-package==1.52.7
 comfyui-workflow-templates==0.11.55
 comfyui-embedded-docs==0.5.11
 torch


### PR DESCRIPTION
✅ **PyPI package confirmed available** — `comfyui-frontend-package==1.52.7` has been published and verified.

Bumps frontend to 1.52.7

Test quickly:

```bash
python main.py --front-end-version Comfy-Org/ComfyUI_frontend@1.52.7
```

- Diff: [v1.51.9...v1.52.7](https://github.com/Comfy-Org/ComfyUI_frontend/compare/v1.51.9...v1.52.7)
- PyPI: https://pypi.org/project/comfyui-frontend-package/1.52.7/
- npm: https://www.npmjs.com/package/@comfyorg/comfyui-frontend-types/v/1.52.7