### PR TITLE
Report downloading and byte progress from the partner node download helper

### DIFF
--- a/comfy_api_nodes/util/download_helpers.py
+++ b/comfy_api_nodes/util/download_helpers.py
@@ -10,6 +10,7 @@ import aiohttp
 import torch
 from aiohttp.client_exceptions import ClientError, ContentTypeError
 
+import comfy.utils
 from comfy_api.latest import IO as COMFY_IO
 from comfy_api.latest import InputImpl, Types
 from folder_paths import get_output_directory
@@ -158,24 +159,29 @@ async def download_url_to_bytesio(
                     sink = dest  # BytesIO or file-like
 
                 written = 0
-                while True:
-                    try:
-                        chunk = await asyncio.wait_for(resp.content.read(1024 * 1024), timeout=1.0)
-                    except asyncio.TimeoutError:
-                        chunk = b""
-                    except asyncio.CancelledError:
-                        raise ProcessingInterrupted("Task cancelled") from None
+                total = resp.content_length
+                pbar = comfy.utils.ProgressBar(total) if total else None
+                with comfy.utils.progress_activity("downloading"):
+                    while True:
+                        try:
+                            chunk = await asyncio.wait_for(resp.content.read(1024 * 1024), timeout=1.0)
+                        except asyncio.TimeoutError:
+                            chunk = b""
+                        except asyncio.CancelledError:
+                            raise ProcessingInterrupted("Task cancelled") from None
 
-                    if is_processing_interrupted():
-                        raise ProcessingInterrupted("Task cancelled")
+                        if is_processing_interrupted():
+                            raise ProcessingInterrupted("Task cancelled")
 
-                    if not chunk:
-                        if resp.content.at_eof():
-                            break
-                        continue
+                        if not chunk:
+                            if resp.content.at_eof():
+                                break
+                            continue
 
-                    sink.write(chunk)
-                    written += len(chunk)
+                        sink.write(chunk)
+                        written += len(chunk)
+                        if pbar is not None:
+                            pbar.update_absolute(written)
 
                 if isinstance(dest, BytesIO):
                     with contextlib.suppress(Exception):

--- a/tests-unit/comfy_api_nodes_test/download_progress_test.py
+++ b/tests-unit/comfy_api_nodes_test/download_progress_test.py
@@ -1,0 +1,69 @@
+import asyncio
+from io import BytesIO
+
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+
+import comfy.utils
+from comfy_api_nodes.util.download_helpers import download_url_to_bytesio
+
+BODY = b"x" * (3 * 1024 * 1024 + 123)
+
+
+def capture_hooks():
+    progress = []
+    activity = []
+    comfy.utils.set_progress_bar_global_hook(
+        lambda value, total, preview, node_id=None: progress.append((value, total))
+    )
+    comfy.utils.set_progress_activity_global_hook(activity.append)
+    return progress, activity
+
+
+def clear_hooks():
+    comfy.utils.set_progress_bar_global_hook(None)
+    comfy.utils.set_progress_activity_global_hook(None)
+
+
+async def serve_and_download(handler):
+    app = web.Application()
+    app.router.add_get("/file", handler)
+    async with TestServer(app) as server:
+        dest = BytesIO()
+        await download_url_to_bytesio(str(server.make_url("/file")), dest, max_retries=0)
+        return dest.getvalue()
+
+
+def test_download_reports_bytes_against_declared_length():
+    async def handler(request):
+        return web.Response(body=BODY)
+
+    progress, activity = capture_hooks()
+    try:
+        data = asyncio.run(serve_and_download(handler))
+    finally:
+        clear_hooks()
+
+    assert data == BODY
+    assert activity == ["downloading", None]
+    assert progress[-1] == (len(BODY), len(BODY))
+    assert all(total == len(BODY) for _, total in progress)
+
+
+def test_download_without_declared_length_says_downloading_only():
+    async def handler(request):
+        resp = web.StreamResponse()
+        await resp.prepare(request)
+        await resp.write(BODY)
+        await resp.write_eof()
+        return resp
+
+    progress, activity = capture_hooks()
+    try:
+        data = asyncio.run(serve_and_download(handler))
+    finally:
+        clear_hooks()
+
+    assert data == BODY
+    assert activity == ["downloading", None]
+    assert progress == []


### PR DESCRIPTION
A partner node fetching its result sits at 0% until the file is complete, then jumps to 100%. The download helper every partner node goes through already counts bytes written and already has the response's Content-Length, and reports neither.

Sets the node's activity to "downloading" for the length of the transfer (the hook from #16202) and reports bytes written against the declared length through the existing ProgressBar, which throttles the sends. No declared length: the word only. A retry starts the count again.

Stacked on #16202; retarget to master once that merges.

Tests: tests-unit/comfy_api_nodes_test/download_progress_test.py (local aiohttp test server, with and without Content-Length).


<!-- API_NODE_PR_CHECKLIST: do not remove -->

## API Node PR Checklist

### Scope
- [ ] **Is API Node Change**

### Pricing & Billing
- [ ] **Need pricing update**
- [ ] **No pricing update**

If **Need pricing update**:
- [ ] Metronome rate cards updated
- [ ] Auto‑billing tests updated and passing

### QA
- [ ] **QA done**
- [ ] **QA not required**

### Comms
- [ ] Informed **Kosinkadink**

