### PR TITLE
Report 3D models from every 3D node as a standard 3d output item

### DIFF
--- a/comfy_api/latest/_ui.py
+++ b/comfy_api/latest/_ui.py
@@ -456,29 +456,26 @@ class PreviewUI3D(_UIOutput):
         return {"result": [self.model_file, self.camera_info, self.bg_image_path]}
 
 
-class PreviewUI3DAdvanced(_UIOutput):
-    def __init__(
-        self,
-        model_file,
-        camera_info,
-        model_3d_info,
-        folder_type: FolderType | None = None,
-        saved_result: SavedResult | None = None,
-    ):
-        self.model_file = model_file
+class Saved3DModels(_UIOutput):
+    def __init__(self, results: list[SavedResult], camera_info=None, model_3d_info=None):
+        super().__init__()
+        self.results = results
         self.camera_info = camera_info
-        self.model_3d_info = model_3d_info
-        self.folder_type = folder_type
-        self.saved_result = saved_result
+        self.model_3d_info = model_3d_info if model_3d_info is not None else []
 
     def as_dict(self):
-        model_file = self.model_file
-        if self.folder_type is not None:
-            model_file = f"{model_file} [{FolderType(self.folder_type).value}]"
-        data = {"result": [model_file, self.camera_info, self.model_3d_info]}
-        if self.saved_result is not None:
-            data["3d"] = [self.saved_result]
-        return data
+        return {
+            "3d": self.results,
+            "camera_info": [self.camera_info],
+            "model_3d_info": list(self.model_3d_info),
+        }
+
+
+class PreviewUI3DAdvanced(Saved3DModels):
+    def __init__(self, model_file, camera_info, model_3d_info, folder_type: FolderType | None = None):
+        subfolder, _, filename = model_file.replace("\\", "/").rpartition("/")
+        result_type = FolderType(folder_type) if folder_type is not None else FolderType.output
+        super().__init__([SavedResult(filename, subfolder, result_type)], camera_info, model_3d_info)
 
 
 class PreviewText(_UIOutput):
@@ -500,6 +497,7 @@ __all__ = [
     "PreviewAudio",
     "PreviewVideo",
     "PreviewUI3D",
+    "Saved3DModels",
     "PreviewUI3DAdvanced",
     "PreviewText",
 ]

--- a/comfy_extras/nodes_load_3d.py
+++ b/comfy_extras/nodes_load_3d.py
@@ -185,7 +185,7 @@ class Preview3DAdvanced(IO.ComfyNode):
             camera_info,
             width,
             height,
-            ui=UI.PreviewUI3DAdvanced(filename, camera_info, model_3d_info, folder_type=IO.FolderType.temp),
+            ui=UI.Saved3DModels([UI.SavedResult(filename, "", IO.FolderType.temp)], camera_info, model_3d_info),
         )
 
 
@@ -256,7 +256,7 @@ class PreviewGaussianSplat(IO.ComfyNode):
             camera_info,
             width,
             height,
-            ui=UI.PreviewUI3DAdvanced(filename, camera_info, model_3d_info, folder_type=IO.FolderType.temp),
+            ui=UI.Saved3DModels([UI.SavedResult(filename, "", IO.FolderType.temp)], camera_info, model_3d_info),
         )
 
 
@@ -318,7 +318,7 @@ class PreviewPointCloud(IO.ComfyNode):
             camera_info,
             width,
             height,
-            ui=UI.PreviewUI3DAdvanced(filename, camera_info, model_3d_info, folder_type=IO.FolderType.temp),
+            ui=UI.Saved3DModels([UI.SavedResult(filename, "", IO.FolderType.temp)], camera_info, model_3d_info),
         )
 
 

--- a/comfy_extras/nodes_save_3d.py
+++ b/comfy_extras/nodes_save_3d.py
@@ -580,11 +580,7 @@ class SaveGLB(IO.ComfyNode):
             ext = mesh.format or "glb"
             f = f"{filename}_{counter:05}_.{ext}"
             mesh.save_to(os.path.join(full_output_folder, f))
-            results.append({
-                "filename": f,
-                "subfolder": subfolder,
-                "type": "output"
-            })
+            results.append(UI.SavedResult(f, subfolder, IO.FolderType.output))
             counter += 1
         else:
             # Handle Mesh input - save vertices and faces as GLB; carry optional UVs / colors / texture.
@@ -596,13 +592,9 @@ class SaveGLB(IO.ComfyNode):
                 f = f"{filename}_{counter:05}_.glb"
                 with open(os.path.join(full_output_folder, f), "wb") as fh:
                     fh.write(glb)
-                results.append({
-                    "filename": f,
-                    "subfolder": subfolder,
-                    "type": "output"
-                })
+                results.append(UI.SavedResult(f, subfolder, IO.FolderType.output))
                 counter += 1
-        return IO.NodeOutput(ui={"3d": results})
+        return IO.NodeOutput(ui=UI.Saved3DModels(results))
 
 
 class MeshToFile3D(IO.ComfyNode):
@@ -888,7 +880,6 @@ def _save_file3d_to_output(model_3d: Types.File3D, filename_prefix: str) -> UI.S
 
 def execute_save_3d_advanced(model_3d, viewport_state, width, height, filename_prefix, kwargs) -> IO.NodeOutput:
     saved = _save_file3d_to_output(model_3d, filename_prefix)
-    model_file = f"{saved.subfolder}/{saved.filename}" if saved.subfolder else saved.filename
     viewport_state = viewport_state if isinstance(viewport_state, dict) else {}
     camera_info_input = kwargs.get("camera_info", None)
     camera_info = camera_info_input if camera_info_input is not None else viewport_state.get('camera_info')
@@ -900,7 +891,7 @@ def execute_save_3d_advanced(model_3d, viewport_state, width, height, filename_p
         camera_info,
         width,
         height,
-        ui=UI.PreviewUI3DAdvanced(model_file, camera_info, model_3d_info, saved_result=saved),
+        ui=UI.Saved3DModels([saved], camera_info, model_3d_info),
     )
 
 

--- a/tests-unit/comfy_api_test/preview_ui_3d_test.py
+++ b/tests-unit/comfy_api_test/preview_ui_3d_test.py
@@ -1,5 +1,6 @@
 import os
 from io import BytesIO
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -7,35 +8,39 @@ import pytest
 import folder_paths
 from comfy_api.latest import IO, UI, Types
 from comfy_extras.nodes_load_3d import Preview3DAdvanced, PreviewGaussianSplat, PreviewPointCloud
-from comfy_extras.nodes_save_3d import Save3DAdvanced, SaveGaussianSplat, SavePointCloud
+from comfy_extras.nodes_save_3d import Save3DAdvanced, SaveGaussianSplat, SaveGLB, SavePointCloud
 
 
-def test_preview_ui_3d_advanced_keeps_bare_path_by_default():
-    ui = UI.PreviewUI3DAdvanced("3d/model.glb", {"fov": 35}, [])
-
-    assert ui.as_dict() == {"result": ["3d/model.glb", {"fov": 35}, []]}
-
-
-def test_preview_ui_3d_advanced_reports_saved_result_as_standard_output_item():
+def test_saved_3d_models_reports_files_and_viewer_state():
     saved = UI.SavedResult("model_00001.glb", "3d", IO.FolderType.output)
-    ui = UI.PreviewUI3DAdvanced("3d/model_00001.glb", None, [], saved_result=saved)
+    ui = UI.Saved3DModels([saved], {"fov": 35}, [{"scale": 1}])
 
     assert ui.as_dict() == {
-        "result": ["3d/model_00001.glb", None, []],
         "3d": [{"filename": "model_00001.glb", "subfolder": "3d", "type": "output"}],
+        "camera_info": [{"fov": 35}],
+        "model_3d_info": [{"scale": 1}],
     }
 
 
+def test_saved_3d_models_defaults_to_no_viewer_state():
+    ui = UI.Saved3DModels([UI.SavedResult("m.glb", "", IO.FolderType.output)])
+
+    assert ui.as_dict()["camera_info"] == [None]
+    assert ui.as_dict()["model_3d_info"] == []
+
+
+def test_preview_ui_3d_advanced_splits_the_path_into_a_saved_result():
+    ui = UI.PreviewUI3DAdvanced("3d/model.glb", {"fov": 35}, [])
+
+    assert ui.as_dict()["3d"] == [{"filename": "model.glb", "subfolder": "3d", "type": "output"}]
+    assert ui.as_dict()["camera_info"] == [{"fov": 35}]
+
+
 @pytest.mark.parametrize("folder_type", [IO.FolderType.temp, "temp"])
-def test_preview_ui_3d_advanced_annotates_folder_type(folder_type):
+def test_preview_ui_3d_advanced_uses_the_folder_type(folder_type):
     ui = UI.PreviewUI3DAdvanced("preview.glb", None, [], folder_type=folder_type)
 
-    result = ui.as_dict()["result"]
-
-    assert result[0] == "preview.glb [temp]"
-    name, base_dir = folder_paths.annotated_filepath(result[0])
-    assert name == "preview.glb"
-    assert base_dir == folder_paths.get_temp_directory()
+    assert ui.as_dict()["3d"] == [{"filename": "preview.glb", "subfolder": "", "type": "temp"}]
 
 
 @pytest.mark.parametrize(
@@ -47,25 +52,24 @@ def test_preview_ui_3d_advanced_annotates_folder_type(folder_type):
         (PreviewPointCloud, "ply", "preview_pointcloud_"),
     ],
 )
-def test_preview_nodes_report_where_they_wrote_the_file(tmp_path, node_cls, file_format, prefix):
+def test_preview_nodes_report_the_temp_file_they_wrote(tmp_path, node_cls, file_format, prefix):
     model = Types.File3D(BytesIO(b"model-bytes"), file_format)
 
     with patch.object(folder_paths, "get_temp_directory", return_value=str(tmp_path)):
         output = node_cls.execute(model, viewport_state={}, width=1, height=1)
-        reported = output.ui.as_dict()["result"][0]
-        name, base_dir = folder_paths.annotated_filepath(reported)
 
-    assert reported.endswith(f".{file_format} [temp]")
-    assert name.startswith(prefix)
-    assert base_dir == str(tmp_path)
-    assert os.path.isfile(os.path.join(tmp_path, name))
+    (item,) = output.ui.as_dict()["3d"]
+    assert item["type"] == "temp"
+    assert item["subfolder"] == ""
+    assert item["filename"].startswith(prefix) and item["filename"].endswith(f".{file_format}")
+    assert os.path.isfile(os.path.join(tmp_path, item["filename"]))
 
 
 @pytest.mark.parametrize(
     ("node_cls", "file_format"),
     [(Save3DAdvanced, "glb"), (SaveGaussianSplat, "spz"), (SavePointCloud, "ply")],
 )
-def test_save_nodes_report_the_saved_file_as_a_3d_output_item(tmp_path, node_cls, file_format):
+def test_save_nodes_report_the_output_file_they_wrote(tmp_path, node_cls, file_format):
     model = Types.File3D(BytesIO(b"model-bytes"), file_format)
 
     with patch.object(folder_paths, "get_output_directory", return_value=str(tmp_path)):
@@ -73,8 +77,25 @@ def test_save_nodes_report_the_saved_file_as_a_3d_output_item(tmp_path, node_cls
 
     ui = output.ui.as_dict()
     (item,) = ui["3d"]
-    assert item["subfolder"] == "3d"
     assert item["type"] == "output"
+    assert item["subfolder"] == "3d"
     assert item["filename"].startswith("ComfyUI_") and item["filename"].endswith(f".{file_format}")
-    assert ui["result"][0] == f"3d/{item['filename']}"
+    assert set(ui) == {"3d", "camera_info", "model_3d_info"}
+    assert os.path.isfile(os.path.join(tmp_path, "3d", item["filename"]))
+
+
+def test_save_glb_reports_a_file3d_input_in_the_same_shape(tmp_path):
+    model = Types.File3D(BytesIO(b"model-bytes"), "glb")
+
+    with (
+        patch.object(folder_paths, "get_output_directory", return_value=str(tmp_path)),
+        patch.object(SaveGLB, "hidden", SimpleNamespace(prompt=None, extra_pnginfo=None)),
+    ):
+        output = SaveGLB.execute(model, filename_prefix="3d/ComfyUI")
+
+    ui = output.ui.as_dict()
+    (item,) = ui["3d"]
+    assert item == {"filename": item["filename"], "subfolder": "3d", "type": "output"}
+    assert item["filename"].endswith("_.glb")
+    assert ui["camera_info"] == [None]
     assert os.path.isfile(os.path.join(tmp_path, "3d", item["filename"]))


### PR DESCRIPTION
The Save 3D (Advanced), Preview 3D (Advanced), Gaussian splat and point cloud nodes reported their model as a bare path in the first slot of a positional `result` list. Output registration only understands file objects, so these models never got a job_id, were only picked up by a later full asset scan, and were never grouped with the other outputs of their job; the cloud worker carries a special case to translate the string form.

All seven 3D nodes, SaveGLB included, now emit one shape through a shared Saved3DModels UI output: a `3d` list of SavedResult plus `camera_info` and `model_3d_info`. The positional `result` list is gone. PreviewUI3DAdvanced stays as a thin subclass for nodes that build the output from a path string and folder type.

Requires a frontend that reads the `3d` item (readModel3DOutput). https://github.com/Comfy-Org/ComfyUI_frontend/pull/17245