### PR TITLE
Fix V3 node subclasses inheriting the parent's cached schema values

### DIFF
--- a/comfy_api/latest/_io.py
+++ b/comfy_api/latest/_io.py
@@ -1976,6 +1976,22 @@ class _ComfyNodeBaseInternal(_ComfyNodeInternal):
     # filled in during execution
     hidden: HiddenHolder = None
 
+    # filled in by GET_SCHEMA per node class
+    _SCHEMA_CACHE_ATTRS = (
+        "SCHEMA", "_DESCRIPTION", "_CATEGORY", "_EXPERIMENTAL", "_DEPRECATED", "_DEV_ONLY", "_API_NODE",
+        "_OUTPUT_NODE", "_HAS_INTERMEDIATE_OUTPUT", "_INPUT_IS_LIST", "_OUTPUT_IS_LIST", "_RETURN_TYPES",
+        "_RETURN_NAMES", "_OUTPUT_TOOLTIPS", "_NOT_IDEMPOTENT", "_ACCEPT_ALL_INPUTS",
+    )
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        # A subclass must not inherit the values GET_SCHEMA computed for its parent, otherwise the
+        # `is None` guards never fire and it keeps the parent's RETURN_TYPES etc. Class clones copy
+        # the parent's __dict__ on purpose, so only reset what the new class does not define itself.
+        for name in cls._SCHEMA_CACHE_ATTRS:
+            if name not in cls.__dict__:
+                setattr(cls, name, None)
+
     @classmethod
     @abstractmethod
     def define_schema(cls) -> Schema:

--- a/tests-unit/comfy_api_test/node_schema_cache_test.py
+++ b/tests-unit/comfy_api_test/node_schema_cache_test.py
@@ -1,0 +1,48 @@
+from comfy_api.latest import io
+
+
+class ParentNode(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="SchemaCacheParent",
+            category="test",
+            inputs=[],
+            outputs=[io.Conditioning.Output(), io.Latent.Output()],
+        )
+
+    @classmethod
+    def execute(cls):
+        return io.NodeOutput(None, None)
+
+
+class ChildNode(ParentNode):
+    @classmethod
+    def define_schema(cls):
+        schema = super().define_schema()
+        schema.node_id = "SchemaCacheChild"
+        schema.is_output_node = True
+        schema.outputs.insert(0, io.Model.Output(display_name="model"))
+        return schema
+
+
+def test_subclass_does_not_inherit_parent_schema_cache():
+    # schema the parent first, as node registration does
+    assert ParentNode.RETURN_TYPES == ["CONDITIONING", "LATENT"]
+    assert ParentNode.OUTPUT_NODE is False
+
+    assert ChildNode.RETURN_TYPES == ["MODEL", "CONDITIONING", "LATENT"]
+    assert ChildNode.RETURN_NAMES == ["model", "CONDITIONING", "LATENT"]
+    assert ChildNode.OUTPUT_NODE is True
+    assert ChildNode.SCHEMA.node_id == "SchemaCacheChild"
+
+    assert ParentNode.RETURN_TYPES == ["CONDITIONING", "LATENT"]
+    assert ParentNode.SCHEMA.node_id == "SchemaCacheParent"
+
+
+def test_class_clone_keeps_schema_cache():
+    ParentNode.GET_SCHEMA()
+    clone = ParentNode.PREPARE_CLASS_CLONE(None)
+
+    assert clone.__dict__["_RETURN_TYPES"] is ParentNode.RETURN_TYPES
+    assert clone.__dict__["SCHEMA"] is ParentNode.SCHEMA


### PR DESCRIPTION
Fixes #16132
Fixes #16026 (same bug, reported for `OUTPUT_IS_LIST`)

**Problem:** The `_RETURN_TYPES`, `_RETURN_NAMES`, `_OUTPUT_NODE`, … sentinels on `_ComfyNodeBaseInternal` are plain class attributes. Once a parent V3 node has been schema'd (registration does this), every subclass inherits the populated values, so the `is None` guards in `GET_SCHEMA()` never fire for the subclass. A subclass that overrides `define_schema()` to change its outputs keeps the parent's `RETURN_TYPES` while `SCHEMA` (assigned unconditionally) is correct, and output validation in `execution.py` then indexes the stale tuple.

**Change:** `_ComfyNodeBaseInternal.__init_subclass__` resets the cached values on every new subclass. `shallow_clone_class` / `copy_class` / `lock_class` build the clone namespace from the parent's `__dict__` on purpose, so attributes the new class already carries in its own `__dict__` are left untouched and clones keep the cached schema (no extra `GET_SCHEMA` per execution).

**Tests:** `tests-unit/comfy_api_test/node_schema_cache_test.py` covers the parent/child case from the issue and asserts that a class clone keeps the parent's cache. The first test fails on master and passes with this change.

```
pytest tests-unit/comfy_api_test tests-unit/nodes_test tests-unit/comfy_extras_test tests-unit/execution_test tests-unit/comfy_api_nodes_test tests-unit/prompt_server_test
797 passed, 2 skipped
```

**Related:** #16058 addresses #16026 by changing every `is None` guard to `cls.__dict__.get(...)`. This PR takes the smaller route of resetting the caches once per subclass in `__init_subclass__`, so the guards and the clone behaviour stay as they are. Happy to close either one depending on which approach is preferred.

On the design question raised in #16026 ("should this class be prohibited from being inherited?"): with the reset in `__init_subclass__` the cache is class-local by construction, so subclassing a V3 node keeps working (the reporter's own `EmptyImage2(EmptyImage1)` case relies on it) without any per-property inheritance checks.
