### PR TITLE
Let extensions declare HTTP routes

### DIFF
--- a/comfy_api/latest/__init__.py
+++ b/comfy_api/latest/__init__.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Awaitable, Callable
 from comfy_api.internal import ComfyAPIBase
 from comfy_api.internal.singleton import ProxiedSingleton
 from comfy_api.internal.async_to_sync import create_sync_class
@@ -113,6 +114,31 @@ class ComfyAPI_latest(ComfyAPIBase):
             from comfy_execution.cache_provider import unregister_cache_provider
             unregister_cache_provider(provider)
 
+if TYPE_CHECKING:
+    from aiohttp import web
+
+    RouteHandler = Callable[["web.Request"], Awaitable["web.StreamResponse"]]
+else:
+    RouteHandler = Callable
+
+
+@dataclass(frozen=True)
+class ExtensionRoute:
+    """One HTTP endpoint an extension serves.
+
+    ``path`` is a literal path relative to the extension, starting with a
+    slash. ComfyUI mounts it under a fixed prefix and the extension's own
+    name, so an extension does not choose where it lands in the URL space.
+
+    Deliberately not an aiohttp type: an extension declares what it serves,
+    and ComfyUI decides how to register it. The handler itself is an aiohttp
+    handler, and must be a coroutine, since it runs on the server event loop.
+    """
+    method: str
+    path: str
+    handler: RouteHandler
+
+
 class ComfyExtension(ABC):
     async def on_load(self) -> None:
         """
@@ -125,6 +151,16 @@ class ComfyExtension(ABC):
         """
         Returns a list of nodes that this extension provides.
         """
+
+    async def get_routes(self) -> list[ExtensionRoute]:
+        """
+        Returns the HTTP endpoints that this extension provides.
+
+        Only reached for extensions loaded through comfy_entrypoint. A module
+        that defines NODE_CLASS_MAPPINGS is handled by the V1 path, which
+        returns before the extension is constructed.
+        """
+        return []
 
 class Input:
     Image = ImageInput
@@ -164,6 +200,7 @@ UI = ui
 
 __all__ = [
     "ComfyAPI",
+    "ExtensionRoute",
     "ComfyAPISync",
     "Input",
     "InputImpl",

--- a/comfy_api/v0_0_2/__init__.py
+++ b/comfy_api/v0_0_2/__init__.py
@@ -6,7 +6,7 @@ from comfy_api.latest import (
 )
 from typing import Type, TYPE_CHECKING
 from comfy_api.internal.async_to_sync import create_sync_class
-from comfy_api.latest import io, ui, IO, UI, ComfyExtension  #noqa: F401
+from comfy_api.latest import io, ui, IO, UI, ComfyExtension, ExtensionRoute  #noqa: F401
 
 
 class ComfyAPIAdapter_v0_0_2(ComfyAPI_latest):
@@ -37,6 +37,7 @@ ComfyAPISync = create_sync_class(ComfyAPIAdapter_v0_0_2)
 
 __all__ = [
     "ComfyAPI",
+    "ExtensionRoute",
     "ComfyAPISync",
     "Input",
     "InputImpl",

--- a/custom_nodes/example_node.py.example
+++ b/custom_nodes/example_node.py.example
@@ -1,6 +1,6 @@
 from typing_extensions import override
 
-from comfy_api.latest import ComfyExtension, io
+from comfy_api.latest import ComfyExtension, ExtensionRoute, io
 
 
 class Example(io.ComfyNode):
@@ -109,11 +109,10 @@ class Example(io.ComfyNode):
 # WEB_DIRECTORY = "./somejs"
 
 
-# Add custom API routes, using router
+# Add custom API routes. ComfyUI serves these under /ext/<your extension>/,
+# so this one is reachable at /api/ext/example_node/hello.
 from aiohttp import web
-from server import PromptServer
 
-@PromptServer.instance.routes.get("/hello")
 async def get_hello(request):
     return web.json_response("hello")
 
@@ -123,6 +122,12 @@ class ExampleExtension(ComfyExtension):
     async def get_node_list(self) -> list[type[io.ComfyNode]]:
         return [
             Example,
+        ]
+
+    @override
+    async def get_routes(self) -> list[ExtensionRoute]:
+        return [
+            ExtensionRoute("get", "/hello", get_hello),
         ]
 
 

--- a/nodes.py
+++ b/nodes.py
@@ -7,6 +7,7 @@ import json
 import glob
 import hashlib
 import inspect
+import re
 
 import traceback
 import math
@@ -2221,6 +2222,50 @@ EXTENSION_WEB_DIRS = {}
 LOADED_MODULE_DIRS = {}
 
 
+#: Routes declared by extensions through ComfyExtension.get_routes(),
+#: consumed by server.add_routes(). Entries are (namespace, method, path,
+#: handler); the server mounts each at /ext/<namespace><path>.
+EXTENSION_ROUTES = []
+
+ROUTE_METHODS = ("get", "post", "put", "delete", "patch", "head")
+ROUTE_NAMESPACE = re.compile(r"[A-Za-z0-9._-]+")
+
+
+def collect_extension_routes(routes, namespace):
+    """Record an extension's declared endpoints for server.add_routes().
+
+    Only checks what the server cannot: that the namespace and path are plain
+    URL segments, and that the handler can actually be awaited. Conflicts
+    between two routes are the router's business, not this function's.
+
+    A bad declaration is skipped with a warning rather than taken as a reason
+    to reject the extension, which is how every other failure here behaves.
+    """
+    if not ROUTE_NAMESPACE.fullmatch(namespace):
+        logging.warning("Cannot serve routes for {}: its name is not a plain URL segment.".format(namespace))
+        return
+    if not isinstance(routes, list):
+        logging.warning("get_routes() in {} did not return a list, skipping its routes.".format(namespace))
+        return
+    for route in routes:
+        method = getattr(route, "method", None)
+        path = getattr(route, "path", None)
+        handler = getattr(route, "handler", None)
+        if not isinstance(method, str) or not isinstance(path, str) or handler is None:
+            logging.warning("{} declared a route that is not an ExtensionRoute, skipping it.".format(namespace))
+            continue
+        if method.lower() not in ROUTE_METHODS:
+            logging.warning("{} declared route {} with unsupported method {}, skipping it.".format(namespace, path, method))
+            continue
+        if not path.startswith("/") or any(c in path for c in "{}%") or ".." in path or any(c.isspace() for c in path):
+            logging.warning("{} declared route {} that is not a literal path, skipping it.".format(namespace, path))
+            continue
+        if not inspect.iscoroutinefunction(handler):
+            logging.warning("{} declared route {} whose handler is not a coroutine, skipping it.".format(namespace, path))
+            continue
+        EXTENSION_ROUTES.append((namespace, method.lower(), path, handler))
+
+
 def get_module_name(module_path: str) -> str:
     """
     Returns the module name based on the given module path.
@@ -2327,6 +2372,15 @@ async def load_custom_node(module_path: str, ignore=set(), module_parent="custom
                         node_cls.RELATIVE_PYTHON_MODULE = "{}.{}".format(module_parent, get_module_name(module_path))
                     if schema.display_name is not None:
                         NODE_DISPLAY_NAME_MAPPINGS[schema.node_id] = schema.display_name
+                try:
+                    routes = extension.get_routes()
+                    if inspect.isawaitable(routes):
+                        routes = await routes
+                    collect_extension_routes(routes, get_module_name(module_path))
+                except Exception as e:
+                    # The nodes are already registered; a bad route list must
+                    # not turn this into a failed import.
+                    logging.warning(f"Error while collecting routes from {module_path}: {e}")
                 return True
             except Exception as e:
                 logging.warning(f"Error while calling comfy_entrypoint in {module_path}: {e}")

--- a/server.py
+++ b/server.py
@@ -1217,12 +1217,27 @@ class PromptServer():
         timeout = aiohttp.ClientTimeout(total=None) # no timeout
         self.client_session = aiohttp.ClientSession(timeout=timeout)
 
+    def add_extension_routes(self, extension_routes):
+        """Mount endpoints declared through ComfyExtension.get_routes().
+
+        Everything lands under /ext/<extension name>/, so an extension cannot
+        take a top level path or shadow a core route. These go into
+        self.routes with everything else, so the /api mirror below serves
+        them at /api/ext/... too, which is the form the frontend dev server
+        forwards.
+        """
+        for namespace, method, path, handler in extension_routes:
+            full_path = "/ext/{}{}".format(namespace, path)
+            getattr(self.routes, method)(full_path)(handler)
+            logging.info("Registered extension route {} {}".format(method.upper(), full_path))
+
     def add_routes(self):
         self.user_manager.add_routes(self.routes)
         self.model_file_manager.add_routes(self.routes)
         self.custom_node_manager.add_routes(self.routes, self.app, nodes.LOADED_MODULE_DIRS.items())
         self.subgraph_manager.add_routes(self.routes, nodes.LOADED_MODULE_DIRS.items())
         self.node_replace_manager.add_routes(self.routes)
+        self.add_extension_routes(nodes.EXTENSION_ROUTES)
         self.app.add_subapp('/internal', self.internal_routes.get_app())
 
         # Prefix every route with /api for easier matching for delegation.


### PR DESCRIPTION
## Let extensions declare HTTP routes

`ComfyExtension` lets a pack declare what it provides and hand it to core as
data. It has two methods today, `on_load` and `get_node_list`. This adds a
third, `get_routes`, because routes are the one part of the extension surface
with no V3 form:

| what a pack provides | V1, import-time side effect | V3, declared as data |
|---|---|---|
| nodes | `NODE_CLASS_MAPPINGS` | `get_node_list()` |
| routes | `@PromptServer.instance.routes.get(...)` | nothing |

A pack that has fully migrated to `comfy_entrypoint` still has to write
`from server import PromptServer` to serve an endpoint. That is the import V3
exists to make unnecessary, and it is the only one left.

```python
class MyExtension(ComfyExtension):
    async def get_node_list(self): ...

    async def get_routes(self) -> list[ExtensionRoute]:
        return [ExtensionRoute("get", "/status", self.status)]
```

Served under `/ext/<extension>/`, so the example above is reachable at
`/api/ext/my_extension/status`.

### What this changes, and what it does not

It makes registration declarative and owned by core. The pack describes, core
decides, the same split `get_node_list` already uses. Three things follow:
the `server` import disappears, core knows which pack owns which path, and a
bad route becomes a warning naming the pack instead of an aiohttp error during
boot that names nobody.

It does not improve the endpoint contract itself. Handlers are still
`async def(request) -> response` against aiohttp, with no schema, typing,
validation or versioning. This is the prerequisite for that work, not that
work. Worth flagging: `ExtensionRoute.handler` names aiohttp types in
`comfy_api`, which is a coupling that was not there before. It is behind
`TYPE_CHECKING` so there is no runtime import, but the commitment is real and
I would rather raise it than have it found in review.

### Why declaring beats decorating

The decorator only works if the pack imports into the ComfyUI process while
`PromptServer.instance` already exists. That holds by accident of ordering
(`main.py` builds the server at :537 and imports packs at :543), not by
contract, and it fails entirely for anything out of process.

### Compatibility and conflicts

Nothing changes for existing packs. `get_routes` is non-abstract and returns
`[]`, like `on_load`; the decorator keeps working.

Route conflicts are left to #15541, which already dedupes them for all routes
including GET-implies-HEAD and wildcards. With both branches merged, four route
definitions across two colliding packs reduce to two kept, two named warnings,
server starts. This PR validates namespace and path shape only.
