### PR TITLE
Fix duplicate charges when a paid API-node submission is retried

### DIFF
--- a/comfy_api_nodes/util/client.py
+++ b/comfy_api_nodes/util/client.py
@@ -43,11 +43,17 @@ class ApiEndpoint:
         *,
         query_params: dict[str, Any] | None = None,
         headers: dict[str, str] | None = None,
+        idempotent: bool | None = None,
     ):
         self.path = path
         self.method = method
         self.query_params = query_params or {}
         self.headers = headers or {}
+        # Whether sending this request twice is harmless. None means "decide by
+        # method": GET/HEAD/OPTIONS are, anything else is not. A paid submission is
+        # never idempotent; a status poll that happens to use POST is, and the poll
+        # loop marks it so.
+        self.idempotent = idempotent
 
 
 @dataclass
@@ -71,9 +77,6 @@ class _RequestConfig:
     price_extractor: Callable[[dict[str, Any]], float | None] | None = None
     is_rate_limited: Callable[[int, Any], bool] | None = None
     response_header_validator: Callable[[dict[str, str]], None] | None = None
-    # Set only by the poll loop. A resent request must cost nothing: a status poll
-    # does, a paid submission never does, so no public helper exposes this.
-    resend_is_free: bool = False
 
 
 @dataclass
@@ -96,19 +99,23 @@ _SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
 _RAISED_BEFORE_SEND = (aiohttp.ClientConnectorError, aiohttp.ConnectionTimeoutError)
 
 
-def _connection_error_is_retryable(method: str, err: BaseException, resend_is_free: bool = False) -> bool:
-    """Whether repeating ``method`` after ``err`` is free or can charge the user twice.
+def _is_idempotent(endpoint: ApiEndpoint) -> bool:
+    if endpoint.idempotent is not None:
+        return endpoint.idempotent
+    return endpoint.method.upper() in _SAFE_METHODS
 
-    Repeating a GET costs nothing. Repeating a POST is a second submission, and on a
-    proxied partner call that is a second paid generation: the provider bills every
-    request it accepts, so a request the server already received must not be sent
-    again. ClientConnectorError (and its DNS, proxy and TLS subclasses) is raised
-    before the request is written, so it stays retryable for every method.
 
-    ``resend_is_free`` is the poll loop saying its request only reads status, so a
-    POST there costs nothing to send again.
+def _connection_error_is_retryable(endpoint: ApiEndpoint, err: BaseException) -> bool:
+    """Whether resending ``endpoint`` after ``err`` is harmless or can charge the user twice.
+
+    Resending an idempotent request costs nothing. Resending a submission is a
+    second submission, and on a proxied partner call that is a second paid
+    generation: the provider bills every request it accepts, so a request the
+    server already received must not be sent again. ClientConnectorError (and its
+    DNS, proxy and TLS subclasses) and the connect-phase timeout are raised before
+    the request is written, so those stay retryable for every endpoint.
     """
-    if resend_is_free or method.upper() in _SAFE_METHODS:
+    if _is_idempotent(endpoint):
         return True
     return isinstance(err, _RAISED_BEFORE_SEND)
 
@@ -270,52 +277,6 @@ async def sync_op_raw(
       - If as_binary=True: returns bytes.
       - response_header_validator: optional callback receiving response headers dict
     """
-    cfg = _request_config(
-        cls,
-        endpoint,
-        price_extractor=price_extractor,
-        data=data,
-        files=files,
-        content_type=content_type,
-        timeout=timeout,
-        multipart_parser=multipart_parser,
-        max_retries=max_retries,
-        retry_delay=retry_delay,
-        retry_backoff=retry_backoff,
-        wait_label=wait_label,
-        estimated_duration=estimated_duration,
-        final_label_on_success=final_label_on_success,
-        progress_origin_ts=progress_origin_ts,
-        monitor_progress=monitor_progress,
-        max_retries_on_rate_limit=max_retries_on_rate_limit,
-        is_rate_limited=is_rate_limited,
-        response_header_validator=response_header_validator,
-    )
-    return await _request_base(cfg, expect_binary=as_binary)
-
-
-def _request_config(
-    cls: type[IO.ComfyNode],
-    endpoint: ApiEndpoint,
-    *,
-    price_extractor: Callable[[dict[str, Any]], float | None] | None = None,
-    data: dict[str, Any] | BaseModel | None = None,
-    files: dict[str, Any] | list[tuple[str, Any]] | None = None,
-    content_type: str = "application/json",
-    timeout: float = 3600.0,
-    multipart_parser: Callable | None = None,
-    max_retries: int = 3,
-    retry_delay: float = 1.0,
-    retry_backoff: float = 2.0,
-    wait_label: str = "Waiting for server",
-    estimated_duration: int | None = None,
-    final_label_on_success: str | None = "Completed",
-    progress_origin_ts: float | None = None,
-    monitor_progress: bool = True,
-    max_retries_on_rate_limit: int = 16,
-    is_rate_limited: Callable[[int, Any], bool] | None = None,
-    response_header_validator: Callable[[dict[str, str]], None] | None = None,
-) -> _RequestConfig:
     if isinstance(data, BaseModel):
         data = data.model_dump(exclude_none=True)
         for k, v in list(data.items()):
@@ -342,7 +303,7 @@ def _request_config(
         is_rate_limited=is_rate_limited,
         response_header_validator=response_header_validator,
     )
-    return cfg
+    return await _request_base(cfg, expect_binary=as_binary)
 
 
 async def poll_op_raw(
@@ -411,11 +372,21 @@ async def poll_op_raw(
         except Exception as exc:
             logging.debug("Polling ticker exited: %s", exc)
 
+    # A poll only reads the task's status, whatever its method: resending it is free.
+    if poll_endpoint.idempotent is None:
+        poll_endpoint = ApiEndpoint(
+            poll_endpoint.path,
+            poll_endpoint.method,
+            query_params=poll_endpoint.query_params,
+            headers=poll_endpoint.headers,
+            idempotent=True,
+        )
+
     ticker_task = asyncio.create_task(_ticker())
     try:
         while consumed_attempts < max_poll_attempts:
             try:
-                poll_cfg = _request_config(
+                resp_json = await sync_op_raw(
                     cls,
                     poll_endpoint,
                     data=data,
@@ -425,11 +396,10 @@ async def poll_op_raw(
                     retry_backoff=retry_backoff_per_poll,
                     wait_label="Checking",
                     estimated_duration=None,
+                    as_binary=False,
                     final_label_on_success=None,
                     monitor_progress=False,
                 )
-                poll_cfg.resend_is_free = True  # a status poll only reads
-                resp_json = await _request_base(poll_cfg, expect_binary=False)
                 if not isinstance(resp_json, dict):
                     raise Exception("Polling endpoint returned non-JSON response.")
             except ProcessingInterrupted:
@@ -979,7 +949,7 @@ async def _request_base(cfg: _RequestConfig, expect_binary: bool):
             logging.debug("Polling was interrupted by user")
             raise
         except (ClientError, OSError) as e:
-            retryable = _connection_error_is_retryable(method, e, cfg.resend_is_free)
+            retryable = _connection_error_is_retryable(cfg.endpoint, e)
             if retryable and (attempt - rate_limit_attempts) <= cfg.max_retries:
                 logging.warning(
                     "Connection error calling %s %s. Retrying in %.2fs (%d/%d): %s",
@@ -1017,11 +987,11 @@ async def _request_base(cfg: _RequestConfig, expect_binary: bool):
                     request_headers=dict(payload_headers) if payload_headers else None,
                     request_params=dict(params) if params else None,
                     request_data=request_body_log,
-                    error_message=f"{type(e).__name__}: {str(e)} (not retried: the request had been sent)",
+                    error_message=f"{type(e).__name__}: {str(e)} (not retried: the request may have been received)",
                 )
                 raise ApiServerError(
-                    f"The connection to {default_base_url()} dropped after the request was sent. "
-                    "It was not sent again, because the provider may already have run and billed it. "
+                    f"The connection to {default_base_url()} dropped while the request was in flight. "
+                    "It was not sent again, because the provider may have run and billed it. "
                     "Check your usage history before trying again."
                 ) from e
             diag = await _diagnose_connectivity()

--- a/comfy_api_nodes/util/client.py
+++ b/comfy_api_nodes/util/client.py
@@ -71,7 +71,9 @@ class _RequestConfig:
     price_extractor: Callable[[dict[str, Any]], float | None] | None = None
     is_rate_limited: Callable[[int, Any], bool] | None = None
     response_header_validator: Callable[[dict[str, str]], None] | None = None
-    repeatable: bool = False
+    # Set only by the poll loop. A resent request must cost nothing: a status poll
+    # does, a paid submission never does, so no public helper exposes this.
+    resend_is_free: bool = False
 
 
 @dataclass
@@ -94,7 +96,7 @@ _SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
 _RAISED_BEFORE_SEND = (aiohttp.ClientConnectorError, aiohttp.ConnectionTimeoutError)
 
 
-def _connection_error_is_retryable(method: str, err: BaseException, repeatable: bool = False) -> bool:
+def _connection_error_is_retryable(method: str, err: BaseException, resend_is_free: bool = False) -> bool:
     """Whether repeating ``method`` after ``err`` is free or can charge the user twice.
 
     Repeating a GET costs nothing. Repeating a POST is a second submission, and on a
@@ -103,11 +105,10 @@ def _connection_error_is_retryable(method: str, err: BaseException, repeatable: 
     again. ClientConnectorError (and its DNS, proxy and TLS subclasses) is raised
     before the request is written, so it stays retryable for every method.
 
-    ``repeatable`` is the caller's statement that this particular request has no
-    side effect worth paying for twice -- a status poll, or an upload URL request --
-    which is the case for a POST that only reads.
+    ``resend_is_free`` is the poll loop saying its request only reads status, so a
+    POST there costs nothing to send again.
     """
-    if repeatable or method.upper() in _SAFE_METHODS:
+    if resend_is_free or method.upper() in _SAFE_METHODS:
         return True
     return isinstance(err, _RAISED_BEFORE_SEND)
 
@@ -164,7 +165,6 @@ async def sync_op(
     monitor_progress: bool = True,
     max_retries_on_rate_limit: int = 16,
     is_rate_limited: Callable[[int, Any], bool] | None = None,
-    repeatable: bool = False,
 ) -> M:
     raw = await sync_op_raw(
         cls,
@@ -186,7 +186,6 @@ async def sync_op(
         monitor_progress=monitor_progress,
         max_retries_on_rate_limit=max_retries_on_rate_limit,
         is_rate_limited=is_rate_limited,
-            repeatable=repeatable,
     )
     if not isinstance(raw, dict):
         raise Exception("Expected JSON response to validate into a Pydantic model, got non-JSON (binary or text).")
@@ -264,7 +263,6 @@ async def sync_op_raw(
     max_retries_on_rate_limit: int = 16,
     is_rate_limited: Callable[[int, Any], bool] | None = None,
     response_header_validator: Callable[[dict[str, str]], None] | None = None,
-    repeatable: bool = False,
 ) -> dict[str, Any] | bytes:
     """
     Make a single network request.
@@ -272,6 +270,52 @@ async def sync_op_raw(
       - If as_binary=True: returns bytes.
       - response_header_validator: optional callback receiving response headers dict
     """
+    cfg = _request_config(
+        cls,
+        endpoint,
+        price_extractor=price_extractor,
+        data=data,
+        files=files,
+        content_type=content_type,
+        timeout=timeout,
+        multipart_parser=multipart_parser,
+        max_retries=max_retries,
+        retry_delay=retry_delay,
+        retry_backoff=retry_backoff,
+        wait_label=wait_label,
+        estimated_duration=estimated_duration,
+        final_label_on_success=final_label_on_success,
+        progress_origin_ts=progress_origin_ts,
+        monitor_progress=monitor_progress,
+        max_retries_on_rate_limit=max_retries_on_rate_limit,
+        is_rate_limited=is_rate_limited,
+        response_header_validator=response_header_validator,
+    )
+    return await _request_base(cfg, expect_binary=as_binary)
+
+
+def _request_config(
+    cls: type[IO.ComfyNode],
+    endpoint: ApiEndpoint,
+    *,
+    price_extractor: Callable[[dict[str, Any]], float | None] | None = None,
+    data: dict[str, Any] | BaseModel | None = None,
+    files: dict[str, Any] | list[tuple[str, Any]] | None = None,
+    content_type: str = "application/json",
+    timeout: float = 3600.0,
+    multipart_parser: Callable | None = None,
+    max_retries: int = 3,
+    retry_delay: float = 1.0,
+    retry_backoff: float = 2.0,
+    wait_label: str = "Waiting for server",
+    estimated_duration: int | None = None,
+    final_label_on_success: str | None = "Completed",
+    progress_origin_ts: float | None = None,
+    monitor_progress: bool = True,
+    max_retries_on_rate_limit: int = 16,
+    is_rate_limited: Callable[[int, Any], bool] | None = None,
+    response_header_validator: Callable[[dict[str, str]], None] | None = None,
+) -> _RequestConfig:
     if isinstance(data, BaseModel):
         data = data.model_dump(exclude_none=True)
         for k, v in list(data.items()):
@@ -297,9 +341,8 @@ async def sync_op_raw(
         max_retries_on_rate_limit=max_retries_on_rate_limit,
         is_rate_limited=is_rate_limited,
         response_header_validator=response_header_validator,
-        repeatable=repeatable,
     )
-    return await _request_base(cfg, expect_binary=as_binary)
+    return cfg
 
 
 async def poll_op_raw(
@@ -372,7 +415,7 @@ async def poll_op_raw(
     try:
         while consumed_attempts < max_poll_attempts:
             try:
-                resp_json = await sync_op_raw(
+                poll_cfg = _request_config(
                     cls,
                     poll_endpoint,
                     data=data,
@@ -382,11 +425,11 @@ async def poll_op_raw(
                     retry_backoff=retry_backoff_per_poll,
                     wait_label="Checking",
                     estimated_duration=None,
-                    as_binary=False,
                     final_label_on_success=None,
                     monitor_progress=False,
-                    repeatable=True,
                 )
+                poll_cfg.resend_is_free = True  # a status poll only reads
+                resp_json = await _request_base(poll_cfg, expect_binary=False)
                 if not isinstance(resp_json, dict):
                     raise Exception("Polling endpoint returned non-JSON response.")
             except ProcessingInterrupted:
@@ -936,7 +979,7 @@ async def _request_base(cfg: _RequestConfig, expect_binary: bool):
             logging.debug("Polling was interrupted by user")
             raise
         except (ClientError, OSError) as e:
-            retryable = _connection_error_is_retryable(method, e, cfg.repeatable)
+            retryable = _connection_error_is_retryable(method, e, cfg.resend_is_free)
             if retryable and (attempt - rate_limit_attempts) <= cfg.max_retries:
                 logging.warning(
                     "Connection error calling %s %s. Retrying in %.2fs (%d/%d): %s",

--- a/comfy_api_nodes/util/client.py
+++ b/comfy_api_nodes/util/client.py
@@ -71,6 +71,7 @@ class _RequestConfig:
     price_extractor: Callable[[dict[str, Any]], float | None] | None = None
     is_rate_limited: Callable[[int, Any], bool] | None = None
     response_header_validator: Callable[[dict[str, str]], None] | None = None
+    repeatable: bool = False
 
 
 @dataclass
@@ -89,7 +90,7 @@ _RETRY_STATUS = {408, 500, 502, 503, 504}  # status 429 is handled separately
 _SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
 
 
-def _connection_error_is_retryable(method: str, err: BaseException) -> bool:
+def _connection_error_is_retryable(method: str, err: BaseException, repeatable: bool = False) -> bool:
     """Whether repeating ``method`` after ``err`` is free or can charge the user twice.
 
     Repeating a GET costs nothing. Repeating a POST is a second submission, and on a
@@ -97,8 +98,12 @@ def _connection_error_is_retryable(method: str, err: BaseException) -> bool:
     request it accepts, so a request the server already received must not be sent
     again. ClientConnectorError (and its DNS, proxy and TLS subclasses) is raised
     before the request is written, so it stays retryable for every method.
+
+    ``repeatable`` is the caller's statement that this particular request has no
+    side effect worth paying for twice -- a status poll, or an upload URL request --
+    which is the case for a POST that only reads.
     """
-    if method.upper() in _SAFE_METHODS:
+    if repeatable or method.upper() in _SAFE_METHODS:
         return True
     return isinstance(err, aiohttp.ClientConnectorError)
 
@@ -155,6 +160,7 @@ async def sync_op(
     monitor_progress: bool = True,
     max_retries_on_rate_limit: int = 16,
     is_rate_limited: Callable[[int, Any], bool] | None = None,
+    repeatable: bool = False,
 ) -> M:
     raw = await sync_op_raw(
         cls,
@@ -176,6 +182,7 @@ async def sync_op(
         monitor_progress=monitor_progress,
         max_retries_on_rate_limit=max_retries_on_rate_limit,
         is_rate_limited=is_rate_limited,
+            repeatable=repeatable,
     )
     if not isinstance(raw, dict):
         raise Exception("Expected JSON response to validate into a Pydantic model, got non-JSON (binary or text).")
@@ -253,6 +260,7 @@ async def sync_op_raw(
     max_retries_on_rate_limit: int = 16,
     is_rate_limited: Callable[[int, Any], bool] | None = None,
     response_header_validator: Callable[[dict[str, str]], None] | None = None,
+    repeatable: bool = False,
 ) -> dict[str, Any] | bytes:
     """
     Make a single network request.
@@ -285,6 +293,7 @@ async def sync_op_raw(
         max_retries_on_rate_limit=max_retries_on_rate_limit,
         is_rate_limited=is_rate_limited,
         response_header_validator=response_header_validator,
+        repeatable=repeatable,
     )
     return await _request_base(cfg, expect_binary=as_binary)
 
@@ -372,6 +381,7 @@ async def poll_op_raw(
                     as_binary=False,
                     final_label_on_success=None,
                     monitor_progress=False,
+                    repeatable=True,
                 )
                 if not isinstance(resp_json, dict):
                     raise Exception("Polling endpoint returned non-JSON response.")
@@ -922,7 +932,9 @@ async def _request_base(cfg: _RequestConfig, expect_binary: bool):
             logging.debug("Polling was interrupted by user")
             raise
         except (ClientError, OSError) as e:
-            if (attempt - rate_limit_attempts) <= cfg.max_retries and _connection_error_is_retryable(method, e):
+            if (attempt - rate_limit_attempts) <= cfg.max_retries and _connection_error_is_retryable(
+                method, e, cfg.repeatable
+            ):
                 logging.warning(
                     "Connection error calling %s %s. Retrying in %.2fs (%d/%d): %s",
                     method,

--- a/comfy_api_nodes/util/client.py
+++ b/comfy_api_nodes/util/client.py
@@ -88,6 +88,10 @@ class _PollUIState:
 _RETRY_STATUS = {408, 500, 502, 503, 504}  # status 429 is handled separately
 
 _SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+# Failures aiohttp raises before any request byte is written: DNS, TCP connect, TLS,
+# proxy (all ClientConnectorError subclasses) and the connect-phase timeout. Every
+# other ClientError means the server may have taken the request.
+_RAISED_BEFORE_SEND = (aiohttp.ClientConnectorError, aiohttp.ConnectionTimeoutError)
 
 
 def _connection_error_is_retryable(method: str, err: BaseException, repeatable: bool = False) -> bool:
@@ -105,7 +109,7 @@ def _connection_error_is_retryable(method: str, err: BaseException, repeatable: 
     """
     if repeatable or method.upper() in _SAFE_METHODS:
         return True
-    return isinstance(err, aiohttp.ClientConnectorError)
+    return isinstance(err, _RAISED_BEFORE_SEND)
 
 _MAX_RETRY_AFTER_WAIT = 150.0  # Cap a server Retry-After at this many seconds so a large hint can't block execution
 
@@ -932,9 +936,8 @@ async def _request_base(cfg: _RequestConfig, expect_binary: bool):
             logging.debug("Polling was interrupted by user")
             raise
         except (ClientError, OSError) as e:
-            if (attempt - rate_limit_attempts) <= cfg.max_retries and _connection_error_is_retryable(
-                method, e, cfg.repeatable
-            ):
+            retryable = _connection_error_is_retryable(method, e, cfg.repeatable)
+            if retryable and (attempt - rate_limit_attempts) <= cfg.max_retries:
                 logging.warning(
                     "Connection error calling %s %s. Retrying in %.2fs (%d/%d): %s",
                     method,
@@ -963,6 +966,21 @@ async def _request_base(cfg: _RequestConfig, expect_binary: bool):
                 )
                 delay *= cfg.retry_backoff
                 continue
+            if not retryable:
+                request_logger.log_request_response(
+                    operation_id=operation_id,
+                    request_method=method,
+                    request_url=url,
+                    request_headers=dict(payload_headers) if payload_headers else None,
+                    request_params=dict(params) if params else None,
+                    request_data=request_body_log,
+                    error_message=f"{type(e).__name__}: {str(e)} (not retried: the request had been sent)",
+                )
+                raise ApiServerError(
+                    f"The connection to {default_base_url()} dropped after the request was sent. "
+                    "It was not sent again, because the provider may already have run and billed it. "
+                    "Check your usage history before trying again."
+                ) from e
             diag = await _diagnose_connectivity()
             if not diag["internet_accessible"]:
                 request_logger.log_request_response(

--- a/comfy_api_nodes/util/client.py
+++ b/comfy_api_nodes/util/client.py
@@ -85,6 +85,23 @@ class _PollUIState:
 
 
 _RETRY_STATUS = {408, 500, 502, 503, 504}  # status 429 is handled separately
+
+_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+
+
+def _connection_error_is_retryable(method: str, err: BaseException) -> bool:
+    """Whether repeating ``method`` after ``err`` is free or can charge the user twice.
+
+    Repeating a GET costs nothing. Repeating a POST is a second submission, and on a
+    proxied partner call that is a second paid generation: the provider bills every
+    request it accepts, so a request the server already received must not be sent
+    again. ClientConnectorError (and its DNS, proxy and TLS subclasses) is raised
+    before the request is written, so it stays retryable for every method.
+    """
+    if method.upper() in _SAFE_METHODS:
+        return True
+    return isinstance(err, aiohttp.ClientConnectorError)
+
 _MAX_RETRY_AFTER_WAIT = 150.0  # Cap a server Retry-After at this many seconds so a large hint can't block execution
 
 PRICE_CREDITS_HEADER = "X-Comfy-Credits-Used"
@@ -905,7 +922,7 @@ async def _request_base(cfg: _RequestConfig, expect_binary: bool):
             logging.debug("Polling was interrupted by user")
             raise
         except (ClientError, OSError) as e:
-            if (attempt - rate_limit_attempts) <= cfg.max_retries:
+            if (attempt - rate_limit_attempts) <= cfg.max_retries and _connection_error_is_retryable(method, e):
                 logging.warning(
                     "Connection error calling %s %s. Retrying in %.2fs (%d/%d): %s",
                     method,

--- a/comfy_api_nodes/util/upload_helpers.py
+++ b/comfy_api_nodes/util/upload_helpers.py
@@ -212,7 +212,6 @@ async def upload_file_to_comfyapi(
         response_model=UploadResponse,
         final_label_on_success=None,
         monitor_progress=False,
-        repeatable=True,  # mints an upload URL; nothing is charged for asking twice
     )
     await upload_file(
         cls,

--- a/comfy_api_nodes/util/upload_helpers.py
+++ b/comfy_api_nodes/util/upload_helpers.py
@@ -207,7 +207,8 @@ async def upload_file_to_comfyapi(
         request_object = UploadRequest(file_name=filename, content_type=upload_mime_type)
     create_resp = await sync_op(
         cls,
-        endpoint=ApiEndpoint(path="/customers/storage", method="POST"),
+        # Asks for an upload URL; nothing is billed, so asking twice is harmless.
+        endpoint=ApiEndpoint(path="/customers/storage", method="POST", idempotent=True),
         data=request_object,
         response_model=UploadResponse,
         final_label_on_success=None,

--- a/comfy_api_nodes/util/upload_helpers.py
+++ b/comfy_api_nodes/util/upload_helpers.py
@@ -212,6 +212,7 @@ async def upload_file_to_comfyapi(
         response_model=UploadResponse,
         final_label_on_success=None,
         monitor_progress=False,
+        repeatable=True,  # mints an upload URL; nothing is charged for asking twice
     )
     await upload_file(
         cls,

--- a/tests-unit/comfy_api_nodes_test/client_retry_test.py
+++ b/tests-unit/comfy_api_nodes_test/client_retry_test.py
@@ -1,7 +1,7 @@
 import aiohttp
 import pytest
 
-from comfy_api_nodes.util.client import _connection_error_is_retryable
+from comfy_api_nodes.util.client import ApiEndpoint, _connection_error_is_retryable
 
 
 class _ConnectorError(aiohttp.ClientConnectorError):
@@ -11,35 +11,36 @@ class _ConnectorError(aiohttp.ClientConnectorError):
         pass
 
 
-@pytest.mark.parametrize("method", ["GET", "get", "HEAD", "OPTIONS"])
+def _ep(method, idempotent=None):
+    return ApiEndpoint("/proxy/x", method, idempotent=idempotent)
+
+
+@pytest.mark.parametrize("method", ["GET", "HEAD", "OPTIONS"])
 def test_safe_methods_retry_any_connection_error(method):
-    assert _connection_error_is_retryable(method, aiohttp.ServerDisconnectedError())
-    assert _connection_error_is_retryable(method, _ConnectorError())
+    assert _connection_error_is_retryable(_ep(method), aiohttp.ServerDisconnectedError())
+    assert _connection_error_is_retryable(_ep(method), _ConnectorError())
 
 
-@pytest.mark.parametrize("method", ["POST", "post", "PUT", "PATCH", "DELETE"])
-def test_unsafe_methods_do_not_repeat_a_request_the_server_received(method):
+@pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE"])
+def test_submissions_are_not_resent_once_the_server_may_have_them(method):
     # The server closed the connection after taking the request: the partner may
-    # already be generating, and a retry is a second charge.
-    assert not _connection_error_is_retryable(method, aiohttp.ServerDisconnectedError())
-    assert not _connection_error_is_retryable(method, aiohttp.ClientOSError("broken pipe"))
+    # already be generating, and a resend is a second charge.
+    assert not _connection_error_is_retryable(_ep(method), aiohttp.ServerDisconnectedError())
+    assert not _connection_error_is_retryable(_ep(method), aiohttp.ClientOSError("broken pipe"))
+    assert not _connection_error_is_retryable(_ep(method), aiohttp.SocketTimeoutError())
+    assert not _connection_error_is_retryable(_ep(method), aiohttp.ClientPayloadError("truncated body"))
 
 
 @pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE"])
-def test_unsafe_methods_still_retry_when_the_request_was_never_sent(method):
-    assert _connection_error_is_retryable(method, _ConnectorError())
-    assert _connection_error_is_retryable(method, aiohttp.ConnectionTimeoutError())
+def test_submissions_still_retry_when_the_request_was_never_sent(method):
+    assert _connection_error_is_retryable(_ep(method), _ConnectorError())
+    assert _connection_error_is_retryable(_ep(method), aiohttp.ConnectionTimeoutError())
 
 
-@pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE"])
-def test_a_read_timeout_after_send_is_not_repeated(method):
-    # sock_read timed out: the request was written, the provider may be running it.
-    assert not _connection_error_is_retryable(method, aiohttp.SocketTimeoutError())
-    assert not _connection_error_is_retryable(method, aiohttp.ClientPayloadError("truncated body"))
+def test_an_endpoint_declared_idempotent_keeps_retrying():
+    # A status poll that happens to use POST: resending it is free.
+    assert _connection_error_is_retryable(_ep("POST", idempotent=True), aiohttp.ServerDisconnectedError())
 
 
-@pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE"])
-def test_a_status_poll_keeps_retrying(method):
-    # The poll loop marks its requests: a status read costs nothing to send again.
-    assert _connection_error_is_retryable(method, aiohttp.ServerDisconnectedError(), resend_is_free=True)
-    assert _connection_error_is_retryable(method, aiohttp.ClientOSError("broken pipe"), resend_is_free=True)
+def test_an_endpoint_declared_non_idempotent_is_guarded_whatever_its_method():
+    assert not _connection_error_is_retryable(_ep("GET", idempotent=False), aiohttp.ServerDisconnectedError())

--- a/tests-unit/comfy_api_nodes_test/client_retry_test.py
+++ b/tests-unit/comfy_api_nodes_test/client_retry_test.py
@@ -28,3 +28,11 @@ def test_unsafe_methods_do_not_repeat_a_request_the_server_received(method):
 @pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE"])
 def test_unsafe_methods_still_retry_when_the_request_was_never_sent(method):
     assert _connection_error_is_retryable(method, _ConnectorError())
+
+
+@pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE"])
+def test_a_repeatable_call_keeps_retrying(method):
+    # Status polls and the upload-URL request cost nothing to repeat, so they keep
+    # the retry the paid submits give up.
+    assert _connection_error_is_retryable(method, aiohttp.ServerDisconnectedError(), repeatable=True)
+    assert _connection_error_is_retryable(method, aiohttp.ClientOSError("broken pipe"), repeatable=True)

--- a/tests-unit/comfy_api_nodes_test/client_retry_test.py
+++ b/tests-unit/comfy_api_nodes_test/client_retry_test.py
@@ -1,0 +1,30 @@
+import aiohttp
+import pytest
+
+from comfy_api_nodes.util.client import _connection_error_is_retryable
+
+
+class _ConnectorError(aiohttp.ClientConnectorError):
+    """A ClientConnectorError without aiohttp's version-specific ConnectionKey."""
+
+    def __init__(self):  # noqa: D107 - the base __init__ needs internals we don't test
+        pass
+
+
+@pytest.mark.parametrize("method", ["GET", "get", "HEAD", "OPTIONS"])
+def test_safe_methods_retry_any_connection_error(method):
+    assert _connection_error_is_retryable(method, aiohttp.ServerDisconnectedError())
+    assert _connection_error_is_retryable(method, _ConnectorError())
+
+
+@pytest.mark.parametrize("method", ["POST", "post", "PUT", "PATCH", "DELETE"])
+def test_unsafe_methods_do_not_repeat_a_request_the_server_received(method):
+    # The server closed the connection after taking the request: the partner may
+    # already be generating, and a retry is a second charge.
+    assert not _connection_error_is_retryable(method, aiohttp.ServerDisconnectedError())
+    assert not _connection_error_is_retryable(method, aiohttp.ClientOSError("broken pipe"))
+
+
+@pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE"])
+def test_unsafe_methods_still_retry_when_the_request_was_never_sent(method):
+    assert _connection_error_is_retryable(method, _ConnectorError())

--- a/tests-unit/comfy_api_nodes_test/client_retry_test.py
+++ b/tests-unit/comfy_api_nodes_test/client_retry_test.py
@@ -39,8 +39,7 @@ def test_a_read_timeout_after_send_is_not_repeated(method):
 
 
 @pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE"])
-def test_a_repeatable_call_keeps_retrying(method):
-    # Status polls and the upload-URL request cost nothing to repeat, so they keep
-    # the retry the paid submits give up.
-    assert _connection_error_is_retryable(method, aiohttp.ServerDisconnectedError(), repeatable=True)
-    assert _connection_error_is_retryable(method, aiohttp.ClientOSError("broken pipe"), repeatable=True)
+def test_a_status_poll_keeps_retrying(method):
+    # The poll loop marks its requests: a status read costs nothing to send again.
+    assert _connection_error_is_retryable(method, aiohttp.ServerDisconnectedError(), resend_is_free=True)
+    assert _connection_error_is_retryable(method, aiohttp.ClientOSError("broken pipe"), resend_is_free=True)

--- a/tests-unit/comfy_api_nodes_test/client_retry_test.py
+++ b/tests-unit/comfy_api_nodes_test/client_retry_test.py
@@ -28,6 +28,14 @@ def test_unsafe_methods_do_not_repeat_a_request_the_server_received(method):
 @pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE"])
 def test_unsafe_methods_still_retry_when_the_request_was_never_sent(method):
     assert _connection_error_is_retryable(method, _ConnectorError())
+    assert _connection_error_is_retryable(method, aiohttp.ConnectionTimeoutError())
+
+
+@pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE"])
+def test_a_read_timeout_after_send_is_not_repeated(method):
+    # sock_read timed out: the request was written, the provider may be running it.
+    assert not _connection_error_is_retryable(method, aiohttp.SocketTimeoutError())
+    assert not _connection_error_is_retryable(method, aiohttp.ClientPayloadError("truncated body"))
 
 
 @pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE"])


### PR DESCRIPTION
## Problem

`_request_base` retries any `aiohttp.ClientError` up to `max_retries` (default 3). `ServerDisconnectedError` is a `ClientError`, and it means the request *did* reach api.comfy.org. Partner providers bill every request they accept, so each retry of a submission is a second paid generation, with no idempotency key to collapse them.

Measured in prod on Seedream 5.0 Pro, one user action (job `3b8b9c34-...`, 2026-09-09):

- four submissions, 61.2 / 62.1 / 64.1 s apart — one constant ~60.1 s connection failure plus this file's 1 s / 2 s / 4 s backoff
- all four generations completed on the provider (85-87 s each) and all four were billed, 9.5 credits each
- the user received no image

Seven days across all users: 732 retry-shaped resubmissions from 59 people, 426 of them billed. It lands on Seedream 5.0 Pro because 34% of its generations take longer than 60 s while 4.5 and Lite finish inside it. Tracked as BE-12911.

## Change

`ApiEndpoint` gains `idempotent: bool | None = None`: whether sending the request twice is harmless. `None` means decide by method — `GET`/`HEAD`/`OPTIONS` are, anything else is not.

A connection failure is retried only when resending is harmless:

- Idempotent endpoints — unchanged, still retried on any connection error.
- Everything else — retried only for failures raised before the request is written (`ClientConnectorError` and its DNS/TLS/proxy subclasses, and the connect-phase timeout). A disconnect, reset, read timeout or truncated body after that is not resent, because the provider may already be running and billing the request.

`poll_op_raw` marks its status endpoint idempotent once before polling, so every poller keeps mid-flight retry whatever verb the provider chose (Veo, HitPaw, Hunyuan3D and Rodin poll with POST). The byte upload is unaffected (it uses its own session); the `/customers/storage` request in front of it is declared idempotent and keeps its retry.

When a resend is refused, the error says so: the connection dropped while the request was in flight, it was not sent again because the provider may have run and billed it, check usage history before trying again. The old text said the server was unreachable, which was wrong on both counts.

Nothing else moves: status-code retries (408/500/502/503/504), the rate-limit ladder and every timeout are untouched.

The attribute is also the hook for attaching an `Idempotency-Key` to non-idempotent endpoints once the server honours it (follow-up in cloud, reusing `common/idempotency` on the `/proxy/*` routes).

## Known gap

A paid POST that gets 408/500/502/503/504 back is still resent. That is safe when the status came from the provider — the proxy returns those unbilled — and not when an intermediary timed out a request the backend kept running. Closed server-side by the `common/idempotency` follow-up, not here.

Also worth knowing: a paid POST now fails immediately on a dropped connection even though the charge may already have been taken. That is the intended trade-off until the server can refuse a duplicate.

## Tests

`tests-unit/comfy_api_nodes_test/client_retry_test.py`: idempotent endpoints retry any connection error; submissions are not resent once the server may have them (disconnect, reset, read timeout, truncated body); submissions still retry when the request was never sent (connector error, connect timeout); an endpoint declared idempotent keeps retrying whatever its method; one declared non-idempotent is guarded whatever its method.

<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [x] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [x] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [ ] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**