### PR TITLE
Fix small_input attention fallback OOMing without pytorch attention

### DIFF
--- a/comfy/ldm/modules/attention.py
+++ b/comfy/ldm/modules/attention.py
@@ -908,7 +908,7 @@ def optimized_attention_for_device(device, mask=False, small_input=False):
         if model_management.pytorch_attention_enabled():
             return attention_pytorch #TODO: need to confirm but this is probably slightly faster for small inputs in all cases
         else:
-            return attention_basic
+            return attention_sub_quad
 
     if device == torch.device("cpu"):
         return attention_sub_quad

--- a/tests-unit/comfy_test/optimized_attention_for_device_test.py
+++ b/tests-unit/comfy_test/optimized_attention_for_device_test.py
@@ -1,0 +1,17 @@
+from unittest.mock import patch
+
+import torch
+
+from comfy.ldm.modules.attention import (
+    attention_basic,
+    attention_sub_quad,
+    optimized_attention_for_device,
+)
+
+
+def test_small_input_without_pytorch_attention_uses_chunked_fallback():
+    with patch("comfy.ldm.modules.attention.model_management.pytorch_attention_enabled", return_value=False):
+        func = optimized_attention_for_device(torch.device("cpu"), small_input=True)
+
+    assert func is attention_sub_quad
+    assert func is not attention_basic

--- a/tests-unit/comfy_test/optimized_attention_for_device_test.py
+++ b/tests-unit/comfy_test/optimized_attention_for_device_test.py
@@ -2,7 +2,12 @@ from unittest.mock import patch
 
 import torch
 
-from comfy.ldm.modules.attention import (
+from comfy.cli_args import args
+
+if not torch.cuda.is_available():
+    args.cpu = True
+
+from comfy.ldm.modules.attention import (  # noqa: E402
     attention_basic,
     attention_sub_quad,
     optimized_attention_for_device,


### PR DESCRIPTION
Fixes #16160

## Problem

`optimized_attention_for_device(small_input=True)` only offered a two-way
choice: `attention_pytorch` when pytorch attention (SDPA) is enabled, or
`attention_basic` otherwise. `attention_basic` materializes the full
`N x N` score matrix, which is fine for typical short text-encoder
sequences but becomes the largest allocation in the run once `N` grows —
e.g. MiniMax H3's `<Picture i>` reference-image tokens are appended to the
same sequence CLIP encodes with `small_input=True`
(`comfy/text_encoders/llama.py:757`), so encoding several reference images
pushes `N` into the thousands.

On GPUs where `pytorch_attention_enabled()` is `False` — notably AMD
RDNA2-and-older architectures (`gfx1030`, `gfx1031`, `gfx1035`, `gfx1010`,
`gfx1011`, `gfx1012`, `gfx906`, `gfx900`, `gfx803`), which ship no aotriton
SDPA kernels — there was no way to avoid this path. `--use-pytorch-cross-attention`
makes it worse (falls through to PyTorch's math SDPA backend, which uses
~5x more memory than `attention_basic` at the same shape per the issue's
own benchmark), and `--use-split-cross-attention` / `--use-quad-cross-attention`
don't help either since the `small_input=True` branch is hardcoded and
bypasses the module-level `optimized_attention` rebinding those flags use.

## Fix

Change the `small_input=True`, no-pytorch-attention fallback from
`attention_basic` to `attention_sub_quad`, which:
- has an identical call signature (`mask`, `skip_reshape`,
  `skip_output_reshape`, `enable_gqa` via `**kwargs`),
- is already ComfyUI's own hardware-agnostic, chunked default fallback
  used elsewhere in this file (e.g. for `device == cpu`),
- per the issue's measurements, drops peak allocation for the reported
  repro from 10.25 GiB (OOM) to ~1.3 GiB.

`attention_split` was considered and rejected (by the issue reporter) as
the alternative: its chunk size falls back to no chunking at all when the
sequence length isn't evenly divisible by the step count, which can still
OOM.

## Test plan

Added `tests-unit/comfy_test/optimized_attention_for_device_test.py`,
asserting that `optimized_attention_for_device(..., small_input=True)`
returns `attention_sub_quad` (not `attention_basic`) when
`pytorch_attention_enabled()` is `False`.

This sandbox (and CI's unit-test job, which installs CPU-only torch)
has no CUDA device, and importing `comfy.ldm.modules.attention` pulls
in `comfy.model_management`, which calls `torch.cuda.current_device()`
at module import time. The test file guards against this the same way
`tests-unit/comfy_test/gemma4_template_test.py` already does — setting
`comfy.cli_args.args.cpu = True` before the import when CUDA isn't
available — so it collects and passes standalone, with no dependency
on import order relative to other test files.

Ran the exact command from `.github/workflows/test-unit.yml` in
isolation, both before and after the source fix:

```
$ python -m pytest tests-unit/comfy_test/optimized_attention_for_device_test.py -v
# before the fix (comfy/ldm/modules/attention.py reverted via `git checkout HEAD~2 -- ...`):
FAILED tests-unit/comfy_test/optimized_attention_for_device_test.py::test_small_input_without_pytorch_attention_uses_chunked_fallback
AssertionError: assert <function attention_basic at 0x7f815d159120> is attention_sub_quad
1 failed in 2.58s

# after the fix:
tests-unit/comfy_test/optimized_attention_for_device_test.py::test_small_input_without_pytorch_attention_uses_chunked_fallback PASSED
1 passed in 2.57s
```

Also ran `ruff check` on both changed files: all checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
