### PR TITLE
Add an activity field to node progress and report model loading

### DIFF
--- a/comfy/model_base.py
+++ b/comfy/model_base.py
@@ -83,7 +83,6 @@ from comfy.ldm.sensenova.sampling import SenseNovaModelSampling, time_snr_shift
 import comfy.ldm.depth_anything_3.model
 
 import comfy.model_management
-import comfy.utils
 import comfy.patcher_extension
 import comfy.conds
 import comfy.ops
@@ -368,8 +367,7 @@ class BaseModel(torch.nn.Module):
                 to_load[k[len(unet_prefix):]] = sd.pop(k)
 
         to_load = self.model_config.process_unet_state_dict(to_load)
-        with comfy.utils.progress_activity("loading"):
-            m, u = self.diffusion_model.load_state_dict(to_load, strict=False, assign=assign)
+        m, u = self.diffusion_model.load_state_dict(to_load, strict=False, assign=assign)
         if len(m) > 0:
             logging.warning("unet missing: {}".format(m))
 

--- a/comfy/model_base.py
+++ b/comfy/model_base.py
@@ -83,6 +83,7 @@ from comfy.ldm.sensenova.sampling import SenseNovaModelSampling, time_snr_shift
 import comfy.ldm.depth_anything_3.model
 
 import comfy.model_management
+import comfy.utils
 import comfy.patcher_extension
 import comfy.conds
 import comfy.ops
@@ -367,7 +368,8 @@ class BaseModel(torch.nn.Module):
                 to_load[k[len(unet_prefix):]] = sd.pop(k)
 
         to_load = self.model_config.process_unet_state_dict(to_load)
-        m, u = self.diffusion_model.load_state_dict(to_load, strict=False, assign=assign)
+        with comfy.utils.progress_activity("loading"):
+            m, u = self.diffusion_model.load_state_dict(to_load, strict=False, assign=assign)
         if len(m) > 0:
             logging.warning("unet missing: {}".format(m))
 

--- a/comfy/model_management.py
+++ b/comfy/model_management.py
@@ -1017,7 +1017,8 @@ def load_models_gpu(models, memory_required=0, force_patch_weights=False, minimu
         if vram_set_state == VRAMState.NO_VRAM:
             lowvram_model_memory = 0.1
 
-        loaded_model.model_load(lowvram_model_memory, force_patch_weights=force_patch_weights)
+        with comfy.utils.progress_activity("loading"):
+            loaded_model.model_load(lowvram_model_memory, force_patch_weights=force_patch_weights)
         vram_used = 0 if is_device_cpu(torch_dev) else loaded_model.model_loaded_memory()
         ram_used = model.loaded_ram_size() if model.is_dynamic() else loaded_model.model_memory() - vram_used
         detail("Model loaded: patcher=%s model=%s ram_mb=%.1f vram_mb=%.1f", model.__class__.__name__, model.model.__class__.__name__, ram_used / (1024 ** 2), vram_used / (1024 ** 2))

--- a/comfy/sd.py
+++ b/comfy/sd.py
@@ -2223,7 +2223,8 @@ def load_state_dict_guess_config(sd, output_vae=True, output_clip=True, output_c
         ModelPatcher = comfy.model_patcher.ModelPatcher if disable_dynamic else comfy.model_patcher.CoreModelPatcher
         offload_device = model_options.get("offload_device", model_management.unet_offload_device())
         model_patcher = ModelPatcher(model, load_device=load_device, offload_device=offload_device)
-        model.load_model_weights(sd, diffusion_model_prefix, assign=model_patcher.is_dynamic())
+        with comfy.utils.progress_activity("loading"):
+            model.load_model_weights(sd, diffusion_model_prefix, assign=model_patcher.is_dynamic())
 
     if output_vae:
         vae_sd = comfy.utils.state_dict_prefix_replace(sd, {k: "" for k in model_config.vae_key_prefix}, filter_keys=True)
@@ -2365,7 +2366,8 @@ def load_diffusion_model_state_dict(sd, model_options={}, metadata=None, disable
     model_patcher = ModelPatcher(model, load_device=load_device, offload_device=offload_device)
     if not model_management.is_device_cpu(offload_device):
         model.to(offload_device)
-    model.load_model_weights(new_sd, "", assign=model_patcher.is_dynamic())
+    with comfy.utils.progress_activity("loading"):
+        model.load_model_weights(new_sd, "", assign=model_patcher.is_dynamic())
     left_over = sd.keys()
     if len(left_over) > 0:
         logging.info("left over keys in diffusion model: {}".format(left_over))

--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -22,6 +22,7 @@ import math
 import struct
 import ctypes
 import os
+import contextlib
 import comfy.memory_management
 import safetensors.torch
 import numpy as np
@@ -1296,6 +1297,26 @@ PROGRESS_BAR_HOOK = None
 def set_progress_bar_global_hook(function):
     global PROGRESS_BAR_HOOK
     PROGRESS_BAR_HOOK = function
+
+PROGRESS_ACTIVITY_HOOK = None
+def set_progress_activity_global_hook(function):
+    global PROGRESS_ACTIVITY_HOOK
+    PROGRESS_ACTIVITY_HOOK = function
+
+@contextlib.contextmanager
+def progress_activity(activity):
+    """Report what the running node is spending time on, so the UI can tell a
+    slow load apart from slow compute."""
+    hook = PROGRESS_ACTIVITY_HOOK
+    if hook is None:
+        yield
+        return
+
+    hook(activity)
+    try:
+        yield
+    finally:
+        hook(None)
 
 # Throttle settings for progress bar updates to reduce WebSocket flooding
 PROGRESS_THROTTLE_MIN_INTERVAL = 0.1  # 100ms minimum between updates

--- a/comfy_execution/progress.py
+++ b/comfy_execution/progress.py
@@ -1,5 +1,5 @@
 from typing import TypedDict, Dict, Optional, Tuple
-from typing_extensions import override
+from typing_extensions import override, NotRequired
 from PIL import Image
 from enum import Enum
 from abc import ABC
@@ -27,6 +27,7 @@ class NodeProgressState(TypedDict):
     state: NodeState
     value: float
     max: float
+    activity: NotRequired[str]  # what a running node is spending time on, e.g. "loading"
 
 
 class ProgressHandler(ABC):
@@ -163,8 +164,11 @@ class WebUIProgressHandler(ProgressHandler):
             return
 
         # Only send info for non-pending nodes
-        active_nodes = {
-            node_id: {
+        active_nodes = {}
+        for node_id, state in nodes.items():
+            if state["state"] == NodeState.Pending:
+                continue
+            active_nodes[node_id] = {
                 "value": state["value"],
                 "max": state["max"],
                 "state": state["state"].value,
@@ -174,9 +178,8 @@ class WebUIProgressHandler(ProgressHandler):
                 "parent_node_id": self.registry.dynprompt.get_parent_node_id(node_id),
                 "real_node_id": self.registry.dynprompt.get_real_node_id(node_id),
             }
-            for node_id, state in nodes.items()
-            if state["state"] != NodeState.Pending
-        }
+            if "activity" in state:
+                active_nodes[node_id]["activity"] = state["activity"]
 
         # Send a combined progress_state message with all node states
         # Include client_id to ensure message is only sent to the initiating client
@@ -299,6 +302,23 @@ class ProgressRegistry:
             if handler.enabled:
                 handler.update_handler(
                     node_id, value, max_value, entry, self.prompt_id, image
+                )
+
+    def set_activity(self, node_id: str, activity: str | None) -> None:
+        """Set what a running node is spending time on, or None to clear it"""
+        entry = self.ensure_entry(node_id)
+        if entry.get("activity") == activity:
+            return
+        if activity is None:
+            entry.pop("activity", None)
+        else:
+            entry["activity"] = activity
+
+        # Notify all enabled handlers
+        for handler in self.handlers.values():
+            if handler.enabled:
+                handler.update_handler(
+                    node_id, entry["value"], entry["max"], entry, self.prompt_id
                 )
 
     def finish_progress(self, node_id: str) -> None:

--- a/comfy_execution/progress.py
+++ b/comfy_execution/progress.py
@@ -164,11 +164,8 @@ class WebUIProgressHandler(ProgressHandler):
             return
 
         # Only send info for non-pending nodes
-        active_nodes = {}
-        for node_id, state in nodes.items():
-            if state["state"] == NodeState.Pending:
-                continue
-            active_nodes[node_id] = {
+        active_nodes = {
+            node_id: {
                 "value": state["value"],
                 "max": state["max"],
                 "state": state["state"].value,
@@ -178,8 +175,13 @@ class WebUIProgressHandler(ProgressHandler):
                 "parent_node_id": self.registry.dynprompt.get_parent_node_id(node_id),
                 "real_node_id": self.registry.dynprompt.get_real_node_id(node_id),
             }
-            if "activity" in state:
-                active_nodes[node_id]["activity"] = state["activity"]
+            for node_id, state in nodes.items()
+            if state["state"] != NodeState.Pending
+        }
+        for node_id, node in active_nodes.items():
+            activity = nodes[node_id].get("activity")
+            if activity is not None:
+                node["activity"] = activity
 
         # Send a combined progress_state message with all node states
         # Include client_id to ensure message is only sent to the initiating client

--- a/main.py
+++ b/main.py
@@ -483,7 +483,14 @@ def hijack_progress(server_instance):
                     server_instance.client_id,
                 )
 
+    def activity_hook(activity):
+        executing_context = get_executing_context()
+        if executing_context is None:
+            return
+        get_progress_state().set_activity(executing_context.node_id, activity)
+
     comfy.utils.set_progress_bar_global_hook(hook)
+    comfy.utils.set_progress_activity_global_hook(activity_hook)
 
 
 def cleanup_temp():

--- a/tests-unit/execution_test/progress_activity_test.py
+++ b/tests-unit/execution_test/progress_activity_test.py
@@ -1,0 +1,90 @@
+from unittest.mock import Mock
+
+import comfy.utils
+from comfy_execution.progress import (
+    NodeState,
+    ProgressRegistry,
+    WebUIProgressHandler,
+)
+
+
+def make_registry():
+    dynprompt = Mock()
+    dynprompt.get_display_node_id.return_value = "1"
+    dynprompt.get_parent_node_id.return_value = None
+    dynprompt.get_real_node_id.return_value = "1"
+    return ProgressRegistry(prompt_id="p", dynprompt=dynprompt)
+
+
+def test_activity_is_set_and_cleared():
+    registry = make_registry()
+    registry.start_progress("1")
+
+    registry.set_activity("1", "loading")
+    assert registry.nodes["1"]["activity"] == "loading"
+
+    registry.set_activity("1", None)
+    assert "activity" not in registry.nodes["1"]
+
+
+def test_unchanged_activity_does_not_notify():
+    registry = make_registry()
+    handler = Mock(enabled=True)
+    registry.handlers["test"] = handler
+    registry.start_progress("1")
+
+    registry.set_activity("1", "loading")
+    assert handler.update_handler.call_count == 1
+
+    registry.set_activity("1", "loading")
+    assert handler.update_handler.call_count == 1
+
+    registry.set_activity("1", None)
+    assert handler.update_handler.call_count == 2
+
+
+def test_activity_is_only_sent_when_set():
+    server = Mock(client_id="c")
+    registry = make_registry()
+    handler = WebUIProgressHandler(server)
+    handler.set_registry(registry)
+    registry.register_handler(handler)
+
+    registry.start_progress("1")
+    nodes = server.send_sync.call_args[0][1]["nodes"]
+    assert "activity" not in nodes["1"]
+
+    registry.set_activity("1", "loading")
+    nodes = server.send_sync.call_args[0][1]["nodes"]
+    assert nodes["1"]["activity"] == "loading"
+    assert nodes["1"]["state"] == NodeState.Running.value
+
+
+def test_progress_activity_reports_and_clears():
+    seen = []
+    comfy.utils.set_progress_activity_global_hook(seen.append)
+    try:
+        with comfy.utils.progress_activity("loading"):
+            assert seen == ["loading"]
+    finally:
+        comfy.utils.set_progress_activity_global_hook(None)
+    assert seen == ["loading", None]
+
+
+def test_progress_activity_clears_on_error():
+    seen = []
+    comfy.utils.set_progress_activity_global_hook(seen.append)
+    try:
+        with comfy.utils.progress_activity("loading"):
+            raise RuntimeError("boom")
+    except RuntimeError:
+        pass
+    finally:
+        comfy.utils.set_progress_activity_global_hook(None)
+    assert seen == ["loading", None]
+
+
+def test_progress_activity_without_hook():
+    comfy.utils.set_progress_activity_global_hook(None)
+    with comfy.utils.progress_activity("loading"):
+        pass


### PR DESCRIPTION
A node that is loading weights looks the same as one that is computing. `progress_state` carries only `state`/`value`/`max`, and `load_models_gpu` runs inside the sampler (`comfy/sampler_helpers.py`), so the UI shows the sampler sitting at 0% while weights move to VRAM.

Adds an optional `activity` string to the node progress state, reported through a module-level hook in the same shape as the existing `PROGRESS_BAR_HOOK`, and sets it to `"loading"` around the VRAM load and around state-dict loading. `activity` is state the engine already owns about its own work, not an id or a client concept passed through it; nothing is read out of `extra_data` and `execution.py` is untouched. The field is left out of the websocket payload unless something sets it, so existing clients see no change, and it can be renamed or dropped later without breaking anything.

Why it touches more than one file: `comfy/` cannot import `comfy_execution/`, so the hook is declared in `comfy/utils.py`, installed in `main.py`, and read in `comfy_execution/progress.py`. That is the same split the progress bar already uses, and core already reports through it from `comfy/sd.py`, `comfy/text_encoders/llama.py` and `comfy/ldm/seedvr/vae.py`. `send_progress_text` was not usable here: it is only reachable through `PromptServer.instance`, which `comfy/` must not import.

`set_activity` sends only when the value changes, so a load produces two messages, not one per chunk.

Reader: Comfy-Org/ComfyUI_frontend#17367 shows the value as a badge on the node header. It merges first and is harmless without this producer; once it ships in `comfyui-frontend-package` the pinned frontend reads the field.

Tests: `tests-unit/execution_test/progress_activity_test.py`.

<img width="331" height="182" alt="A Load Checkpoint node showing a Loading badge with a spinner" src="https://github.com/user-attachments/assets/8b3d8b4e-ece8-4d30-9f8f-e396b0e0693a" />
