### PR TITLE
ModelPatchLoader: migrate legacy quant metadata before quant detection

### DIFF
--- a/comfy_extras/nodes_model_patch.py
+++ b/comfy_extras/nodes_model_patch.py
@@ -243,6 +243,7 @@ class ModelPatchLoader:
     def load_model_patch(self, name):
         model_patch_path = folder_paths.get_full_path_or_raise("model_patches", name)
         sd, metadata = comfy.utils.load_torch_file(model_patch_path, safe_load=True, return_metadata=True)
+        sd, metadata = comfy.utils.convert_old_quants(sd, model_prefix="", metadata=metadata)
         dtype = comfy.utils.weight_dtype(sd)
 
         if 'lllite_conditioning1.conv1.weight' in sd:


### PR DESCRIPTION
**What breaks**: \`ModelPatchLoader.load_model_patch()\` calls \`comfy.utils.detect_layer_quantization(sd, "")\` directly on the raw \`load_torch_file()\` output, which only recognizes the native per-tensor \`.comfy_quant\` marker — it never calls \`comfy.utils.convert_old_quants(sd, model_prefix, metadata)\` first, unlike every UNET/checkpoint loading path in \`comfy/sd.py\` (5 call sites). So a legacy/reference-format quantized model patch (metadata carrying \`_quantization_metadata\` + per-tensor \`weight_codebook\`/\`weight_s_channel\`/\`weight_s_rel\` siblings instead of the native marker) is never detected as quantized: the loader builds a plain full-precision model and \`load_state_dict()\` fails with "Unexpected key(s)" for every quant-suffix tensor plus K-dimension shape mismatches (the packed W4A8 weight tensor is legitimately half the K-dim of the unpacked model).

**Replay proof / before-after**: reproduced against a real \`asym_w4a8_int8\`/ConvRot-256 quantized MiniMax H3 Fun ControlNet Union checkpoint. Before the fix: \`detect_layer_quantization\` returns \`None\`, \`MiniMaxH3FunControl\` is built at full precision, and \`load_state_dict()\` raises immediately. After inserting \`sd, metadata = comfy.utils.convert_old_quants(sd, model_prefix="", metadata=metadata)\` right after the \`load_torch_file()\` call (same placement \`comfy/sd.py\` already uses everywhere): \`detect_layer_quantization\` returns \`{"mixed_ops": True}\`, and the full \`MiniMaxH3FunControl\` construction + \`load_state_dict()\` succeeds in under half a second with all control_blocks present. The fix is unconditional and format-agnostic (\`convert_old_quants\` no-ops when there's nothing to migrate), so it changes nothing for currently-working \`ModelPatchLoader\` inputs — it only unblocks the previously-unloadable legacy-quant case.