### PR TITLE
Fix hook patching crashing on quantized models

### DIFF
--- a/comfy/model_patcher.py
+++ b/comfy/model_patcher.py
@@ -231,7 +231,11 @@ def get_key_weight(model, key):
         except AttributeError:
             pass
 
-        weight = getattr(op, op_keys[1])
+        try:
+            weight = getattr(op, op_keys[1])
+        except AttributeError:
+            # quantized ops list their scale/metadata tensors in the state dict without exposing them as attributes
+            weight = None
         if convert_func is not None:
             weight = comfy.utils.get_attr(model, key)
 

--- a/tests-unit/comfy_test/model_patcher_key_weight_test.py
+++ b/tests-unit/comfy_test/model_patcher_key_weight_test.py
@@ -1,0 +1,39 @@
+import torch
+
+from comfy.cli_args import args
+
+if not torch.cuda.is_available():
+    args.cpu = True
+
+from comfy.model_patcher import ModelPatcher, get_key_weight
+
+
+class QuantizedLikeLinear(torch.nn.Linear):
+    """Lists a scale tensor in the state dict without exposing it as an attribute, like the quantized ops do."""
+
+    def state_dict(self, *args, destination=None, prefix="", **kwargs):
+        sd = super().state_dict(*args, destination=destination, prefix=prefix, **kwargs)
+        sd[f"{prefix}weight_scale"] = torch.ones(1)
+        return sd
+
+
+def _model():
+    return torch.nn.Sequential(QuantizedLikeLinear(2, 2), torch.nn.Linear(2, 2))
+
+
+def test_get_key_weight_returns_none_for_state_dict_only_keys():
+    model = _model()
+
+    assert get_key_weight(model, "0.weight")[0] is model[0].weight
+    assert get_key_weight(model, "0.weight_scale") == (None, None, None)
+
+
+def test_get_key_patches_includes_state_dict_only_keys():
+    model = _model()
+    patcher = ModelPatcher(model, load_device=torch.device("cpu"), offload_device=torch.device("cpu"))
+
+    patches = patcher.get_key_patches()
+
+    assert patches["0.weight"][0][0] is model[0].weight
+    assert patches["1.weight"][0][0] is model[1].weight
+    assert patches["0.weight_scale"][0][0] is None


### PR DESCRIPTION
Fixes #16164

**Problem:** `patch_hooks()` snapshots every weight via `get_key_patches()`, which iterates the full `model.state_dict()`. For quantized ops the state dict also contains the `QuantizedTensor` sidecar entries (`*.weight_scale`, `*.weight_scale_2`, `*.comfy_quant`, …) that are not attributes of the module, so `get_key_weight()` raised `AttributeError` on the first of them and applying a hook-based patch (regional / masked LoRA, hook scheduling) to a mixed-precision or otherwise quantized model crashed on the first sampling step.

**Change:** `get_key_weight()` returns `None` as the weight when the module has no such attribute, the same way its `set_*` / `convert_*` lookups two lines above already fail soft, and the same `weight is None` outcome `_load_list` already handles for missing biases. `get_key_patches()` keeps an entry for the sidecar key with a `None` weight; the hook path only ever reads `original_weights[key]` for keys in its own combined patches, which are validated against the model keys first.

**Tests:** `tests-unit/comfy_test/model_patcher_key_weight_test.py` uses a `Linear` whose `state_dict()` lists a `weight_scale` entry and checks `get_key_weight` and `ModelPatcher.get_key_patches`. Both tests fail on master with the `AttributeError` from the issue and pass with this change.

```
pytest tests-unit/comfy_test tests-unit/comfy_quant
157 passed
```
