### PR TITLE
Add generic attention key-measure execution support

### DIFF
--- a/comfy/attention_measure.py
+++ b/comfy/attention_measure.py
@@ -1,0 +1,475 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fractions import Fraction
+import hashlib
+import json
+import math
+from typing import Any, Callable, Mapping
+
+import torch
+import torch.nn.functional as F
+
+ATTENTION_MEASURE_KEY = "attention_measure_v1"
+ATTENTION_MEASURE_CAPABILITIES_KEY = "attention_measure_capabilities_v1"
+ATTENTION_MEASURE_API = 1
+KEY_LOG_MEASURE_OPERATOR = "key_log_measure"
+H3_SOURCE_CARRIER_NORMALIZATION = "h3_native_source_carrier_v1"
+MIXED_GRID_TOPOLOGY = "mixed_grid_low_suffix"
+H3_COORDINATE_POLICY = "minimax_h3_native_frame_grid_v1"
+SUPPORTED_PROFILES = frozenset({"dense_exact_v1", "weighted_exact_blocks_v1"})
+
+
+@dataclass(frozen=True, slots=True)
+class MeasureExecutionContext:
+    provider_identity: str
+    block_index: int
+    owner: object
+    owner_generation: str
+    layout: object
+    q_rows: int
+    kv_rows: int
+    dtype: torch.dtype
+    device: torch.device
+    head_dim: int
+    mask_class: str
+    preprocess_digest: str
+    numerical_route: str
+    existing_sink: tuple[int, int] = (0, 0)
+    external_sequence: Mapping[str, Any] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class BoundMeasurePlan:
+    semantic_digest: str
+    implementation_profile: str
+    provider_identity: str
+    owner_generation: str
+    numerical_route: str
+    preprocess_digest: str
+    q_rows: int
+    kv_rows: int
+    exact_k_block_range: tuple[int, int]
+    exact_range_digest: str
+    key_log_measure: torch.Tensor
+    completion_hook: Callable[[Mapping[str, Any]], None] | None = None
+
+
+def _integer(name: str, value: Any, minimum: int = 0) -> int:
+    if type(value) is not int:
+        raise TypeError(f"attention measure {name} must be an integer")
+    if value < minimum:
+        raise ValueError(f"attention measure {name} must be >= {minimum}")
+    return value
+
+
+def _grid(name: str, value: Any) -> tuple[int, int]:
+    if not isinstance(value, (list, tuple)) or len(value) != 2:
+        raise TypeError(f"attention measure {name} must be a two-element grid")
+    return _integer(f"{name}[0]", value[0], 1), _integer(f"{name}[1]", value[1], 1)
+
+
+def _ratio(name: str, num: Any, den: Any) -> Fraction:
+    num = _integer(f"{name}.mass_num", num, 1)
+    den = _integer(f"{name}.mass_den", den, 1)
+    ratio = Fraction(num, den)
+    if not math.isfinite(math.log(ratio.numerator) - math.log(ratio.denominator)):
+        raise ValueError(f"attention measure {name} derives a non-finite key-log-measure")
+    return ratio
+
+
+def _canonical_segments(raw_segments, *, kv_rows: int):
+    if not isinstance(raw_segments, (list, tuple)) or not raw_segments:
+        raise TypeError("attention measure segments must be a nonempty list")
+    segments: list[dict[str, int]] = []
+    cursor = 0
+    for i, raw in enumerate(raw_segments):
+        if not isinstance(raw, Mapping):
+            raise TypeError(f"attention measure segments[{i}] must be a mapping")
+        start = _integer(f"segments[{i}].start", raw.get("start"))
+        stop = _integer(f"segments[{i}].stop", raw.get("stop"))
+        if start != cursor or stop <= start or stop > kv_rows:
+            raise ValueError("attention measure segments must be sorted, contiguous, nonempty and in range")
+        ratio = _ratio(f"segments[{i}]", raw.get("mass_num"), raw.get("mass_den"))
+        if segments and (segments[-1]["mass_num"], segments[-1]["mass_den"]) == (ratio.numerator, ratio.denominator):
+            segments[-1]["stop"] = stop
+        else:
+            segments.append({
+                "start": start,
+                "stop": stop,
+                "mass_num": ratio.numerator,
+                "mass_den": ratio.denominator,
+            })
+        cursor = stop
+    if cursor != kv_rows:
+        raise ValueError("attention measure segments must cover every key row exactly once")
+    return segments
+
+
+def normalize(request: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(request, Mapping):
+        raise TypeError("attention_measure_v1 must be a mapping")
+    literals = {
+        "api": ATTENTION_MEASURE_API,
+        "operator": KEY_LOG_MEASURE_OPERATOR,
+        "normalization": H3_SOURCE_CARRIER_NORMALIZATION,
+        "topology": MIXED_GRID_TOPOLOGY,
+        "coordinate_policy": H3_COORDINATE_POLICY,
+    }
+    for key, expected in literals.items():
+        if request.get(key) != expected:
+            raise ValueError(f"attention measure {key} must be {expected!r}")
+
+    q_rows = _integer("q_rows", request.get("q_rows"), 1)
+    kv_rows = _integer("kv_rows", request.get("kv_rows"), 1)
+    video_start = _integer("video_start", request.get("video_start"))
+    temporal = _integer("temporal", request.get("temporal"), 2)
+    prefix_t = _integer("prefix_t", request.get("prefix_t"), 1)
+    source_grid = _grid("source_grid", request.get("source_grid"))
+    prefix_grid = _grid("prefix_grid", request.get("prefix_grid"))
+    if q_rows != kv_rows:
+        raise ValueError("attention measure requires the all-row self-attention domain")
+    if video_start >= kv_rows or prefix_t >= temporal:
+        raise ValueError("attention measure video geometry is invalid")
+    source_rows = math.prod(source_grid)
+    prefix_rows = math.prod(prefix_grid)
+    if source_rows > prefix_rows:
+        raise ValueError("mixed-grid source measure cannot exceed the protected-prefix grid")
+    if q_rows != video_start + prefix_t * prefix_rows + (temporal - prefix_t) * source_rows:
+        raise ValueError("attention measure row count disagrees with mixed-grid geometry")
+
+    segments = _canonical_segments(request.get("segments"), kv_rows=kv_rows)
+    weighted_start = video_start
+    weighted_stop = video_start + prefix_t * prefix_rows
+    wanted = Fraction(source_rows, prefix_rows)
+    for segment in segments:
+        start, stop = segment["start"], segment["stop"]
+        overlap = max(start, weighted_start) < min(stop, weighted_stop)
+        ratio = Fraction(segment["mass_num"], segment["mass_den"])
+        if overlap and ratio != wanted:
+            raise ValueError("protected-prefix keys use the wrong spatial measure")
+        if not overlap and ratio != 1:
+            raise ValueError("non-prefix keys must retain unit measure")
+        if wanted != 1 and (start < weighted_start < stop or start < weighted_stop < stop):
+            raise ValueError("attention measure boundaries must align with the protected-prefix interval")
+
+    return {
+        **literals,
+        "q_rows": q_rows,
+        "kv_rows": kv_rows,
+        "video_start": video_start,
+        "temporal": temporal,
+        "prefix_t": prefix_t,
+        "source_grid": list(source_grid),
+        "prefix_grid": list(prefix_grid),
+        "segments": segments,
+    }
+
+
+def semantic_digest(request: Mapping[str, Any]) -> str:
+    encoded = json.dumps(normalize(request), sort_keys=True, separators=(",", ":")).encode("ascii")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def is_unit_measure(request: Mapping[str, Any]) -> bool:
+    return all((s["mass_num"], s["mass_den"]) == (1, 1) for s in normalize(request)["segments"])
+
+
+def validate_h3(request, *, layout, q_rows, kv_rows, external_sequence=None):
+    normalized = normalize(request)
+    if type(q_rows) is not int or type(kv_rows) is not int:
+        raise TypeError("attention measure runtime row counts must be integers")
+    if normalized["q_rows"] != q_rows or normalized["kv_rows"] != kv_rows:
+        raise ValueError("attention measure row counts are stale")
+    if layout is None or getattr(layout, "seq_len", None) != q_rows:
+        raise ValueError("attention measure requires the actual H3 mixed layout")
+    video = next(((a, b) for a, b, kind in getattr(layout, "segments", ()) if kind == "video"), None)
+    if video != (normalized["video_start"], q_rows):
+        raise ValueError("attention measure video interval disagrees with the H3 layout")
+    if external_sequence is not None:
+        if not isinstance(external_sequence, Mapping):
+            raise TypeError("attention measure VDN external-sequence contract must be a mapping")
+        integer_fields = (
+            "api",
+            "native_sequence_rows",
+            "sequence_rows",
+            "video_start",
+            "temporal",
+            "prefix_t",
+            "source_rows_per_frame",
+            "prefix_rows_per_frame",
+        )
+        if any(type(external_sequence.get(key)) is not int for key in integer_fields):
+            raise TypeError("attention measure VDN external-sequence row counts must be integers")
+        source_rows = math.prod(normalized["source_grid"])
+        prefix_rows = math.prod(normalized["prefix_grid"])
+        native_rows = normalized["video_start"] + normalized["temporal"] * source_rows
+        checks = {
+            "api": 2,
+            "mode": "dense_gate_no_linear",
+            "topology": MIXED_GRID_TOPOLOGY,
+            "native_sequence_rows": native_rows,
+            "sequence_rows": q_rows,
+            "video_start": normalized["video_start"],
+            "temporal": normalized["temporal"],
+            "prefix_t": normalized["prefix_t"],
+            "source_rows_per_frame": source_rows,
+            "prefix_rows_per_frame": prefix_rows,
+        }
+        if any(external_sequence.get(k) != v for k, v in checks.items()):
+            raise ValueError("attention measure disagrees with the VDN external-sequence contract")
+    return normalized
+
+
+def materialize(request, *, device, dtype=torch.float32):
+    normalized = normalize(request)
+    if not dtype.is_floating_point:
+        raise TypeError("attention measure bias requires floating point")
+    out = torch.empty(normalized["kv_rows"], device=device, dtype=dtype)
+    for segment in normalized["segments"]:
+        value = math.log(segment["mass_num"]) - math.log(segment["mass_den"])
+        out[segment["start"]:segment["stop"]] = value
+    return out.contiguous()
+
+
+def merge_exact_k_blocks(request, block_size: int, existing=(0, 0)) -> tuple[int, int]:
+    normalized = normalize(request)
+    if type(block_size) is not int or block_size <= 0:
+        raise ValueError("block_size must be a positive integer")
+    if (
+        not isinstance(existing, (tuple, list))
+        or len(existing) != 2
+        or any(type(x) is not int for x in existing)
+        or existing[0] < 0
+        or existing[1] < existing[0]
+    ):
+        raise ValueError("existing sink range is invalid")
+    max_blocks = (normalized["kv_rows"] + block_size - 1) // block_size
+    if existing[1] > max_blocks:
+        raise ValueError("existing sink range exceeds the K/V domain")
+    weighted = [s for s in normalized["segments"] if (s["mass_num"], s["mass_den"]) != (1, 1)]
+    if not weighted:
+        return int(existing[0]), int(existing[1])
+    first = min(s["start"] for s in weighted) // block_size
+    last = (max(s["stop"] for s in weighted) + block_size - 1) // block_size
+    if existing[0] == existing[1]:
+        return first, last
+    return min(existing[0], first), max(existing[1], last)
+
+
+def bind(
+    request,
+    *,
+    context: MeasureExecutionContext,
+    block_size: int,
+    implementation_profile: str,
+    completion_hook: Callable[[Mapping[str, Any]], None] | None = None,
+):
+    normalized = validate_h3(
+        request,
+        layout=context.layout,
+        q_rows=context.q_rows,
+        kv_rows=context.kv_rows,
+        external_sequence=context.external_sequence,
+    )
+    if implementation_profile not in SUPPORTED_PROFILES:
+        raise ValueError("unsupported attention-measure implementation profile")
+    if not context.provider_identity or not context.owner_generation or not context.preprocess_digest:
+        raise ValueError("attention measure execution ownership identity is incomplete")
+    blocks = merge_exact_k_blocks(normalized, block_size, context.existing_sink)
+    range_digest = hashlib.sha256(f"{blocks[0]}:{blocks[1]}".encode("ascii")).hexdigest()
+    return BoundMeasurePlan(
+        semantic_digest(normalized),
+        implementation_profile,
+        context.provider_identity,
+        context.owner_generation,
+        context.numerical_route,
+        context.preprocess_digest,
+        context.q_rows,
+        context.kv_rows,
+        blocks,
+        range_digest,
+        materialize(normalized, device=context.device),
+        completion_hook,
+    )
+
+
+def register_capability(transformer_options, provider_identity, capability):
+    if not isinstance(provider_identity, str) or not provider_identity:
+        raise ValueError("attention-measure provider identity must be a nonempty string")
+    if not callable(getattr(capability, "prepare", None)):
+        raise TypeError("attention-measure capability must provide prepare(request, execution_context)")
+    current = transformer_options.get(ATTENTION_MEASURE_CAPABILITIES_KEY)
+    registry = dict(current) if isinstance(current, Mapping) else {}
+    existing = registry.get(provider_identity)
+    if existing is not None and existing is not capability:
+        raise RuntimeError(f"attention-measure provider {provider_identity!r} already has another owner")
+    registry[provider_identity] = capability
+    transformer_options[ATTENTION_MEASURE_CAPABILITIES_KEY] = registry
+
+
+def prepare_capability(transformer_options, request, context: MeasureExecutionContext) -> BoundMeasurePlan:
+    registry = transformer_options.get(ATTENTION_MEASURE_CAPABILITIES_KEY)
+    if not isinstance(registry, Mapping):
+        raise RuntimeError("attention measure requested but no provider capabilities are registered")
+    capability = registry.get(context.provider_identity)
+    if capability is None:
+        raise RuntimeError(f"attention measure provider {context.provider_identity!r} is not capable")
+    plan = capability.prepare(request, context)
+    if not isinstance(plan, BoundMeasurePlan):
+        raise TypeError("attention-measure capability returned an invalid bound plan")
+    if (
+        plan.provider_identity != context.provider_identity
+        or plan.owner_generation != context.owner_generation
+        or plan.preprocess_digest != context.preprocess_digest
+        or plan.q_rows != context.q_rows
+        or plan.kv_rows != context.kv_rows
+        or plan.semantic_digest != semantic_digest(request)
+    ):
+        raise RuntimeError("attention-measure capability returned a stale or wrong-owner bound plan")
+    return plan
+
+
+def _mask(mask, *, batch, q_rows, kv_rows, dtype, device):
+    if not torch.is_tensor(mask) or mask.device != device:
+        raise ValueError("attention measure mask must be a tensor on the attention device")
+    if mask.ndim == 2 and tuple(mask.shape) == (q_rows, kv_rows):
+        mask = mask[None, None]
+    elif mask.ndim == 2 and tuple(mask.shape) == (batch, kv_rows):
+        mask = mask[:, None, None, :]
+    elif mask.ndim == 3 and tuple(mask.shape) == (batch, q_rows, kv_rows):
+        mask = mask[:, None]
+    elif mask.ndim == 4 and mask.shape[-2:] == (q_rows, kv_rows) and mask.shape[0] in (1, batch):
+        pass
+    else:
+        raise ValueError("unsupported attention mask shape for key-measure composition")
+    if mask.dtype == torch.bool:
+        return torch.zeros(mask.shape, dtype=dtype, device=device).masked_fill(~mask, float("-inf"))
+    if not mask.dtype.is_floating_point:
+        raise TypeError("attention mask must be boolean or floating point")
+    if torch.isnan(mask).any() or torch.isposinf(mask).any():
+        raise ValueError("additive attention mask cannot contain NaN or +inf")
+    return mask.to(dtype=dtype)
+
+
+def _heads(q, k, v, heads, skip_reshape):
+    if skip_reshape:
+        if any(x.ndim != 4 for x in (q, k, v)) or q.shape[1] != heads or k.shape[1] != heads or v.shape[1] != heads:
+            raise ValueError("weighted dense skip_reshape expects matching BHND Q/K/V heads")
+        return q, k, v, q.shape[0], q.shape[2], q.shape[-1]
+    if any(x.ndim != 3 for x in (q, k, v)):
+        raise ValueError("weighted dense expects BND Q/K/V when skip_reshape is false")
+    batch, q_rows, inner = q.shape
+    if inner % heads or k.shape[-1] != inner or v.shape[-1] != inner:
+        raise ValueError("weighted dense head geometry is invalid")
+    dim_head = inner // heads
+    return (
+        q.view(batch, q_rows, heads, dim_head).transpose(1, 2),
+        k.view(batch, k.shape[1], heads, dim_head).transpose(1, 2),
+        v.view(batch, v.shape[1], heads, dim_head).transpose(1, 2),
+        batch,
+        q_rows,
+        dim_head,
+    )
+
+
+def weighted_dense(
+    q,
+    k,
+    v,
+    heads,
+    *,
+    key_bias,
+    mask=None,
+    attn_precision=None,
+    skip_reshape=False,
+    skip_output_reshape=False,
+    scale=None,
+):
+    """Exact all-row key-measure attention through PyTorch SDPA.
+
+    ``key_bias`` is natural-log measure and is composed as additive score bias;
+    it is never expanded to a materialized BxHxTq x Tkv tensor by this helper.
+    """
+    qh, kh, vh, batch, q_rows, dim_head = _heads(q, k, v, heads, skip_reshape)
+    kv_rows = kh.shape[2]
+    if kh.shape != vh.shape or qh.shape[-1] != kh.shape[-1]:
+        raise ValueError("weighted dense Q/K/V geometry is inconsistent")
+    if not torch.is_tensor(key_bias) or key_bias.ndim != 1 or key_bias.shape[0] != kv_rows or key_bias.device != q.device:
+        raise ValueError("key bias must be a device-matched vector with one value per K/V row")
+    if not key_bias.dtype.is_floating_point:
+        raise TypeError("key bias must be floating point")
+    dtype = torch.float32 if attn_precision == torch.float32 else qh.dtype
+    bias = key_bias.to(dtype=dtype).view(1, 1, 1, kv_rows)
+    if mask is not None:
+        bias = _mask(mask, batch=batch, q_rows=q_rows, kv_rows=kv_rows, dtype=dtype, device=q.device) + bias
+    out = F.scaled_dot_product_attention(
+        qh.to(dtype), kh.to(dtype), vh.to(dtype), attn_mask=bias, dropout_p=0.0, is_causal=False, scale=scale
+    ).to(v.dtype)
+    if skip_output_reshape:
+        return out
+    return out.transpose(1, 2).reshape(batch, q_rows, heads * dim_head)
+
+
+def weighted_dense_streaming(
+    q,
+    k,
+    v,
+    heads,
+    *,
+    key_bias,
+    mask=None,
+    skip_reshape=False,
+    skip_output_reshape=False,
+    scale=None,
+    key_chunk_size=2048,
+):
+    """Bounded-memory exact fallback with online max/numerator/denominator accumulation."""
+    qh, kh, vh, batch, q_rows, dim_head = _heads(q, k, v, heads, skip_reshape)
+    kv_rows = kh.shape[2]
+    if kh.shape != vh.shape or qh.shape[-1] != kh.shape[-1]:
+        raise ValueError("weighted dense Q/K/V geometry is inconsistent")
+    if not torch.is_tensor(key_bias) or key_bias.ndim != 1 or key_bias.shape[0] != kv_rows or key_bias.device != q.device:
+        raise ValueError("key bias must be a device-matched vector with one value per K/V row")
+    if type(key_chunk_size) is not int or key_chunk_size <= 0:
+        raise ValueError("key_chunk_size must be a positive integer")
+    if scale is None:
+        scale = dim_head ** -0.5
+    scale = float(scale)
+    if not math.isfinite(scale) or scale <= 0.0:
+        raise ValueError("attention scale must be finite and positive")
+
+    work = torch.float32
+    qf, kf, vf = qh.to(work), kh.to(work), vh.to(work)
+    bias = key_bias.to(work)
+    composed_mask = None if mask is None else _mask(
+        mask,
+        batch=batch,
+        q_rows=q_rows,
+        kv_rows=kv_rows,
+        dtype=work,
+        device=q.device,
+    )
+    row_max = torch.full((batch, heads, q_rows, 1), float("-inf"), device=q.device, dtype=work)
+    row_sum = torch.zeros_like(row_max)
+    numerator = torch.zeros((batch, heads, q_rows, dim_head), device=q.device, dtype=work)
+    for start in range(0, kv_rows, key_chunk_size):
+        stop = min(start + key_chunk_size, kv_rows)
+        scores = torch.matmul(qf, kf[:, :, start:stop].transpose(-1, -2)) * scale
+        scores.add_(bias[start:stop])
+        if composed_mask is not None:
+            scores.add_(composed_mask[..., start:stop])
+        chunk_max = scores.amax(dim=-1, keepdim=True)
+        new_max = torch.maximum(row_max, chunk_max)
+        safe_old = torch.where(torch.isfinite(row_max), row_max, torch.zeros_like(row_max))
+        safe_new = torch.where(torch.isfinite(new_max), new_max, torch.zeros_like(new_max))
+        old_scale = torch.where(torch.isfinite(row_max), torch.exp(safe_old - safe_new), torch.zeros_like(row_sum))
+        prob = torch.exp(scores - safe_new)
+        prob = torch.where(torch.isfinite(scores), prob, torch.zeros_like(prob))
+        numerator = numerator * old_scale + torch.matmul(prob, vf[:, :, start:stop])
+        row_sum = row_sum * old_scale + prob.sum(dim=-1, keepdim=True)
+        row_max = new_max
+    out = (numerator / row_sum.clamp_min(torch.finfo(work).tiny)).to(v.dtype)
+    if skip_output_reshape:
+        return out
+    return out.transpose(1, 2).reshape(batch, q_rows, heads * dim_head)

--- a/comfy_extras/nodes_sparse_attention.py
+++ b/comfy_extras/nodes_sparse_attention.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 import re
+import uuid
 import weakref
 
 import comfy_kitchen as ck
@@ -15,6 +16,7 @@ import comfy.model_prefetch
 import comfy.patcher_extension
 from comfy.ldm.minimax.model import MiniMaxH3Model
 from comfy_api.latest import ComfyExtension, io
+from comfy_extras import sparse_attention_measure as measure
 
 HEAD_DIM = 128
 BLOCK_SIZE = 64
@@ -52,10 +54,16 @@ class SparseAttnPatch:
         self.sink_conditioning = sink_conditioning
         self.verbose = verbose
         self.installed = set()    # the override closures this patch has put on the hook
+        # A ModelPatcher clone may reuse this SparseAttnPatch for many forwards.
+        # The generation is stable for that concrete owner but cannot be confused
+        # with a later patch object that happens to reuse the same source/config.
+        self.measure_owner_generation = f"core-bsa-{uuid.uuid4().hex}"
+        self.measure_capability = None
         self.reset()
 
     def reset(self):
-        self.pooled = {}          # (block, rows) -> (kmean, vscale) from the previous step
+        self.pooled = {}          # numerical pool tensors from the previous step
+        self.measure_plans = {}   # run-scoped O(T) measure bindings/bias tensors
         self.vsa_plans = {}       # small LRU of tiling plans
         self.vsa_rope = None
         self._logged = set()
@@ -170,22 +178,51 @@ def _ineligible(q, k, v, dim_head):
 
 def make_attention_override(patch: SparseAttnPatch, previous):
     """Attention override; declined calls run ``previous`` (the override that was
-    on the hook before this one) or ``func``. Dense-only in VSA mode: a
-    VSA-trained model must never see plain block-sparse attention."""
+    on the hook before this one) or ``func``. A key-measure request never falls
+    through to an unweighted provider: supported dense reasons use the explicit
+    weighted dense operator, VSA is rejected, and sparse execution binds key
+    bias plus exact K coverage before dispatch."""
     def override(func, q, k, v, heads, mask=None, attn_precision=None,
                  skip_reshape=False, skip_output_reshape=False, **kwargs):
         transformer_options = kwargs.get("transformer_options") or {}
+        request = transformer_options.get(measure.ATTENTION_MEASURE_KEY)
+        block_index = transformer_options.get("block_index")
 
-        def dense():
+        def dense_unweighted():
             args = (q, k, v, heads)
             kw = dict(mask=mask, attn_precision=attn_precision, skip_reshape=skip_reshape,
                       skip_output_reshape=skip_output_reshape, **kwargs)
             return func(*args, **kw) if previous is None else previous(func, *args, **kw)
 
+        def dense():
+            if request is None:
+                return dense_unweighted()
+            if type(block_index) is not int:
+                raise RuntimeError("attention measure requires a concrete H3 block index")
+            result = measure.dense_call(
+                patch,
+                transformer_options,
+                q,
+                k,
+                v,
+                heads,
+                mask=mask,
+                attn_precision=attn_precision,
+                skip_reshape=skip_reshape,
+                skip_output_reshape=skip_output_reshape,
+                scale=kwargs.get("scale"),
+                block_index=block_index,
+            )
+            if result is None:
+                raise RuntimeError("attention measure disappeared during dense route binding")
+            return result
+
+        if request is not None and patch.vsa:
+            raise RuntimeError("Mixed-Grid attention measure cannot execute through VSA tile planning")
         if mask is not None or patch.vsa:
             return dense()
         tokens = q.shape[2] if skip_reshape else q.shape[1]
-        reason = patch.dense_reason(transformer_options, tokens, transformer_options.get("block_index"))
+        reason = patch.dense_reason(transformer_options, tokens, block_index)
         if reason is not None:
             patch.log_once(("dense", tokens, reason), f"dense ({tokens} tokens): {reason}")
             return dense()
@@ -201,12 +238,43 @@ def make_attention_override(patch: SparseAttnPatch, previous):
             patch.log_once(("ineligible", tuple(qs.shape), reason), f"dense {tuple(qs.shape)}: {reason}")
             return dense()
         sink, sink_q = patch.sinks(transformer_options, tokens)
+        measure_plan = None
+        if request is not None:
+            if type(block_index) is not int:
+                raise RuntimeError("attention measure requires a concrete H3 block index")
+            measure_plan = measure.prepare(
+                patch,
+                transformer_options,
+                block_index=block_index,
+                q_rows=tokens,
+                kv_rows=tokens,
+                device=q.device,
+                dtype=q.dtype,
+                head_dim=dim_head,
+                mask_class="none",
+                existing_sink=sink,
+                provider=ck.sol_attn,
+                profile="weighted_exact_blocks_v1",
+                numerical_route="core_bsa_direct",
+                preprocess_digest="caller_attention_domain_v1",
+            )
+            if measure_plan is None:
+                raise RuntimeError("attention measure disappeared during sparse route binding")
+            sink = measure_plan.exact_k_block_range
         if q.dtype == torch.float32:   # the kernel quantizes to int8 anyway; bf16 keeps the fp32 range
             qs, ks, vs = (t.to(torch.bfloat16) for t in (qs, ks, vs))
-        out = ck.sol_attn(qs, ks, vs, tau=patch.tau, scale=kwargs.get("scale"),
-                          sink_blocks=list(sink), sink_q=list(sink_q), topk_ratio=patch.topk_ratio,
-                          token_aug=patch.extra_tokens).to(q.dtype)
-        patch.log_once(("sparse", tuple(qs.shape)), f"sparse {tuple(qs.shape)}, sinks {sink}/{sink_q}")
+        out = ck.sol_attn(
+            qs, ks, vs,
+            tau=patch.tau,
+            scale=kwargs.get("scale"),
+            sink_blocks=list(sink),
+            sink_q=list(sink_q),
+            key_bias=None if measure_plan is None else measure_plan.key_log_measure,
+            topk_ratio=patch.topk_ratio,
+            token_aug=patch.extra_tokens,
+        ).to(q.dtype)
+        patch.log_once(("sparse", tuple(qs.shape), None if measure_plan is None else measure_plan.semantic_digest),
+                       f"sparse {tuple(qs.shape)}, sinks {sink}/{sink_q}")
         if skip_output_reshape:
             return out.transpose(1, 2)
         return out.reshape(b, -1, heads * dim_head)
@@ -218,6 +286,7 @@ def install_override(patch: SparseAttnPatch, transformer_options):
     """Put this patch's override on top of whatever attention override is on the
     hook. Runs at patch time and again from ON_PREPARE_STATE each step, so a node
     applied later cannot silently replace it; idempotent once it is on top."""
+    measure.register(patch, transformer_options)
     current = transformer_options.get("optimized_attention_override")
     if current in patch.installed:
         return
@@ -229,6 +298,9 @@ def install_override(patch: SparseAttnPatch, transformer_options):
 def h3_eligible(attn, x, rope_freqs, transformer_options, patch: SparseAttnPatch, block_index):
     """Whether this H3 block call takes the sparse producer (decided before any work)."""
     n_tokens = x.shape[0]
+    request = transformer_options.get(measure.ATTENTION_MEASURE_KEY)
+    if request is not None and patch.vsa:
+        raise RuntimeError("Mixed-Grid attention measure cannot execute through VSA tile planning")
     if rope_freqs is None or x.dtype != torch.bfloat16 or x.device.type != "cuda" or attn.head_dim != HEAD_DIM:
         return False
     reason = patch.dense_reason(transformer_options, n_tokens, block_index)
@@ -237,6 +309,13 @@ def h3_eligible(attn, x, rope_freqs, transformer_options, patch: SparseAttnPatch
     if reason is not None:
         patch.log_once(("dense", n_tokens, reason), f"dense ({n_tokens} tokens): {reason}")
         return False
+    if request is not None and not measure.supports_key_bias(ck.sol_attn_chunked):
+        # Do not silently fall through to native full-QKV H3 attention: this path
+        # was selected specifically for the chunked producer's memory contract.
+        raise RuntimeError(
+            "Mixed-Grid attention measure requires comfy-kitchen sol_attn_chunked(key_bias=...); "
+            "the selected kitchen build does not expose that capability"
+        )
     if patch.vsa:
         layout = transformer_options.get("minimax_h3_layout")
         if layout is None or layout.seq_len != n_tokens:
@@ -254,13 +333,52 @@ def h3_sparse_attention(attn, x, rope_freqs, transformer_options, patch: SparseA
     kw = comfy.model_management.cast_to(attn.k_norm.weight, device=x.device)
     extra, plan, gate = {}, None, None
     n, freqs = n_tokens, rope_freqs
+    request = transformer_options.get(measure.ATTENTION_MEASURE_KEY)
     with comfy.model_prefetch.pause_malloc_graph():
         if patch.vsa:
             plan = patch.vsa_plan(transformer_options["minimax_h3_layout"], x.device)
             n = plan["n"]
             freqs = patch.vsa_rope_freqs(rope_freqs, plan)
 
-        key = (block_index, n, tuple(transformer_options.get("uuids", ())))   # statistics per conditioning branch
+        sink, sink_q = ((0, 0), (0, 0)) if patch.vsa else patch.sinks(transformer_options, n_tokens)
+        measure_plan = None
+        vdn_epilogue = None
+        if request is not None:
+            measure_plan = measure.prepare(
+                patch,
+                transformer_options,
+                block_index=block_index,
+                q_rows=n_tokens,
+                kv_rows=n_tokens,
+                device=x.device,
+                dtype=x.dtype,
+                head_dim=head_dim,
+                mask_class="none",
+                existing_sink=sink,
+                provider=ck.sol_attn_chunked,
+                profile="weighted_exact_blocks_v1",
+                numerical_route="core_bsa_h3_chunked",
+                preprocess_digest="core_h3_chunked_rms_rope_split_half_v1",
+            )
+            if measure_plan is None:
+                raise RuntimeError("attention measure disappeared during H3 chunked binding")
+            sink = measure_plan.exact_k_block_range
+            vdn_epilogue = measure.prepare_vdn_epilogue(
+                attn, x, rope_freqs, transformer_options, block_index
+            )
+
+        measure_identity = None if measure_plan is None else (
+            measure_plan.semantic_digest,
+            measure_plan.provider_identity,
+            measure_plan.owner_generation,
+            measure_plan.numerical_route,
+        )
+        key = measure.pool_key(
+            block_index,
+            n,
+            transformer_options.get("uuids", ()),
+            measure_plan,
+        )
         pooled = patch.pooled.get(key)
         first = pooled is None
         if first:
@@ -275,8 +393,8 @@ def h3_sparse_attention(attn, x, rope_freqs, transformer_options, patch: SparseA
         gate = attn.to_gate_compress
         if gate is not None:
             extra["coarse_gate"] = x.new_empty(n, heads * head_dim).view(1, n, heads, head_dim)
-    else:
-        sink, sink_q = patch.sinks(transformer_options, n_tokens)
+    elif measure_plan is not None:
+        extra["key_bias"] = measure_plan.key_log_measure
 
     def chunks():
         for i in range(0, n, PRODUCER_CHUNK):
@@ -300,8 +418,13 @@ def h3_sparse_attention(attn, x, rope_freqs, transformer_options, patch: SparseA
     pooled[1].copy_(vscale)
     patch.pooled[key] = pooled
     mode = f"VSA tiles ({n} padded rows, {sink[1]} prefix tiles)" if plan is not None else f"sinks {sink}/{sink_q}"
-    patch.log_once(("producer", n), f"sparse producer path: {n_tokens} tokens, {mode}")
-    out = out.view(n, heads * head_dim)
+    patch.log_once(("producer", n, measure_identity), f"sparse producer path: {n_tokens} tokens, {mode}")
+    out = out.view(n, heads, head_dim)
+    if vdn_epilogue is not None:
+        if plan is not None:
+            raise RuntimeError("VDN Mixed-Grid epilogue cannot consume VSA-reordered rows")
+        return vdn_epilogue.apply(out, x)
+    out = out.reshape(n, heads * head_dim)
     if plan is not None:
         out = out[plan["inv"]]
     return attn.out_proj(out)

--- a/comfy_extras/sparse_attention_measure.py
+++ b/comfy_extras/sparse_attention_measure.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import inspect
+from collections.abc import Mapping
+
+import torch
+
+from comfy.attention_measure import (
+    ATTENTION_MEASURE_CAPABILITIES_KEY,
+    ATTENTION_MEASURE_KEY,
+    BoundMeasurePlan,
+    MeasureExecutionContext,
+    bind,
+    prepare_capability,
+    register_capability,
+    semantic_digest,
+    validate_h3,
+    weighted_dense,
+)
+
+PROVIDER_IDENTITY = "comfy.core.block_sparse_attention"
+VDN_EPILOGUE_KEY = "vdn_h3_external_softmax_epilogue_v1"
+VDN_EXTERNAL_SEQUENCE_KEY = "vdn_h3_external_sequence_v1"
+VDN_FORWARD_MARKER = "_vdn_forward"
+VDN_EXTERNAL_SEQUENCE_API_ATTR = "_vdn_external_sequence_api"
+
+
+def supports_key_bias(provider) -> bool:
+    try:
+        parameters = inspect.signature(provider).parameters
+    except (TypeError, ValueError):
+        return False
+    return "key_bias" in parameters or any(
+        p.kind == inspect.Parameter.VAR_KEYWORD for p in parameters.values()
+    )
+
+
+# Keep the currently staged BlockSparseAttention call site valid while this
+# companion remains split across files. This alias is temporary compatibility,
+# not a second capability surface.
+_supports_key_bias = supports_key_bias
+
+
+def pool_key(block_index, rows, uuids, plan: BoundMeasurePlan | None):
+    """Return the BSA calibration key without perturbing the established path.
+
+    Unweighted H3 calls intentionally retain the historical three-tuple used by
+    Spectrum's reviewed cold/primed ownership proof. Weighted calls add the
+    numerical measure identity so their kmean/vscale calibration cannot be
+    mistaken for an unweighted or differently weighted attention domain.
+    """
+
+    base = (int(block_index), int(rows), tuple(uuids))
+    if plan is None:
+        return base
+    return (
+        *base,
+        (
+            ATTENTION_MEASURE_KEY,
+            plan.semantic_digest,
+            plan.provider_identity,
+            plan.owner_generation,
+            plan.numerical_route,
+            plan.preprocess_digest,
+            plan.implementation_profile,
+        ),
+    )
+
+
+def prepare_vdn_epilogue(attn, x, rope_freqs, transformer_options, block_index):
+    """Resolve the optional VDN-owned external Mixed-Grid gate/projection epilogue.
+
+    Flow's API-2 external-sequence contract describes mixed geometry and can be
+    present without VDN. Only a concrete VDN attention owner must provide the
+    owner-bound epilogue; an installed VDN owner without that capability remains
+    fail-closed because falling back to ``attn.out_proj`` would drop its learned
+    gate.
+    """
+
+    external = transformer_options.get(VDN_EXTERNAL_SEQUENCE_KEY)
+    if not isinstance(external, Mapping) or external.get("api") != 2:
+        return None
+    if external.get("mode") != "dense_gate_no_linear" or external.get("topology") != "mixed_grid_low_suffix":
+        raise RuntimeError("Mixed-Grid attention measure received an unsupported VDN external-sequence contract")
+    forward = getattr(attn, "forward", None)
+    if getattr(forward, VDN_FORWARD_MARKER, False) is not True:
+        return None
+    if getattr(forward, VDN_EXTERNAL_SEQUENCE_API_ATTR, None) != 2:
+        raise RuntimeError("VDN Mixed-Grid attention owner does not advertise external-sequence API 2")
+    capability = getattr(forward, VDN_EPILOGUE_KEY, None)
+    prepare_epilogue = getattr(capability, "prepare", None)
+    if not callable(prepare_epilogue):
+        raise RuntimeError(
+            "VDN API-2 Mixed-Grid attention requires the owner-bound external softmax epilogue capability"
+        )
+    bound = prepare_epilogue(x, rope_freqs, transformer_options, block_index)
+    if not callable(getattr(bound, "apply", None)) or not callable(getattr(bound, "receipt_fields", None)):
+        raise RuntimeError("VDN external softmax epilogue capability returned an invalid bound owner")
+    return bound
+
+
+def _cache(patch):
+    cache = getattr(patch, "measure_plans", None)
+    if cache is None:
+        cache = {}
+        patch.measure_plans = cache
+    return cache
+
+
+def prepare(
+    patch,
+    transformer_options,
+    *,
+    block_index,
+    q_rows,
+    kv_rows,
+    device,
+    dtype,
+    head_dim,
+    mask_class,
+    existing_sink,
+    provider,
+    profile,
+    numerical_route,
+    preprocess_digest,
+) -> BoundMeasurePlan | None:
+    request = transformer_options.get(ATTENTION_MEASURE_KEY)
+    if request is None:
+        return None
+    if patch.vsa:
+        raise RuntimeError("Mixed-Grid attention measure is incompatible with VSA tile planning")
+    if profile == "weighted_exact_blocks_v1" and not supports_key_bias(provider):
+        raise RuntimeError(
+            "Mixed-Grid attention measure selected a sparse provider without key_bias support; "
+            "install a comfy-kitchen build with weighted sparse attention support"
+        )
+    context = MeasureExecutionContext(
+        provider_identity=PROVIDER_IDENTITY,
+        block_index=int(block_index),
+        owner=patch,
+        owner_generation=patch.measure_owner_generation,
+        layout=transformer_options.get("minimax_h3_layout"),
+        q_rows=int(q_rows),
+        kv_rows=int(kv_rows),
+        dtype=dtype,
+        device=torch.device(device),
+        head_dim=int(head_dim),
+        mask_class=str(mask_class),
+        preprocess_digest=str(preprocess_digest),
+        numerical_route=str(numerical_route),
+        existing_sink=tuple(existing_sink),
+        external_sequence=transformer_options.get(VDN_EXTERNAL_SEQUENCE_KEY),
+    )
+
+    # A cached plan owns only the immutable O(T) measure materialization. Runtime
+    # layout/external geometry and the concrete capability registry are live
+    # execution facts and must be re-proven on every use; otherwise a wrapper can
+    # replace them after the first bind while the cache still returns stale proof.
+    normalized = validate_h3(
+        request,
+        layout=context.layout,
+        q_rows=context.q_rows,
+        kv_rows=context.kv_rows,
+        external_sequence=context.external_sequence,
+    )
+    digest = semantic_digest(normalized)
+    registry = transformer_options.get(ATTENTION_MEASURE_CAPABILITIES_KEY)
+    capability = registry.get(PROVIDER_IDENTITY) if isinstance(registry, Mapping) else None
+    if (
+        capability is not getattr(patch, "measure_capability", None)
+        or getattr(capability, "patch", None) is not patch
+    ):
+        raise RuntimeError("core sparse attention measure capability owner changed after binding")
+
+    key = (
+        digest,
+        context.block_index,
+        context.q_rows,
+        context.kv_rows,
+        str(context.device),
+        str(context.dtype),
+        context.head_dim,
+        context.mask_class,
+        context.existing_sink,
+        profile,
+        context.numerical_route,
+        context.preprocess_digest,
+        context.owner_generation,
+    )
+    cache = _cache(patch)
+    result = cache.get(key)
+    if result is None:
+        result = prepare_capability(transformer_options, normalized, context)
+        if result.implementation_profile != profile:
+            raise RuntimeError(
+                "core sparse attention measure capability selected an unexpected implementation profile"
+            )
+        cache[key] = result
+    return result
+
+
+def dense_call(
+    patch,
+    transformer_options,
+    q,
+    k,
+    v,
+    heads,
+    *,
+    mask,
+    attn_precision,
+    skip_reshape,
+    skip_output_reshape,
+    scale,
+    block_index,
+):
+    q_rows = q.shape[2] if skip_reshape else q.shape[1]
+    kv_rows = k.shape[2] if skip_reshape else k.shape[1]
+    sink, _ = patch.sinks(transformer_options, q_rows)
+    plan = prepare(
+        patch,
+        transformer_options,
+        block_index=block_index,
+        q_rows=q_rows,
+        kv_rows=kv_rows,
+        device=q.device,
+        dtype=q.dtype,
+        head_dim=q.shape[-1] if skip_reshape else q.shape[-1] // heads,
+        mask_class="none" if mask is None else ("boolean" if mask.dtype == torch.bool else "additive"),
+        existing_sink=sink,
+        provider=weighted_dense,
+        profile="dense_exact_v1",
+        numerical_route="core_dense_sdpa",
+        preprocess_digest="caller_attention_domain_v1",
+    )
+    if plan is None:
+        return None
+    return weighted_dense(
+        q,
+        k,
+        v,
+        heads,
+        key_bias=plan.key_log_measure,
+        mask=mask,
+        attn_precision=attn_precision,
+        skip_reshape=skip_reshape,
+        skip_output_reshape=skip_output_reshape,
+        scale=scale,
+    )
+
+
+class Capability:
+    api = 1
+    operator = "key_log_measure"
+    provider_identity = PROVIDER_IDENTITY
+
+    def __init__(self, patch):
+        self.patch = patch
+
+    def prepare(self, request, execution_context):
+        if not isinstance(execution_context, MeasureExecutionContext):
+            raise TypeError("core sparse attention requires MeasureExecutionContext")
+        if execution_context.owner is not self.patch:
+            raise RuntimeError("core sparse attention measure capability is bound to another patch owner")
+        profile = (
+            "weighted_exact_blocks_v1"
+            if execution_context.numerical_route.startswith("core_bsa")
+            else "dense_exact_v1"
+        )
+        return bind(
+            request,
+            context=execution_context,
+            block_size=64,
+            implementation_profile=profile,
+        )
+
+
+def register(patch, transformer_options):
+    if getattr(patch, "measure_capability", None) is None:
+        patch.measure_capability = Capability(patch)
+    register_capability(transformer_options, PROVIDER_IDENTITY, patch.measure_capability)

--- a/tests-unit/comfy_test/attention_measure_test.py
+++ b/tests-unit/comfy_test/attention_measure_test.py
@@ -1,0 +1,315 @@
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from comfy import attention_measure as m
+from comfy_extras import sparse_attention_measure as sparse_measure
+
+
+def request(*, equal=False):
+    source = [2, 3]
+    prefix = source if equal else [3, 4]
+    source_rows = 6
+    prefix_rows = 6 if equal else 12
+    rows = 6 + prefix_rows + source_rows
+    ratio = (1, 1) if equal else (1, 2)
+    return {
+        "api": 1,
+        "operator": "key_log_measure",
+        "normalization": "h3_native_source_carrier_v1",
+        "topology": "mixed_grid_low_suffix",
+        "q_rows": rows,
+        "kv_rows": rows,
+        "video_start": 6,
+        "temporal": 2,
+        "prefix_t": 1,
+        "source_grid": source,
+        "prefix_grid": prefix,
+        "segments": [
+            {"start": 0, "stop": 6, "mass_num": 1, "mass_den": 1},
+            {"start": 6, "stop": 6 + prefix_rows, "mass_num": ratio[0], "mass_den": ratio[1]},
+            {"start": 6 + prefix_rows, "stop": rows, "mass_num": 1, "mass_den": 1},
+        ],
+        "coordinate_policy": "minimax_h3_native_frame_grid_v1",
+    }
+
+
+def layout(rows):
+    return SimpleNamespace(seq_len=rows, segments=((0, 6, "text"), (6, rows, "video")))
+
+
+def context(r):
+    return m.MeasureExecutionContext(
+        provider_identity="test.provider",
+        block_index=3,
+        owner=object(),
+        owner_generation="gen-1",
+        layout=layout(r["q_rows"]),
+        q_rows=r["q_rows"],
+        kv_rows=r["kv_rows"],
+        dtype=torch.bfloat16,
+        device=torch.device("cpu"),
+        head_dim=128,
+        mask_class="none",
+        preprocess_digest="pre-1",
+        numerical_route="test",
+    )
+
+
+def test_normalize_is_semantic_not_segment_spelling():
+    r = request()
+    canonical = m.normalize(r)
+    split = {**r, "segments": [
+        {"start": 0, "stop": 2, "mass_num": 4, "mass_den": 4},
+        {"start": 2, "stop": 6, "mass_num": 1, "mass_den": 1},
+        {"start": 6, "stop": 12, "mass_num": 2, "mass_den": 4},
+        {"start": 12, "stop": 18, "mass_num": 1, "mass_den": 2},
+        {"start": 18, "stop": 24, "mass_num": 3, "mass_den": 3},
+    ]}
+    assert m.normalize(split) == canonical
+    assert m.semantic_digest(split) == m.semantic_digest(r)
+
+
+def test_equal_grid_is_unit_measure_and_preserves_existing_sink():
+    r = request(equal=True)
+    normalized = m.normalize(r)
+    assert normalized["segments"] == [{"start": 0, "stop": 18, "mass_num": 1, "mass_den": 1}]
+    assert m.is_unit_measure(r)
+    assert m.merge_exact_k_blocks(r, 64, existing=(0, 1)) == (0, 1)
+    assert torch.equal(m.materialize(r, device="cpu"), torch.zeros(18))
+
+
+def test_ragged_weighted_interval_expands_to_physical_k_blocks():
+    r = {
+        "api": 1,
+        "operator": "key_log_measure",
+        "normalization": "h3_native_source_carrier_v1",
+        "topology": "mixed_grid_low_suffix",
+        "q_rows": 303,
+        "kv_rows": 303,
+        "video_start": 63,
+        "temporal": 3,
+        "prefix_t": 1,
+        "source_grid": [8, 8],
+        "prefix_grid": [8, 14],
+        "segments": [
+            {"start": 0, "stop": 63, "mass_num": 1, "mass_den": 1},
+            {"start": 63, "stop": 175, "mass_num": 4, "mass_den": 7},
+            {"start": 175, "stop": 303, "mass_num": 1, "mass_den": 1},
+        ],
+        "coordinate_policy": "minimax_h3_native_frame_grid_v1",
+    }
+    assert m.merge_exact_k_blocks(r, 64) == (0, 3)
+    assert m.merge_exact_k_blocks(r, 64, existing=(0, 1)) == (0, 3)
+
+
+def test_h3_validation_cross_checks_actual_layout_and_vdn_when_present():
+    r = request()
+    rows = r["q_rows"]
+    external = {
+        "api": 2,
+        "mode": "dense_gate_no_linear",
+        "topology": "mixed_grid_low_suffix",
+        "native_sequence_rows": 18,
+        "sequence_rows": rows,
+        "video_start": 6,
+        "temporal": 2,
+        "prefix_t": 1,
+        "source_rows_per_frame": 6,
+        "prefix_rows_per_frame": 12,
+    }
+    assert m.validate_h3(r, layout=layout(rows), q_rows=rows, kv_rows=rows, external_sequence=external) == m.normalize(r)
+    with pytest.raises(ValueError):
+        m.validate_h3(r, layout=SimpleNamespace(seq_len=rows, segments=((0, rows, "video"),)), q_rows=rows, kv_rows=rows)
+    with pytest.raises(ValueError):
+        m.validate_h3(r, layout=layout(rows), q_rows=rows, kv_rows=rows, external_sequence={**external, "prefix_t": 2})
+
+
+def test_bind_and_capability_validate_concrete_owner_identity():
+    r = request()
+    ctx = context(r)
+
+    class Capability:
+        def prepare(self, request, execution_context):
+            return m.bind(
+                request,
+                context=execution_context,
+                block_size=64,
+                implementation_profile="weighted_exact_blocks_v1",
+            )
+
+    options = {}
+    cap = Capability()
+    m.register_capability(options, "test.provider", cap)
+    plan = m.prepare_capability(options, r, ctx)
+    assert plan.semantic_digest == m.semantic_digest(r)
+    assert plan.exact_k_block_range == (0, 1)
+    assert plan.provider_identity == "test.provider"
+    with pytest.raises(RuntimeError):
+        m.prepare_capability(options, r, replace(ctx, provider_identity="other"))
+
+
+def test_bsa_pool_key_preserves_existing_unweighted_history_domain():
+    assert sparse_measure.pool_key(7, 56029, ("cond", 2), None) == (
+        7,
+        56029,
+        ("cond", 2),
+    )
+
+    plan = m.BoundMeasurePlan(
+        semantic_digest="measure-a",
+        implementation_profile="weighted_exact_blocks_v1",
+        provider_identity="comfy.core.block_sparse_attention",
+        owner_generation="owner-a",
+        numerical_route="core_bsa_h3_chunked",
+        preprocess_digest="pre-a",
+        q_rows=56029,
+        kv_rows=56029,
+        exact_k_block_range=(0, 387),
+        exact_range_digest="range-a",
+        key_log_measure=torch.empty(0),
+    )
+    weighted = sparse_measure.pool_key(7, 56029, ("cond", 2), plan)
+    assert weighted[:3] == (7, 56029, ("cond", 2))
+    assert weighted[3] == (
+        "attention_measure_v1",
+        "measure-a",
+        "comfy.core.block_sparse_attention",
+        "owner-a",
+        "core_bsa_h3_chunked",
+        "pre-a",
+        "weighted_exact_blocks_v1",
+    )
+    assert weighted != sparse_measure.pool_key(7, 56029, ("cond", 2), None)
+
+
+def test_sparse_measure_rejects_provider_without_key_bias_before_binding():
+    class Patch:
+        vsa = False
+        measure_owner_generation = "owner"
+        measure_plans = {}
+
+    def provider_without_bias(q, k, v):
+        raise AssertionError("provider must not execute during capability check")
+
+    assert not sparse_measure.supports_key_bias(provider_without_bias)
+    with pytest.raises(RuntimeError, match="without key_bias support"):
+        sparse_measure.prepare(
+            Patch(),
+            {m.ATTENTION_MEASURE_KEY: request()},
+            block_index=0,
+            q_rows=24,
+            kv_rows=24,
+            device="cpu",
+            dtype=torch.bfloat16,
+            head_dim=128,
+            mask_class="none",
+            existing_sink=(0, 1),
+            provider=provider_without_bias,
+            profile="weighted_exact_blocks_v1",
+            numerical_route="core_bsa_h3_chunked",
+            preprocess_digest="pre",
+        )
+
+
+def test_vdn_epilogue_resolution_is_optional_but_owner_bound_when_installed():
+    class Bound:
+        def apply(self, softmax_out, x):
+            return softmax_out
+
+        def receipt_fields(self):
+            return (("completed", True),)
+
+    class Capability:
+        def __init__(self):
+            self.calls = []
+
+        def prepare(self, x, rope, options, block_index):
+            self.calls.append((x, rope, options, block_index))
+            return Bound()
+
+    x = torch.zeros(24, 8)
+    rope = torch.zeros(1, 24, 1, 1)
+    options = {
+        "vdn_h3_external_sequence_v1": {
+            "api": 2,
+            "mode": "dense_gate_no_linear",
+            "topology": "mixed_grid_low_suffix",
+        }
+    }
+
+    # Flow publishes API-2 mixed geometry independently of whether VDN is
+    # installed. A native H3 owner therefore keeps its native projection.
+    native = SimpleNamespace(forward=lambda *args, **kwargs: None)
+    assert sparse_measure.prepare_vdn_epilogue(native, x, rope, options, 5) is None
+
+    forward = lambda *args, **kwargs: None
+    setattr(forward, sparse_measure.VDN_FORWARD_MARKER, True)
+    setattr(forward, sparse_measure.VDN_EXTERNAL_SEQUENCE_API_ATTR, 2)
+    capability = Capability()
+    setattr(forward, sparse_measure.VDN_EPILOGUE_KEY, capability)
+    attn = SimpleNamespace(forward=forward)
+    bound = sparse_measure.prepare_vdn_epilogue(attn, x, rope, options, 5)
+    assert isinstance(bound, Bound)
+    assert capability.calls == [(x, rope, options, 5)]
+
+    missing = lambda *args, **kwargs: None
+    setattr(missing, sparse_measure.VDN_FORWARD_MARKER, True)
+    setattr(missing, sparse_measure.VDN_EXTERNAL_SEQUENCE_API_ATTR, 2)
+    with pytest.raises(RuntimeError, match="owner-bound"):
+        sparse_measure.prepare_vdn_epilogue(
+            SimpleNamespace(forward=missing), x, rope, options, 5
+        )
+
+    incompatible = lambda *args, **kwargs: None
+    setattr(incompatible, sparse_measure.VDN_FORWARD_MARKER, True)
+    setattr(incompatible, sparse_measure.VDN_EXTERNAL_SEQUENCE_API_ATTR, 1)
+    with pytest.raises(RuntimeError, match="API 2"):
+        sparse_measure.prepare_vdn_epilogue(
+            SimpleNamespace(forward=incompatible), x, rope, options, 5
+        )
+
+    assert sparse_measure.prepare_vdn_epilogue(
+        native,
+        x,
+        rope,
+        {"vdn_h3_external_sequence_v1": {"api": 1}},
+        5,
+    ) is None
+
+
+def test_weighted_dense_sdpa_and_streaming_match_and_preserve_masks():
+    torch.manual_seed(12)
+    q = torch.randn(1, 2, 5, 8)
+    k = torch.randn(1, 2, 24, 8)
+    v = torch.randn(1, 2, 24, 8)
+    bias = m.materialize(request(), device="cpu")
+    mask = torch.ones(1, 1, 5, 24, dtype=torch.bool)
+    mask[..., 1, :] = False
+    mask[..., 3, 17:] = False
+    got = m.weighted_dense(q, k, v, 2, key_bias=bias, mask=mask, skip_reshape=True, skip_output_reshape=True)
+    streamed = m.weighted_dense_streaming(
+        q, k, v, 2, key_bias=bias, mask=mask, skip_reshape=True, skip_output_reshape=True, key_chunk_size=7
+    )
+    torch.testing.assert_close(streamed, got, rtol=2e-5, atol=2e-5)
+    assert torch.count_nonzero(got[:, :, 1]) == 0
+
+
+def test_malformed_values_and_additive_nan_rejected():
+    r = request()
+    with pytest.raises(TypeError):
+        m.normalize({**r, "q_rows": True})
+    bad = {**r, "segments": [dict(x) for x in r["segments"]]}
+    bad["segments"][1]["mass_den"] = False
+    with pytest.raises(TypeError):
+        m.normalize(bad)
+    q = torch.zeros(1, 1, 1, 8)
+    k = torch.zeros(1, 1, 24, 8)
+    v = torch.zeros_like(k)
+    bias = m.materialize(r, device="cpu")
+    mask = torch.zeros(1, 1, 1, 24)
+    mask[..., 0] = float("nan")
+    with pytest.raises(ValueError):
+        m.weighted_dense(q, k, v, 1, key_bias=bias, mask=mask, skip_reshape=True)

--- a/tests-unit/comfy_test/sparse_attention_measure_cache_test.py
+++ b/tests-unit/comfy_test/sparse_attention_measure_cache_test.py
@@ -1,0 +1,108 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from comfy import attention_measure as m
+from comfy_extras import sparse_attention_measure as sparse_measure
+
+
+def _request():
+    return {
+        "api": 1,
+        "operator": "key_log_measure",
+        "normalization": "h3_native_source_carrier_v1",
+        "topology": "mixed_grid_low_suffix",
+        "q_rows": 24,
+        "kv_rows": 24,
+        "video_start": 6,
+        "temporal": 2,
+        "prefix_t": 1,
+        "source_grid": [2, 3],
+        "prefix_grid": [3, 4],
+        "segments": [
+            {"start": 0, "stop": 6, "mass_num": 1, "mass_den": 1},
+            {"start": 6, "stop": 18, "mass_num": 1, "mass_den": 2},
+            {"start": 18, "stop": 24, "mass_num": 1, "mass_den": 1},
+        ],
+        "coordinate_policy": "minimax_h3_native_frame_grid_v1",
+    }
+
+
+def _layout(video_start=6):
+    return SimpleNamespace(
+        seq_len=24,
+        segments=((0, video_start, "text"), (video_start, 24, "video")),
+    )
+
+
+def _external(*, prefix_t=1):
+    return {
+        "api": 2,
+        "mode": "dense_gate_no_linear",
+        "topology": "mixed_grid_low_suffix",
+        "native_sequence_rows": 18,
+        "sequence_rows": 24,
+        "video_start": 6,
+        "temporal": 2,
+        "prefix_t": prefix_t,
+        "source_rows_per_frame": 6,
+        "prefix_rows_per_frame": 12,
+    }
+
+
+def _provider(*args, key_bias=None, **kwargs):
+    raise AssertionError("provider must not execute while binding a measure plan")
+
+
+def _prepare(patch, options):
+    return sparse_measure.prepare(
+        patch,
+        options,
+        block_index=0,
+        q_rows=24,
+        kv_rows=24,
+        device="cpu",
+        dtype=torch.bfloat16,
+        head_dim=128,
+        mask_class="none",
+        existing_sink=(0, 1),
+        provider=_provider,
+        profile="weighted_exact_blocks_v1",
+        numerical_route="core_bsa_h3_chunked",
+        preprocess_digest="pre",
+    )
+
+
+def test_cached_measure_plan_revalidates_live_layout_external_and_owner():
+    patch = SimpleNamespace(
+        vsa=False,
+        measure_owner_generation="owner",
+        measure_capability=None,
+        measure_plans={},
+    )
+    options = {
+        m.ATTENTION_MEASURE_KEY: _request(),
+        "minimax_h3_layout": _layout(),
+    }
+    sparse_measure.register(patch, options)
+
+    first = _prepare(patch, options)
+    assert first is _prepare(patch, options)
+    assert len(patch.measure_plans) == 1
+
+    options["minimax_h3_layout"] = _layout(video_start=5)
+    with pytest.raises(ValueError, match="video interval"):
+        _prepare(patch, options)
+
+    options["minimax_h3_layout"] = _layout()
+    options[sparse_measure.VDN_EXTERNAL_SEQUENCE_KEY] = _external(prefix_t=2)
+    with pytest.raises(ValueError, match="VDN external-sequence"):
+        _prepare(patch, options)
+
+    options.pop(sparse_measure.VDN_EXTERNAL_SEQUENCE_KEY)
+    options[m.ATTENTION_MEASURE_CAPABILITIES_KEY] = {
+        sparse_measure.PROVIDER_IDENTITY: object()
+    }
+    with pytest.raises(RuntimeError, match="capability owner changed"):
+        _prepare(patch, options)


### PR DESCRIPTION
Implements the generic core contract and execution support required for heterogeneous MiniMax-H3 mixed-grid attention.

## What this adds

- canonical `attention_measure_v1` normalization/validation with positive rational per-key measure and semantic digesting;
- H3 mixed-layout validation and optional VDN external-sequence API-2 geometry cross-checking;
- provider capability binding with concrete provider/owner/generation/preprocess identity;
- an O(T) contiguous FP32 natural-log key-measure buffer; no O(T²) measure tensor is materialized;
- exact physical K-block coverage for every non-unit-measure key interval, merged with any existing exact sink;
- exact dense weighted SDPA and a bounded streaming dense oracle;
- weighted BlockSparseAttention execution for direct and H3 chunked routes;
- measure-aware sparse calibration identity while preserving the existing unweighted pool key unchanged;
- cache-hit hardening: cached plans reuse only immutable measure materialization, while the live H3 layout, optional API-2 external geometry, and concrete provider capability owner are revalidated on every use;
- optional VDN epilogue delegation only when the concrete attention forward is VDN-owned. API-2 mixed-grid geometry alone does not imply that VDN is installed; the native projection path remains valid without VDN.

The weighted route preserves all Q/K/V rows. Spatial carrier density is represented by adding `log(measure_k)` to attention logits. It does not implement representative-K/V deletion or downsampling.

## Compatibility invariants

- Existing unweighted sparse-attention calibration identity remains `(block_index, rows, uuids)`.
- Query-prefix exactness and key-block exactness remain independent.
- Calibration values (`kmean` / `vscale`) are not modified by the key measure; only weighted cache identity is measure-specific.
- A cached measure tensor is not accepted as proof of current runtime geometry or capability ownership.
- A VDN external epilogue is required only when the actual attention forward is the VDN forward; stale or foreign ownership fails closed.
- Existing serialized workflows without an `attention_measure_v1` request retain their prior numerical semantics.

## Validation

The current clean head `8406da920f9df19cbc14b76aef1bcd3dc4cf1119` is one implementation commit on current upstream `master` `1d48d9cf7bcecb6022a87b3cb13e0fb435bf9b8a`.

Focused cache-hardening run `34560181433` completed **11 passed** across the attention-measure contract suite and the new cache regression. The regression first proves a legitimate cache hit, then separately rejects a changed H3 layout, changed API-2 external geometry, and replacement of the registered capability owner.

The exact clean head also passes fork Python-lint run `34560729867`: both Ruff and Pylint completed successfully.

Current companion structural validation was rerun from Spectrum run `34561055104`, pinned to:

- Core `8406da920f9df19cbc14b76aef1bcd3dc4cf1119`;
- Flow `a6bf395133c8ce496217ca9194f3ab3f2b9181ef`;
- VDN `d5f158a1c1750d79b37cb6ef22b0f14e6a8cbad6`.

The weighted Core-BSA / Flow / VDN / Spectrum targeted suites completed **43 passed, 1 skipped**. The single skip is the separate Untwist-composition fixture, which was intentionally not installed in that targeted run; it is not part of the weighted Core/Flow/VDN contract being revalidated.

These are structural/CPU compatibility evidence only. They do **not** establish GPU numerical or decoded-media correctness.

Still required before production release:

- compiled CUDA numerical validation of the weighted chunked sparse path;
- real SM120 Sol-Attn validation through the provider companion;
- end-to-end schedule/receipt validation proving no additional H3 NFE and preserving the applicable `18 logical / 14 actual / 4 forecast` schedule;
- decoded-media and performance validation.

Authoritative architecture: https://github.com/xmarre/MiniMax-H3-Flow-Aligned-Regenerate/blob/3afc6c63063f410afec756c42811a8cf1ad2ed77/docs/MIXED_GRID_MEASURE_ARCHITECTURE.md

Companion design PR: https://github.com/xmarre/MiniMax-H3-Flow-Aligned-Regenerate/pull/29