### PR TITLE
Support positioned FL2VA keyframes in MiniMax H3

### DIFF
--- a/comfy/ldm/minimax/model.py
+++ b/comfy/ldm/minimax/model.py
@@ -371,15 +371,25 @@ class PackedLayout:
 
         if keyframes:
             # fl2va: keyframe cond rows right after text, sharing the target spatial grid;
-            # anchors count from the target timeline origin, FRAME_RESCALE per pixel frame, 1.0 per audio latent frame
+            # anchors count from the target timeline origin, FRAME_RESCALE per pixel frame, 1.0 per audio latent frame.
+            # A keyframe latent smaller than the target frame is placed at its optional
+            # latent_y/latent_x offset (latent units, 2-aligned like the 2x2 patch grid)
+            # so its tokens take the positions of the target patches they cover.
             for kf in keyframes:
                 cond_t = cursor + FRAME_RESCALE * kf["resolved_frame_index"]
                 video_latent = kf.get("latent")
                 if video_latent is not None:
-                    vt = video_latent.shape[2]
-                    n = vt * frame_rows
+                    vt, vh, vw = video_latent.shape[2:]
+                    latent_y = kf.get("latent_y", 0)
+                    latent_x = kf.get("latent_x", 0)
+                    target_frame = frame.reshape(latent_h // 2, latent_w // 2, 2)
+                    cond_frame = target_frame[
+                        latent_y // 2 : (latent_y + vh) // 2,
+                        latent_x // 2 : (latent_x + vw) // 2,
+                    ].reshape(-1, 2)
+                    n = vt * cond_frame.shape[0]
                     segments.append(("cond", n))
-                    pos.append(_video_grid(vt, frame, cond_t))
+                    pos.append(_video_grid(vt, cond_frame, cond_t))
                     img_pos.append(torch.arange(row, row + n))
                     img_update.append(torch.zeros(n, dtype=torch.bool))
                     row += n


### PR DESCRIPTION
Problem

PackedLayout assumes every minimax_keyframes video latent spans the full target frame: positions come from the whole target grid and the token count is `vt * frame_rows`. A keyframe latent that covers only part of the canvas (outpainting, inpainting) either fails the token count or, if padded to full size, is placed at the canvas origin.

Change

Keyframe dicts accept optional latent_y / latent_x (latent units, even, matching the 2×2 patch grid). The target patch grid is sliced to the rectangle the latent covers and those positions are used for the keyframe tokens. Keyframes without the keys take the previous code path unchanged. No node changes - the keys are set by custom nodes that build keyframes (ComfyUI-H3VideoOutpaint uses them to pin the source rectangle inside the expanded canvas per sliding window).

Testing

- Keyframe without offsets: token count and position ids identical to before.
- 44×78 latent at latent_y=8 on a 60×78 target: cond positions equal full-frame patch rows 4–25; target stream positions unchanged.
- End-to-end outpaint with the FL2VA int8 checkpoint on 1254×720→1248×960 and 1280×720→1280×960 sources.

No behavior change for existing workflows.

This is to support outpainting: https://github.com/TwoAbove/ComfyUI-H3VideoOutpaint which this model does surprisingly well.