### PR TITLE
Fix apply_rope shape crash when Wan reference latent has odd spatial size

### DIFF
--- a/comfy/ldm/wan/model.py
+++ b/comfy/ldm/wan/model.py
@@ -578,6 +578,7 @@ class WanModel(torch.nn.Module):
         if self.ref_conv is not None:
             full_ref = kwargs.get("reference_latent", None)
             if full_ref is not None:
+                full_ref = comfy.ldm.common_dit.pad_to_patch_size(full_ref, self.patch_size[1:])
                 full_ref = self.ref_conv(full_ref).flatten(2).transpose(1, 2)
                 x = torch.concat((full_ref, x), dim=1)
                 img_offset = full_ref.shape[1]

--- a/tests-unit/comfy_test/test_wan_ref_conv.py
+++ b/tests-unit/comfy_test/test_wan_ref_conv.py
@@ -1,0 +1,49 @@
+"""Regression test for Wan reference-latent/rope token-count mismatch (issue #16181)."""
+
+from __future__ import annotations
+
+import torch
+
+from comfy.cli_args import args
+
+if not torch.cuda.is_available():
+    args.cpu = True
+
+import comfy.ops  # noqa: E402
+from comfy.ldm.wan.model import WanModel  # noqa: E402
+
+
+def _make_model():
+    return WanModel(
+        model_type="t2v",
+        patch_size=(1, 2, 2),
+        text_len=8,
+        in_dim=4,
+        dim=32,
+        ffn_dim=16,
+        freq_dim=8,
+        text_dim=8,
+        out_dim=4,
+        num_heads=2,
+        num_layers=1,
+        in_dim_ref_conv=4,
+        operations=comfy.ops.disable_weight_init,
+    )
+
+
+def test_wan_model_accepts_odd_sized_reference_latent():
+    # A reference latent whose spatial size isn't an even multiple of the
+    # (1, 2, 2) patch size used to make ref_conv emit fewer tokens than the
+    # rope embedding allocated for it, crashing apply_rope with a
+    # "freqs shape is not broadcastable to input" error.
+    torch.manual_seed(0)
+    model = _make_model()
+
+    x = torch.randn(1, 4, 2, 5, 6)
+    timestep = torch.tensor([1.0])
+    context = torch.randn(1, 8, 8)
+    reference_latent = torch.randn(1, 4, 5, 6)
+
+    out = model(x, timestep, context, reference_latent=reference_latent)
+
+    assert out.shape == x.shape


### PR DESCRIPTION
Fixes #16181

## Problem

`Wan22FunControlToVideo` with a `ref_image` connected crashes with:

```
RuntimeError: apply_rope freqs shape is not broadcastable to input
```

## Root cause

In `comfy/ldm/wan/model.py`, `WanModel.forward_orig` patches the reference
latent through `self.ref_conv`, a `Conv2d` with `kernel_size=stride=patch_size[1:]`
and **no padding**. Meanwhile `WanModel._forward`/`rope_encode` allocates rope
positions for the reference assuming it contributes exactly
`ceil(h/2) * ceil(w/2)` tokens (the same rounding used for the main video
latent, which *is* padded via `pad_to_patch_size` before patch-embedding).

When the reference latent's height or width isn't an even multiple of the
patch size (e.g. certain width/height values passed to
`Wan22FunControlToVideo`, which are not required to be multiples of 16), the
unpadded `Conv2d` produces fewer spatial tokens (floor-based) than
`rope_encode` allocated (ceil-based). The resulting token-count mismatch
between `x` and `freqs` triggers the `apply_rope` broadcast error.

The reporter's own diagnosis on the issue (produced by testing a local
patch) independently pointed at the same file/function and confirmed padding
the reference latent to the patch size fixes it for their workflow.

## Fix

Pad the reference latent to the patch size the same way the main video
latent is padded, before it goes through `ref_conv`:

```python
full_ref = comfy.ldm.common_dit.pad_to_patch_size(full_ref, self.patch_size[1:])
full_ref = self.ref_conv(full_ref).flatten(2).transpose(1, 2)
```

Even-dimension reference latents are unaffected (padding is a no-op), so
existing workflows keep producing byte-identical results.

## Testing

Added `tests-unit/comfy_test/test_wan_ref_conv.py`, which builds a small
`WanModel` with `in_dim_ref_conv` set and calls it with a reference latent
whose spatial dimensions (5, 6) are not both even multiples of the (1, 2, 2)
patch size.

- Without the fix (`git checkout HEAD~1 -- comfy/ldm/wan/model.py`), the test
  fails with:
  ```
  RuntimeError: The size of tensor a (27) must match the size of tensor b (24) at non-singleton dimension 1
  ```
  raised from `comfy_kitchen`'s `apply_rope1`, the same class of error
  reported in the issue.
- With the fix, the test passes and the model returns output of the expected
  shape.

Full test run after the fix:

```
$ python -m pytest tests-unit -q
1766 passed, 12 skipped, 33 warnings in 49.44s
```

`ruff check comfy/ldm/wan/model.py tests-unit/comfy_test/test_wan_ref_conv.py` passes with no findings.

## AI assistance disclosure

This change was prepared with the help of an AI coding agent (root cause
analysis, fix, and regression test), and verified by running the project's
test suite and lint before submitting.
