### PR TITLE
Keep Qwen2.5-VL cu_window_seqlens on the CPU (fixes Qwen-Image text encoder on Intel XPU)

### DIFF
--- a/comfy/text_encoders/qwen_vl.py
+++ b/comfy/text_encoders/qwen_vl.py
@@ -419,7 +419,7 @@ class Qwen2VLVisionTransformer(nn.Module):
         hidden_states = self.patch_embed(pixel_values)
 
         window_index, cu_window_seqlens = self.get_window_index(image_grid_thw)
-        cu_window_seqlens = torch.tensor(cu_window_seqlens, device=hidden_states.device)
+        cu_window_seqlens = torch.tensor(cu_window_seqlens)  # only read via .tolist(), keep off the device
         cu_window_seqlens = torch.unique_consecutive(cu_window_seqlens)
 
         position_embeddings = self.get_position_embeddings(image_grid_thw, hidden_states.device)


### PR DESCRIPTION
Fixes #16193.

**Issue.** On Intel XPU (torch 2.14.0+xpu, Arc Pro B70) every Qwen-Image / Qwen-Image-Edit prompt encode fails in `Qwen2VLVisionTransformer.forward`: `cu_window_seqlens` is built on the model device and passed through `torch.unique_consecutive`, which on that backend returns an empty tensor (`split_with_sizes expects split_sizes to sum exactly to 784 ... but got split_sizes=[]`) or raises `numel: integer multiplication overflow`.

**Change.** Build `cu_window_seqlens` on the CPU instead. `VisionAttention` only reads it through `lengths.tolist()`, so the device never affected the result; on CUDA this also drops a host-to-device copy and the sync that `.tolist()` forced on every vision block. One line, no behavior change elsewhere.

**Testing.**
- Intel XPU, ComfyUI master `54e03f5`, no custom nodes: the standalone script in the issue fails before the change and encodes `(1, 215, 3584)` after it.
- Same fix on v0.34.5: the encoder's output on XPU matches a CPU encode of the same image and prompt (mean abs diff 2e-4, cosine 1.0); driven through `clip.generate` it answers a text question and describes an image correctly; Qwen-Image-Edit-2511 then follows edit prompts end to end.
- `ruff check` passes.
- I do not have a CUDA machine to run on. The reasoning that results are identical there is that the only consumer is `.tolist()`; a smoke run on CUDA would be welcome.

**Side effects.** None expected. `cu_seqlens` (the other bookkeeping tensor) already lives on the CPU because `image_grid_thw` does, so this makes the two consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
