### PR TITLE
ComfyUI backport release v0.35.1

### DIFF
--- a/comfy_api_nodes/apis/openrouter.py
+++ b/comfy_api_nodes/apis/openrouter.py
@@ -57,6 +57,15 @@ class OpenRouterChatRequest(BaseModel):
     stream: bool = Field(False)
 
 
+class OpenRouterImageRequest(BaseModel):
+    model: str = Field(...)
+    prompt: str = Field(...)
+    aspect_ratio: str | None = Field(None)
+    size: str | None = Field(None)
+    input_references: list[OpenRouterImageContent] | None = Field(None)
+    stream: bool = Field(False)
+
+
 class OpenRouterUsage(BaseModel):
     prompt_tokens: int | None = Field(None)
     completion_tokens: int | None = Field(None)
@@ -89,5 +98,17 @@ class OpenRouterChatResponse(BaseModel):
     object: str | None = Field(None)
     provider: str | None = Field(None)
     choices: list[OpenRouterChoice] | None = Field(None)
+    usage: OpenRouterUsage | None = Field(None)
+    error: OpenRouterError | None = Field(None)
+
+
+class OpenRouterImageData(BaseModel):
+    b64_json: str | None = Field(None)
+    media_type: str | None = Field(None)
+
+
+class OpenRouterImageResponse(BaseModel):
+    created: int | None = Field(None)
+    data: list[OpenRouterImageData] | None = Field(None)
     usage: OpenRouterUsage | None = Field(None)
     error: OpenRouterError | None = Field(None)

--- a/comfy_api_nodes/apis/tripo.py
+++ b/comfy_api_nodes/apis/tripo.py
@@ -38,23 +38,6 @@ class TripoStyle(str, Enum):
     NONE = "None"
 
 
-class TripoTaskType(str, Enum):
-    TEXT_TO_MODEL = "text_to_model"
-    IMAGE_TO_MODEL = "image_to_model"
-    MULTIVIEW_TO_MODEL = "multiview_to_model"
-    TEXTURE_MODEL = "texture_model"
-    ANIMATE_PRERIGCHECK = "animate_prerigcheck"
-    ANIMATE_RIG = "animate_rig"
-    ANIMATE_RETARGET = "animate_retarget"
-    STYLIZE_MODEL = "stylize_model"
-    CONVERT_MODEL = "convert_model"
-    MESH_SEGMENTATION = "mesh_segmentation"
-    MESH_COMPLETION = "mesh_completion"
-    HIGHPOLY_TO_LOWPOLY = "highpoly_to_lowpoly"
-    GENERATE_MULTIVIEW_IMAGE = "generate_multiview_image"
-    EDIT_MULTIVIEW_IMAGE = "edit_multiview_image"
-
-
 class TripoTextureAlignment(str, Enum):
     ORIGINAL_IMAGE = "original_image"
     GEOMETRY = "geometry"
@@ -269,29 +252,18 @@ class TripoUrlReference(BaseModel):
     url: str
 
 
-class TripoObjectStorage(BaseModel):
-    bucket: str
-    key: str
-
-
-class TripoObjectReference(BaseModel):
-    type: str
-    object: TripoObjectStorage
-
-
 class TripoFileEmptyReference(BaseModel):
     pass
 
 
 class TripoFileReference(RootModel):
-    root: TripoFileTokenReference | TripoUrlReference | TripoObjectReference | TripoFileEmptyReference
+    root: TripoFileTokenReference | TripoUrlReference | TripoFileEmptyReference
 
 
 class TripoTextToModelRequest(BaseModel):
-    type: TripoTaskType = Field(TripoTaskType.TEXT_TO_MODEL, description="Type of task")
     prompt: str = Field(..., description="The text prompt describing the model to generate", max_length=1024)
+    model: TripoModelVersion = TripoModelVersion.v3_1_20260211
     negative_prompt: str | None = Field(None, description="The negative text prompt", max_length=255)
-    model_version: TripoModelVersion | None = TripoModelVersion.v2_5_20250123
     face_limit: int | None = Field(None, description="The number of faces to limit the generation to")
     texture: bool | None = Field(True, description="Whether to apply texture to the generated model")
     pbr: bool | None = Field(True, description="Whether to apply PBR to the generated model")
@@ -300,16 +272,14 @@ class TripoTextToModelRequest(BaseModel):
     texture_seed: int | None = Field(None, description="The seed for the texture")
     texture_quality: TripoTextureQuality | None = TripoTextureQuality.standard
     geometry_quality: TripoGeometryQuality | None = TripoGeometryQuality.standard
-    style: TripoStyle | None = None
     auto_size: bool | None = Field(False, description="Whether to auto-size the model")
     quad: bool | None = Field(False, description="Whether to apply quad to the generated model")
     smart_low_poly: bool | None = Field(None, description="Low-poly output with clean, hand-crafted style topology")
 
 
 class TripoImageToModelRequest(BaseModel):
-    type: TripoTaskType = Field(TripoTaskType.IMAGE_TO_MODEL, description="Type of task")
-    file: TripoFileReference = Field(..., description="The file reference to convert to a model")
-    model_version: TripoModelVersion | None = Field(None, description="The model version to use for generation")
+    input: str = Field(..., description="Image URL or file token")
+    model: TripoModelVersion = TripoModelVersion.v3_1_20260211
     face_limit: int | None = Field(None, description="The number of faces to limit the generation to")
     texture: bool | None = Field(True, description="Whether to apply texture to the generated model")
     pbr: bool | None = Field(True, description="Whether to apply PBR to the generated model")
@@ -320,7 +290,6 @@ class TripoImageToModelRequest(BaseModel):
     texture_alignment: TripoTextureAlignment | None = Field(
         TripoTextureAlignment.ORIGINAL_IMAGE, description="The texture alignment method"
     )
-    style: TripoStyle | None = Field(None, description="The style to apply to the generated model")
     auto_size: bool | None = Field(False, description="Whether to auto-size the model")
     orientation: TripoOrientation | None = TripoOrientation.DEFAULT
     quad: bool | None = Field(False, description="Whether to apply quad to the generated model")
@@ -328,10 +297,8 @@ class TripoImageToModelRequest(BaseModel):
 
 
 class TripoMultiviewToModelRequest(BaseModel):
-    type: TripoTaskType = TripoTaskType.MULTIVIEW_TO_MODEL
-    files: list[TripoFileReference] = Field(..., description="The file references to convert to a model")
-    model_version: TripoModelVersion | None = Field(None, description="The model version to use for generation")
-    orthographic_projection: bool | None = Field(False, description="Whether to use orthographic projection")
+    inputs: list[dict[str, str]] = Field(..., description="View-keyed image references: front, left, back, right")
+    model: TripoModelVersion = TripoModelVersion.v3_1_20260211
     face_limit: int | None = Field(None, description="The number of faces to limit the generation to")
     texture: bool | None = Field(True, description="Whether to apply texture to the generated model")
     pbr: bool | None = Field(True, description="Whether to apply PBR to the generated model")
@@ -354,42 +321,32 @@ class TripoTexturePrompt(BaseModel):
 
 
 class TripoTextureModelRequest(BaseModel):
-    type: TripoTaskType = Field(TripoTaskType.TEXTURE_MODEL, description="Type of task")
-    original_model_task_id: str = Field(..., description="The task ID of the original model")
-    model_version: TripoTextureModelVersion | None = Field(None, description="Texture model version")
-    texture: bool | None = Field(True, description="Whether to apply texture to the model")
+    input: str = Field(..., description="The task ID of the model to texture")
+    model: TripoTextureModelVersion | None = Field(None, description="Texture model version")
     pbr: bool | None = Field(True, description="Whether to apply PBR to the model")
-    model_seed: int | None = Field(None, description="The seed for the model")
     texture_seed: int | None = Field(None, description="The seed for the texture")
     texture_quality: TripoTextureQuality | None = Field(None, description="The quality of the texture")
     texture_alignment: TripoTextureAlignment | None = Field(
         TripoTextureAlignment.ORIGINAL_IMAGE, description="The texture alignment method"
     )
-    texture_prompt: TripoTexturePrompt | None = Field(
-        None,
-        description="Optional guidance for texturing. Required in practice for imported models, "
-        "which carry no source image to infer texture from.",
-    )
+    texture_prompt: TripoTexturePrompt | None = Field(None, description="Optional guidance for texturing")
     part_names: list[str] | None = Field(None, description="Parts of a segmented model to texture; all parts when omitted")
 
 
 class TripoAnimatePrerigcheckRequest(BaseModel):
-    type: TripoTaskType = Field(TripoTaskType.ANIMATE_PRERIGCHECK, description="Type of task")
-    original_model_task_id: str = Field(..., description="The task ID of the original model")
+    input: str = Field(..., description="The task ID of the model")
 
 
 class TripoAnimateRigRequest(BaseModel):
-    type: TripoTaskType = Field(TripoTaskType.ANIMATE_RIG, description="Type of task")
-    original_model_task_id: str = Field(..., description="The task ID of the original model")
-    model_version: TripoRigModelVersion | None = Field(None, description="Rigging model version")
+    input: str = Field(..., description="The task ID of the model")
+    model: TripoRigModelVersion | None = Field(None, description="Rigging model version")
     rig_type: TripoRigType | None = Field(None, description="Skeleton type")
     out_format: TripoOutFormat | None = Field(TripoOutFormat.GLB, description="The output format")
     spec: TripoSpec | None = Field(TripoSpec.TRIPO, description="The specification for rigging")
 
 
 class TripoAnimateRetargetRequest(BaseModel):
-    type: TripoTaskType = Field(TripoTaskType.ANIMATE_RETARGET, description="Type of task")
-    original_model_task_id: str = Field(..., description="The task ID of the original model")
+    input: str = Field(..., description="The task ID of the rigged model")
     animation: str = Field(..., description="The animation preset to apply")
     out_format: TripoOutFormat | None = Field(TripoOutFormat.GLB, description="The output format")
     export_with_geometry: bool | None = Field(None, description="Whether to export geometry with the animation")
@@ -397,19 +354,16 @@ class TripoAnimateRetargetRequest(BaseModel):
 
 
 class TripoMeshSegmentationRequest(BaseModel):
-    type: TripoTaskType = Field(TripoTaskType.MESH_SEGMENTATION, description="Type of task")
-    original_model_task_id: str = Field(..., description="The task ID of the original model")
+    input: str = Field(..., description="The task ID of the model to segment")
 
 
 class TripoMeshCompletionRequest(BaseModel):
-    type: TripoTaskType = Field(TripoTaskType.MESH_COMPLETION, description="Type of task")
-    original_model_task_id: str = Field(..., description="The task ID of a mesh segmentation task")
+    input: str = Field(..., description="The task ID of a mesh segmentation task")
     part_names: list[str] | None = Field(None, description="Parts to complete; all parts when omitted")
 
 
 class TripoHighpolyToLowpolyRequest(BaseModel):
-    type: TripoTaskType = Field(TripoTaskType.HIGHPOLY_TO_LOWPOLY, description="Type of task")
-    original_model_task_id: str = Field(..., description="The task ID of the original model")
+    input: str = Field(..., description="The task ID of the model to retopologize")
     face_limit: int | None = Field(None, description="Target face count; adaptive when omitted")
     quad: bool | None = Field(None, description="Whether to output a quad mesh")
     bake: bool | None = Field(None, description="Whether to bake textures onto the low-poly mesh")
@@ -417,8 +371,7 @@ class TripoHighpolyToLowpolyRequest(BaseModel):
 
 
 class TripoGenerateMultiviewImageRequest(BaseModel):
-    type: TripoTaskType = Field(TripoTaskType.GENERATE_MULTIVIEW_IMAGE, description="Type of task")
-    file: TripoFileReference = Field(..., description="The source image")
+    input: str = Field(..., description="URL or file token of the source image")
 
 
 class TripoMultiviewEditPrompt(BaseModel):
@@ -427,15 +380,21 @@ class TripoMultiviewEditPrompt(BaseModel):
 
 
 class TripoEditMultiviewImageRequest(BaseModel):
-    type: TripoTaskType = Field(TripoTaskType.EDIT_MULTIVIEW_IMAGE, description="Type of task")
-    original_task_id: str = Field(..., description="The task ID of the multiview images to edit")
+    input: str = Field(..., description="The task ID of the multiview images to edit")
     prompts: list[TripoMultiviewEditPrompt] = Field(..., description="Per-view edit instructions")
 
 
+class TripoMeshSmartSegmentRequest(BaseModel):
+    input: str = Field(..., description="URL or file token of a GLB model, or of an image")
+    seg_type: str = Field(..., description='"model" or "image"')
+    transform: list[float] | None = Field(None, description="Column-major 4x4 matrix, required for models")
+    granularity: str | None = Field(None, description="coarse, medium or fine")
+    hint: str | None = Field(None, description="Text naming the parts to look for")
+
+
 class TripoConvertModelRequest(BaseModel):
-    type: TripoTaskType = Field(TripoTaskType.CONVERT_MODEL, description="Type of task")
+    input: str = Field(..., description="The task ID of the model to convert")
     format: TripoConvertFormat = Field(..., description="The format to convert to")
-    original_model_task_id: str = Field(..., description="The task ID of the original model")
     quad: bool | None = Field(None, description="Whether to apply quad to the model")
     force_symmetry: bool | None = Field(None, description="Whether to force symmetry")
     face_limit: int | None = Field(None, description="The number of faces to limit the conversion to")
@@ -458,7 +417,7 @@ class TripoConvertModelRequest(BaseModel):
 class TripoP1CommonRequest(BaseModel):
     """Fields supported by Tripo P1 across all input types."""
 
-    model_version: str = Field("P1-20260311")
+    model: str = Field("P1-20260311")
     model_seed: int | None = Field(None, description="Random seed for geometry generation")
     face_limit: int | None = Field(None, ge=48, le=20000, description="Target face count (48-20000)")
     texture: bool | None = Field(None, description="Enable texturing; pbr=True forces this true")
@@ -471,53 +430,40 @@ class TripoP1CommonRequest(BaseModel):
 
 
 class TripoP1TextToModelRequest(TripoP1CommonRequest):
-    type: str = "text_to_model"
     prompt: str = Field(..., max_length=1024)
     negative_prompt: str | None = Field(None, max_length=255)
     image_seed: int | None = None
 
 
 class TripoP1ImageToModelRequest(TripoP1CommonRequest):
-    type: str = "image_to_model"
-    file: TripoFileReference
+    input: str
     enable_image_autofix: bool | None = None
     texture_alignment: str | None = Field(None, description='"original_image" or "geometry"')
     orientation: str | None = Field(None, description='"default" or "align_image"; needs texture=true')
 
 
 class TripoP1MultiviewToModelRequest(TripoP1CommonRequest):
-    """P1 multiview generation.
-
-    Tripo requires `files` to be exactly four entries in [front, left, back, right] order with `{}`
-    (TripoFileEmptyReference) for omitted slots; front is required and at least two images total must be provided.
-    """
-
-    type: str = "multiview_to_model"
-    files: list[TripoFileReference]
+    inputs: list[dict[str, str]]
     texture_alignment: str | None = None
     orientation: str | None = None
 
 
 class TripoImportModelRequest(BaseModel):
-    """Request for the comfy-api composite import endpoint (/proxy/tripo/v2/openapi/import).
-
-    The model file is uploaded to ComfyUI API storage first; the backend downloads it from
-    `url`, re-uploads it to Tripo's storage and creates the import_model task server-side.
-    """
-
-    url: str = Field(..., description="ComfyUI API storage download URL of the model file")
-    format: str = Field(..., description='File format: "glb", "fbx", "obj" or "stl"')
+    input: str = Field(..., description="URL or file token of the model file")
 
 
 class TripoTaskOutput(BaseModel):
-    model: str | None = Field(None, description="URL to the model")
-    base_model: str | None = Field(None, description="URL to the base model")
-    pbr_model: str | None = Field(None, description="URL to the PBR model")
-    rendered_image: str | None = Field(None, description="URL to the rendered image")
+    model_url: str | None = Field(None, description="URL to the model")
+    rendered_image_url: str | None = Field(None, description="URL to the rendered preview")
+    generated_image_url: str | None = Field(None, description="URL to the intermediate image of text-to-model")
     riggable: bool | None = Field(None, description="Whether the model is riggable")
     rig_type: str | None = Field(None, description="Recommended rig type")
-    topology: str | None = Field(None, description="Legacy name of rig_type")
     generate_multiview_image: dict[str, str] | None = Field(None, description="View name to image URL")
+    prompt: str | None = Field(None, description="Smart segmentation: the parts Tripo found")
+    mask_url: str | None = Field(None, description="Smart segmentation: part mask image")
+    seg_model_url: str | None = Field(None, description="Smart segmentation: segmented GLB")
+    seg_task_id: str | None = Field(None, description="Smart segmentation: the mesh_segmentation task")
+    model_task_id: str | None = Field(None, description="Smart segmentation: the imported or generated model task")
 
 
 class TripoTask(BaseModel):
@@ -527,15 +473,25 @@ class TripoTask(BaseModel):
     input: dict[str, Any] | None = Field(None, description="The input parameters for the task")
     output: TripoTaskOutput | None = Field(None, description="The output of the task")
     progress: int | None = Field(None, description="The progress of the task", ge=0, le=100)
-    create_time: int | None = Field(None, description="The creation time of the task")
-    running_left_time: int | None = Field(None, description="The estimated time left for the task")
-    queue_position: int | None = Field(None, description="The position in the queue")
-    consumed_credit: float | None = Field(None)
+    created_at: str | None = Field(None, description="The creation time of the task")
+    completed_at: str | None = Field(None, description="The completion time of the task")
+    credits_consumed: float | None = Field(None)
+    error_code: int | None = Field(None)
+    error_message: str | None = Field(None)
 
 
 class TripoTaskResponse(BaseModel):
     code: int = Field(0, description="The response code")
     data: TripoTask = Field(..., description="The task data")
+
+
+class TripoFileData(BaseModel):
+    file_token: str
+
+
+class TripoFileResponse(BaseModel):
+    code: int = Field(0, description="The response code")
+    data: TripoFileData
 
 
 class TripoErrorResponse(BaseModel):

--- a/comfy_api_nodes/nodes_gemini.py
+++ b/comfy_api_nodes/nodes_gemini.py
@@ -621,6 +621,7 @@ class GeminiNode(IO.ComfyNode):
 
 
 GEMINI_V2_MODELS: dict[str, str] = {
+    "Gemini 3.8 Flash": "gemini-3.8-flash",
     "Gemini 3.7 Flash": "gemini-3.7-flash",
     "Gemini 3.1 Pro": "gemini-3.1-pro-preview",
     "Gemini 3.5 Flash": "gemini-3.5-flash",
@@ -628,8 +629,37 @@ GEMINI_V2_MODELS: dict[str, str] = {
 }
 
 
-def _gemini_text_model_inputs(thinking_default: str, thinking_options: list[str] | None = None) -> list[Input]:
-    """Per-model inputs revealed by the model DynamicCombo (shared media + sampling controls)."""
+def _gemini_text_model_inputs(
+    thinking_default: str,
+    thinking_options: list[str] | None = None,
+    *,
+    sampling: bool = True,
+) -> list[Input]:
+    sampling_inputs: list[Input] = (
+        [
+            IO.Float.Input(
+                "temperature",
+                default=1.0,
+                min=0.0,
+                max=2.0,
+                step=0.01,
+                tooltip="Controls randomness. Lower is more focused/deterministic, higher is more creative.",
+                advanced=True,
+            ),
+            IO.Float.Input(
+                "top_p",
+                default=0.95,
+                min=0.0,
+                max=1.0,
+                step=0.01,
+                tooltip="Nucleus sampling: sample from the smallest token set whose cumulative "
+                "probability reaches top_p.",
+                advanced=True,
+            ),
+        ]
+        if sampling
+        else []
+    )
     return [
         IO.Autogrow.Input(
             "images",
@@ -671,24 +701,7 @@ def _gemini_text_model_inputs(thinking_default: str, thinking_options: list[str]
             tooltip="How hard the model reasons internally before answering. "
             "HIGH improves quality on difficult tasks but costs more (thinking) tokens and is slower.",
         ),
-        IO.Float.Input(
-            "temperature",
-            default=1.0,
-            min=0.0,
-            max=2.0,
-            step=0.01,
-            tooltip="Controls randomness. Lower is more focused/deterministic, higher is more creative.",
-            advanced=True,
-        ),
-        IO.Float.Input(
-            "top_p",
-            default=0.95,
-            min=0.0,
-            max=1.0,
-            step=0.01,
-            tooltip="Nucleus sampling: sample from the smallest token set whose cumulative probability reaches top_p.",
-            advanced=True,
-        ),
+        *sampling_inputs,
         IO.Int.Input(
             "max_output_tokens",
             default=32768,
@@ -724,6 +737,10 @@ class GeminiNodeV2(IO.ComfyNode):
                 IO.DynamicCombo.Input(
                     "model",
                     options=[
+                        IO.DynamicCombo.Option(
+                            "Gemini 3.8 Flash",
+                            _gemini_text_model_inputs("MEDIUM", ["LOW", "MEDIUM", "HIGH"], sampling=False),
+                        ),
                         IO.DynamicCombo.Option(
                             "Gemini 3.7 Flash",
                             _gemini_text_model_inputs("MEDIUM", ["LOW", "MEDIUM", "HIGH"]),
@@ -773,9 +790,9 @@ class GeminiNodeV2(IO.ComfyNode):
                     "usd": [0.00025, 0.0015],
                     "format": { "approximate": true, "separator": "-", "suffix": " per 1K tokens" }
                   }
-                  : $contains($m, "3.7 flash") ? {
+                  : ($contains($m, "3.7 flash") or $contains($m, "3.8 flash")) ? {
                     "type": "list_usd",
-                    "usd": [0.00215, 0.01073],
+                    "usd": [0.002145, 0.010725],
                     "format": { "approximate": true, "separator": "-", "suffix": " per 1K tokens" }
                   }
                   : $contains($m, "3.5 flash") ? {
@@ -829,8 +846,8 @@ class GeminiNodeV2(IO.ComfyNode):
                     )
                 ],
                 generationConfig=GeminiGenerationConfig(
-                    temperature=model["temperature"],
-                    topP=model["top_p"],
+                    temperature=model.get("temperature"),
+                    topP=model.get("top_p"),
                     maxOutputTokens=model["max_output_tokens"],
                     seed=seed if seed > 0 else None,
                     thinkingConfig=GeminiThinkingConfig(thinkingLevel=model["thinking_level"]),

--- a/comfy_api_nodes/nodes_openrouter.py
+++ b/comfy_api_nodes/nodes_openrouter.py
@@ -1,8 +1,11 @@
-"""API Nodes for OpenRouter LLM chat completions."""
+"""API Nodes for OpenRouter chat completions: LLM text generation and image generation."""
 
+import base64
 from dataclasses import dataclass
+from io import BytesIO
 from typing import Literal
 
+import torch
 from typing_extensions import override
 
 from comfy_api.latest import IO, ComfyExtension, Input
@@ -10,7 +13,11 @@ from comfy_api_nodes.apis.openrouter import (
     OpenRouterChatRequest,
     OpenRouterChatResponse,
     OpenRouterContentBlock,
+    OpenRouterError,
     OpenRouterImageContent,
+    OpenRouterImageData,
+    OpenRouterImageRequest,
+    OpenRouterImageResponse,
     OpenRouterImageUrl,
     OpenRouterMessage,
     OpenRouterReasoningConfig,
@@ -21,7 +28,9 @@ from comfy_api_nodes.apis.openrouter import (
 )
 from comfy_api_nodes.util import (
     ApiEndpoint,
+    bytesio_to_image_tensor,
     get_number_of_images,
+    pad_images_to_common_channels,
     sync_op,
     upload_images_to_comfyapi,
     upload_video_to_comfyapi,
@@ -29,6 +38,7 @@ from comfy_api_nodes.util import (
 )
 
 OPENROUTER_CHAT_ENDPOINT = "/proxy/openrouter/api/v1/chat/completions"
+OPENROUTER_IMAGES_ENDPOINT = "/proxy/openrouter/api/v1/images"
 
 
 Profile = Literal["standard", "reasoning", "frontier_reasoning", "perplexity", "perplexity_reasoning"]
@@ -251,10 +261,14 @@ def _build_request(
     )
 
 
+def _raise_on_error(error: OpenRouterError | None) -> None:
+    if error:
+        code = error.code if error.code is not None else "unknown"
+        raise ValueError(f"OpenRouter error ({code}): {error.message or 'no message'}")
+
+
 def _extract_text(response: OpenRouterChatResponse) -> str:
-    if response.error:
-        code = response.error.code if response.error.code is not None else "unknown"
-        raise ValueError(f"OpenRouter error ({code}): {response.error.message or 'no message'}")
+    _raise_on_error(response.error)
     if not response.choices:
         raise ValueError("Empty response from OpenRouter (no choices).")
     message = response.choices[0].message
@@ -263,6 +277,21 @@ def _extract_text(response: OpenRouterChatResponse) -> str:
     if message.refusal:
         raise ValueError(f"Model refused to respond: {message.refusal}")
     return message.content or ""
+
+
+def _image_data_to_tensor(item: OpenRouterImageData) -> torch.Tensor:
+    try:
+        return bytesio_to_image_tensor(BytesIO(base64.b64decode(item.b64_json)))
+    except Exception as e:
+        raise ValueError(f"OpenRouter returned an image that could not be decoded: {e}") from e
+
+
+def _extract_images(response: OpenRouterImageResponse) -> torch.Tensor:
+    _raise_on_error(response.error)
+    tensors = [_image_data_to_tensor(item) for item in response.data or [] if item.b64_json]
+    if not tensors:
+        raise ValueError("OpenRouter returned no image.")
+    return torch.cat(pad_images_to_common_channels(tensors))
 
 
 class OpenRouterLLMNode(IO.ComfyNode):
@@ -370,10 +399,228 @@ class OpenRouterLLMNode(IO.ComfyNode):
         return IO.NodeOutput(_extract_text(response))
 
 
+@dataclass(frozen=True)
+class _ImageModelSpec:
+    slug: str
+    price_text: float
+    price_image_in: float
+    price_image_out: float
+
+
+IMAGE_MODELS: list[_ImageModelSpec] = [
+    _ImageModelSpec("microsoft/mai-image-2.6", 0.000005, 0.000008, 0.000038),
+    _ImageModelSpec("microsoft/mai-image-2.6-flash", 0.00000175, 0.0000025, 0.000019),
+]
+
+_IMAGE_MODELS_BY_SLUG: dict[str, _ImageModelSpec] = {m.slug: m for m in IMAGE_MODELS}
+_IMAGE_SIZES: dict[str, dict[str, tuple[int, int]]] = {
+    "1K": {
+        "1:1": (1024, 1024),
+        "16:9": (1360, 768),
+        "9:16": (768, 1360),
+        "3:2": (1152, 768),
+        "2:3": (768, 1152),
+        "4:3": (1024, 768),
+        "3:4": (768, 1024),
+    },
+    "1.5K": {
+        "1:1": (1536, 1536),
+        "16:9": (2048, 1152),
+        "9:16": (1152, 2048),
+        "3:2": (1872, 1248),
+        "2:3": (1248, 1872),
+        "4:3": (1760, 1312),
+        "3:4": (1312, 1760),
+    },
+}
+_IMAGE_ASPECT_RATIOS = list(_IMAGE_SIZES["1K"])
+_IMAGE_PROMPT_MAX_CHARS = 20000
+_IMAGE_MAX_REFERENCES = 5
+_IMAGE_REFERENCE_MAX_PIXELS = 2048 * 2048
+_IMAGE_REFERENCE_TEXT_OVERHEAD_TOKENS = 256
+
+
+def _image_tokens(width: int, height: int) -> int:
+    return width * height // 1024
+
+
+def _image_model_option(spec: _ImageModelSpec) -> IO.DynamicCombo.Option:
+    return IO.DynamicCombo.Option(
+        spec.slug,
+        [
+            IO.String.Input(
+                "prompt",
+                multiline=True,
+                default="",
+                tooltip="Describes the image to generate, or the edit to apply to the reference images. "
+                f"Up to {_IMAGE_PROMPT_MAX_CHARS} characters.",
+            ),
+            IO.Combo.Input(
+                "aspect_ratio",
+                options=_IMAGE_ASPECT_RATIOS,
+                default="1:1",
+                tooltip="Aspect ratio of the generated image, also applied when reference images are connected.",
+            ),
+            IO.Combo.Input(
+                "resolution",
+                options=list(_IMAGE_SIZES),
+                default="1K",
+                tooltip="Output size tier. 1K is about 1 megapixel (1:1 is 1024x1024, 16:9 is 1360x768); "
+                "1.5K is about 2.3 megapixels (1:1 is 1536x1536, 16:9 is 2048x1152).",
+            ),
+            IO.Autogrow.Input(
+                "images",
+                template=IO.Autogrow.TemplateNames(
+                    IO.Image.Input("image"),
+                    names=[f"image_{i}" for i in range(1, _IMAGE_MAX_REFERENCES + 1)],
+                    min=0,
+                ),
+                tooltip=f"Up to {_IMAGE_MAX_REFERENCES} reference images for image-guided editing; "
+                "a batched input counts once per image.",
+            ),
+            IO.Int.Input(
+                "seed",
+                default=42,
+                min=0,
+                max=2147483647,
+                step=1,
+                display_mode=IO.NumberDisplay.number,
+                control_after_generate=True,
+                tooltip="Seed to determine if node should re-run; the API has no seed, "
+                "so actual results are nondeterministic regardless of this value.",
+            ),
+        ],
+    )
+
+
+def _image_price_badge_jsonata() -> str:
+    rates_pairs = []
+    for spec in IMAGE_MODELS:
+        per_million = [spec.price_text * 1e6, spec.price_image_in * 1e6, spec.price_image_out * 1e6]
+        rates_pairs.append(f'    "{spec.slug}": [{", ".join(f"{p:.8g}" for p in per_million)}]')
+    rates_block = ",\n".join(rates_pairs)
+    size_tables = []
+    for tier, table in _IMAGE_SIZES.items():
+        ratio_tokens = ", ".join(f'"{ratio}": {_image_tokens(w, h)}' for ratio, (w, h) in table.items())
+        size_tables.append(f'"{tier.lower()}": {{{ratio_tokens}}}')
+    default_out = _image_tokens(*_IMAGE_SIZES["1K"]["1:1"])
+    ref_max_tokens = _IMAGE_REFERENCE_MAX_PIXELS // 1024
+    return (
+        "(\n"
+        "  $rates := {\n"
+        f"{rates_block}\n"
+        "  };\n"
+        f"  $outTokens := {{{', '.join(size_tables)}}};\n"
+        "  $r := $lookup($rates, widgets.model);\n"
+        '  $ar := $lookup(widgets, "model.aspect_ratio");\n'
+        '  $res := $lookup(widgets, "model.resolution");\n'
+        '  $prompt := $lookup(widgets, "model.prompt");\n'
+        '  $links := $lookup(inputGroups, "model.images");\n'
+        '  $refs := $type($links) = "number" ? $links : 0;\n'
+        '  $promptTokens := $type($prompt) = "string"\n'
+        "    ? ($length($prompt) + 2 * $count($match($prompt, /[^\\x00-\\x7F]/))) / 4 : 0;\n"
+        '  $table := $type($res) = "string" ? $lookup($outTokens, $res) : null;\n'
+        '  $sized := ($type($table) = "object" and $type($ar) = "string") ? $lookup($table, $ar) : null;\n'
+        f'  $out := $type($sized) = "number" ? $sized : {default_out};\n'
+        "  $r ? ($refs > 0 ? {\n"
+        '    "type": "range_usd",\n'
+        '    "min_usd": ($promptTokens * $r[0] + $out * $r[2]) * 1.43 / 1000000,\n'
+        f'    "max_usd": (($promptTokens + $refs * {_IMAGE_REFERENCE_TEXT_OVERHEAD_TOKENS}) * $r[0]'
+        f" + $refs * {ref_max_tokens} * $r[1] + $out * $r[2]) * 1.43 / 1000000,\n"
+        '    "format": {"approximate": true}\n'
+        "  } : {\n"
+        '    "type": "usd",\n'
+        '    "usd": ($promptTokens * $r[0] + $out * $r[2]) * 1.43 / 1000000,\n'
+        '    "format": {"approximate": true}\n'
+        '  }) : {"type": "text", "text": "Token-based"}\n'
+        ")"
+    )
+
+
+class OpenRouterImageNode(IO.ComfyNode):
+
+    @classmethod
+    def define_schema(cls):
+        return IO.Schema(
+            node_id="OpenRouterImageNode",
+            display_name="OpenRouter Image",
+            category="partner/image/OpenRouter",
+            description=(
+                "Generate or edit images through OpenRouter with Microsoft's MAI-Image-2.6 models: "
+                "text to image, or image-guided editing with up to five reference images, "
+                "in seven aspect ratios at 1K or 1.5K."
+            ),
+            inputs=[
+                IO.DynamicCombo.Input(
+                    "model",
+                    options=[_image_model_option(spec) for spec in IMAGE_MODELS],
+                    tooltip="The OpenRouter image model used to generate the image.",
+                ),
+            ],
+            outputs=[IO.Image.Output()],
+            hidden=[
+                IO.Hidden.auth_token_comfy_org,
+                IO.Hidden.api_key_comfy_org,
+                IO.Hidden.unique_id,
+            ],
+            is_api_node=True,
+            price_badge=IO.PriceBadge(
+                depends_on=IO.PriceBadgeDepends(
+                    widgets=["model", "model.aspect_ratio", "model.resolution", "model.prompt"],
+                    input_groups=["model.images"],
+                ),
+                expr=_image_price_badge_jsonata(),
+            ),
+        )
+
+    @classmethod
+    async def execute(cls, model: dict) -> IO.NodeOutput:
+        slug: str = model["model"]
+        if slug not in _IMAGE_MODELS_BY_SLUG:
+            raise ValueError(f"Unknown OpenRouter model: {slug}")
+        prompt: str = model["prompt"]
+        validate_string(prompt, strip_whitespace=True, min_length=1)
+        validate_string(prompt, strip_whitespace=False, max_length=_IMAGE_PROMPT_MAX_CHARS)
+        width, height = _IMAGE_SIZES[model["resolution"]][model["aspect_ratio"]]
+
+        reference_images = [
+            image for images in (model.get("images") or {}).values() if images is not None for image in images
+        ]
+        if len(reference_images) > _IMAGE_MAX_REFERENCES:
+            raise ValueError(
+                f"A maximum of {_IMAGE_MAX_REFERENCES} reference images is supported; got {len(reference_images)} "
+                "(a batched input counts once per image)."
+            )
+        input_references: list[OpenRouterImageContent] | None = None
+        if reference_images:
+            urls = await upload_images_to_comfyapi(
+                cls,
+                [image[..., :3] for image in reference_images],
+                max_images=_IMAGE_MAX_REFERENCES,
+                mime_type="image/png",
+                total_pixels=_IMAGE_REFERENCE_MAX_PIXELS,
+                wait_label="Uploading reference images",
+            )
+            input_references = [OpenRouterImageContent(image_url=OpenRouterImageUrl(url=url)) for url in urls]
+
+        response = await sync_op(
+            cls,
+            ApiEndpoint(path=OPENROUTER_IMAGES_ENDPOINT, method="POST"),
+            response_model=OpenRouterImageResponse,
+            data=OpenRouterImageRequest(
+                model=slug,
+                prompt=prompt,
+                size=f"{width}x{height}",
+                input_references=input_references,
+            ),
+        )
+        return IO.NodeOutput(_extract_images(response))
+
+
 class OpenRouterExtension(ComfyExtension):
     @override
     async def get_node_list(self) -> list[type[IO.ComfyNode]]:
-        return [OpenRouterLLMNode]
+        return [OpenRouterLLMNode, OpenRouterImageNode]
 
 
 async def comfy_entrypoint() -> OpenRouterExtension:

--- a/comfy_api_nodes/nodes_openrouter.py
+++ b/comfy_api_nodes/nodes_openrouter.py
@@ -433,7 +433,9 @@ _IMAGE_SIZES: dict[str, dict[str, tuple[int, int]]] = {
         "3:4": (1312, 1760),
     },
 }
-_IMAGE_ASPECT_RATIOS = list(_IMAGE_SIZES["1K"])
+_IMAGE_AUTO_ASPECT_RATIO = "auto"
+_IMAGE_ASPECT_RATIOS = [*_IMAGE_SIZES["1K"], _IMAGE_AUTO_ASPECT_RATIO]
+_IMAGE_AUTO_OUTPUT_SIZE = _IMAGE_SIZES["1.5K"]["1:1"]
 _IMAGE_PROMPT_MAX_CHARS = 20000
 _IMAGE_MAX_REFERENCES = 5
 _IMAGE_REFERENCE_MAX_PIXELS = 2048 * 2048
@@ -459,14 +461,16 @@ def _image_model_option(spec: _ImageModelSpec) -> IO.DynamicCombo.Option:
                 "aspect_ratio",
                 options=_IMAGE_ASPECT_RATIOS,
                 default="1:1",
-                tooltip="Aspect ratio of the generated image, also applied when reference images are connected.",
+                tooltip="Aspect ratio of the generated image, also applied when reference images are connected. "
+                "'auto' lets the model choose the ratio for text to image (rendered at the 1.5K size) and keeps "
+                "the aspect ratio of the first reference image when editing.",
             ),
             IO.Combo.Input(
                 "resolution",
                 options=list(_IMAGE_SIZES),
                 default="1K",
                 tooltip="Output size tier. 1K is about 1 megapixel (1:1 is 1024x1024, 16:9 is 1360x768); "
-                "1.5K is about 2.3 megapixels (1:1 is 1536x1536, 16:9 is 2048x1152).",
+                "1.5K is about 2.3 megapixels (1:1 is 1536x1536, 16:9 is 2048x1152). Ignored when aspect_ratio is 'auto'.",
             ),
             IO.Autogrow.Input(
                 "images",
@@ -504,6 +508,7 @@ def _image_price_badge_jsonata() -> str:
         ratio_tokens = ", ".join(f'"{ratio}": {_image_tokens(w, h)}' for ratio, (w, h) in table.items())
         size_tables.append(f'"{tier.lower()}": {{{ratio_tokens}}}')
     default_out = _image_tokens(*_IMAGE_SIZES["1K"]["1:1"])
+    auto_out = _image_tokens(*_IMAGE_AUTO_OUTPUT_SIZE)
     ref_max_tokens = _IMAGE_REFERENCE_MAX_PIXELS // 1024
     return (
         "(\n"
@@ -521,7 +526,8 @@ def _image_price_badge_jsonata() -> str:
         "    ? ($length($prompt) + 2 * $count($match($prompt, /[^\\x00-\\x7F]/))) / 4 : 0;\n"
         '  $table := $type($res) = "string" ? $lookup($outTokens, $res) : null;\n'
         '  $sized := ($type($table) = "object" and $type($ar) = "string") ? $lookup($table, $ar) : null;\n'
-        f'  $out := $type($sized) = "number" ? $sized : {default_out};\n'
+        f'  $out := $ar = "{_IMAGE_AUTO_ASPECT_RATIO}" ? ($refs > 0 ? {default_out} : {auto_out})'
+        f' : ($type($sized) = "number" ? $sized : {default_out});\n'
         "  $r ? ($refs > 0 ? {\n"
         '    "type": "range_usd",\n'
         '    "min_usd": ($promptTokens * $r[0] + $out * $r[2]) * 1.43 / 1000000,\n'
@@ -581,7 +587,11 @@ class OpenRouterImageNode(IO.ComfyNode):
         prompt: str = model["prompt"]
         validate_string(prompt, strip_whitespace=True, min_length=1)
         validate_string(prompt, strip_whitespace=False, max_length=_IMAGE_PROMPT_MAX_CHARS)
-        width, height = _IMAGE_SIZES[model["resolution"]][model["aspect_ratio"]]
+        aspect_ratio: str = model["aspect_ratio"]
+        size: str | None = None
+        if aspect_ratio != _IMAGE_AUTO_ASPECT_RATIO:
+            width, height = _IMAGE_SIZES[model["resolution"]][aspect_ratio]
+            size = f"{width}x{height}"
 
         reference_images = [
             image for images in (model.get("images") or {}).values() if images is not None for image in images
@@ -610,7 +620,8 @@ class OpenRouterImageNode(IO.ComfyNode):
             data=OpenRouterImageRequest(
                 model=slug,
                 prompt=prompt,
-                size=f"{width}x{height}",
+                aspect_ratio=aspect_ratio if size is None else None,
+                size=size,
                 input_references=input_references,
             ),
         )

--- a/comfy_api_nodes/nodes_tripo.py
+++ b/comfy_api_nodes/nodes_tripo.py
@@ -13,14 +13,15 @@ from comfy_api_nodes.apis.tripo import (
     TripoAnimateRigRequest,
     TripoConvertModelRequest,
     TripoEditMultiviewImageRequest,
-    TripoFileEmptyReference,
     TripoFileReference,
+    TripoFileResponse,
     TripoGenerateMultiviewImageRequest,
     TripoHighpolyToLowpolyRequest,
     TripoImageToModelRequest,
     TripoImportModelRequest,
     TripoMeshCompletionRequest,
     TripoMeshSegmentationRequest,
+    TripoMeshSmartSegmentRequest,
     TripoModelVersion,
     TripoMultiviewEditPrompt,
     TripoMultiviewToModelRequest,
@@ -35,7 +36,6 @@ from comfy_api_nodes.apis.tripo import (
     TripoStyle,
     TripoTaskResponse,
     TripoTaskStatus,
-    TripoTaskType,
     TripoTextToModelRequest,
     TripoTextureModelRequest,
     TripoTextureModelVersion,
@@ -48,6 +48,7 @@ from comfy_api_nodes.util import (
     download_url_to_image_tensor,
     poll_op,
     sync_op,
+    tensor_to_bytesio,
     upload_3d_model_to_comfyapi,
     upload_images_to_comfyapi,
 )
@@ -55,6 +56,7 @@ from comfy_api_nodes.util import (
 MULTIVIEW_KEYS = ("front_view_url", "left_view_url", "back_view_url", "right_view_url")
 SEED_MAX = 2**31 - 1
 TEXTURE_SOURCE_TYPES_WITH_IMAGE = ("text_to_model", "image_to_model", "multiview_to_model", "texture_model")
+MIXAMO_RETARGET_ERROR = "Tripo cannot retarget animation presets onto a v1.0 rig made with the mixamo spec."
 
 
 FACE_LIMIT_TOOLTIP = (
@@ -64,10 +66,8 @@ FACE_LIMIT_TOOLTIP = (
 
 
 def get_model_url_from_response(response: TripoTaskResponse) -> str:
-    if response.data is not None:
-        for key in ["pbr_model", "model", "base_model"]:
-            if getattr(response.data.output, key, None) is not None:
-                return getattr(response.data.output, key)
+    if response.data is not None and response.data.output is not None and response.data.output.model_url:
+        return response.data.output.model_url
     raise RuntimeError(f"Failed to get model url from response: {response}")
 
 
@@ -81,7 +81,7 @@ async def poll_task(
         raise RuntimeError(f"Failed to create Tripo task: {response}")
     response_poll = await poll_op(
         node_cls,
-        poll_endpoint=ApiEndpoint(path=f"/proxy/tripo/v2/openapi/task/{response.data.task_id}"),
+        poll_endpoint=ApiEndpoint(path=f"/proxy/tripo/v3/tasks/{response.data.task_id}"),
         response_model=TripoTaskResponse,
         completed_statuses=[TripoTaskStatus.SUCCESS],
         failed_statuses=[
@@ -116,12 +116,12 @@ async def poll_until_finished(
 async def check_riggable(node_cls: type[IO.ComfyNode], model_task_id: str) -> tuple[bool, str]:
     response = await sync_op(
         node_cls,
-        endpoint=ApiEndpoint(path="/proxy/tripo/v2/openapi/task", method="POST"),
+        endpoint=ApiEndpoint(path="/proxy/tripo/v3/animations/rig-check", method="POST"),
         response_model=TripoTaskResponse,
-        data=TripoAnimatePrerigcheckRequest(original_model_task_id=model_task_id),
+        data=TripoAnimatePrerigcheckRequest(input=model_task_id),
     )
     output = (await poll_task(node_cls, response, average_duration=5)).data.output
-    return bool(output.riggable), output.rig_type or output.topology or ""
+    return bool(output.riggable), output.rig_type or ""
 
 
 async def upload_image_reference(node_cls: type[IO.ComfyNode], image: Input.Image) -> TripoFileReference:
@@ -129,9 +129,20 @@ async def upload_image_reference(node_cls: type[IO.ComfyNode], image: Input.Imag
     return TripoFileReference(root=TripoUrlReference(url=url, type="jpeg"))
 
 
-async def multiview_output(node_cls: type[IO.ComfyNode], response: TripoTaskResponse, with_task_id: bool) -> IO.NodeOutput:
+async def multiview_output(
+    node_cls: type[IO.ComfyNode], response: TripoTaskResponse, with_task_id: bool, source_task_id: str | None = None
+) -> IO.NodeOutput:
     response_poll = await poll_task(node_cls, response, average_duration=25)
-    views = response_poll.data.output.generate_multiview_image or {}
+    views = dict(response_poll.data.output.generate_multiview_image or {})
+    if source_task_id and any(not views.get(key) for key in MULTIVIEW_KEYS):
+        source = await sync_op(
+            node_cls,
+            endpoint=ApiEndpoint(path=f"/proxy/tripo/v3/tasks/{source_task_id}"),
+            response_model=TripoTaskResponse,
+        )
+        for key, url in (source.data.output.generate_multiview_image or {}).items():
+            if not views.get(key):
+                views[key] = url
     if any(not views.get(key) for key in MULTIVIEW_KEYS):
         raise RuntimeError(f"Tripo returned incomplete multiview images: {response_poll}")
     images = [await download_url_to_image_tensor(views[key], cls=node_cls) for key in MULTIVIEW_KEYS]
@@ -164,15 +175,222 @@ def check_smart_low_poly_face_limit(smart_low_poly: bool | None, face_limit: int
         )
 
 
-def glb_or_fbx_output(task_id: str, model: Types.File3D) -> IO.NodeOutput:
+def glb_or_fbx_output(task_id: str, model: Types.File3D, legacy: bool = True) -> IO.NodeOutput:
     if model.format not in ("glb", "fbx"):
         raise RuntimeError(f"Tripo returned a file of type {model.format.upper() or 'unknown'} where GLB or FBX was expected")
-    return IO.NodeOutput(
-        f"{task_id}.{model.format}",
-        task_id,
-        model if model.format == "glb" else None,
-        model if model.format == "fbx" else None,
+    outputs = (task_id, model if model.format == "glb" else None, model if model.format == "fbx" else None)
+    return IO.NodeOutput(f"{task_id}.{model.format}", *outputs) if legacy else IO.NodeOutput(*outputs)
+
+
+def model_outputs(
+    legacy: bool,
+    glb_tooltip: str = "Empty when quad is enabled.",
+    fbx_tooltip: str = "Only populated when quad is enabled.",
+) -> list:
+    outputs = [
+        IO.Custom("MODEL_TASK_ID").Output(display_name="model task_id"),
+        IO.File3DGLB.Output(display_name="GLB", tooltip=glb_tooltip),
+        IO.File3DFBX.Output(display_name="FBX", tooltip=fbx_tooltip),
+    ]
+    return [IO.String.Output(display_name="model_file"), *outputs] if legacy else outputs
+
+
+def style_input() -> IO.Combo.Input:
+    return IO.Combo.Input(
+        "style",
+        options=TripoStyle,
+        default="None",
+        optional=True,
+        tooltip="No longer supported by Tripo and ignored. Kept for older workflows.",
     )
+
+
+def texture_inputs() -> list:
+    return [
+        IO.Boolean.Input(
+            "texture",
+            default=True,
+            optional=True,
+            tooltip="Generate texture maps. Off returns bare geometry and ignores pbr.",
+        ),
+        IO.Boolean.Input(
+            "pbr",
+            default=True,
+            optional=True,
+            tooltip="PBR material maps (base color, metallic, roughness, normal). Requires texture.",
+        ),
+    ]
+
+
+def seed_input(name: str) -> IO.Int.Input:
+    return IO.Int.Input(name, default=42, min=0, max=SEED_MAX, optional=True, advanced=True)
+
+
+def texture_quality_input() -> IO.Combo.Input:
+    return IO.Combo.Input(
+        "texture_quality",
+        default="standard",
+        options=["standard", "detailed", "extreme"],
+        optional=True,
+        advanced=True,
+        tooltip="detailed = HD textures, extreme = 8K Ultra textures.",
+    )
+
+
+def texture_alignment_input() -> IO.Combo.Input:
+    return IO.Combo.Input(
+        "texture_alignment",
+        default="original_image",
+        options=["original_image", "geometry"],
+        optional=True,
+        advanced=True,
+    )
+
+
+def orientation_input() -> IO.Combo.Input:
+    return IO.Combo.Input(
+        "orientation",
+        options=TripoOrientation,
+        default=TripoOrientation.DEFAULT,
+        optional=True,
+        advanced=True,
+    )
+
+
+def geometry_inputs(auto_size: bool) -> list:
+    return [
+        IO.Int.Input("face_limit", default=-1, min=-1, max=2000000, optional=True, advanced=True, tooltip=FACE_LIMIT_TOOLTIP),
+        IO.Boolean.Input(
+            "quad",
+            default=False,
+            optional=True,
+            advanced=True,
+            tooltip="Quad mesh output. Tripo delivers quad meshes as FBX, so the result "
+            "arrives on the FBX output and the GLB output stays empty.",
+        ),
+        IO.Combo.Input(
+            "geometry_quality",
+            default="standard",
+            options=["standard", "detailed"],
+            optional=True,
+            advanced=True,
+        ),
+        IO.Boolean.Input(
+            "smart_low_poly",
+            default=False,
+            optional=True,
+            advanced=True,
+            tooltip="Low-poly mesh with clean, hand-crafted style topology (500-20,000 faces, quad 500-10,000). "
+            "Best for simple subjects; complex ones may fail.",
+        ),
+        IO.Boolean.Input(
+            "auto_size",
+            default=auto_size,
+            optional=True,
+            advanced=True,
+            tooltip="Scale textured models to their real-world size in meters. Tripo stores the size as the model's "
+            "scene transform and bakes it in when the model is converted, rigged or retargeted; ignored without texture.",
+        ),
+    ]
+
+
+def generation_price_badge(untextured: int, textured: int) -> IO.PriceBadge:
+    return IO.PriceBadge(
+        depends_on=IO.PriceBadgeDepends(
+            widgets=[
+                "model_version",
+                "texture",
+                "quad",
+                "smart_low_poly",
+                "texture_quality",
+                "geometry_quality",
+            ],
+        ),
+        expr=f"""
+                (
+                  $isV3OrLater := $contains(widgets.model_version,"v3.");
+                  $tq := widgets.texture_quality;
+                  $textureAddon := widgets.texture ? ($tq = "extreme" ? 20 : ($tq = "detailed" ? 10 : 0)) : 0;
+                  $geometryAddon := (widgets.geometry_quality = "detailed" and $isV3OrLater) ? 20 : 0;
+                  $credits := (widgets.texture ? {textured} : {untextured})
+                    + (widgets.quad ? 5 : 0)
+                    + (widgets.smart_low_poly ? 10 : 0)
+                    + $textureAddon
+                    + $geometryAddon;
+                  {{"type":"usd","usd": $credits * 0.01, "format": {{"approximate": true}}}}
+                )
+                """,
+    )
+
+
+def hidden_inputs() -> list:
+    return [
+        IO.Hidden.auth_token_comfy_org,
+        IO.Hidden.api_key_comfy_org,
+        IO.Hidden.unique_id,
+    ]
+
+
+def text_to_model_inputs(legacy: bool) -> list:
+    return [
+        IO.String.Input("prompt", multiline=True),
+        IO.String.Input("negative_prompt", multiline=True, optional=True, tooltip="Up to 255 characters."),
+        IO.Combo.Input(
+            "model_version", options=TripoModelVersion, default=TripoModelVersion.v3_1_20260211, optional=True
+        ),
+        *([style_input()] if legacy else []),
+        *texture_inputs(),
+        seed_input("image_seed"),
+        seed_input("model_seed"),
+        seed_input("texture_seed"),
+        texture_quality_input(),
+        *geometry_inputs(auto_size=True),
+    ]
+
+
+async def text_to_model(
+    cls: type[IO.ComfyNode],
+    *,
+    prompt: str,
+    negative_prompt: str | None,
+    model_version,
+    texture: bool | None,
+    pbr: bool | None,
+    image_seed: int | None,
+    model_seed: int | None,
+    texture_seed: int | None,
+    texture_quality: str | None,
+    geometry_quality: str | None,
+    face_limit: int | None,
+    quad: bool | None,
+    smart_low_poly: bool | None,
+    auto_size: bool,
+) -> tuple[str, Types.File3D]:
+    if not prompt.strip():
+        raise RuntimeError("Prompt is required")
+    check_smart_low_poly_face_limit(smart_low_poly, face_limit, quad)
+    response = await sync_op(
+        cls,
+        endpoint=ApiEndpoint(path="/proxy/tripo/v3/generation/text-to-model", method="POST"),
+        response_model=TripoTaskResponse,
+        data=TripoTextToModelRequest(
+            prompt=prompt,
+            negative_prompt=negative_prompt if negative_prompt else None,
+            model=model_version or TripoModelVersion.v3_1_20260211,
+            texture=texture,
+            pbr=False if texture is False else pbr,
+            image_seed=image_seed,
+            model_seed=model_seed,
+            texture_seed=texture_seed,
+            texture_quality=texture_quality,
+            face_limit=face_limit if face_limit != -1 else None,
+            geometry_quality=geometry_quality,
+            auto_size=auto_size,
+            quad=quad,
+            smart_low_poly=smart_low_poly,
+        ),
+    )
+    return await poll_until_finished(cls, response, average_duration=80)
 
 
 class TripoTextToModelNode(IO.ComfyNode):
@@ -184,116 +402,15 @@ class TripoTextToModelNode(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="TripoTextToModelNode",
-            display_name="Tripo: Text to Model",
+            display_name="Tripo: Text to Model (Legacy)",
             category="partner/3d/Tripo",
-            inputs=[
-                IO.String.Input("prompt", multiline=True),
-                IO.String.Input("negative_prompt", multiline=True, optional=True, tooltip="Up to 255 characters."),
-                IO.Combo.Input(
-                    "model_version", options=TripoModelVersion, default=TripoModelVersion.v3_1_20260211, optional=True
-                ),
-                IO.Combo.Input(
-                    "style",
-                    options=TripoStyle,
-                    default="None",
-                    optional=True,
-                    tooltip="No longer supported by Tripo and ignored. Kept for older workflows.",
-                ),
-                IO.Boolean.Input(
-                    "texture",
-                    default=True,
-                    optional=True,
-                    tooltip="Generate texture maps. Off returns bare geometry and ignores pbr.",
-                ),
-                IO.Boolean.Input(
-                    "pbr",
-                    default=True,
-                    optional=True,
-                    tooltip="PBR material maps (base color, metallic, roughness, normal). Requires texture.",
-                ),
-                IO.Int.Input("image_seed", default=42, min=0, max=SEED_MAX, optional=True, advanced=True),
-                IO.Int.Input("model_seed", default=42, min=0, max=SEED_MAX, optional=True, advanced=True),
-                IO.Int.Input("texture_seed", default=42, min=0, max=SEED_MAX, optional=True, advanced=True),
-                IO.Combo.Input(
-                    "texture_quality",
-                    default="standard",
-                    options=["standard", "detailed", "extreme"],
-                    optional=True,
-                    advanced=True,
-                    tooltip="detailed = HD textures, extreme = 8K Ultra textures.",
-                ),
-                IO.Int.Input("face_limit", default=-1, min=-1, max=2000000, optional=True, advanced=True, tooltip=FACE_LIMIT_TOOLTIP),
-                IO.Boolean.Input(
-                    "quad",
-                    default=False,
-                    optional=True,
-                    advanced=True,
-                    tooltip="Quad mesh output. Tripo delivers quad meshes as FBX, so the result "
-                    "arrives on the FBX output and the GLB output stays empty.",
-                ),
-                IO.Combo.Input(
-                    "geometry_quality",
-                    default="standard",
-                    options=["standard", "detailed"],
-                    optional=True,
-                    advanced=True,
-                ),
-                IO.Boolean.Input(
-                    "smart_low_poly",
-                    default=False,
-                    optional=True,
-                    advanced=True,
-                    tooltip="Low-poly mesh with clean, hand-crafted style topology (500-20,000 faces, quad 500-10,000). "
-                    "Best for simple subjects; complex ones may fail.",
-                ),
-                IO.Boolean.Input(
-                    "auto_size",
-                    default=True,
-                    optional=True,
-                    advanced=True,
-                    tooltip="Scale textured models to their real-world size in meters. Tripo stores the size as the model's "
-                    "scene transform and bakes it in when the model is converted, rigged or retargeted; ignored without texture.",
-                ),
-            ],
-            outputs=[
-                IO.String.Output(display_name="model_file"),  # for backward compatibility only
-                IO.Custom("MODEL_TASK_ID").Output(display_name="model task_id"),
-                IO.File3DGLB.Output(display_name="GLB", tooltip="Empty when quad is enabled."),
-                IO.File3DFBX.Output(display_name="FBX", tooltip="Only populated when quad is enabled."),
-            ],
-            hidden=[
-                IO.Hidden.auth_token_comfy_org,
-                IO.Hidden.api_key_comfy_org,
-                IO.Hidden.unique_id,
-            ],
+            inputs=text_to_model_inputs(legacy=True),
+            outputs=model_outputs(legacy=True),
+            hidden=hidden_inputs(),
             is_api_node=True,
             is_output_node=True,
-            price_badge=IO.PriceBadge(
-                depends_on=IO.PriceBadgeDepends(
-                    widgets=[
-                        "model_version",
-                        "texture",
-                        "quad",
-                        "smart_low_poly",
-                        "texture_quality",
-                        "geometry_quality",
-                    ],
-                ),
-                expr="""
-                (
-                  $isV3OrLater := $contains(widgets.model_version,"v3.");
-                  $tq := widgets.texture_quality;
-                  $textureAddon := widgets.texture ? ($tq = "extreme" ? 20 : ($tq = "detailed" ? 10 : 0)) : 0;
-                  $geometryAddon := (widgets.geometry_quality = "detailed" and $isV3OrLater) ? 20 : 0;
-                  $credits := (widgets.texture ? 20 : 10)
-                    + (widgets.quad ? 5 : 0)
-                    + (widgets.smart_low_poly ? 10 : 0)
-                    + $textureAddon
-                    + $geometryAddon;
-                  {"type":"usd","usd": $credits * 0.01, "format": {"approximate": true}}
-                )
-                """,
-            ),
+            is_deprecated=True,
+            price_badge=generation_price_badge(untextured=10, textured=20),
         )
 
     @classmethod
@@ -315,32 +432,147 @@ class TripoTextToModelNode(IO.ComfyNode):
         smart_low_poly: bool | None = None,
         auto_size: bool = True,
     ) -> IO.NodeOutput:
-        if not prompt.strip():
-            raise RuntimeError("Prompt is required")
-        check_smart_low_poly_face_limit(smart_low_poly, face_limit, quad)
-        response = await sync_op(
-            cls,
-            endpoint=ApiEndpoint(path="/proxy/tripo/v2/openapi/task", method="POST"),
-            response_model=TripoTaskResponse,
-            data=TripoTextToModelRequest(
-                type=TripoTaskType.TEXT_TO_MODEL,
+        return glb_or_fbx_output(
+            *await text_to_model(
+                cls,
                 prompt=prompt,
-                negative_prompt=negative_prompt if negative_prompt else None,
+                negative_prompt=negative_prompt,
                 model_version=model_version,
                 texture=texture,
-                pbr=False if texture is False else pbr,
+                pbr=pbr,
                 image_seed=image_seed,
                 model_seed=model_seed,
                 texture_seed=texture_seed,
                 texture_quality=texture_quality,
-                face_limit=face_limit if face_limit != -1 else None,
                 geometry_quality=geometry_quality,
-                auto_size=auto_size,
+                face_limit=face_limit,
                 quad=quad,
                 smart_low_poly=smart_low_poly,
-            ),
+                auto_size=auto_size,
+            )
         )
-        return glb_or_fbx_output(*await poll_until_finished(cls, response, average_duration=80))
+
+
+class TripoTextToModelNodeV2(IO.ComfyNode):
+
+    @classmethod
+    def define_schema(cls):
+        return IO.Schema(
+            node_id="TripoTextToModelNodeV2",
+            display_name="Tripo: Text to Model",
+            category="partner/3d/Tripo",
+            inputs=text_to_model_inputs(legacy=False),
+            outputs=model_outputs(legacy=False),
+            hidden=hidden_inputs(),
+            is_api_node=True,
+            is_output_node=True,
+            price_badge=generation_price_badge(untextured=10, textured=20),
+        )
+
+    @classmethod
+    async def execute(
+        cls,
+        prompt: str,
+        negative_prompt: str | None = None,
+        model_version=None,
+        texture: bool | None = None,
+        pbr: bool | None = None,
+        image_seed: int | None = None,
+        model_seed: int | None = None,
+        texture_seed: int | None = None,
+        texture_quality: str | None = None,
+        geometry_quality: str | None = None,
+        face_limit: int | None = None,
+        quad: bool | None = None,
+        smart_low_poly: bool | None = None,
+        auto_size: bool = True,
+    ) -> IO.NodeOutput:
+        return glb_or_fbx_output(
+            *await text_to_model(
+                cls,
+                prompt=prompt,
+                negative_prompt=negative_prompt,
+                model_version=model_version,
+                texture=texture,
+                pbr=pbr,
+                image_seed=image_seed,
+                model_seed=model_seed,
+                texture_seed=texture_seed,
+                texture_quality=texture_quality,
+                geometry_quality=geometry_quality,
+                face_limit=face_limit,
+                quad=quad,
+                smart_low_poly=smart_low_poly,
+                auto_size=auto_size,
+            ),
+            legacy=False,
+        )
+
+
+def image_to_model_inputs(legacy: bool) -> list:
+    return [
+        IO.Image.Input("image"),
+        IO.Combo.Input(
+            "model_version",
+            options=TripoModelVersion,
+            tooltip="The model version to use for generation",
+            optional=True,
+        ),
+        *([style_input()] if legacy else []),
+        *texture_inputs(),
+        seed_input("model_seed"),
+        orientation_input(),
+        seed_input("texture_seed"),
+        texture_quality_input(),
+        texture_alignment_input(),
+        *geometry_inputs(auto_size=True),
+    ]
+
+
+async def image_to_model(
+    cls: type[IO.ComfyNode],
+    *,
+    image: Input.Image,
+    model_version: str | None,
+    texture: bool | None,
+    pbr: bool | None,
+    model_seed: int | None,
+    orientation,
+    texture_seed: int | None,
+    texture_quality: str | None,
+    geometry_quality: str | None,
+    texture_alignment: str | None,
+    face_limit: int | None,
+    quad: bool | None,
+    smart_low_poly: bool | None,
+    auto_size: bool,
+) -> tuple[str, Types.File3D]:
+    if image is None:
+        raise RuntimeError("Image is required")
+    check_smart_low_poly_face_limit(smart_low_poly, face_limit, quad)
+    image_url = (await upload_images_to_comfyapi(cls, image, max_images=1))[0]
+    response = await sync_op(
+        cls,
+        endpoint=ApiEndpoint(path="/proxy/tripo/v3/generation/image-to-model", method="POST"),
+        response_model=TripoTaskResponse,
+        data=TripoImageToModelRequest(
+            input=image_url,
+            model=model_version or TripoModelVersion.v3_1_20260211,
+            texture=texture,
+            pbr=False if texture is False else pbr,
+            model_seed=model_seed,
+            orientation=orientation,
+            geometry_quality=geometry_quality,
+            texture_alignment=texture_alignment,
+            texture_seed=texture_seed,
+            texture_quality=texture_quality,
+            face_limit=face_limit if face_limit != -1 else None,
+            auto_size=auto_size,
+            quad=quad,
+            smart_low_poly=smart_low_poly,
+        ),
+    )
+    return await poll_until_finished(cls, response, average_duration=80)
 
 
 class TripoImageToModelNode(IO.ComfyNode):
@@ -352,131 +584,15 @@ class TripoImageToModelNode(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="TripoImageToModelNode",
-            display_name="Tripo: Image to Model",
+            display_name="Tripo: Image to Model (Legacy)",
             category="partner/3d/Tripo",
-            inputs=[
-                IO.Image.Input("image"),
-                IO.Combo.Input(
-                    "model_version",
-                    options=TripoModelVersion,
-                    tooltip="The model version to use for generation",
-                    optional=True,
-                ),
-                IO.Combo.Input(
-                    "style",
-                    options=TripoStyle,
-                    default="None",
-                    optional=True,
-                    tooltip="No longer supported by Tripo and ignored. Kept for older workflows.",
-                ),
-                IO.Boolean.Input(
-                    "texture",
-                    default=True,
-                    optional=True,
-                    tooltip="Generate texture maps. Off returns bare geometry and ignores pbr.",
-                ),
-                IO.Boolean.Input(
-                    "pbr",
-                    default=True,
-                    optional=True,
-                    tooltip="PBR material maps (base color, metallic, roughness, normal). Requires texture.",
-                ),
-                IO.Int.Input("model_seed", default=42, min=0, max=SEED_MAX, optional=True, advanced=True),
-                IO.Combo.Input(
-                    "orientation",
-                    options=TripoOrientation,
-                    default=TripoOrientation.DEFAULT,
-                    optional=True,
-                    advanced=True,
-                ),
-                IO.Int.Input("texture_seed", default=42, min=0, max=SEED_MAX, optional=True, advanced=True),
-                IO.Combo.Input(
-                    "texture_quality",
-                    default="standard",
-                    options=["standard", "detailed", "extreme"],
-                    optional=True,
-                    advanced=True,
-                    tooltip="detailed = HD textures, extreme = 8K Ultra textures.",
-                ),
-                IO.Combo.Input(
-                    "texture_alignment",
-                    default="original_image",
-                    options=["original_image", "geometry"],
-                    optional=True,
-                    advanced=True,
-                ),
-                IO.Int.Input("face_limit", default=-1, min=-1, max=2000000, optional=True, advanced=True, tooltip=FACE_LIMIT_TOOLTIP),
-                IO.Boolean.Input(
-                    "quad",
-                    default=False,
-                    optional=True,
-                    advanced=True,
-                    tooltip="Quad mesh output. Tripo delivers quad meshes as FBX, so the result "
-                    "arrives on the FBX output and the GLB output stays empty.",
-                ),
-                IO.Combo.Input(
-                    "geometry_quality",
-                    default="standard",
-                    options=["standard", "detailed"],
-                    optional=True,
-                    advanced=True,
-                ),
-                IO.Boolean.Input(
-                    "smart_low_poly",
-                    default=False,
-                    optional=True,
-                    advanced=True,
-                    tooltip="Low-poly mesh with clean, hand-crafted style topology (500-20,000 faces, quad 500-10,000). "
-                    "Best for simple subjects; complex ones may fail.",
-                ),
-                IO.Boolean.Input(
-                    "auto_size",
-                    default=True,
-                    optional=True,
-                    advanced=True,
-                    tooltip="Scale textured models to their real-world size in meters. Tripo stores the size as the model's "
-                    "scene transform and bakes it in when the model is converted, rigged or retargeted; ignored without texture.",
-                ),
-            ],
-            outputs=[
-                IO.String.Output(display_name="model_file"),  # for backward compatibility only
-                IO.Custom("MODEL_TASK_ID").Output(display_name="model task_id"),
-                IO.File3DGLB.Output(display_name="GLB", tooltip="Empty when quad is enabled."),
-                IO.File3DFBX.Output(display_name="FBX", tooltip="Only populated when quad is enabled."),
-            ],
-            hidden=[
-                IO.Hidden.auth_token_comfy_org,
-                IO.Hidden.api_key_comfy_org,
-                IO.Hidden.unique_id,
-            ],
+            inputs=image_to_model_inputs(legacy=True),
+            outputs=model_outputs(legacy=True),
+            hidden=hidden_inputs(),
             is_api_node=True,
             is_output_node=True,
-            price_badge=IO.PriceBadge(
-                depends_on=IO.PriceBadgeDepends(
-                    widgets=[
-                        "model_version",
-                        "texture",
-                        "quad",
-                        "smart_low_poly",
-                        "texture_quality",
-                        "geometry_quality",
-                    ],
-                ),
-                expr="""
-                (
-                  $isV3OrLater := $contains(widgets.model_version,"v3.");
-                  $tq := widgets.texture_quality;
-                  $textureAddon := widgets.texture ? ($tq = "extreme" ? 20 : ($tq = "detailed" ? 10 : 0)) : 0;
-                  $geometryAddon := (widgets.geometry_quality = "detailed" and $isV3OrLater) ? 20 : 0;
-                  $credits := (widgets.texture ? 30 : 20)
-                    + (widgets.quad ? 5 : 0)
-                    + (widgets.smart_low_poly ? 10 : 0)
-                    + $textureAddon
-                    + $geometryAddon;
-                  {"type":"usd","usd": $credits * 0.01, "format": {"approximate": true}}
-                )
-                """,
-            ),
+            is_deprecated=True,
+            price_badge=generation_price_badge(untextured=20, textured=30),
         )
 
     @classmethod
@@ -498,38 +614,81 @@ class TripoImageToModelNode(IO.ComfyNode):
         smart_low_poly: bool | None = None,
         auto_size: bool = True,
     ) -> IO.NodeOutput:
-        if image is None:
-            raise RuntimeError("Image is required")
-        check_smart_low_poly_face_limit(smart_low_poly, face_limit, quad)
-        tripo_file = TripoFileReference(
-            root=TripoUrlReference(
-                url=(await upload_images_to_comfyapi(cls, image, max_images=1))[0],
-                type="jpeg",
-            )
-        )
-        response = await sync_op(
-            cls,
-            endpoint=ApiEndpoint(path="/proxy/tripo/v2/openapi/task", method="POST"),
-            response_model=TripoTaskResponse,
-            data=TripoImageToModelRequest(
-                type=TripoTaskType.IMAGE_TO_MODEL,
-                file=tripo_file,
+        return glb_or_fbx_output(
+            *await image_to_model(
+                cls,
+                image=image,
                 model_version=model_version,
                 texture=texture,
-                pbr=False if texture is False else pbr,
+                pbr=pbr,
                 model_seed=model_seed,
                 orientation=orientation,
-                geometry_quality=geometry_quality,
-                texture_alignment=texture_alignment,
                 texture_seed=texture_seed,
                 texture_quality=texture_quality,
-                face_limit=face_limit if face_limit != -1 else None,
-                auto_size=auto_size,
+                geometry_quality=geometry_quality,
+                texture_alignment=texture_alignment,
+                face_limit=face_limit,
                 quad=quad,
                 smart_low_poly=smart_low_poly,
-            ),
+                auto_size=auto_size,
+            )
         )
-        return glb_or_fbx_output(*await poll_until_finished(cls, response, average_duration=80))
+
+
+class TripoImageToModelNodeV2(IO.ComfyNode):
+
+    @classmethod
+    def define_schema(cls):
+        return IO.Schema(
+            node_id="TripoImageToModelNodeV2",
+            display_name="Tripo: Image to Model",
+            category="partner/3d/Tripo",
+            inputs=image_to_model_inputs(legacy=False),
+            outputs=model_outputs(legacy=False),
+            hidden=hidden_inputs(),
+            is_api_node=True,
+            is_output_node=True,
+            price_badge=generation_price_badge(untextured=20, textured=30),
+        )
+
+    @classmethod
+    async def execute(
+        cls,
+        image: Input.Image,
+        model_version: str | None = None,
+        texture: bool | None = None,
+        pbr: bool | None = None,
+        model_seed: int | None = None,
+        orientation=None,
+        texture_seed: int | None = None,
+        texture_quality: str | None = None,
+        geometry_quality: str | None = None,
+        texture_alignment: str | None = None,
+        face_limit: int | None = None,
+        quad: bool | None = None,
+        smart_low_poly: bool | None = None,
+        auto_size: bool = True,
+    ) -> IO.NodeOutput:
+        return glb_or_fbx_output(
+            *await image_to_model(
+                cls,
+                image=image,
+                model_version=model_version,
+                texture=texture,
+                pbr=pbr,
+                model_seed=model_seed,
+                orientation=orientation,
+                texture_seed=texture_seed,
+                texture_quality=texture_quality,
+                geometry_quality=geometry_quality,
+                texture_alignment=texture_alignment,
+                face_limit=face_limit,
+                quad=quad,
+                smart_low_poly=smart_low_poly,
+                auto_size=auto_size,
+            ),
+            legacy=False,
+        )
 
 
 class TripoMultiviewToModelNode(IO.ComfyNode):
@@ -554,114 +713,19 @@ class TripoMultiviewToModelNode(IO.ComfyNode):
                     optional=True,
                     tooltip="The model version to use for generation",
                 ),
-                IO.Combo.Input(
-                    "orientation",
-                    options=TripoOrientation,
-                    default=TripoOrientation.DEFAULT,
-                    optional=True,
-                    advanced=True,
-                ),
-                IO.Boolean.Input(
-                    "texture",
-                    default=True,
-                    optional=True,
-                    tooltip="Generate texture maps. Off returns bare geometry and ignores pbr.",
-                ),
-                IO.Boolean.Input(
-                    "pbr",
-                    default=True,
-                    optional=True,
-                    tooltip="PBR material maps (base color, metallic, roughness, normal). Requires texture.",
-                ),
-                IO.Int.Input("model_seed", default=42, min=0, max=SEED_MAX, optional=True, advanced=True),
-                IO.Int.Input("texture_seed", default=42, min=0, max=SEED_MAX, optional=True, advanced=True),
-                IO.Combo.Input(
-                    "texture_quality",
-                    default="standard",
-                    options=["standard", "detailed", "extreme"],
-                    optional=True,
-                    advanced=True,
-                    tooltip="detailed = HD textures, extreme = 8K Ultra textures.",
-                ),
-                IO.Combo.Input(
-                    "texture_alignment",
-                    default="original_image",
-                    options=["original_image", "geometry"],
-                    optional=True,
-                    advanced=True,
-                ),
-                IO.Int.Input("face_limit", default=-1, min=-1, max=2000000, optional=True, advanced=True, tooltip=FACE_LIMIT_TOOLTIP),
-                IO.Boolean.Input(
-                    "quad",
-                    default=False,
-                    optional=True,
-                    advanced=True,
-                    tooltip="Quad mesh output. Tripo delivers quad meshes as FBX, so the result "
-                    "arrives on the FBX output and the GLB output stays empty.",
-                ),
-                IO.Combo.Input(
-                    "geometry_quality",
-                    default="standard",
-                    options=["standard", "detailed"],
-                    optional=True,
-                    advanced=True,
-                ),
-                IO.Boolean.Input(
-                    "smart_low_poly",
-                    default=False,
-                    optional=True,
-                    advanced=True,
-                    tooltip="Low-poly mesh with clean, hand-crafted style topology (500-20,000 faces, quad 500-10,000). "
-                    "Best for simple subjects; complex ones may fail.",
-                ),
-                IO.Boolean.Input(
-                    "auto_size",
-                    default=False,
-                    optional=True,
-                    advanced=True,
-                    tooltip="Scale textured models to their real-world size in meters. Tripo stores the size as the model's "
-                    "scene transform and bakes it in when the model is converted, rigged or retargeted; ignored without texture.",
-                ),
+                orientation_input(),
+                *texture_inputs(),
+                seed_input("model_seed"),
+                seed_input("texture_seed"),
+                texture_quality_input(),
+                texture_alignment_input(),
+                *geometry_inputs(auto_size=False),
             ],
-            outputs=[
-                IO.String.Output(display_name="model_file"),  # for backward compatibility only
-                IO.Custom("MODEL_TASK_ID").Output(display_name="model task_id"),
-                IO.File3DGLB.Output(display_name="GLB", tooltip="Empty when quad is enabled."),
-                IO.File3DFBX.Output(display_name="FBX", tooltip="Only populated when quad is enabled."),
-            ],
-            hidden=[
-                IO.Hidden.auth_token_comfy_org,
-                IO.Hidden.api_key_comfy_org,
-                IO.Hidden.unique_id,
-            ],
+            outputs=model_outputs(legacy=True),
+            hidden=hidden_inputs(),
             is_api_node=True,
             is_output_node=True,
-            price_badge=IO.PriceBadge(
-                depends_on=IO.PriceBadgeDepends(
-                    widgets=[
-                        "model_version",
-                        "texture",
-                        "quad",
-                        "smart_low_poly",
-                        "texture_quality",
-                        "geometry_quality",
-                    ],
-                ),
-                expr="""
-                (
-                  $isV3OrLater := $contains(widgets.model_version,"v3.");
-                  $tq := widgets.texture_quality;
-                  $textureAddon := widgets.texture ? ($tq = "extreme" ? 20 : ($tq = "detailed" ? 10 : 0)) : 0;
-                  $geometryAddon := (widgets.geometry_quality = "detailed" and $isV3OrLater) ? 20 : 0;
-                  $credits := (widgets.texture ? 30 : 20)
-                    + (widgets.quad ? 5 : 0)
-                    + (widgets.smart_low_poly ? 10 : 0)
-                    + $textureAddon
-                    + $geometryAddon;
-                  {"type":"usd","usd": $credits * 0.01, "format": {"approximate": true}}
-                )
-                """,
-            ),
+            price_badge=generation_price_badge(untextured=20, textured=30),
         )
 
     @classmethod
@@ -688,30 +752,19 @@ class TripoMultiviewToModelNode(IO.ComfyNode):
         if image is None:
             raise RuntimeError("front image for multiview is required")
         images = []
-        image_dict = {"image": image, "image_left": image_left, "image_back": image_back, "image_right": image_right}
         if image_left is None and image_back is None and image_right is None:
             raise RuntimeError("At least one of left, back, or right image must be provided for multiview")
         check_smart_low_poly_face_limit(smart_low_poly, face_limit, quad)
-        for image_name in ["image", "image_left", "image_back", "image_right"]:
-            image_ = image_dict[image_name]
+        for view, image_ in zip(("front", "left", "back", "right"), (image, image_left, image_back, image_right)):
             if image_ is not None:
-                images.append(
-                    TripoFileReference(
-                        root=TripoUrlReference(
-                            url=(await upload_images_to_comfyapi(cls, image_, max_images=1))[0], type="jpeg"
-                        )
-                    )
-                )
-            else:
-                images.append(TripoFileEmptyReference())
+                images.append({view: (await upload_images_to_comfyapi(cls, image_, max_images=1))[0]})
         response = await sync_op(
             cls,
-            ApiEndpoint(path="/proxy/tripo/v2/openapi/task", method="POST"),
+            ApiEndpoint(path="/proxy/tripo/v3/generation/multiview-to-model", method="POST"),
             response_model=TripoTaskResponse,
             data=TripoMultiviewToModelRequest(
-                type=TripoTaskType.MULTIVIEW_TO_MODEL,
-                files=images,
-                model_version=model_version,
+                inputs=images,
+                model=model_version or TripoModelVersion.v3_1_20260211,
                 orientation=orientation,
                 texture=texture,
                 pbr=False if texture is False else pbr,
@@ -762,9 +815,9 @@ class TripoImageToMultiviewNode(IO.ComfyNode):
     async def execute(cls, image: Input.Image) -> IO.NodeOutput:
         response = await sync_op(
             cls,
-            endpoint=ApiEndpoint(path="/proxy/tripo/v2/openapi/task", method="POST"),
+            endpoint=ApiEndpoint(path="/proxy/tripo/v3/generation/image-to-multiview", method="POST"),
             response_model=TripoTaskResponse,
-            data=TripoGenerateMultiviewImageRequest(file=await upload_image_reference(cls, image)),
+            data=TripoGenerateMultiviewImageRequest(input=(await upload_images_to_comfyapi(cls, image, max_images=1))[0]),
         )
         return await multiview_output(cls, response, with_task_id=True)
 
@@ -826,11 +879,169 @@ class TripoEditMultiviewNode(IO.ComfyNode):
             raise ValueError("Provide an edit instruction for at least one view.")
         response = await sync_op(
             cls,
-            endpoint=ApiEndpoint(path="/proxy/tripo/v2/openapi/task", method="POST"),
+            endpoint=ApiEndpoint(path="/proxy/tripo/v3/generation/edit-multiview", method="POST"),
             response_model=TripoTaskResponse,
-            data=TripoEditMultiviewImageRequest(original_task_id=multiview_task_id, prompts=prompts),
+            data=TripoEditMultiviewImageRequest(input=multiview_task_id, prompts=prompts),
         )
-        return await multiview_output(cls, response, with_task_id=False)
+        return await multiview_output(cls, response, with_task_id=False, source_task_id=multiview_task_id)
+
+
+def texture_model_inputs(legacy: bool) -> list:
+    return [
+        IO.Custom("MODEL_TASK_ID,SEGMENT_TASK_ID").Input("model_task_id"),
+        *(
+            [
+                IO.Boolean.Input(
+                    "texture",
+                    default=True,
+                    optional=True,
+                    tooltip="Ignored: this node always generates textures. Kept for older workflows.",
+                )
+            ]
+            if legacy
+            else []
+        ),
+        IO.Boolean.Input(
+            "pbr",
+            default=True,
+            optional=True,
+            tooltip="PBR material maps (base color, metallic, roughness, normal); off gives a plain color texture.",
+        ),
+        seed_input("texture_seed"),
+        texture_quality_input(),
+        texture_alignment_input(),
+        IO.String.Input(
+            "texture_prompt",
+            default="",
+            multiline=True,
+            optional=True,
+            tooltip="Optional text guidance for texturing. Required in practice for imported "
+            "models (Tripo: Import Model), which carry no source image to infer colors from. "
+            "Cannot be combined with reference images.",
+        ),
+        IO.Combo.Input(
+            "model_version",
+            options=TripoTextureModelVersion,
+            default=TripoTextureModelVersion.v3_0_20250812,
+            optional=True,
+            tooltip="Texture model: v3.0 for meshes generated with v3.x, v2.5 for meshes generated with v2.5.",
+        ),
+        IO.Image.Input(
+            "style_image",
+            optional=True,
+            tooltip="Reference image for the artistic style of the textures. Only used together with texture_prompt.",
+        ),
+        IO.DynamicCombo.Input(
+            "reference",
+            options=[
+                IO.DynamicCombo.Option("none", []),
+                IO.DynamicCombo.Option(
+                    "image",
+                    [IO.Image.Input("reference_image", tooltip="Single reference image the textures should follow.")],
+                ),
+                IO.DynamicCombo.Option(
+                    "multiview",
+                    [
+                        IO.Image.Input("image_front", tooltip="Front view (0°)."),
+                        IO.Image.Input("image_left", tooltip="Left view (90°)."),
+                        IO.Image.Input("image_back", tooltip="Back view (180°)."),
+                        IO.Image.Input("image_right", tooltip="Right view (270°)."),
+                    ],
+                ),
+            ],
+            optional=True,
+            tooltip="Reference images guiding the textures. Cannot be combined with texture_prompt or style_image.",
+        ),
+        IO.String.Input(
+            "part_names",
+            default="",
+            optional=True,
+            advanced=True,
+            tooltip="Comma-separated part names from Tripo: Segment Model to texture. Empty textures every part.",
+        ),
+    ]
+
+
+def texture_model_outputs(legacy: bool) -> list:
+    return model_outputs(
+        legacy,
+        glb_tooltip="Empty when the source is a quad mesh or an FBX import.",
+        fbx_tooltip="Tripo returns FBX for quad meshes and FBX imports; empty otherwise.",
+    )
+
+
+def texture_price_badge() -> IO.PriceBadge:
+    return IO.PriceBadge(
+        depends_on=IO.PriceBadgeDepends(widgets=["texture_quality"]),
+        expr="""
+                (
+                  $tq := widgets.texture_quality;
+                  {"type":"usd","usd": ($tq = "extreme" ? 0.3 : ($tq = "detailed" ? 0.2 : 0.1)), "format": {"approximate": true}}
+                )
+                """,
+    )
+
+
+async def texture_model(
+    cls: type[IO.ComfyNode],
+    *,
+    model_task_id,
+    pbr: bool | None,
+    texture_seed: int | None,
+    texture_quality: str | None,
+    texture_alignment: str | None,
+    texture_prompt: str,
+    model_version: str | None,
+    style_image: Input.Image | None,
+    reference: dict | None,
+    part_names: str,
+) -> tuple[str, Types.File3D]:
+    text = texture_prompt.strip()
+    mode = reference["reference"] if reference else "none"
+    if mode != "none" and (text or style_image is not None):
+        raise ValueError("Reference images cannot be combined with texture_prompt or style_image.")
+    if style_image is not None and not text:
+        raise ValueError("style_image requires a texture_prompt.")
+    if not text:
+        source = await sync_op(
+            cls,
+            endpoint=ApiEndpoint(path=f"/proxy/tripo/v3/tasks/{model_task_id}"),
+            response_model=TripoTaskResponse,
+        )
+        if source.data.type not in TEXTURE_SOURCE_TYPES_WITH_IMAGE:
+            raise ValueError(
+                "This model has no source image to texture from (imported, segmented, completed or retopologized). "
+                "Give a texture_prompt; Tripo accepts reference images only for models it generated itself."
+            )
+    if mode == "image":
+        prompt = TripoTexturePrompt(image=await upload_image_reference(cls, reference["reference_image"]))
+    elif mode == "multiview":
+        views = [reference[k] for k in ("image_front", "image_left", "image_back", "image_right")]
+        urls = await upload_images_to_comfyapi(cls, views, max_images=4)
+        prompt = TripoTexturePrompt(images=[TripoFileReference(root=TripoUrlReference(url=u, type="jpeg")) for u in urls])
+    elif text:
+        prompt = TripoTexturePrompt(
+            text=text,
+            style_image=await upload_image_reference(cls, style_image) if style_image is not None else None,
+        )
+    else:
+        prompt = None
+    response = await sync_op(
+        cls,
+        endpoint=ApiEndpoint(path="/proxy/tripo/v3/models/texture", method="POST"),
+        response_model=TripoTaskResponse,
+        data=TripoTextureModelRequest(
+            input=model_task_id,
+            model=model_version,
+            pbr=pbr,
+            texture_seed=texture_seed,
+            texture_quality=texture_quality,
+            texture_alignment=texture_alignment,
+            texture_prompt=prompt,
+            part_names=split_part_names(part_names),
+        ),
+    )
+    return await poll_until_finished(cls, response, average_duration=80)
 
 
 class TripoTextureNode(IO.ComfyNode):
@@ -839,113 +1050,15 @@ class TripoTextureNode(IO.ComfyNode):
     def define_schema(cls):
         return IO.Schema(
             node_id="TripoTextureNode",
-            display_name="Tripo: Texture model",
+            display_name="Tripo: Texture model (Legacy)",
             category="partner/3d/Tripo",
-            inputs=[
-                IO.Custom("MODEL_TASK_ID,SEGMENT_TASK_ID").Input("model_task_id"),
-                IO.Boolean.Input(
-                    "texture",
-                    default=True,
-                    optional=True,
-                    tooltip="Ignored: this node always generates textures. Kept for older workflows.",
-                ),
-                IO.Boolean.Input(
-                    "pbr",
-                    default=True,
-                    optional=True,
-                    tooltip="PBR material maps (base color, metallic, roughness, normal); off gives a plain color texture.",
-                ),
-                IO.Int.Input("texture_seed", default=42, min=0, max=SEED_MAX, optional=True, advanced=True),
-                IO.Combo.Input(
-                    "texture_quality",
-                    default="standard",
-                    options=["standard", "detailed", "extreme"],
-                    optional=True,
-                    advanced=True,
-                    tooltip="detailed = HD textures, extreme = 8K Ultra textures.",
-                ),
-                IO.Combo.Input(
-                    "texture_alignment",
-                    default="original_image",
-                    options=["original_image", "geometry"],
-                    optional=True,
-                    advanced=True,
-                ),
-                IO.String.Input(
-                    "texture_prompt",
-                    default="",
-                    multiline=True,
-                    optional=True,
-                    tooltip="Optional text guidance for texturing. Required in practice for imported "
-                    "models (Tripo: Import Model), which carry no source image to infer colors from. "
-                    "Cannot be combined with reference images.",
-                ),
-                IO.Combo.Input(
-                    "model_version",
-                    options=TripoTextureModelVersion,
-                    default=TripoTextureModelVersion.v3_0_20250812,
-                    optional=True,
-                    tooltip="Texture model: v3.0 for meshes generated with v3.x, v2.5 for meshes generated with v2.5.",
-                ),
-                IO.Image.Input(
-                    "style_image",
-                    optional=True,
-                    tooltip="Reference image for the artistic style of the textures. Only used together with texture_prompt.",
-                ),
-                IO.DynamicCombo.Input(
-                    "reference",
-                    options=[
-                        IO.DynamicCombo.Option("none", []),
-                        IO.DynamicCombo.Option(
-                            "image",
-                            [IO.Image.Input("reference_image", tooltip="Single reference image the textures should follow.")],
-                        ),
-                        IO.DynamicCombo.Option(
-                            "multiview",
-                            [
-                                IO.Image.Input("image_front", tooltip="Front view (0°)."),
-                                IO.Image.Input("image_left", tooltip="Left view (90°)."),
-                                IO.Image.Input("image_back", tooltip="Back view (180°)."),
-                                IO.Image.Input("image_right", tooltip="Right view (270°)."),
-                            ],
-                        ),
-                    ],
-                    optional=True,
-                    tooltip="Reference images guiding the textures. Cannot be combined with texture_prompt or style_image.",
-                ),
-                IO.String.Input(
-                    "part_names",
-                    default="",
-                    optional=True,
-                    advanced=True,
-                    tooltip="Comma-separated part names from Tripo: Segment Model to texture. Empty textures every part.",
-                ),
-            ],
-            outputs=[
-                IO.String.Output(display_name="model_file"),  # for backward compatibility only
-                IO.Custom("MODEL_TASK_ID").Output(display_name="model task_id"),
-                IO.File3DGLB.Output(display_name="GLB", tooltip="Empty when the source is a quad mesh or an FBX import."),
-                IO.File3DFBX.Output(
-                    display_name="FBX",
-                    tooltip="Tripo returns FBX for quad meshes and FBX imports; empty otherwise.",
-                ),
-            ],
-            hidden=[
-                IO.Hidden.auth_token_comfy_org,
-                IO.Hidden.api_key_comfy_org,
-                IO.Hidden.unique_id,
-            ],
+            inputs=texture_model_inputs(legacy=True),
+            outputs=texture_model_outputs(legacy=True),
+            hidden=hidden_inputs(),
             is_api_node=True,
             is_output_node=True,
-            price_badge=IO.PriceBadge(
-                depends_on=IO.PriceBadgeDepends(widgets=["texture_quality"]),
-                expr="""
-                (
-                  $tq := widgets.texture_quality;
-                  {"type":"usd","usd": ($tq = "extreme" ? 0.3 : ($tq = "detailed" ? 0.2 : 0.1)), "format": {"approximate": true}}
-                )
-                """,
-            ),
+            is_deprecated=True,
+            price_badge=texture_price_badge(),
         )
 
     @classmethod
@@ -963,53 +1076,69 @@ class TripoTextureNode(IO.ComfyNode):
         reference: dict | None = None,
         part_names: str = "",
     ) -> IO.NodeOutput:
-        text = texture_prompt.strip()
-        mode = reference["reference"] if reference else "none"
-        if mode != "none" and (text or style_image is not None):
-            raise ValueError("Reference images cannot be combined with texture_prompt or style_image.")
-        if style_image is not None and not text:
-            raise ValueError("style_image requires a texture_prompt.")
-        if not text:
-            source = await sync_op(
+        return glb_or_fbx_output(
+            *await texture_model(
                 cls,
-                endpoint=ApiEndpoint(path=f"/proxy/tripo/v2/openapi/task/{model_task_id}"),
-                response_model=TripoTaskResponse,
-            )
-            if source.data.type not in TEXTURE_SOURCE_TYPES_WITH_IMAGE:
-                raise ValueError(
-                    "This model has no source image to texture from (imported, segmented, completed or retopologized). "
-                    "Give a texture_prompt; Tripo accepts reference images only for models it generated itself."
-                )
-        if mode == "image":
-            prompt = TripoTexturePrompt(image=await upload_image_reference(cls, reference["reference_image"]))
-        elif mode == "multiview":
-            views = [reference[k] for k in ("image_front", "image_left", "image_back", "image_right")]
-            urls = await upload_images_to_comfyapi(cls, views, max_images=4)
-            prompt = TripoTexturePrompt(images=[TripoFileReference(root=TripoUrlReference(url=u, type="jpeg")) for u in urls])
-        elif text:
-            prompt = TripoTexturePrompt(
-                text=text,
-                style_image=await upload_image_reference(cls, style_image) if style_image is not None else None,
-            )
-        else:
-            prompt = None
-        response = await sync_op(
-            cls,
-            endpoint=ApiEndpoint(path="/proxy/tripo/v2/openapi/task", method="POST"),
-            response_model=TripoTaskResponse,
-            data=TripoTextureModelRequest(
-                original_model_task_id=model_task_id,
-                model_version=model_version,
-                texture=True,
+                model_task_id=model_task_id,
                 pbr=pbr,
                 texture_seed=texture_seed,
                 texture_quality=texture_quality,
                 texture_alignment=texture_alignment,
-                texture_prompt=prompt,
-                part_names=split_part_names(part_names),
-            ),
+                texture_prompt=texture_prompt,
+                model_version=model_version,
+                style_image=style_image,
+                reference=reference,
+                part_names=part_names,
+            )
         )
-        return glb_or_fbx_output(*await poll_until_finished(cls, response, average_duration=80))
+
+
+class TripoTextureNodeV2(IO.ComfyNode):
+
+    @classmethod
+    def define_schema(cls):
+        return IO.Schema(
+            node_id="TripoTextureNodeV2",
+            display_name="Tripo: Texture model",
+            category="partner/3d/Tripo",
+            inputs=texture_model_inputs(legacy=False),
+            outputs=texture_model_outputs(legacy=False),
+            hidden=hidden_inputs(),
+            is_api_node=True,
+            is_output_node=True,
+            price_badge=texture_price_badge(),
+        )
+
+    @classmethod
+    async def execute(
+        cls,
+        model_task_id,
+        pbr: bool | None = None,
+        texture_seed: int | None = None,
+        texture_quality: str | None = None,
+        texture_alignment: str | None = None,
+        texture_prompt: str = "",
+        model_version: str | None = None,
+        style_image: Input.Image | None = None,
+        reference: dict | None = None,
+        part_names: str = "",
+    ) -> IO.NodeOutput:
+        return glb_or_fbx_output(
+            *await texture_model(
+                cls,
+                model_task_id=model_task_id,
+                pbr=pbr,
+                texture_seed=texture_seed,
+                texture_quality=texture_quality,
+                texture_alignment=texture_alignment,
+                texture_prompt=texture_prompt,
+                model_version=model_version,
+                style_image=style_image,
+                reference=reference,
+                part_names=part_names,
+            ),
+            legacy=False,
+        )
 
 
 class TripoRigNode(IO.ComfyNode):
@@ -1088,11 +1217,11 @@ class TripoRigNode(IO.ComfyNode):
             raise ValueError(f"Rig model v1.0-20240301 only supports biped skeletons; use v2.5-20260210 for {rig_type}.")
         response = await sync_op(
             cls,
-            endpoint=ApiEndpoint(path="/proxy/tripo/v2/openapi/task", method="POST"),
+            endpoint=ApiEndpoint(path="/proxy/tripo/v3/animations/rig", method="POST"),
             response_model=TripoTaskResponse,
             data=TripoAnimateRigRequest(
-                original_model_task_id=original_model_task_id,
-                model_version=model_version,
+                input=original_model_task_id,
+                model=model_version,
                 rig_type=rig_type,
                 out_format=out_format,
                 spec=spec,
@@ -1114,8 +1243,9 @@ class TripoRetargetNode(IO.ComfyNode):
                 IO.Combo.Input(
                     "animation",
                     options=[*[a.value for a in TripoAnimation], *TRIPO_BIPED_ANIMATIONS],
-                    tooltip="preset:* animations work with both rig models; "
-                    "preset:biped:* animations require a rig made with model v1.0-20240301.",
+                    tooltip="preset:* animations work with both rig models. preset:biped:* animations are made for rigs "
+                    "from model v1.0-20240301; a v2.5 rig accepts only chop, climb, dive, fall, hurt, idle, jump, run, "
+                    "shoot, slash, turn and walk.",
                 ),
                 IO.Combo.Input(
                     "out_format",
@@ -1168,25 +1298,31 @@ class TripoRetargetNode(IO.ComfyNode):
     ) -> IO.NodeOutput:
         rig = await sync_op(
             cls,
-            endpoint=ApiEndpoint(path=f"/proxy/tripo/v2/openapi/task/{original_model_task_id}"),
+            endpoint=ApiEndpoint(path=f"/proxy/tripo/v3/tasks/{original_model_task_id}"),
             response_model=TripoTaskResponse,
         )
         rig_input = rig.data.input or {}
-        if rig_input.get("spec") == "mixamo" and str(rig_input.get("model_version", "")).startswith("v1.0"):
-            raise ValueError("Tripo cannot retarget animation presets onto a v1.0 rig made with the mixamo spec.")
+        mixamo = rig_input.get("spec") == "mixamo"
+        if mixamo and str(rig_input.get("model_version", "")).startswith("v1.0"):
+            raise ValueError(MIXAMO_RETARGET_ERROR)
         response = await sync_op(
             cls,
-            endpoint=ApiEndpoint(path="/proxy/tripo/v2/openapi/task", method="POST"),
+            endpoint=ApiEndpoint(path="/proxy/tripo/v3/animations/retarget", method="POST"),
             response_model=TripoTaskResponse,
             data=TripoAnimateRetargetRequest(
-                original_model_task_id=original_model_task_id,
+                input=original_model_task_id,
                 animation=animation,
                 out_format=out_format,
                 export_with_geometry=export_with_geometry,
                 animate_in_place=animate_in_place,
             ),
         )
-        return glb_or_fbx_output(*await poll_until_finished(cls, response, average_duration=30))
+        try:
+            return glb_or_fbx_output(*await poll_until_finished(cls, response, average_duration=30))
+        except Exception as error:
+            if mixamo and "mixamo" in str(error):
+                raise ValueError(MIXAMO_RETARGET_ERROR) from error
+            raise
 
 
 class TripoRigCheckNode(IO.ComfyNode):
@@ -1257,9 +1393,9 @@ class TripoSegmentNode(IO.ComfyNode):
     async def execute(cls, model_task_id) -> IO.NodeOutput:
         response = await sync_op(
             cls,
-            endpoint=ApiEndpoint(path="/proxy/tripo/v2/openapi/task", method="POST"),
+            endpoint=ApiEndpoint(path="/proxy/tripo/v3/mesh/segment", method="POST"),
             response_model=TripoTaskResponse,
-            data=TripoMeshSegmentationRequest(original_model_task_id=model_task_id),
+            data=TripoMeshSegmentationRequest(input=model_task_id),
         )
         task_id, model = await poll_until_finished(cls, response, average_duration=160)
         return IO.NodeOutput(f"{task_id}.glb", task_id, model, ",".join(part_names_from_glb(model)))
@@ -1304,10 +1440,10 @@ class TripoMeshCompleteNode(IO.ComfyNode):
     async def execute(cls, segment_task_id, part_names: str = "") -> IO.NodeOutput:
         response = await sync_op(
             cls,
-            endpoint=ApiEndpoint(path="/proxy/tripo/v2/openapi/task", method="POST"),
+            endpoint=ApiEndpoint(path="/proxy/tripo/v3/mesh/complete", method="POST"),
             response_model=TripoTaskResponse,
             data=TripoMeshCompletionRequest(
-                original_model_task_id=segment_task_id,
+                input=segment_task_id,
                 part_names=split_part_names(part_names),
             ),
         )
@@ -1384,10 +1520,10 @@ class TripoRetopologyNode(IO.ComfyNode):
             raise ValueError("face_limit must be between 500 and 20,000 for triangles or 500 and 10,000 for quads.")
         response = await sync_op(
             cls,
-            endpoint=ApiEndpoint(path="/proxy/tripo/v2/openapi/task", method="POST"),
+            endpoint=ApiEndpoint(path="/proxy/tripo/v3/mesh/decimate", method="POST"),
             response_model=TripoTaskResponse,
             data=TripoHighpolyToLowpolyRequest(
-                original_model_task_id=model_task_id,
+                input=model_task_id,
                 face_limit=face_limit if face_limit != -1 else None,
                 quad=quad,
                 bake=bake,
@@ -1395,6 +1531,133 @@ class TripoRetopologyNode(IO.ComfyNode):
             ),
         )
         return glb_or_fbx_output(*await poll_until_finished(cls, response, average_duration=200))
+
+
+IDENTITY_TRANSFORM = [1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0]
+
+
+def smart_segment_inputs() -> list:
+    return [
+        IO.Combo.Input("granularity", options=["coarse", "medium", "fine"], default="medium", optional=True),
+        IO.String.Input(
+            "hint",
+            default="",
+            multiline=True,
+            optional=True,
+            tooltip="Optional text naming the parts to look for, e.g. 'game character with sword and armor'.",
+        ),
+    ]
+
+
+class TripoSmartSegmentNode(IO.ComfyNode):
+
+    @classmethod
+    def define_schema(cls):
+        return IO.Schema(
+            node_id="TripoSmartSegmentNode",
+            display_name="Tripo: Smart Segment",
+            category="partner/3d/Tripo",
+            description="Splits a model into semantically meaningful parts and names them. From an image, Tripo first "
+            "generates the model. The segment task_id feeds Tripo: Complete Mesh Parts, Tripo: Retopology, "
+            "Tripo: Texture model and Tripo: Convert model like a Tripo: Segment Model result.",
+            inputs=[
+                IO.DynamicCombo.Input(
+                    "source",
+                    options=[
+                        IO.DynamicCombo.Option(
+                            "model",
+                            [
+                                IO.Custom("MODEL_TASK_ID").Input(
+                                    "model_task_id",
+                                    tooltip="A GLB result. Quad (FBX) meshes must go through Tripo: Convert model (GLTF) first.",
+                                ),
+                                *smart_segment_inputs(),
+                            ],
+                        ),
+                        IO.DynamicCombo.Option("image", [IO.Image.Input("image"), *smart_segment_inputs()]),
+                    ],
+                    tooltip="Segment an existing model, or generate a model from an image and segment it.",
+                ),
+            ],
+            outputs=[
+                IO.Custom("SEGMENT_TASK_ID").Output(display_name="segment task_id"),
+                IO.Custom("MODEL_TASK_ID").Output(
+                    display_name="model task_id", tooltip="The model that was segmented (generated from the image, or imported)."
+                ),
+                IO.File3DGLB.Output(display_name="GLB"),
+                IO.String.Output(display_name="part_names", tooltip="Comma-separated names of the parts."),
+                IO.String.Output(display_name="parts", tooltip="Tripo's description of the parts it found."),
+                IO.Image.Output(display_name="mask"),
+            ],
+            hidden=[
+                IO.Hidden.auth_token_comfy_org,
+                IO.Hidden.api_key_comfy_org,
+                IO.Hidden.unique_id,
+            ],
+            is_api_node=True,
+            is_output_node=True,
+            price_badge=IO.PriceBadge(
+                depends_on=IO.PriceBadgeDepends(widgets=["source"]),
+                expr="""{"type":"usd","usd": (widgets.source = "image" ? 0.85 : 0.55), "format": {"approximate": true}}""",
+            ),
+        )
+
+    @classmethod
+    async def execute(cls, source: dict) -> IO.NodeOutput:
+        granularity = source.get("granularity", "medium")
+        hint = source.get("hint", "")
+        if source["source"] == "image":
+            uploaded = await sync_op(
+                cls,
+                endpoint=ApiEndpoint(path="/proxy/tripo/v3/files", method="POST"),
+                response_model=TripoFileResponse,
+                files={"file": ("image.png", tensor_to_bytesio(source["image"]), "image/png")},
+                content_type="multipart/form-data",
+            )
+            request = TripoMeshSmartSegmentRequest(
+                input=uploaded.data.file_token,
+                seg_type="image",
+                granularity=granularity,
+                hint=hint.strip() or None,
+            )
+        else:
+            task = await sync_op(
+                cls,
+                endpoint=ApiEndpoint(path=f"/proxy/tripo/v3/tasks/{source['model_task_id']}"),
+                response_model=TripoTaskResponse,
+            )
+            url = get_model_url_from_response(task)
+            if Path(urlparse(url).path).suffix.lower() != ".glb":
+                raise ValueError(
+                    "Tripo: Smart Segment accepts GLB models only. Convert quad (FBX) meshes with "
+                    "Tripo: Convert model (GLTF) first."
+                )
+            request = TripoMeshSmartSegmentRequest(
+                input=url,
+                seg_type="model",
+                transform=IDENTITY_TRANSFORM,
+                granularity=granularity,
+                hint=hint.strip() or None,
+            )
+        response = await sync_op(
+            cls,
+            endpoint=ApiEndpoint(path="/proxy/tripo/v3/mesh/smartsegment", method="POST"),
+            response_model=TripoTaskResponse,
+            data=request,
+        )
+        output = (await poll_task(cls, response, average_duration=180)).data.output
+        if not (output.seg_task_id and output.seg_model_url and output.mask_url):
+            raise RuntimeError(f"Tripo returned an incomplete smart segmentation result: {output}")
+        model = await download_url_to_file_3d(output.seg_model_url, "glb", task_id=output.seg_task_id)
+        mask = await download_url_to_image_tensor(output.mask_url, cls=cls)
+        return IO.NodeOutput(
+            output.seg_task_id,
+            output.model_task_id,
+            model,
+            ",".join(part_names_from_glb(model)),
+            output.prompt or "",
+            mask,
+        )
 
 
 class TripoConversionNode(IO.ComfyNode):
@@ -1563,10 +1826,10 @@ class TripoConversionNode(IO.ComfyNode):
 
         response = await sync_op(
             cls,
-            endpoint=ApiEndpoint(path="/proxy/tripo/v2/openapi/task", method="POST"),
+            endpoint=ApiEndpoint(path="/proxy/tripo/v3/models/convert", method="POST"),
             response_model=TripoTaskResponse,
             data=TripoConvertModelRequest(
-                original_model_task_id=original_model_task_id,
+                input=original_model_task_id,
                 format=format,
                 quad=quad if quad else None,
                 force_symmetry=force_symmetry if force_symmetry else None,
@@ -1647,17 +1910,17 @@ class TripoImportModelNode(IO.ComfyNode):
         url = await upload_3d_model_to_comfyapi(cls, model_3d, file_format)
         response = await sync_op(
             cls,
-            endpoint=ApiEndpoint(path="/proxy/tripo/v2/openapi/import", method="POST"),
+            endpoint=ApiEndpoint(path="/proxy/tripo/v3/models/import", method="POST"),
             response_model=TripoTaskResponse,
-            data=TripoImportModelRequest(url=url, format=file_format),
+            data=TripoImportModelRequest(input=url),
         )
         if response.code != 0:
-            raise RuntimeError(f"Failed to import model: {response.error}")
+            raise RuntimeError(f"Failed to import model: {response}")
 
         task_id = response.data.task_id
         response_poll = await poll_op(
             cls,
-            poll_endpoint=ApiEndpoint(path=f"/proxy/tripo/v2/openapi/task/{task_id}"),
+            poll_endpoint=ApiEndpoint(path=f"/proxy/tripo/v3/tasks/{task_id}"),
             response_model=TripoTaskResponse,
             failed_statuses=[
                 TripoTaskStatus.FAILED,
@@ -1875,7 +2138,7 @@ class TripoP1TextToModelNode(IO.ComfyNode):
         )
         response = await sync_op(
             cls,
-            endpoint=ApiEndpoint(path="/proxy/tripo/v2/openapi/task", method="POST"),
+            endpoint=ApiEndpoint(path="/proxy/tripo/v3/generation/text-to-model", method="POST"),
             response_model=TripoTaskResponse,
             data=request,
         )
@@ -1934,12 +2197,7 @@ class TripoP1ImageToModelNode(IO.ComfyNode):
     ) -> IO.NodeOutput:
         if image is None:
             raise RuntimeError("Image is required")
-        tripo_file = TripoFileReference(
-            root=TripoUrlReference(
-                url=(await upload_images_to_comfyapi(cls, image, max_images=1))[0],
-                type="jpeg",
-            )
-        )
+        image_url = (await upload_images_to_comfyapi(cls, image, max_images=1))[0]
         common = _build_p1_request_kwargs(
             output_mode=output_mode,
             face_limit=face_limit,
@@ -1949,13 +2207,13 @@ class TripoP1ImageToModelNode(IO.ComfyNode):
             compress_geometry=compress_geometry,
         )
         request = TripoP1ImageToModelRequest(
-            file=tripo_file,
+            input=image_url,
             enable_image_autofix=enable_image_autofix,
             **common,
         )
         response = await sync_op(
             cls,
-            endpoint=ApiEndpoint(path="/proxy/tripo/v2/openapi/task", method="POST"),
+            endpoint=ApiEndpoint(path="/proxy/tripo/v3/generation/image-to-model", method="POST"),
             response_model=TripoTaskResponse,
             data=request,
         )
@@ -2023,13 +2281,10 @@ class TripoP1MultiviewToModelNode(IO.ComfyNode):
         if sum(1 for v in views if v is not None) < 2:
             raise RuntimeError("Tripo P1 multiview requires at least 2 images (front plus one of left/back/right).")
 
-        files: list[TripoFileReference] = []
-        for view in views:
-            if view is None:
-                files.append(TripoFileReference(root=TripoFileEmptyReference()))
-                continue
-            url = (await upload_images_to_comfyapi(cls, view, max_images=1))[0]
-            files.append(TripoFileReference(root=TripoUrlReference(url=url, type="jpeg")))
+        inputs: list[dict[str, str]] = []
+        for name, view in zip(("front", "left", "back", "right"), views):
+            if view is not None:
+                inputs.append({name: (await upload_images_to_comfyapi(cls, view, max_images=1))[0]})
 
         common = _build_p1_request_kwargs(
             output_mode=output_mode,
@@ -2039,10 +2294,10 @@ class TripoP1MultiviewToModelNode(IO.ComfyNode):
             export_uv=export_uv,
             compress_geometry=compress_geometry,
         )
-        request = TripoP1MultiviewToModelRequest(files=files, **common)
+        request = TripoP1MultiviewToModelRequest(inputs=inputs, **common)
         response = await sync_op(
             cls,
-            endpoint=ApiEndpoint(path="/proxy/tripo/v2/openapi/task", method="POST"),
+            endpoint=ApiEndpoint(path="/proxy/tripo/v3/generation/multiview-to-model", method="POST"),
             response_model=TripoTaskResponse,
             data=request,
         )
@@ -2054,7 +2309,9 @@ class TripoExtension(ComfyExtension):
     async def get_node_list(self) -> list[type[IO.ComfyNode]]:
         return [
             TripoTextToModelNode,
+            TripoTextToModelNodeV2,
             TripoImageToModelNode,
+            TripoImageToModelNodeV2,
             TripoMultiviewToModelNode,
             TripoP1TextToModelNode,
             TripoP1ImageToModelNode,
@@ -2063,12 +2320,14 @@ class TripoExtension(ComfyExtension):
             TripoImageToMultiviewNode,
             TripoEditMultiviewNode,
             TripoTextureNode,
+            TripoTextureNodeV2,
             TripoRigCheckNode,
             TripoRigNode,
             TripoRetargetNode,
             TripoSegmentNode,
             TripoMeshCompleteNode,
             TripoRetopologyNode,
+            TripoSmartSegmentNode,
             TripoConversionNode,
         ]
 

--- a/comfy_api_nodes/util/client.py
+++ b/comfy_api_nodes/util/client.py
@@ -583,6 +583,26 @@ def _is_terminal_service_refusal(body: Any) -> bool:
     return isinstance(body, dict) and body.get("error") in _TERMINAL_SERVICE_REFUSALS
 
 
+def _provider_error_detail(metadata: Any) -> str | None:
+    if not isinstance(metadata, dict):
+        return None
+    raw = metadata.get("raw")
+    if isinstance(raw, str) and raw.strip():
+        try:
+            parsed = json.loads(raw)
+        except ValueError:
+            return raw.strip()[:500]
+        if isinstance(parsed, dict):
+            inner = parsed.get("error")
+            if isinstance(inner, dict) and isinstance(inner.get("message"), str):
+                return inner["message"]
+            if isinstance(parsed.get("message"), str):
+                return parsed["message"]
+        return raw.strip()[:500]
+    code = metadata.get("provider_error_code")
+    return code if isinstance(code, str) and code else None
+
+
 def _friendly_http_message(status: int, body: Any) -> str:
     if status == 401:
         return "Unauthorized: Please login first to use this node."
@@ -602,7 +622,14 @@ def _friendly_http_message(status: int, body: Any) -> str:
                     return msg
             if isinstance(err, dict):
                 msg = err.get("message")
+                if msg is not None and not isinstance(msg, str):
+                    msg = str(msg)
                 typ = err.get("type")
+                detail = _provider_error_detail(err.get("metadata"))
+                if detail and not msg:
+                    msg = detail
+                elif msg and detail and detail not in msg:
+                    msg = f"{msg}: {detail}"
                 if msg and typ:
                     return f"API Error: {msg} (Type: {typ})"
                 if msg:

--- a/comfy_api_nodes/util/validation_utils.py
+++ b/comfy_api_nodes/util/validation_utils.py
@@ -188,7 +188,7 @@ def validate_string(
         )
     if max_length and len(string) > max_length:
         raise Exception(
-            f" Field '{field_name} cannot be longer than {max_length} characters; was {len(string)} characters long."
+            f"Field '{field_name}' cannot be longer than {max_length} characters; was {len(string)} characters long."
         )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 comfyui-frontend-package==1.51.10
-comfyui-workflow-templates==0.11.57
+comfyui-workflow-templates==0.11.59
 comfyui-embedded-docs==0.5.11
 torch
 torchsde


### PR DESCRIPTION
Backport for v0.35.1.

Cherry-picked from `master` onto `v0.35.0`, oldest first:

| Commit | PR | What |
|---|---|---|
| `ab25d079` | #16188 | OpenRouter: Microsoft `mai-image-2.6` models |
| `dcbcf08a` | #16195 | Gemini: add Gemini 3.8 Flash to the Gemini text node |
| `82e16247` | #16201 | Tripo: migrate to the v3 API, add Smart Segment, retire dead widgets |
| `aa1bf932` | #16229 | OpenRouter: auto aspect ratio on the MAI image node |
| `926a3a80` | #16233 | chore: workflow templates to v0.11.59 |

All five backends are already live in production on `comfy-api`.

Version files deliberately untouched — the Backport Release workflow owns `comfyui_version.py` and `pyproject.toml`.
`release/v0.35` does not exist yet; the workflow creates it from the `v0.35.0` tag.

<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [ ] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [ ] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [ ] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**

