### PR TITLE
Track numerical backend history for Model Sparse Attention

### DIFF
--- a/comfy_extras/nodes_sparse_attention.py
+++ b/comfy_extras/nodes_sparse_attention.py
@@ -15,12 +15,22 @@ import comfy.model_prefetch
 import comfy.patcher_extension
 from comfy.ldm.minimax.model import MiniMaxH3Model
 from comfy_api.latest import ComfyExtension, io
+from comfy_extras.sparse_attention_history import (
+    H3_BLOCK_SCOPE,
+    SparseAttentionHistoryPolicy,
+    append_history_receipt,
+    append_scoped_h3_receipt,
+    install_history_policy,
+    mark_attention_override,
+    mark_h3_block_patch,
+)
 
 HEAD_DIM = 128
 BLOCK_SIZE = 64
 PRODUCER_CHUNK = 4096
 VSA_CUBE = (4, 4, 4)
 VSA_PLAN_CACHE = 4
+_MISSING = object()
 
 
 def parse_block_list(text):
@@ -52,6 +62,8 @@ class SparseAttnPatch:
         self.sink_conditioning = sink_conditioning
         self.verbose = verbose
         self.installed = set()    # the override closures this patch has put on the hook
+        self.h3_block_count = None
+        self.history_policy = SparseAttentionHistoryPolicy(self)
         self.reset()
 
     def reset(self):
@@ -180,7 +192,10 @@ def make_attention_override(patch: SparseAttnPatch, previous):
             args = (q, k, v, heads)
             kw = dict(mask=mask, attn_precision=attn_precision, skip_reshape=skip_reshape,
                       skip_output_reshape=skip_output_reshape, **kwargs)
-            return func(*args, **kw) if previous is None else previous(func, *args, **kw)
+            out = func(*args, **kw) if previous is None else previous(func, *args, **kw)
+            tokens = q.shape[2] if skip_reshape else q.shape[1]
+            append_scoped_h3_receipt(transformer_options, patch, "h3_dense", tokens)
+            return out
 
         if mask is not None or patch.vsa:
             return dense()
@@ -207,11 +222,14 @@ def make_attention_override(patch: SparseAttnPatch, previous):
                           sink_blocks=list(sink), sink_q=list(sink_q), topk_ratio=patch.topk_ratio,
                           token_aug=patch.extra_tokens).to(q.dtype)
         patch.log_once(("sparse", tuple(qs.shape)), f"sparse {tuple(qs.shape)}, sinks {sink}/{sink_q}")
+        append_scoped_h3_receipt(
+            transformer_options, patch, "h3_override_sparse", tokens, sink, sink_q
+        )
         if skip_output_reshape:
             return out.transpose(1, 2)
         return out.reshape(b, -1, heads * dim_head)
 
-    return override
+    return mark_attention_override(override, patch, previous)
 
 
 def install_override(patch: SparseAttnPatch, transformer_options):
@@ -304,20 +322,47 @@ def h3_sparse_attention(attn, x, rope_freqs, transformer_options, patch: SparseA
     out = out.view(n, heads * head_dim)
     if plan is not None:
         out = out[plan["inv"]]
-    return attn.out_proj(out)
+    out = attn.out_proj(out)
+    append_history_receipt(
+        transformer_options,
+        patch,
+        block_index,
+        "h3_chunked_sparse_cold" if first else "h3_chunked_sparse_primed",
+        n_tokens,
+        sink,
+        sink_q,
+    )
+    return out
 
 
-def make_h3_block_patch(block, block_index, patch: SparseAttnPatch):
-    """Runs the block with its attention swapped for the sparse producer."""
+def make_h3_block_patch(block, block_index, patch: SparseAttnPatch, previous=None):
+    """Runs the block with its attention swapped for the sparse producer.
+
+    Preserve an existing H3 block replacement rather than overwriting it. The
+    scoped marker lets the generic fallback emit exactly one receipt for this main
+    H3 block while excluding token-refiner or unrelated attention calls.
+    """
     def attention(h, rope_freqs=None, transformer_options={}):
         return h3_sparse_attention(block.attn, h, rope_freqs, transformer_options, patch, block_index)
 
     def block_patch(args, extra):
-        if h3_eligible(block.attn, args["img"], args["rope_freqs"], args["transformer_options"], patch, block_index):
-            args = {**args, "attention": attention}
-        return extra["original_block"](args)
+        transformer_options = args["transformer_options"]
+        old_scope = transformer_options.get(H3_BLOCK_SCOPE, _MISSING)
+        transformer_options[H3_BLOCK_SCOPE] = (patch, block_index)
+        try:
+            call_args = args
+            if h3_eligible(block.attn, args["img"], args["rope_freqs"], transformer_options, patch, block_index):
+                call_args = {**args, "attention": attention}
+            if previous is None:
+                return extra["original_block"](call_args)
+            return previous(call_args, extra)
+        finally:
+            if old_scope is _MISSING:
+                transformer_options.pop(H3_BLOCK_SCOPE, None)
+            else:
+                transformer_options[H3_BLOCK_SCOPE] = old_scope
 
-    return block_patch
+    return mark_h3_block_patch(block_patch, patch, block_index, previous)
 
 
 def apply_block_sparse_attention(model, *, tau, topk_ratio, vsa, start_percent, end_percent, min_tokens,
@@ -334,15 +379,31 @@ def apply_block_sparse_attention(model, *, tau, topk_ratio, vsa, start_percent, 
                             sink_conditioning=sink_conditioning, extra_tokens=extra_tokens, verbose=verbose)
     m = model.clone()
     install_override(patch, m.model_options["transformer_options"])
+    install_history_policy(patch, m.model_options["transformer_options"])
+
+    def prepare_state(model_patcher, timestep, model_options):
+        transformer_options = model_options["transformer_options"]
+        install_override(patch, transformer_options)
+        install_history_policy(patch, transformer_options)
+
     m.add_callback_with_key(comfy.patcher_extension.CallbacksMP.ON_PREPARE_STATE, "block_sparse_attention",
-                            lambda model_patcher, timestep, model_options: install_override(patch, model_options["transformer_options"]))
+                            prepare_state)
     m.add_callback_with_key(comfy.patcher_extension.CallbacksMP.ON_CLEANUP,
                             "block_sparse_attention", lambda model_patcher: patch.reset())
 
     diffusion_model = model.get_model_object("diffusion_model")
     if isinstance(diffusion_model, MiniMaxH3Model):
+        patch.h3_block_count = len(diffusion_model.blocks)
+        previous_blocks = dict(
+            m.model_options.get("transformer_options", {})
+            .get("patches_replace", {})
+            .get("dit", {})
+        )
         for i, block in enumerate(diffusion_model.blocks):
-            m.set_model_patch_replace(make_h3_block_patch(block, i, patch), "dit", "double_block", i)
+            previous = previous_blocks.get(("double_block", i))
+            m.set_model_patch_replace(
+                make_h3_block_patch(block, i, patch, previous), "dit", "double_block", i
+            )
         if vsa and diffusion_model.blocks[0].attn.to_gate_compress is None:
             logging.warning("VSA: the model has no to_gate_compress layers; running the fine stage without the coarse branch")
     elif vsa:

--- a/comfy_extras/sparse_attention_history.py
+++ b/comfy_extras/sparse_attention_history.py
@@ -1,0 +1,276 @@
+"""Numerical-backend history contract for core block-sparse attention.
+
+The contract is intentionally duck-typed: forecast providers such as Spectrum can
+consume it without ComfyUI importing them. A policy describes the numerical route
+that the next MiniMax-H3 transformer evaluation would take; successful actual
+calls append receipts that confirm the route that really executed.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+POLICIES_KEY = "attention_backend_history_v1"
+RECEIPTS_KEY = "attention_backend_receipts_v1"
+PROVIDER_KEY = "comfy_core_block_sparse_attention"
+CONTRACT_VERSION = 1
+H3_BLOCK_SCOPE = "_block_sparse_attention_h3_block_v1"
+
+_ALLOWED_ROUTES = {
+    "h3_dense",
+    "h3_override_sparse",
+    "h3_chunked_sparse_cold",
+    "h3_chunked_sparse_primed",
+}
+
+
+def _freeze(value):
+    """Turn small runtime/config values into a stable hashable identity."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return tuple(sorted((str(key), _freeze(item)) for key, item in value.items()))
+    if isinstance(value, (tuple, list)):
+        return tuple(_freeze(item) for item in value)
+    if isinstance(value, (set, frozenset)):
+        return tuple(sorted((_freeze(item) for item in value), key=repr))
+    return repr(value)
+
+
+def _callable_identity(function):
+    if function is None:
+        return ("comfy.default",)
+    function = getattr(function, "__func__", function)
+    return (
+        str(getattr(function, "__module__", "<unknown>")),
+        str(getattr(function, "__qualname__", type(function).__name__)),
+        id(function),
+    )
+
+
+def _attention_provider_identity(provider):
+    """Describe an inherited dense provider plus explicit preprocessing chain."""
+    transforms = []
+    seen = set()
+    while hasattr(provider, "attention_preprocess_v1"):
+        if id(provider) in seen:
+            return ("cyclic_preprocess", id(provider))
+        seen.add(id(provider))
+        contract = provider.attention_preprocess_v1
+        if not isinstance(contract, tuple) or len(contract) != 2:
+            return ("invalid_preprocess", _callable_identity(provider))
+        transform, provider = contract
+        transforms.append(_callable_identity(transform))
+    return (tuple(transforms), _callable_identity(provider))
+
+
+def mark_attention_override(override, patch, previous):
+    """Publish enough provenance for preflight to prove which BSA owns the hook."""
+    override._block_sparse_attention_patch = patch
+    override._block_sparse_attention_previous = previous
+    return override
+
+
+def mark_h3_block_patch(block_patch, patch, block_index, previous):
+    block_patch._block_sparse_attention_patch = patch
+    block_patch._block_sparse_attention_index = int(block_index)
+    block_patch._block_sparse_attention_previous = previous
+    return block_patch
+
+
+def append_history_receipt(options, patch, block_index, route, tokens, sink=(0, 0), sink_q=(0, 0)):
+    """Append a receipt only when a forecast provider requested receipt tracking."""
+    receipts = options.get(RECEIPTS_KEY)
+    if receipts is None:
+        return
+    receipts.append((
+        PROVIDER_KEY,
+        CONTRACT_VERSION,
+        id(patch),
+        int(block_index),
+        str(route),
+        int(tokens),
+        tuple(int(value) for value in sink),
+        tuple(int(value) for value in sink_q),
+    ))
+
+
+def append_scoped_h3_receipt(options, patch, route, tokens, sink=(0, 0), sink_q=(0, 0)):
+    """Record generic-override execution only while a main H3 block owns the call."""
+    scope = options.get(H3_BLOCK_SCOPE)
+    if not isinstance(scope, tuple) or len(scope) != 2 or scope[0] is not patch:
+        return
+    append_history_receipt(options, patch, scope[1], route, tokens, sink, sink_q)
+
+
+def _patch_mode(patch):
+    if patch.vsa:
+        return "vsa"
+    return "sol-attn" if float(patch.topk_ratio) == 0.0 else "sla"
+
+
+def _sigma(options):
+    sigmas = options.get("sigmas")
+    if sigmas is None:
+        return None
+    try:
+        if len(sigmas) == 0:
+            return None
+    except TypeError:
+        return None
+    try:
+        return float(sigmas[0])
+    except (TypeError, ValueError, RuntimeError):
+        return None
+
+
+def _replacement_identity(options, block_count):
+    replacements = options.get("patches_replace", {}).get("dit", {})
+    identities = []
+    for index in range(block_count):
+        replacement = replacements.get(("double_block", index))
+        if replacement is None:
+            return None
+        identities.append(_callable_identity(replacement))
+    return tuple(identities)
+
+
+def _forward_identity(model):
+    identities = []
+    for block in model.blocks:
+        attn = getattr(block, "attn", None)
+        forward = getattr(attn, "forward", None)
+        if forward is None:
+            return None
+        identities.append(_callable_identity(forward))
+    return tuple(identities)
+
+
+@dataclass(frozen=True)
+class SparseAttentionHistoryPolicy:
+    """Preflight identity and receipt validator for MiniMax-H3 core BSA.
+
+    H3's chunked Sol-Attn producer reuses per-block pooled K/V statistics from
+    the previous actual evaluation. The policy therefore distinguishes a cold
+    geometry/conditioning branch from a primed one. A newly primed key changes
+    the policy identity and forces Spectrum to establish a fresh actual anchor
+    before forecasting through that regime.
+    """
+
+    patch: object
+
+    def __call__(self, *, layout, options, model):
+        patch = self.patch
+        block_count = getattr(patch, "h3_block_count", None)
+        if patch.vsa or type(block_count) is not int or block_count <= 0:
+            return None
+        blocks = getattr(model, "blocks", None)
+        if blocks is None or len(blocks) != block_count:
+            return None
+
+        seq_len = getattr(layout, "seq_len", None)
+        segments = getattr(layout, "segments", None)
+        if type(seq_len) is not int or seq_len <= 0 or not segments:
+            return None
+
+        current = options.get("optimized_attention_override")
+        if getattr(current, "_block_sparse_attention_patch", None) is not patch:
+            return None
+        previous = getattr(current, "_block_sparse_attention_previous", None)
+        # Two BSA instances stacked on one attention hook are not an audited
+        # numerical route. They may still execute, but forecasts stay fail-closed.
+        if getattr(previous, "_block_sparse_attention_patch", None) is not None:
+            return None
+
+        sigma = _sigma(options)
+        if sigma is None:
+            return None
+        replacement_identity = _replacement_identity(options, block_count)
+        forward_identity = _forward_identity(model)
+        if replacement_identity is None or forward_identity is None:
+            return None
+
+        inside_window = patch.sigma_end <= sigma <= patch.sigma_start
+        sparse_phase = inside_window and seq_len >= patch.min_tokens
+        phase = "sparse" if sparse_phase else "dense"
+
+        uuids = tuple(options.get("uuids", ()))
+        primed = tuple(sorted(
+            int(key[0])
+            for key in patch.pooled
+            if isinstance(key, tuple)
+            and len(key) == 3
+            and key[1] == seq_len
+            and key[2] == uuids
+        ))
+
+        signature = _freeze(getattr(layout, "signature", None))
+        return (
+            PROVIDER_KEY,
+            CONTRACT_VERSION,
+            id(patch),
+            _patch_mode(patch),
+            float(patch.tau),
+            float(patch.topk_ratio),
+            int(patch.extra_tokens),
+            float(patch.sigma_start),
+            float(patch.sigma_end),
+            phase,
+            int(patch.min_tokens),
+            tuple(sorted(int(index) for index in patch.dense_blocks)),
+            str(patch.sink_conditioning),
+            seq_len,
+            signature,
+            _freeze(tuple(segments)),
+            _freeze(uuids),
+            primed,
+            str(getattr(model, "dtype", None)),
+            _attention_provider_identity(previous),
+            replacement_identity,
+            forward_identity,
+        )
+
+    def accept_receipts(self, receipts):
+        block_count = getattr(self.patch, "h3_block_count", None)
+        if type(block_count) is not int or block_count <= 0 or not receipts:
+            return False
+        seen = set()
+        token_counts = set()
+        for item in receipts:
+            if not isinstance(item, tuple) or len(item) != 8:
+                return False
+            provider, version, patch_id, block, route, tokens, sink, sink_q = item
+            if provider != PROVIDER_KEY or version != CONTRACT_VERSION or patch_id != id(self.patch):
+                return False
+            if type(block) is not int or block < 0 or block >= block_count or block in seen:
+                return False
+            if route not in _ALLOWED_ROUTES or type(tokens) is not int or tokens <= 0:
+                return False
+            if not (
+                isinstance(sink, tuple) and len(sink) == 2
+                and isinstance(sink_q, tuple) and len(sink_q) == 2
+            ):
+                return False
+            seen.add(block)
+            token_counts.add(tokens)
+        return seen == set(range(block_count)) and len(token_counts) == 1
+
+
+def install_history_policy(patch, transformer_options):
+    """Publish BSA's provider without disturbing unrelated history providers."""
+    policy = getattr(patch, "history_policy", None)
+    if policy is None:
+        policy = SparseAttentionHistoryPolicy(patch)
+        patch.history_policy = policy
+    current = transformer_options.get(POLICIES_KEY)
+    if current is None:
+        providers = {}
+    elif isinstance(current, dict):
+        providers = dict(current)
+    else:
+        # An unknown owner already uses the key with a non-contract shape. Do not
+        # overwrite it; Spectrum will continue to fail closed for core BSA.
+        return False
+    providers[PROVIDER_KEY] = policy
+    transformer_options[POLICIES_KEY] = providers
+    return True

--- a/tests-unit/comfy_extras_test/nodes_sparse_attention_history_test.py
+++ b/tests-unit/comfy_extras_test/nodes_sparse_attention_history_test.py
@@ -1,0 +1,186 @@
+from types import SimpleNamespace
+
+from comfy_extras.sparse_attention_history import (
+    H3_BLOCK_SCOPE,
+    PROVIDER_KEY,
+    SparseAttentionHistoryPolicy,
+    append_history_receipt,
+    install_history_policy,
+    mark_attention_override,
+)
+
+
+def _forward():
+    return None
+
+
+def _model(blocks=3):
+    return SimpleNamespace(
+        blocks=[SimpleNamespace(attn=SimpleNamespace(forward=_forward)) for _ in range(blocks)],
+        dtype="bf16",
+    )
+
+
+def _layout(rows=128):
+    return SimpleNamespace(
+        seq_len=rows,
+        signature=(16, 2, 8, 8, 4),
+        segments=((0, 16, "text"), (16, 24, "audio"), (24, rows, "video")),
+    )
+
+
+def _patch(blocks=3):
+    return SimpleNamespace(
+        vsa=False,
+        h3_block_count=blocks,
+        tau=1.0,
+        topk_ratio=0.0,
+        extra_tokens=256,
+        sigma_start=0.8,
+        sigma_end=0.0,
+        min_tokens=64,
+        dense_blocks={0},
+        sink_conditioning="exact_kv",
+        pooled={},
+        installed=set(),
+        history_policy=None,
+    )
+
+
+def _options(patch, sigma=0.5, uuids=("positive",)):
+    previous = lambda *args, **kwargs: None
+    override = mark_attention_override(lambda *args, **kwargs: None, patch, previous)
+    patch.installed.add(override)
+    return {
+        "optimized_attention_override": override,
+        "sigmas": [sigma],
+        "uuids": uuids,
+        "patches_replace": {
+            "dit": {
+                ("double_block", index): (lambda index=index: index)
+                for index in range(patch.h3_block_count)
+            }
+        },
+    }
+
+
+def test_history_policy_registration_preserves_other_providers():
+    patch = _patch()
+    options = {"attention_backend_history_v1": {"other": object()}}
+    assert install_history_policy(patch, options)
+    providers = options["attention_backend_history_v1"]
+    assert "other" in providers
+    assert providers[PROVIDER_KEY] is patch.history_policy
+
+
+def test_history_policy_does_not_overwrite_unknown_contract_shape():
+    patch = _patch()
+    options = {"attention_backend_history_v1": object()}
+    assert not install_history_policy(patch, options)
+    assert PROVIDER_KEY not in options
+
+
+def test_history_identity_is_hashable_and_tracks_sparse_state():
+    patch = _patch()
+    options = _options(patch)
+    policy = SparseAttentionHistoryPolicy(patch)
+    identity_cold = policy(layout=_layout(), options=options, model=_model())
+    assert identity_cold is not None
+    hash(identity_cold)
+
+    patch.pooled[(1, 128, ("positive",))] = (object(), object())
+    identity_primed = policy(layout=_layout(), options=options, model=_model())
+    assert identity_primed is not None
+    assert identity_primed != identity_cold
+
+
+def test_history_identity_tracks_dense_sparse_window_transition():
+    patch = _patch()
+    policy = SparseAttentionHistoryPolicy(patch)
+    dense_options = _options(patch, sigma=0.9)
+    sparse_options = dict(dense_options)
+    sparse_options["sigmas"] = [0.5]
+    dense_identity = policy(layout=_layout(), options=dense_options, model=_model())
+    sparse_identity = policy(layout=_layout(), options=sparse_options, model=_model())
+    assert dense_identity is not None
+    assert sparse_identity is not None
+    assert dense_identity != sparse_identity
+
+
+def test_history_policy_refuses_vsa_stacked_bsa_and_lost_override():
+    patch = _patch()
+    options = _options(patch)
+    policy = SparseAttentionHistoryPolicy(patch)
+
+    patch.vsa = True
+    assert policy(layout=_layout(), options=options, model=_model()) is None
+    patch.vsa = False
+
+    previous = lambda *args, **kwargs: None
+    previous._block_sparse_attention_patch = object()
+    options["optimized_attention_override"] = mark_attention_override(
+        lambda *args, **kwargs: None, patch, previous
+    )
+    assert policy(layout=_layout(), options=options, model=_model()) is None
+
+    options["optimized_attention_override"] = lambda *args, **kwargs: None
+    assert policy(layout=_layout(), options=options, model=_model()) is None
+
+
+def test_history_receipts_require_exact_h3_block_coverage():
+    patch = _patch(blocks=3)
+    policy = SparseAttentionHistoryPolicy(patch)
+    options = {"attention_backend_receipts_v1": []}
+    routes = ("h3_dense", "h3_chunked_sparse_cold", "h3_chunked_sparse_primed")
+    for block, route in enumerate(routes):
+        append_history_receipt(options, patch, block, route, 128, (0, 1), (0, 0))
+    receipts = tuple(options["attention_backend_receipts_v1"])
+    assert policy.accept_receipts(receipts)
+
+    assert not policy.accept_receipts(receipts[:-1])
+    duplicate = list(receipts)
+    duplicate[-1] = duplicate[0]
+    assert not policy.accept_receipts(tuple(duplicate))
+
+    foreign = list(receipts)
+    foreign[0] = ("other",) + foreign[0][1:]
+    assert not policy.accept_receipts(tuple(foreign))
+
+    wrong_tokens = list(receipts)
+    wrong_tokens[-1] = wrong_tokens[-1][:5] + (64,) + wrong_tokens[-1][6:]
+    assert not policy.accept_receipts(tuple(wrong_tokens))
+
+
+def test_h3_block_patch_preserves_previous_replacement_and_scope(monkeypatch):
+    import comfy_extras.nodes_sparse_attention as sparse
+
+    patch = _patch(blocks=1)
+    block = SimpleNamespace(attn=SimpleNamespace())
+    calls = []
+
+    monkeypatch.setattr(sparse, "h3_eligible", lambda *args, **kwargs: False)
+
+    def previous(args, extra):
+        calls.append(("previous", args["transformer_options"].get(H3_BLOCK_SCOPE)))
+        return extra["original_block"](args)
+
+    def original(args):
+        calls.append(("original", args["transformer_options"].get(H3_BLOCK_SCOPE)))
+        return {"img": "ok"}
+
+    options = {}
+    block_patch = sparse.make_h3_block_patch(block, 0, patch, previous)
+    result = block_patch(
+        {"img": object(), "rope_freqs": None, "transformer_options": options},
+        {"original_block": original},
+    )
+
+    assert result == {"img": "ok"}
+    assert calls == [("previous", (patch, 0)), ("original", (patch, 0))]
+    assert H3_BLOCK_SCOPE not in options
+    assert block_patch._block_sparse_attention_previous is previous
+
+
+def test_h3_scope_key_is_private_and_stable():
+    assert H3_BLOCK_SCOPE.startswith("_")
+    assert "block_sparse_attention" in H3_BLOCK_SCOPE


### PR DESCRIPTION
## Summary

Expose core `Model Sparse Attention` through the existing duck-typed `attention_backend_history_v1` / `attention_backend_receipts_v1` contract so forecast providers can safely retain MiniMax-H3 history when the sparse route is stable instead of treating core BSA as permanently opaque.

## What changes

- publishes a deterministic MiniMax-H3 backend policy without importing any forecast package;
- emits one successful actual receipt per main H3 transformer block from both the chunked H3 producer and dense/generic fallback routes;
- tracks dense/sparse sigma-window transitions, layout/sequence geometry, inherited attention ownership, block-replacement topology and H3 attention-forward ownership;
- treats the chunked Sol-Attn producer's pooled `(kmean, vscale)` state as part of numerical history: a cold geometry/conditioning branch transitions to a primed identity after its first successful actual evaluation, forcing a fresh anchor before forecasts can resume;
- fails closed for VSA, stacked BSA instances, missing/foreign/duplicate receipts or incomplete H3 block coverage;
- preserves an existing H3 block replacement instead of silently overwriting it;
- keeps the existing legacy behavior unchanged for consumers that do not use the history contract.

## Motivation

Core BSA currently registers `block_sparse_attention` but does not describe its numerical schedule. Forecast runtimes therefore cannot prove that retained H3 anchors were produced by the same attention route and have to execute every logical call as an actual transformer evaluation.

The provider/receipt protocol is generic and optional: core owns only its routing identity and actual execution receipts; consumers remain responsible for deciding whether and how to forecast.

## Validation

Adds focused unit coverage for provider registration, hashable identities, dense/sparse transitions, cold/primed pooled state, fail-closed ownership cases, exact per-block receipt coverage, token-geometry consistency, and preservation of an existing H3 block replacement.

Kept as one implementation commit on top of current upstream `4989cdd95487531b50438c6a091dffa06e4af4b2`.