### PR TITLE
Support per-model H3 compiler opt-out

### DIFF
--- a/comfy/ldm/minimax/model.py
+++ b/comfy/ldm/minimax/model.py
@@ -570,7 +570,10 @@ class MiniMaxH3Model(nn.Module):
             carry = (sigma_a / sigma_v).to(audio_src.dtype)
             x = [x[0], audio_src * carry]
 
-        compile_allocations = comfy.model_prefetch.malloc_graph_enabled(x[0].device)
+        compile_allocations = (
+            not transformer_options.get("disable_comfy_compiler", False)
+            and comfy.model_prefetch.malloc_graph_enabled(x[0].device)
+        )
         if compile_allocations:
             out = [torch.empty_like(x[0]), torch.empty_like(x[1])]
             comfy.model_prefetch.malloc_graph_begin(x[0].device)

--- a/tests-unit/comfy_test/test_minimax_h3_model.py
+++ b/tests-unit/comfy_test/test_minimax_h3_model.py
@@ -1,6 +1,7 @@
 import torch
 from torch import nn
 
+import comfy.model_prefetch
 from comfy.ldm.minimax.model import MiniMaxH3Model, time_shift_sigma
 from comfy.model_sampling import CONST
 
@@ -12,6 +13,29 @@ def make_model(video_output, audio_output):
     model.sigma_shift_audio = 3.0
     model._forward = lambda *args, **kwargs: [video_output.clone(), audio_output.clone()]
     return model
+
+
+def test_forward_can_disable_the_allocation_compiler_for_one_model(monkeypatch):
+    video_output = torch.ones((1, 1, 1, 1, 1))
+    audio_output = torch.ones((1, 1, 2, 2))
+    model = make_model(video_output, audio_output)
+
+    def unexpected_compiler_call(*args, **kwargs):
+        raise AssertionError("allocation compiler should be disabled for this model")
+
+    monkeypatch.setattr(comfy.model_prefetch, "malloc_graph_enabled", unexpected_compiler_call)
+    monkeypatch.setattr(comfy.model_prefetch, "malloc_graph_begin", unexpected_compiler_call)
+
+    out = model(
+        [torch.zeros_like(video_output), torch.zeros_like(audio_output)],
+        torch.tensor([500.0]),
+        torch.empty(1, 1, 1),
+        transformer_options={"disable_comfy_compiler": True},
+        minimax_payload={"audio_scale": 1.0},
+    )
+
+    torch.testing.assert_close(out[0], video_output)
+    torch.testing.assert_close(out[1], audio_output)
 
 
 def test_forward_scales_velocity_to_mask_timestep():


### PR DESCRIPTION
## Summary

- let MiniMax H3 opt out of the allocation compiler through `transformer_options["disable_comfy_compiler"]`
- preserve the existing compiler behavior when the option is absent
- cover the opt-out with a focused forward-path test

## Why

A high-resolution two-pass MiniMax H3 workflow on Windows with AIMDO enabled aborted in the second pass with `CUDA API FAILED (1): status: invalid argument`. The same 1344x736 to 2688x1472, 243-frame workflow also failed with only `--disable-cuda-graphs`, but completed with the global `--disable-comfy-compiler` fallback.

Setting the option on one model clone and checking it before H3 starts its malloc graph completed the same workflow while leaving the compiler enabled globally. Models that do not set the option keep the current path unchanged.

## Test

`python -m pytest tests-unit/comfy_test/test_minimax_h3_model.py -q` (`3 passed`)

The global compiler-off run and the per-model opt-out run both completed in about 8 minutes on an RTX PRO 6000 with ComfyUI 0.35.0, PyTorch 2.9.1+cu130, comfy-aimdo 0.5.3, and comfy-kitchen 0.2.33.
