### PR TITLE
Remove more workflow media packages from portable install.

### DIFF
--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -119,7 +119,8 @@ jobs:
 
           grep comfy ../ComfyUI/requirements.txt > ./requirements_comfyui.txt
           ./python.exe -s -m pip install -r requirements_comfyui.txt
-          ./python.exe -s -m pip uninstall -y comfyui-workflow-templates-media-image comfyui-workflow-templates-media-video comfyui-workflow-templates-media-other
+          ./python.exe -s -m pip uninstall -y comfyui-workflow-templates-media-image comfyui-workflow-templates-media-video comfyui-workflow-templates-media-other comfyui-workflow-templates-media-api comfyui-workflow-templates-media-assets-01
+
           rm requirements_comfyui.txt
 
           sed -i '1i../ComfyUI' ./python3${{ inputs.python_minor }}._pth


### PR DESCRIPTION
## Summary
- Uninstall `comfyui-workflow-templates-media-api` and `comfyui-workflow-templates-media-assets-01` from the Windows portable build, in addition to the existing image/video/other media packs.
- These are also template asset packs, so dropping them further reduces portable release size.

## Test plan
- [ ] Confirm the next stable portable workflow still installs templates and then uninstalls all five media packs.
- [ ] Spot-check that portable still starts (`--quick-test-for-ci`) after the extra uninstalls.