### PR TITLE
Fix Lanczos mask resizing losing the channel dimension

### DIFF
--- a/comfy/utils.py
+++ b/comfy/utils.py
@@ -1093,6 +1093,7 @@ def bislerp(samples, width, height):
     return result.to(orig_dtype)
 
 def lanczos(samples, width, height):
+    orig_ndim = samples.ndim
     #the below API is strict and expects grayscale to be squeezed
     if samples.ndim == 4:
         samples = samples.squeeze(1) if samples.shape[1] == 1 else samples.movedim(1, -1)
@@ -1100,6 +1101,8 @@ def lanczos(samples, width, height):
     images = [image.resize((width, height), resample=Image.Resampling.LANCZOS) for image in images]
     images = [torch.from_numpy(t).movedim(-1, 0) if (t := np.array(image).astype(np.float32) / 255.0).ndim == 3 else torch.from_numpy(t) for image in images]
     result = torch.stack(images)
+    if orig_ndim == 4 and result.ndim == 3:
+        result = result.unsqueeze(1)
     return result.to(samples.device, samples.dtype)
 
 def common_upscale(samples, width, height, upscale_method, crop):

--- a/tests-unit/comfy_extras_test/image_resize_lanczos_test.py
+++ b/tests-unit/comfy_extras_test/image_resize_lanczos_test.py
@@ -1,0 +1,55 @@
+import pytest
+import torch
+
+from comfy.cli_args import args as cli_args
+
+if not torch.cuda.is_available():
+    cli_args.cpu = True
+
+from comfy.utils import common_upscale, lanczos
+from comfy_extras.nodes_mask import MaskToImage
+from comfy_extras.nodes_post_processing import ResizeImageMaskNode, ResizeType
+
+
+@pytest.mark.parametrize("channels", [1, 3, 4])
+@pytest.mark.parametrize("height,width", [(1, 9), (5, 1), (5, 9)])
+def test_lanczos_preserves_channels_and_batch(channels, height, width):
+    samples = torch.zeros(2, channels, 8, 16)
+    samples[1] = 1
+
+    result = common_upscale(samples, width, height, "lanczos", "disabled")
+
+    assert result.shape == (2, channels, height, width)
+    assert torch.equal(result[0], torch.zeros_like(result[0]))
+    assert torch.equal(result[1], torch.ones_like(result[1]))
+    assert result.dtype == samples.dtype
+    assert result.device == samples.device
+
+
+@pytest.mark.parametrize("batch", [1, 2])
+@pytest.mark.parametrize("height,width", [(1, 9), (5, 1), (5, 9)])
+def test_lanczos_resized_mask_converts_to_image(batch, height, width):
+    mask = torch.zeros(batch, 8, 16)
+    mask[-1] = 1
+
+    resized = ResizeImageMaskNode.execute(mask, "lanczos", {
+        "resize_type": ResizeType.SCALE_DIMENSIONS,
+        "width": width,
+        "height": height,
+        "crop": "disabled",
+    }).result[0]
+
+    assert resized.shape == (batch, height, width)
+    image = MaskToImage.execute(resized).result[0]
+    assert image.shape == (batch, height, width, 3)
+    assert torch.equal(image, mask[:, :1, :1, None].expand_as(image))
+
+
+def test_lanczos_preserves_three_dimensional_input():
+    samples = torch.ones(2, 8, 16, dtype=torch.float16)
+
+    result = lanczos(samples, 9, 1)
+
+    assert result.shape == (2, 1, 9)
+    assert result.dtype == samples.dtype
+    assert torch.equal(result, torch.ones_like(result))


### PR DESCRIPTION
Lanczos resizing drops the channel dimension for single-channel tensors. Resizing a mask batch to one row then makes Convert Mask to Image combine the batch into one image. Restore the channel axis when the input has one.

Fixes #16208.

Tested: 46 CPU tests covering resize, blend and invert nodes.