### PR TITLE
Use index select for VSA output reorder

### DIFF
--- a/comfy_extras/nodes_sparse_attention.py
+++ b/comfy_extras/nodes_sparse_attention.py
@@ -303,7 +303,7 @@ def h3_sparse_attention(attn, x, rope_freqs, transformer_options, patch: SparseA
     patch.log_once(("producer", n), f"sparse producer path: {n_tokens} tokens, {mode}")
     out = out.view(n, heads * head_dim)
     if plan is not None:
-        out = out[plan["inv"]]
+        out = torch.index_select(out, 0, plan["inv"])
     return attn.out_proj(out)
 
 

--- a/tests-unit/comfy_test/test_sparse_attention_unpermute.py
+++ b/tests-unit/comfy_test/test_sparse_attention_unpermute.py
@@ -1,0 +1,42 @@
+import pytest
+import torch
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_index_select_matches_advanced_indexing(dtype):
+    out = torch.arange(48, dtype=torch.float32).reshape(8, 6).to(dtype)
+    inverse = torch.tensor([3, 0, 7, 2, 6, 1, 5, 4], dtype=torch.int64)
+
+    expected = out[inverse]
+    actual = torch.index_select(out, 0, inverse)
+
+    assert actual.shape == expected.shape
+    assert actual.dtype == expected.dtype
+    assert torch.equal(actual, expected)
+
+
+def test_index_select_matches_advanced_indexing_gradients():
+    inverse = torch.tensor([2, 0, 3, 1], dtype=torch.int64)
+    source = torch.arange(12, dtype=torch.float32).reshape(4, 3).requires_grad_()
+
+    expected = source[inverse].square().sum()
+    expected.backward()
+    expected_grad = source.grad.clone()
+    source.grad = None
+
+    actual = torch.index_select(source, 0, inverse).square().sum()
+    actual.backward()
+
+    assert torch.equal(source.grad, expected_grad)
+
+
+def test_index_select_restores_partial_vsa_order():
+    packed = torch.tensor(
+        [[10.0], [20.0], [30.0], [40.0], [50.0], [60.0]]
+    )
+    inverse = torch.tensor([1, 4, 0, 5], dtype=torch.int64)
+
+    expected = packed[inverse]
+    actual = torch.index_select(packed, 0, inverse)
+
+    assert torch.equal(actual, expected)


### PR DESCRIPTION
## Summary

Use `torch.index_select` to restore original token order after the VSA sparse-attention kernel. This is the same dimension-zero gather over the existing inverse map as advanced indexing, without changing routing, selected blocks, quantization, model weights, or attention math.

## Tests

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests-unit/comfy_test/test_sparse_attention_unpermute.py -q`
- `python3 -m ruff check comfy_extras/nodes_sparse_attention.py tests-unit/comfy_test/test_sparse_attention_unpermute.py`

Not run: CUDA VSA microbenchmark and full VSA model workflow.