### PR TITLE
[Partner Nodes] feat(Comfy-Cloud): re-enable the reference-to-video node

### DIFF
--- a/comfy_api_nodes/nodes_comfy_cloud.py
+++ b/comfy_api_nodes/nodes_comfy_cloud.py
@@ -583,7 +583,11 @@ def _video_schema(node_id: str, display_name: str, summary: str, inputs: list[IO
     )
 
 
-_MINIMAX_H3_MAX_REFERENCES = 4
+# The limits the graph behind the workflow actually declares: see
+# comfy_extras/nodes_minimax_h3.py, where MiniMaxH3ReferenceToVideo grows
+# ref_images to 9 and ref_videos / ref_audios to 3 each.
+_MINIMAX_H3_MAX_REFERENCES = 9
+_MINIMAX_H3_MAX_VIDEO_REFERENCES = 3
 _MINIMAX_H3_MAX_AUDIO_REFERENCES = 3
 
 
@@ -758,15 +762,24 @@ class ComfyCloudMiniMaxH3ReferenceToVideoNode(IO.ComfyNode):
                     template=IO.Autogrow.TemplatePrefix(
                         input=IO.Image.Input("reference_image"),
                         prefix="reference_image_",
-                        min=0,
+                        min=1,
                         max=_MINIMAX_H3_MAX_REFERENCES,
                     ),
                     tooltip=(
-                        "Up to four references, addressed in the prompt as <Picture 1> upwards "
-                        "in connection order."
+                        "Up to nine references, addressed in the prompt as <Picture 1> upwards "
+                        "in connection order. At least one is required."
                     ),
                 ),
-                IO.Video.Input("ref_video", optional=True),
+                IO.Autogrow.Input(
+                    "ref_videos",
+                    template=IO.Autogrow.TemplatePrefix(
+                        input=IO.Video.Input("ref_video"),
+                        prefix="ref_video_",
+                        min=0,
+                        max=_MINIMAX_H3_MAX_VIDEO_REFERENCES,
+                    ),
+                    tooltip="Addressed in the prompt as <Video 1> upwards in connection order.",
+                ),
                 IO.Autogrow.Input(
                     "ref_audio",
                     template=IO.Autogrow.TemplatePrefix(
@@ -800,7 +813,7 @@ class ComfyCloudMiniMaxH3ReferenceToVideoNode(IO.ComfyNode):
         cls,
         prompt: str,
         reference_images: dict[str, Input.Image] | None = None,
-        ref_video: Input.Video | None = None,
+        ref_videos: dict[str, Input.Video] | None = None,
         ref_audio: dict[str, Input.Audio] | None = None,
         seed: int = 42,
         aspect_ratio: str = "16:9",
@@ -812,6 +825,9 @@ class ComfyCloudMiniMaxH3ReferenceToVideoNode(IO.ComfyNode):
         images = [image for image in (reference_images or {}).values() if image is not None]
         if len(images) > _MINIMAX_H3_MAX_REFERENCES:
             raise ValueError(f"At most {_MINIMAX_H3_MAX_REFERENCES} reference images are supported.")
+        videos = [video for video in (ref_videos or {}).values() if video is not None]
+        if len(videos) > _MINIMAX_H3_MAX_VIDEO_REFERENCES:
+            raise ValueError(f"At most {_MINIMAX_H3_MAX_VIDEO_REFERENCES} reference videos are supported.")
         audios = [audio for audio in (ref_audio or {}).values() if audio is not None]
         if len(audios) > _MINIMAX_H3_MAX_AUDIO_REFERENCES:
             raise ValueError(f"At most {_MINIMAX_H3_MAX_AUDIO_REFERENCES} reference audio inputs are supported.")
@@ -821,8 +837,10 @@ class ComfyCloudMiniMaxH3ReferenceToVideoNode(IO.ComfyNode):
             f"reference_image_{index}": await _minimax_h3_asset(cls, image)
             for index, image in enumerate(images, 1)
         }
-        if ref_video is not None:
-            assets["ref_video"] = await _minimax_h3_video_asset(cls, ref_video)
+        assets.update({
+            f"ref_video_{index}": await _minimax_h3_video_asset(cls, video)
+            for index, video in enumerate(videos, 1)
+        })
         assets.update({
             f"ref_audio_{index}": await _minimax_h3_audio_asset(cls, audio)
             for index, audio in enumerate(audios, 1)
@@ -844,7 +862,7 @@ class ComfyCloudExtension(ComfyExtension):
         return [
             ComfyCloudMiniMaxH3TextToVideoNode,
             ComfyCloudMiniMaxH3FirstLastFrameToVideoNode,
-            # ComfyCloudMiniMaxH3ReferenceToVideoNode,  # Disabled until the server-side issue is fixed.
+            ComfyCloudMiniMaxH3ReferenceToVideoNode,
             ComfyCloudMiniMaxH3ImageToVideoNode,
             ComfyCloudMiniMaxMusic3TextToAudioNode,
             ComfyCloudFlux2TextToImageNode,

--- a/tests-unit/comfy_api_nodes_test/comfy_cloud_test.py
+++ b/tests-unit/comfy_api_nodes_test/comfy_cloud_test.py
@@ -371,7 +371,6 @@ def test_music_node_sends_its_hidden_caption_cfg(monkeypatch):
     assert output == "audio-output"
 
 
-@pytest.mark.skip(reason="Disabled until the server-side issue is fixed")
 def test_reference_video_exposes_and_sends_multimodal_references(monkeypatch):
     node = nodes_comfy_cloud.ComfyCloudMiniMaxH3ReferenceToVideoNode
     run = AsyncMock(return_value="video-output")
@@ -395,12 +394,17 @@ def test_reference_video_exposes_and_sends_multimodal_references(monkeypatch):
     schema = node.define_schema()
     input_names = [input_spec.id for input_spec in schema.inputs]
     assert input_names == [
-        "reference_images", "ref_video", "ref_audio", "prompt", "seed",
+        "reference_images", "ref_videos", "ref_audio", "prompt", "seed",
         "aspect_ratio", "resolution", "duration_seconds", "ref_image_size",
     ]
-    assert next(input_spec for input_spec in schema.inputs if input_spec.id == "ref_video").optional is True
+    # The slot counts are the graph's, not ours: MiniMaxH3ReferenceToVideo in
+    # comfy_extras/nodes_minimax_h3.py grows ref_images to 9 and the other two
+    # to 3. reference_images starts at 1 because comfy-api's binding table makes
+    # reference_image_1 required, so a request without it is refused.
     image_template = next(input_spec for input_spec in schema.inputs if input_spec.id == "reference_images").template
-    assert (image_template.min, image_template.max) == (0, 4)
+    assert (image_template.min, image_template.max) == (1, 9)
+    video_template = next(input_spec for input_spec in schema.inputs if input_spec.id == "ref_videos").template
+    assert (video_template.min, video_template.max) == (0, 3)
     audio_template = next(input_spec for input_spec in schema.inputs if input_spec.id == "ref_audio").template
     assert (audio_template.min, audio_template.max) == (0, 3)
 
@@ -408,7 +412,7 @@ def test_reference_video_exposes_and_sends_multimodal_references(monkeypatch):
         node.execute(
             prompt="A glass forest",
             reference_images={"reference_image_1": "image"},
-            ref_video="video",
+            ref_videos={"ref_video_1": "video"},
             ref_audio={"ref_audio_1": "audio-1", "ref_audio_2": "audio-2"},
             ref_image_size="max",
         )
@@ -418,7 +422,7 @@ def test_reference_video_exposes_and_sends_multimodal_references(monkeypatch):
     assert inputs.ref_image_size == "max"
     assert inputs.assets == {
         "reference_image_1": nodes_comfy_cloud.ComfyCloudAssetInput(type="IMAGE", url="/uploads/reference.png"),
-        "ref_video": nodes_comfy_cloud.ComfyCloudAssetInput(type="VIDEO", url="/uploads/reference.mp4"),
+        "ref_video_1": nodes_comfy_cloud.ComfyCloudAssetInput(type="VIDEO", url="/uploads/reference.mp4"),
         "ref_audio_1": nodes_comfy_cloud.ComfyCloudAssetInput(type="AUDIO", url="/uploads/reference-1.m4a"),
         "ref_audio_2": nodes_comfy_cloud.ComfyCloudAssetInput(type="AUDIO", url="/uploads/reference-2.m4a"),
     }
@@ -426,17 +430,27 @@ def test_reference_video_exposes_and_sends_multimodal_references(monkeypatch):
     assert audio_asset.await_count == 2
 
 
-@pytest.mark.skip(reason="Disabled until the server-side issue is fixed")
-def test_reference_video_accepts_no_references(monkeypatch):
+def test_reference_video_sends_only_the_slots_that_were_connected(monkeypatch):
+    """One image and nothing else is the minimum comfy-api accepts, and it must
+    not carry empty video or audio keys: an asset name the binding table does
+    not know is refused outright, and one with a blank URL drops its loader."""
     run = AsyncMock(return_value="video-output")
+    asset = AsyncMock(
+        return_value=nodes_comfy_cloud.ComfyCloudAssetInput(type="IMAGE", url="/uploads/reference.png")
+    )
     monkeypatch.setattr(nodes_comfy_cloud, "_run_video_workflow", run)
+    monkeypatch.setattr(nodes_comfy_cloud, "_minimax_h3_asset", asset)
 
-    output = _execute_with_defaults(
-        nodes_comfy_cloud.ComfyCloudMiniMaxH3ReferenceToVideoNode,
-        "An empty desert",
+    output = asyncio.run(
+        nodes_comfy_cloud.ComfyCloudMiniMaxH3ReferenceToVideoNode.execute(
+            prompt="An empty desert",
+            reference_images={"reference_image_1": "image"},
+        )
     )
 
-    assert run.call_args.args[2].assets == {}
+    assert run.call_args.args[2].assets == {
+        "reference_image_1": nodes_comfy_cloud.ComfyCloudAssetInput(type="IMAGE", url="/uploads/reference.png"),
+    }
     assert output == "video-output"
 
 
@@ -486,7 +500,7 @@ PLAIN_CONTROLS = {
     # Video: the frame-size budget is a headline choice rather than a dial, and
     # reference-to-video's slots are its media inputs. ref_image_size is that
     # graph's one quality-against-speed switch.
-    "resolution", "reference_images", "ref_video", "ref_audio", "ref_image_size",
+    "resolution", "reference_images", "ref_videos", "ref_audio", "ref_image_size",
     # Mage Flow: a negative prompt is a second prompt rather than a dial, and the
     # pixel budget is how that graph is sized at all, so neither is "advanced".
     "negative_prompt", "megapixels",
@@ -733,6 +747,7 @@ def test_extension_registers_exactly_the_shipped_set():
         nodes_comfy_cloud.ComfyCloudMageFlowTurboTextToImageNode,
         nodes_comfy_cloud.ComfyCloudMiniMaxMusic3TextToAudioNode,
         nodes_comfy_cloud.ComfyCloudMiniMaxH3FirstLastFrameToVideoNode,
+        nodes_comfy_cloud.ComfyCloudMiniMaxH3ReferenceToVideoNode,
         nodes_comfy_cloud.ComfyCloudMiniMaxH3ImageToVideoNode,
     }
     registered = set(asyncio.run(nodes_comfy_cloud.ComfyCloudExtension().get_node_list()))


### PR DESCRIPTION
<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [x] **Is API Node Change**

### Pricing & Billing
- [ ] Need pricing update
- [x] **No pricing update**

No new billable surface: `minimax-h3/reference-to-video` is already a registered workflow and already priced per GPU-second like the other Comfy Cloud video nodes. This only makes the node placeable.

### QA
- [ ] QA done
- [x] **QA not required** — see below

The backend path is verified end to end on an ephemeral preview (details in **Verification**). What is *not* covered is the node's own UI: the autogrow video slots have not been clicked through in a running ComfyUI. Worth a look before merge if you want the widget behaviour confirmed.

### Comms
- [ ] Informed **Kosinkadink**

Not done. Flagging rather than checking.

---

## What

`ComfyCloudMiniMaxH3ReferenceToVideoNode` has existed since #15935 but was left out of `get_node_list()`, so nobody can place it. It was disabled because comfy-api rejected its video and audio reference inputs: `build()` treated a binding as media only when its kind was `IMAGE`, so `assets.ref_video` came back as `inputs.assets.ref_video is not supported` *after* the client had uploaded the file.

Comfy-Org/cloud#8747 fixes that. This turns the node on and corrects three things that were wrong with it.

| | before | after |
|---|---|---|
| reference images | max 4, `min=0` | max **9**, `min=1` |
| reference videos | one optional `ref_video` | autogrow **3**, `ref_video_1..3` |
| shipped set | commented out | registered |

## Review Focus

**Four was never a model limit.** `MiniMaxH3ReferenceToVideo` in `comfy_extras/nodes_minimax_h3.py` declares `ref_images` `max=9` and `ref_videos` / `ref_audios` `max=3`, and the frozen graph wires every one of those slots. The partner node just capped lower for no stated reason.

**`min=1` on reference images is a contract fix, not a preference.** comfy-api makes `reference_image_1` required, so `min=0` offered a shape the server refuses: a user wiring only a video would have uploaded it and then been turned away. Lifting it is a server change first, and it needs its own execution test.

**`ref_video` becomes `ref_video_1..3`.** The asset key changes shape to match `reference_image_N` and `ref_audio_N`. Input names are permanent once released, and this node has never been registered, so this is the last free moment to change them.

**One test was replaced rather than un-skipped.** `test_reference_video_accepts_no_references` asserted `assets == {}`, which contradicts the required first image. It is now `test_reference_video_sends_only_the_slots_that_were_connected`: one image and nothing else, proving no empty video or audio keys ride along.

## Verification

Run against an ephemeral preview carrying the cloud fix, not only in unit tests.

- One image reference: job `success`, real 5.17s 864x480 MP4 with a soundtrack.
- One image + one reference video + one reference audio: job `success`, same shape. The graph comfy-api submitted carried `LoadVideo` 158 through `GetVideoComponents` 159 and `LoadAudio` 164 with the staged upload hashes, and every unconnected slot was dropped (22 nodes of the manifest's 32).

Tests: **113 pass** across `tests-unit/comfy_api_nodes_test`.

## Companion PRs
- Comfy-Org/cloud#8747 — accepts `VIDEO` / `AUDIO` assets and binds all nine image slots. **Must merge and deploy first**; without it this node's video and audio inputs are refused.
