### PR TITLE
Make /view Content-Disposition headers RFC 2183/6266 compliant

### DIFF
--- a/server.py
+++ b/server.py
@@ -630,14 +630,8 @@ class PromptServer():
                         # and execute in the page origin) to download instead of
                         # displaying inline, preventing stored XSS. SVG loaded
                         # into an <img> is exempt, see renders_safely_as_image.
-                        # The disposition type must be explicit per RFC 2183/6266:
-                        # a bare filename= parameter has no disposition-type and
-                        # breaks strict parsers like Go's mime.ParseMediaType
-                        # (issue #8914). inline preserves browser display of
-                        # legitimate images; attachment on the dangerous branch
-                        # below is the load-bearing XSS guard. Reverting inline
-                        # to attachment here breaks previews (#13093, reverted
-                        # in #13733).
+                        # inline is required for RFC-compliant parsing; the
+                        # dangerous branch below must retain attachment.
                         # Escape backslash/quote per RFC 6266 quoted-string so a
                         # filename containing a double quote (which passes the
                         # ".."/leading-slash filter above) can't break out of the

--- a/server.py
+++ b/server.py
@@ -573,8 +573,12 @@ class PromptServer():
                             img.save(buffer, format=image_format, quality=quality)
                             buffer.seek(0)
 
+                            # Explicit inline disposition per RFC 2183/6266: the
+                            # filename hints below previously had no
+                            # disposition-type, which strict parsers such as Go's
+                            # mime.ParseMediaType reject (issue #8914).
                             return web.Response(body=buffer.read(), content_type=f'image/{image_format}',
-                                                headers={"Content-Disposition": f"filename=\"{filename}\""})
+                                                headers={"Content-Disposition": f"inline; filename=\"{filename}\""})
 
                     if 'channel' not in request.rel_url.query:
                         channel = 'rgba'
@@ -594,7 +598,7 @@ class PromptServer():
                             buffer.seek(0)
 
                             return web.Response(body=buffer.read(), content_type='image/png',
-                                                headers={"Content-Disposition": f"filename=\"{filename}\""})
+                                                headers={"Content-Disposition": f"inline; filename=\"{filename}\""})
 
                     elif channel == 'a':
                         with Image.open(file) as img:
@@ -611,7 +615,7 @@ class PromptServer():
                             alpha_buffer.seek(0)
 
                             return web.Response(body=alpha_buffer.read(), content_type='image/png',
-                                                headers={"Content-Disposition": f"filename=\"{filename}\""})
+                                                headers={"Content-Disposition": f"inline; filename=\"{filename}\""})
                     else:
                         # Use the content type from asset resolution if available,
                         # otherwise guess from the filename.
@@ -626,16 +630,20 @@ class PromptServer():
                         # and execute in the page origin) to download instead of
                         # displaying inline, preventing stored XSS. SVG loaded
                         # into an <img> is exempt, see renders_safely_as_image.
-                        # The attachment disposition is the load-bearing guard: a
-                        # bare filename= hint does not force a download per
-                        # RFC 6266, so we only attach it on the dangerous branch
-                        # to avoid breaking inline display of legitimate images.
+                        # The disposition type must be explicit per RFC 2183/6266:
+                        # a bare filename= parameter has no disposition-type and
+                        # breaks strict parsers like Go's mime.ParseMediaType
+                        # (issue #8914). inline preserves browser display of
+                        # legitimate images; attachment on the dangerous branch
+                        # below is the load-bearing XSS guard. Reverting inline
+                        # to attachment here breaks previews (#13093, reverted
+                        # in #13733).
                         # Escape backslash/quote per RFC 6266 quoted-string so a
                         # filename containing a double quote (which passes the
                         # ".."/leading-slash filter above) can't break out of the
                         # header's quoted-string and malform the disposition.
                         safe_filename = filename.replace("\\", "\\\\").replace('"', '\\"')
-                        disposition = f"filename=\"{safe_filename}\""
+                        disposition = f"inline; filename=\"{safe_filename}\""
                         headers = {"X-Content-Type-Options": "nosniff"}
                         sec_fetch_dest = request.headers.get('Sec-Fetch-Dest')
                         if folder_paths.is_dangerous_content_type(content_type):

--- a/tests-unit/test_view_content_disposition.py
+++ b/tests-unit/test_view_content_disposition.py
@@ -111,6 +111,11 @@ def _get(handler, path):
     return handler(make_mocked_request("GET", path))
 
 
+def _get_with_header(handler, path, header_name, header_value):
+    headers = {header_name: header_value}
+    return handler(make_mocked_request("GET", path, headers=headers))
+
+
 @pytest.fixture
 def view_handler():
     return _load_view_handler()
@@ -175,9 +180,26 @@ async def test_dangerous_type_keeps_attachment(view_handler, output_dir):
     assert response.headers["Content-Type"] == "application/octet-stream"
 
 
+async def test_svg_with_image_fetch_dest_serves_inline(view_handler, output_dir):
+    """SVG requested as an <img> source (Sec-Fetch-Dest: image) is safe to
+    serve inline: the browser will not execute scripts in that context, so
+    the preview path keeps inline while the no-header branch stays attachment.
+    """
+    (output_dir / "evil.svg").write_text(SVG_WITH_SCRIPT)
+
+    response = await _get_with_header(
+        view_handler, "/view?filename=evil.svg", "Sec-Fetch-Dest", "image"
+    )
+
+    assert response.headers["Content-Disposition"] == 'inline; filename="evil.svg"'
+    assert response.headers["Content-Type"] == "image/svg+xml"
+    assert response.headers["X-Content-Type-Options"] == "nosniff"
+    assert response.headers["Vary"] == "Sec-Fetch-Dest"
+    assert response.headers["Cache-Control"] == "no-store"
+
+
 async def test_every_disposition_survives_rfc6266_parse(view_handler, output_dir):
     """Case 4: simulate Go's mime.ParseMediaType on every /view disposition.
-
     A strict media-type parser must extract both the disposition-type and the
     filename parameter from every header the endpoint emits — exactly what Go
     downloaders failed on in issue #8914.

--- a/tests-unit/test_view_content_disposition.py
+++ b/tests-unit/test_view_content_disposition.py
@@ -1,0 +1,213 @@
+"""Regression tests for ComfyUI issue #8914 — /view Content-Disposition
+headers must carry an explicit disposition-type per RFC 2183/6266.
+
+Before the fix every /view branch emitted a bare `filename="..."` value with
+no disposition-type. That is not a valid Content-Disposition: Go's
+mime.ParseMediaType rejects it outright (downloads saved as "view"), and
+Python's email parser reads the whole value back as a bogus disposition type.
+The fix prefixes the safe paths with `inline;` and leaves the existing
+`attachment;` branch (the stored-XSS guard from #15149) untouched.
+
+server.py cannot be imported in a unit test (it pulls in torch and the full
+node runtime), so these tests extract the view_image handler from the
+server.py AST and execute it directly against the real folder_paths module
+with a stub PromptServer — the same server-free approach as
+tests-unit/security_test/. No network, no server socket, no real PromptServer.
+"""
+
+import ast
+import email.message
+import mimetypes
+import os
+import textwrap
+from io import BytesIO
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
+from PIL import Image
+
+import folder_paths
+
+pytestmark = pytest.mark.asyncio
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SERVER_PY = os.path.join(REPO_ROOT, "server.py")
+
+SVG_WITH_SCRIPT = (
+    '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>'
+)
+
+
+def _load_view_handler():
+    """Extract the view_image closure from server.py and rebuild it callable.
+
+    view_image is defined (and captured) inside PromptServer.__init__, so the
+    only way to unit-test it without a full server is to pull the function
+    source out of the AST, wrap it in a tiny factory that injects `self`, and
+    exec it with the handler's module-level dependencies resolved to
+    lightweight stand-ins: the real folder_paths (its dangerous-type logic is
+    part of what these tests pin) plus stubs for the asset-hash resolver and
+    the PromptServer instance, neither of which the tested paths reach.
+    """
+    with open(SERVER_PY, "r", encoding="utf-8") as f:
+        source = f.read()
+
+    func_node = next(
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "view_image"
+    )
+
+    # Drop the @routes.get("/view") decorator line; registering on a real
+    # RouteTableDef is neither possible nor needed for direct invocation.
+    body = "".join(
+        line
+        for line in ast.get_source_segment(source, func_node).splitlines(True)
+        if not line.strip().startswith("@")
+    )
+    factory_src = "def _make_view_image(self):\n" + textwrap.indent(
+        textwrap.dedent(body), "    "
+    )
+    # The original closure ends with the (stripped) decorator registration and
+    # no return, so the factory has to hand back the rebuilt handler itself.
+    # get_source_segment's last line carries no trailing newline.
+    if not factory_src.endswith("\n"):
+        factory_src += "\n"
+    factory_src += "    return view_image\n"
+
+    namespace = {
+        "folder_paths": folder_paths,
+        "resolve_hash_to_path": MagicMock(return_value=None),
+        "web": web,
+        "os": os,
+        "mimetypes": mimetypes,
+        "Image": Image,
+        "BytesIO": BytesIO,
+    }
+    exec(compile(factory_src, SERVER_PY, "exec"), namespace)
+    return namespace["_make_view_image"](MagicMock())
+
+
+def _parse_content_disposition(value):
+    """Parse Content-Disposition with Python's RFC 2231/6266 parser.
+
+    Stands in for Go's mime.ParseMediaType (the parser reported broken in
+    issue #8914): both expect a disposition-type followed by parameters, so a
+    bare `filename=...` value surfaces here as a bogus disposition type
+    instead of inline/attachment.
+    """
+    msg = email.message.Message()
+    msg["Content-Disposition"] = value
+    return msg.get_content_disposition(), msg.get_filename()
+
+
+def _write_png(path):
+    Image.new("RGBA", (4, 4), (255, 0, 0, 255)).save(path, format="PNG")
+
+
+def _get(handler, path):
+    return handler(make_mocked_request("GET", path))
+
+
+@pytest.fixture
+def view_handler():
+    return _load_view_handler()
+
+
+@pytest.fixture
+def output_dir(tmp_path, monkeypatch):
+    """Point /view's default output directory at a temp dir.
+
+    The handler resolves type=output through folder_paths.get_directory_by_type;
+    monkeypatching it keeps the test self-contained without mutating the
+    module's global directory state.
+    """
+    monkeypatch.setattr(
+        folder_paths,
+        "get_directory_by_type",
+        lambda type_name: str(tmp_path) if type_name == "output" else None,
+    )
+    return tmp_path
+
+
+async def test_default_path_serves_inline_with_filename(view_handler, output_dir):
+    """Case 1: ordinary image, default FileResponse path -> inline; filename=..."""
+    _write_png(output_dir / "example.png")
+
+    response = await _get(view_handler, "/view?filename=example.png")
+
+    assert response.headers["Content-Disposition"] == 'inline; filename="example.png"'
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "filename=example.png&preview=webp",
+        "filename=example.png&channel=rgb",
+        "filename=example.png&channel=a",
+    ],
+    ids=["preview_transcode", "channel_rgb_transcode", "channel_alpha_transcode"],
+)
+async def test_transcode_paths_serve_inline_with_filename(
+    view_handler, output_dir, query
+):
+    """Case 2: the three PIL-transcoded paths -> inline; filename=..."""
+    _write_png(output_dir / "example.png")
+
+    response = await _get(view_handler, "/view?" + query)
+
+    assert response.headers["Content-Disposition"] == 'inline; filename="example.png"'
+
+
+async def test_dangerous_type_keeps_attachment(view_handler, output_dir):
+    """Case 3: SVG stays attachment — the #15149 stored-XSS guard must not regress."""
+    (output_dir / "evil.svg").write_text(SVG_WITH_SCRIPT)
+
+    response = await _get(view_handler, "/view?filename=evil.svg")
+
+    assert response.headers["Content-Disposition"] == 'attachment; filename="evil.svg"'
+    # The #15149 hardening around the dangerous branch stays intact.
+    assert response.headers["X-Content-Type-Options"] == "nosniff"
+    assert response.headers["Vary"] == "Sec-Fetch-Dest"
+    assert response.headers["Cache-Control"] == "no-store"
+    assert response.headers["Content-Type"] == "application/octet-stream"
+
+
+async def test_every_disposition_survives_rfc6266_parse(view_handler, output_dir):
+    """Case 4: simulate Go's mime.ParseMediaType on every /view disposition.
+
+    A strict media-type parser must extract both the disposition-type and the
+    filename parameter from every header the endpoint emits — exactly what Go
+    downloaders failed on in issue #8914.
+    """
+    _write_png(output_dir / "example.png")
+    (output_dir / "evil.svg").write_text(SVG_WITH_SCRIPT)
+
+    cases = {
+        "/view?filename=example.png": ("inline", "example.png"),
+        "/view?filename=example.png&preview=webp": ("inline", "example.png"),
+        "/view?filename=example.png&channel=rgb": ("inline", "example.png"),
+        "/view?filename=example.png&channel=a": ("inline", "example.png"),
+        "/view?filename=evil.svg": ("attachment", "evil.svg"),
+    }
+    for path, (expected_type, expected_name) in cases.items():
+        response = await _get(view_handler, path)
+        disp_type, filename = _parse_content_disposition(
+            response.headers["Content-Disposition"]
+        )
+        assert disp_type == expected_type, path
+        assert filename == expected_name, path
+
+
+async def test_bare_filename_has_no_disposition_type():
+    """Negative control: the RFC parser above rejects the old bare filename= form.
+
+    Without a disposition-type the parser hands back garbage (Go's
+    mime.ParseMediaType errors out with "no media type" instead) — this is
+    exactly the failure reported in issue #8914.
+    """
+    disp_type, filename = _parse_content_disposition('filename="example.png"')
+
+    assert disp_type not in ("inline", "attachment")


### PR DESCRIPTION
## Summary

`/view` responses set `Content-Disposition: filename="..."` without a
disposition-type. Per RFC 2183/6266 the `filename=` parameter is only
valid inside a `inline` or `attachment` value, and strict media-type
parsers — e.g. Go's `mime.ParseMediaType` — reject the bare form
outright, which is what the reporter of #8914 hit.

This adds the missing `inline;` prefix on every `filename=` hint that
`/view` emits:

- the three preview-transcode paths (preview/webp → jpeg, alpha → png,
  channel → png)
- the default path (previously a bare `filename=` by design after #15149,
  with a comment asserting the bare form "does not force a download per
RFC 6266" — true for browsers, but still non-conformant)

The dangerous-content-type branch keeps its `attachment;` disposition —
that is the load-bearing XSS guard from #15149 — and `inline` preserves
browser display of legitimate images, so the preview breakage of
#13093 (reverted in #13733) cannot recur.

## Test plan

New `tests-unit/test_view_content_disposition.py` (7 cases):

- default and transcode paths serve `inline; filename=...`
- dangerous types keep `attachment;` (XSS guard intact)
- every emitted disposition round-trips through an RFC 6266 parser
- bare `filename=` is asserted to have no disposition-type (red side of
  the red/green split)

Verified red/green: with `server.py` stashed, 5 of 7 new cases fail;
with the fix, 7/7 pass. Existing suites `tests-unit/server_test/` and
`tests-unit/prompt_server_test/` stay green (72 passed), confirming no
behaviour change on the attachment path or cache-control handling.

Fixes #8914
