### PR TITLE
main: bump the AMD Windows VA quota to 4TB (CORE-409)

### DIFF
--- a/main.py
+++ b/main.py
@@ -111,7 +111,7 @@ if __name__ == "__main__":
             os.environ['CUBLAS_WORKSPACE_CONFIG'] = ":4096:8"
 
     if "rocm" in cuda_malloc.get_torch_version_noimport():
-        os.environ['OCL_SET_SVM_SIZE'] = '262144'  # set at the request of AMD
+        os.environ['OCL_SET_SVM_SIZE'] = '4194304'  # 4TB. Much larger than the ROCM 64GB/256GB defaults for Aimdos liberal VA use
 
 
 def handle_comfyui_manager_unavailable():


### PR DESCRIPTION
AMD+windows sets an unusually low maximum GPU virtual memory quota compared to other plaforms. For reference, the hardware limits on XT9060 are 128TB. On Nvidia RTX3060 it is 1TB. On nvidia RTX5090 it is 128TB.

Bump this into the same league, but keep it to a modest 4TB pending further usage case need + testing going even higher to the hardware limits.

ROCM crashes when this quota is exhausted, and Aimdos VBAR allocations can exhaust in on large-vram GPUs with multiple models.

Example test conditions:

Windows 11, XT9060(16GB), 48GB RAM, RoCM 7.2 --enable-dynamic-vram
Comfy Aimdo hacked to the use 128GB as the phyiscal RAM quota input for VBAR sizing - partially emulating Strix Halo
Flux2 dev

<img width="2210" height="535" alt="image" src="https://github.com/user-attachments/assets/6b252f33-2ad3-405b-aa50-b39ad8a2dfea" />

Before:

```
[INFO] Requested to load Flux2
[ERROR] !!! Exception during processing !!! exception: access violation reading 0x00000000000000E0
[ERROR] Traceback (most recent call last):
  File "C:\Users\rattus\ComfyUI_windows_portable_amd\ComfyUI_windows_portable\ComfyUI\execution.py", line 545, in execute
    output_data, output_ui, has_subgraph, has_pending_tasks = await get_output_data(prompt_id, unique_id, obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data)
                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\rattus\ComfyUI_windows_portable_amd\ComfyUI_windows_portable\ComfyUI\execution.py", line 344, in get_output_data
    return_values = await _async_map_node_over_list(prompt_id, unique_id, obj, input_data_all, obj.FUNCTION, allow_interrupt=True, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\rattus\ComfyUI_windows_portable_amd\ComfyUI_windows_portable\ComfyUI\execution.py", line 318, in _async_map_node_over_list
    await process_inputs(input_dict, i)
  File "C:\Users\rattus\ComfyUI_windows_portable_amd\ComfyUI_windows_portable\ComfyUI\execution.py", line 306, in process_inputs
    result = f(**inputs)
             ^^^^^^^^^^^
  File "C:\Users\rattus\ComfyUI_windows_portable_amd\ComfyUI_windows_portable\ComfyUI\comfy_api\internal\__init__.py", line 149, in wrapped_func
    return method(locked_class, **inputs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\rattus\ComfyUI_windows_portable_amd\ComfyUI_windows_portable\ComfyUI\comfy_api\latest\_io.py", line 2046, in EXECUTE_NORMALIZED
    to_return = cls.execute(*args, **kwargs)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\rattus\ComfyUI_windows_portable_amd\ComfyUI_windows_portable\ComfyUI\comfy_extras\nodes_custom_sampler.py", line 1055, in execute
    samples = guider.sample(noise.generate_noise(latent), latent_image, sampler, sigmas, denoise_mask=noise_mask, callback=callback, disable_pbar=disable_pbar, seed=noise.seed)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\rattus\ComfyUI_windows_portable_amd\ComfyUI_windows_portable\ComfyUI\comfy\samplers.py", line 1335, in sample
    output = executor.execute(noise, latent_image, sampler, sigmas, denoise_mask, callback, disable_pbar, seed, latent_shapes=latent_shapes)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\rattus\ComfyUI_windows_portable_amd\ComfyUI_windows_portable\ComfyUI\comfy\patcher_extension.py", line 113, in execute
    return self.original(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\rattus\ComfyUI_windows_portable_amd\ComfyUI_windows_portable\ComfyUI\comfy\samplers.py", line 1241, in outer_sample
    self.inner_model, self.conds, self.loaded_models = comfy.sampler_helpers.prepare_sampling(self.model_patcher, noise.shape, self.conds, self.model_options)
                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\rattus\ComfyUI_windows_portable_amd\ComfyUI_windows_portable\ComfyUI\comfy\sampler_helpers.py", line 186, in prepare_sampling
    return executor.execute(model, noise_shape, conds, model_options=model_options, force_full_load=force_full_load, force_offload=force_offload)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\rattus\ComfyUI_windows_portable_amd\ComfyUI_windows_portable\ComfyUI\comfy\patcher_extension.py", line 113, in execute
    return self.original(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\rattus\ComfyUI_windows_portable_amd\ComfyUI_windows_portable\ComfyUI\comfy\sampler_helpers.py", line 201, in _prepare_sampling
    comfy.model_management.load_models_gpu([model] + models, memory_required=memory_required, minimum_memory_required=minimum_memory_required, force_full_load=force_full_load)
  File "C:\Users\rattus\ComfyUI_windows_portable_amd\ComfyUI_windows_portable\ComfyUI\comfy\model_management.py", line 1020, in load_models_gpu
    loaded_model.model_load(lowvram_model_memory, force_patch_weights=force_patch_weights)
  File "C:\Users\rattus\ComfyUI_windows_portable_amd\ComfyUI_windows_portable\ComfyUI\comfy\model_management.py", line 806, in model_load
    self.model_use_more_vram(use_more_vram, force_patch_weights=force_patch_weights)
  File "C:\Users\rattus\ComfyUI_windows_portable_amd\ComfyUI_windows_portable\ComfyUI\comfy\model_management.py", line 834, in model_use_more_vram
    return self.model.partially_load(self.device, extra_memory, force_patch_weights=force_patch_weights)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\rattus\ComfyUI_windows_portable_amd\ComfyUI_windows_portable\ComfyUI\comfy\model_patcher.py", line 2153, in partially_load
    raise e
  File "C:\Users\rattus\ComfyUI_windows_portable_amd\ComfyUI_windows_portable\ComfyUI\comfy\model_patcher.py", line 2150, in partially_load
    self.load(device_to, dirty=dirty)
  File "C:\Users\rattus\ComfyUI_windows_portable_amd\ComfyUI_windows_portable\ComfyUI\comfy\model_patcher.py", line 1873, in load
    vbar = self._vbar_get(create=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\rattus\ComfyUI_windows_portable_amd\ComfyUI_windows_portable\ComfyUI\comfy\model_patcher.py", line 1805, in _vbar_get
    vbar = comfy_aimdo.model_vbar.ModelVBAR(self.model_size() * 10, self.load_device.index)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\rattus\ComfyUI_windows_portable_amd\ComfyUI_windows_portable\python_embeded\Lib\site-packages\comfy_aimdo\model_vbar.py", line 57, in __init__
    self._ptr = lib.vbar_allocate(self._devctx, size, device)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: exception: access violation reading 0x00000000000000E0

[INFO] Prompt executed in 15.16 seconds
```

After:

```
[INFO] got prompt
[INFO] Found quantization metadata version 1
[INFO] Using MixedPrecisionOps for text encoder
[INFO] CLIP/text encoder model load device: cuda:0, offload device: cpu, current: cpu, dtype: torch.float16
[INFO] Requested to load Flux2TEModel_
[INFO] Model Flux2TEModel_ prepared for dynamic VRAM loading. 17180MB Staged. 0 patches attached. Force pre-loaded 270 weights: 600 KB.
C:\Users\rattus\ComfyUI_windows_portable_amd\ComfyUI_windows_portable\ComfyUI\comfy\ops.py:95: UserWarning: Using AOTriton backend for Efficient Attention forward... (Triggered internally at C:/b/pytorch/aten/src/ATen/native/transformers/hip/attention.hip:1452.)
  return torch.nn.functional.scaled_dot_product_attention(q, k, v, *args, **kwargs)
[INFO] Found quantization metadata version 1
[INFO] Detected mixed precision quantization
[INFO] Using mixed precision operations
[INFO] Native ops: asym_w4a8_int8, float8_e4m3fn, convrot_w4a4, int8_tensorwise, float8_e5m2 , emulated ops: mxfp8, nvfp4
[INFO] model weight dtype torch.bfloat16, manual cast: torch.bfloat16
[INFO] model_type FLUX
[INFO] Requested to load Flux2
[INFO] Model Flux2 prepared for dynamic VRAM loading. 33813MB Staged. 0 patches attached. Force pre-loaded 256 weights: 71 KB.
100%|##########| 1/1 [00:23<00:00, 23.23s/it,  Model Initialization complete!  ]
[INFO] Prompt executed in 38.10 seconds
```