### PR TITLE
Enable ComfyUI-Manager by default in the Windows portable build

### DIFF
--- a/.ci/update_windows/update.py
+++ b/.ci/update_windows/update.py
@@ -123,8 +123,10 @@ repo_update_py_path = os.path.join(repo_path, ".ci/update_windows/update.py")
 cur_path = os.path.dirname(update_py_path)
 
 
-req_path = os.path.join(cur_path, "current_requirements.txt")
-repo_req_path = os.path.join(repo_path, "requirements.txt")
+requirement_files = [
+    (os.path.join(repo_path, "requirements.txt"), os.path.join(cur_path, "current_requirements.txt")),
+    (os.path.join(repo_path, "manager_requirements.txt"), os.path.join(cur_path, "current_manager_requirements.txt")),
+]
 
 
 def files_equal(file1, file2):
@@ -144,8 +146,13 @@ if self_update and not files_equal(update_py_path, repo_update_py_path) and file
     shutil.copy(repo_update_py_path, os.path.join(cur_path, "update_new.py"))
     exit()
 
-if not os.path.exists(req_path) or not files_equal(repo_req_path, req_path):
-    import subprocess
+import subprocess
+
+for repo_req_path, req_path in requirement_files:
+    if not os.path.exists(repo_req_path):
+        continue
+    if os.path.exists(req_path) and files_equal(repo_req_path, req_path):
+        continue
     try:
         subprocess.check_call([sys.executable, '-s', '-m', 'pip', 'install', '-r', repo_req_path])
         shutil.copy(repo_req_path, req_path)

--- a/.ci/windows_amd_base_files/run_amd_gpu.bat
+++ b/.ci/windows_amd_base_files/run_amd_gpu.bat
@@ -1,2 +1,2 @@
-.\python_embeded\python.exe -s ComfyUI\main.py --windows-standalone-build
+.\python_embeded\python.exe -s ComfyUI\main.py --windows-standalone-build --enable-manager
 pause

--- a/.ci/windows_amd_base_files/run_amd_gpu_enable_dynamic_vram.bat
+++ b/.ci/windows_amd_base_files/run_amd_gpu_enable_dynamic_vram.bat
@@ -1,2 +1,2 @@
-.\python_embeded\python.exe -s ComfyUI\main.py --windows-standalone-build --enable-dynamic-vram
+.\python_embeded\python.exe -s ComfyUI\main.py --windows-standalone-build --enable-dynamic-vram --enable-manager
 pause

--- a/.ci/windows_intel_base_files/run_intel_gpu.bat
+++ b/.ci/windows_intel_base_files/run_intel_gpu.bat
@@ -1,2 +1,2 @@
-.\python_embeded\python.exe -s ComfyUI\main.py --windows-standalone-build
+.\python_embeded\python.exe -s ComfyUI\main.py --windows-standalone-build --enable-manager
 pause

--- a/.ci/windows_nightly_base_files/run_nvidia_gpu_fast.bat
+++ b/.ci/windows_nightly_base_files/run_nvidia_gpu_fast.bat
@@ -1,2 +1,2 @@
-.\python_embeded\python.exe -s ComfyUI\main.py --windows-standalone-build --fast
+.\python_embeded\python.exe -s ComfyUI\main.py --windows-standalone-build --fast --enable-manager
 pause

--- a/.ci/windows_nvidia_base_files/advanced/run_nvidia_gpu_disable_api_nodes.bat
+++ b/.ci/windows_nvidia_base_files/advanced/run_nvidia_gpu_disable_api_nodes.bat
@@ -1,3 +1,3 @@
-..\python_embeded\python.exe -s ..\ComfyUI\main.py --windows-standalone-build --disable-api-nodes
+..\python_embeded\python.exe -s ..\ComfyUI\main.py --windows-standalone-build --disable-api-nodes --enable-manager
 echo If you see this and ComfyUI did not start try updating your Nvidia Drivers to the latest. If you get a c10.dll error you need to install vc redist that you can find: https://aka.ms/vc14/vc_redist.x64.exe
 pause

--- a/.ci/windows_nvidia_base_files/run_cpu.bat
+++ b/.ci/windows_nvidia_base_files/run_cpu.bat
@@ -1,2 +1,2 @@
-.\python_embeded\python.exe -s ComfyUI\main.py --cpu --windows-standalone-build
+.\python_embeded\python.exe -s ComfyUI\main.py --cpu --windows-standalone-build --enable-manager
 pause

--- a/.ci/windows_nvidia_base_files/run_nvidia_gpu.bat
+++ b/.ci/windows_nvidia_base_files/run_nvidia_gpu.bat
@@ -1,3 +1,3 @@
-.\python_embeded\python.exe -s ComfyUI\main.py --windows-standalone-build
+.\python_embeded\python.exe -s ComfyUI\main.py --windows-standalone-build --enable-manager
 echo If you see this and ComfyUI did not start try updating your Nvidia Drivers to the latest. If you get a c10.dll error you need to install vc redist that you can find: https://aka.ms/vc14/vc_redist.x64.exe
 pause

--- a/.ci/windows_nvidia_base_files/run_nvidia_gpu_fast_fp16_accumulation.bat
+++ b/.ci/windows_nvidia_base_files/run_nvidia_gpu_fast_fp16_accumulation.bat
@@ -1,3 +1,3 @@
-.\python_embeded\python.exe -s ComfyUI\main.py --windows-standalone-build --fast fp16_accumulation
+.\python_embeded\python.exe -s ComfyUI\main.py --windows-standalone-build --fast fp16_accumulation --enable-manager
 echo If you see this and ComfyUI did not start try updating your Nvidia Drivers to the latest. If you get a c10.dll error you need to install vc redist that you can find: https://aka.ms/vc14/vc_redist.x64.exe
 pause

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -160,7 +160,8 @@ jobs:
         run: |
           cd ..
           cd ComfyUI_windows_portable
-          python_embeded/python.exe -s ComfyUI/main.py --quick-test-for-ci --cpu --enable-manager
+          python_embeded/python.exe -s ComfyUI/main.py --quick-test-for-ci --cpu --enable-manager | tee manager_smoke.log
+          grep -q "\[START\] ComfyUI-Manager" manager_smoke.log
 
           python_embeded/python.exe -s ./update/update.py ComfyUI/
 

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -122,6 +122,8 @@ jobs:
           ./python.exe -s -m pip uninstall -y comfyui-workflow-templates-media-image comfyui-workflow-templates-media-video comfyui-workflow-templates-media-other
           rm requirements_comfyui.txt
 
+          ./python.exe -s -m pip install -r ../ComfyUI/manager_requirements.txt
+
           sed -i '1i../ComfyUI' ./python3${{ inputs.python_minor }}._pth
 
           if test -f ./Lib/site-packages/torch/lib/dnnl.lib; then
@@ -158,7 +160,7 @@ jobs:
         run: |
           cd ..
           cd ComfyUI_windows_portable
-          python_embeded/python.exe -s ComfyUI/main.py --quick-test-for-ci --cpu
+          python_embeded/python.exe -s ComfyUI/main.py --quick-test-for-ci --cpu --enable-manager
 
           python_embeded/python.exe -s ./update/update.py ComfyUI/
 

--- a/.github/workflows/windows_release_dependencies.yml
+++ b/.github/workflows/windows_release_dependencies.yml
@@ -53,7 +53,7 @@ jobs:
             echo If you just want to update normally, close this and run update_comfyui.bat instead.
             echo -
             pause
-            ..\python_embeded\python.exe -s -m pip install --upgrade torch torchvision torchaudio ${{ inputs.xformers }} --extra-index-url https://download.pytorch.org/whl/cu${{ inputs.cu }} -r ../ComfyUI/requirements.txt pygit2
+            ..\python_embeded\python.exe -s -m pip install --upgrade torch torchvision torchaudio ${{ inputs.xformers }} --extra-index-url https://download.pytorch.org/whl/cu${{ inputs.cu }} -r ../ComfyUI/requirements.txt -r ../ComfyUI/manager_requirements.txt pygit2
             pause" > update_comfyui_and_python_dependencies.bat
 
             grep -v comfyui requirements.txt > requirements_nocomfyui.txt

--- a/.github/workflows/windows_release_dependencies_manual.yml
+++ b/.github/workflows/windows_release_dependencies_manual.yml
@@ -45,7 +45,7 @@ jobs:
             echo If you just want to update normally, close this and run update_comfyui.bat instead.
             echo -
             pause
-            ..\python_embeded\python.exe -s -m pip install --upgrade ${{ inputs.torch_dependencies }} -r ../ComfyUI/requirements.txt pygit2
+            ..\python_embeded\python.exe -s -m pip install --upgrade ${{ inputs.torch_dependencies }} -r ../ComfyUI/requirements.txt -r ../ComfyUI/manager_requirements.txt pygit2
             pause" > update_comfyui_and_python_dependencies.bat
 
             grep -v comfyui requirements.txt > requirements_nocomfyui.txt

--- a/.github/workflows/windows_release_nightly_pytorch.yml
+++ b/.github/workflows/windows_release_nightly_pytorch.yml
@@ -81,7 +81,8 @@ jobs:
             mv ComfyUI_windows_portable_nightly_pytorch.7z ComfyUI/ComfyUI_windows_portable_nvidia_or_cpu_nightly_pytorch.7z
 
             cd ComfyUI_windows_portable_nightly_pytorch
-            python_embeded/python.exe -s ComfyUI/main.py --quick-test-for-ci --cpu --enable-manager
+            python_embeded/python.exe -s ComfyUI/main.py --quick-test-for-ci --cpu --enable-manager | tee manager_smoke.log
+            grep -q "\[START\] ComfyUI-Manager" manager_smoke.log
 
             ls
 

--- a/.github/workflows/windows_release_nightly_pytorch.yml
+++ b/.github/workflows/windows_release_nightly_pytorch.yml
@@ -52,6 +52,7 @@ jobs:
             python -m pip wheel torch torchvision torchaudio --pre --extra-index-url https://download.pytorch.org/whl/nightly/cu${{ inputs.cu }} -r ../ComfyUI/requirements.txt pygit2 -w ../temp_wheel_dir
             ls ../temp_wheel_dir
             ./python.exe -s -m pip install --pre ../temp_wheel_dir/*
+            ./python.exe -s -m pip install -r ../ComfyUI/manager_requirements.txt
             sed -i '1i../ComfyUI' ./python3${{ inputs.python_minor }}._pth
 
             rm ./Lib/site-packages/torch/lib/dnnl.lib #I don't think this is actually used and I need the space
@@ -72,7 +73,7 @@ jobs:
             cp -r ComfyUI/.ci/windows_nightly_base_files/* ./
 
             echo "call update_comfyui.bat nopause
-            ..\python_embeded\python.exe -s -m pip install --upgrade --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu${{ inputs.cu }} -r ../ComfyUI/requirements.txt pygit2
+            ..\python_embeded\python.exe -s -m pip install --upgrade --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu${{ inputs.cu }} -r ../ComfyUI/requirements.txt -r ../ComfyUI/manager_requirements.txt pygit2
             pause" > ./update/update_comfyui_and_python_dependencies.bat
             cd ..
 
@@ -80,7 +81,7 @@ jobs:
             mv ComfyUI_windows_portable_nightly_pytorch.7z ComfyUI/ComfyUI_windows_portable_nvidia_or_cpu_nightly_pytorch.7z
 
             cd ComfyUI_windows_portable_nightly_pytorch
-            python_embeded/python.exe -s ComfyUI/main.py --quick-test-for-ci --cpu
+            python_embeded/python.exe -s ComfyUI/main.py --quick-test-for-ci --cpu --enable-manager
 
             ls
 

--- a/.github/workflows/windows_release_package.yml
+++ b/.github/workflows/windows_release_package.yml
@@ -91,7 +91,8 @@ jobs:
             mv ComfyUI_windows_portable.7z ComfyUI/new_ComfyUI_windows_portable_nvidia_cu${{ inputs.cu }}_or_cpu.7z
 
             cd ComfyUI_windows_portable
-            python_embeded/python.exe -s ComfyUI/main.py --quick-test-for-ci --cpu --enable-manager
+            python_embeded/python.exe -s ComfyUI/main.py --quick-test-for-ci --cpu --enable-manager | tee manager_smoke.log
+            grep -q "\[START\] ComfyUI-Manager" manager_smoke.log
 
             python_embeded/python.exe -s ./update/update.py ComfyUI/
 

--- a/.github/workflows/windows_release_package.yml
+++ b/.github/workflows/windows_release_package.yml
@@ -63,6 +63,7 @@ jobs:
             curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
             ./python.exe get-pip.py
             ./python.exe -s -m pip install ../cu${{ inputs.cu }}_python_deps/*
+            ./python.exe -s -m pip install -r ../ComfyUI/manager_requirements.txt
             sed -i '1i../ComfyUI' ./python3${{ inputs.python_minor }}._pth
 
             rm ./Lib/site-packages/torch/lib/dnnl.lib #I don't think this is actually used and I need the space
@@ -90,7 +91,7 @@ jobs:
             mv ComfyUI_windows_portable.7z ComfyUI/new_ComfyUI_windows_portable_nvidia_cu${{ inputs.cu }}_or_cpu.7z
 
             cd ComfyUI_windows_portable
-            python_embeded/python.exe -s ComfyUI/main.py --quick-test-for-ci --cpu
+            python_embeded/python.exe -s ComfyUI/main.py --quick-test-for-ci --cpu --enable-manager
 
             python_embeded/python.exe -s ./update/update.py ComfyUI/
 


### PR DESCRIPTION
*PR Created by the Glary-Bot Agent*

---

Proposal + implementation for the second half of a #dev-core-engine thread: Portable users must install a pip package and hand-edit a `.bat` file before the custom node manager appears. Desktop already enables it (`DEFAULT_LAUNCH_ARGS = '--enable-manager'`), Portable does not.

Companion PR (UI rename) in `Comfy-Org/ComfyUI_frontend`.

## Adding the flag alone would have shipped a broken UI

Worth stating up front, because it is the non-obvious part and it drove the shape of this PR.

The portable bundle **never installed `manager_requirements.txt`** — `stable-release.yml` only installed `grep comfy requirements.txt`. So `--enable-manager` on its own is not merely a no-op:

1. `main.py` hits `handle_comfyui_manager_unavailable()`, logs a warning, and sets `args.enable_manager = False`.
2. But the frontend gate reads **raw `sys.argv`**, not the parsed args, so it still sees `--enable-manager`.
3. Core advertises `extension.manager.supports_v4: true` **unconditionally** (it is hardcoded in `_CORE_FEATURE_FLAGS`), while `supports_csrf_post` is published only by the manager package at runtime.
4. `useManagerState.ts` therefore resolves `serverSupportsV4 === true && supportsCsrfPost !== true` → **`INCOMPATIBLE`** → it hides the button and toasts *"Please upgrade ComfyUI-Manager to version 4.2.1 or higher"* — about a package the user never installed.

Verified locally against a real backend:

```
# no package, flag passed
argv includes --enable-manager ? True
/features -> extension.manager.supports_v4: true      (no supports_csrf_post)
/api/manager/* -> 404

# package installed, flag passed
/features -> supports_v4: true, supports_csrf_post: true
[START] ComfyUI-Manager
```

So the package install and the flag have to land together. That is why this is one PR rather than a one-line `.bat` change.

## Changes

**Bundle the pinned package** (`manager_requirements.txt` stays the single source of the version) in all three workflows that build a portable:
- `stable-release.yml` (nvidia / amd / intel, via `release-stable-all.yml`)
- `windows_release_package.yml`
- `windows_release_nightly_pytorch.yml`

The latter two copy the nvidia base files, so they picked up the flag from the launchers and would have shipped exactly the broken state described above.

**Keep it in sync on update**, so a bumped pin is not ignored:
- `.ci/update_windows/update.py` — the existing single-file requirements sync becomes a loop over `requirements.txt` + `manager_requirements.txt`. This is the path `update_comfyui.bat` uses.
- The generated `update_comfyui_and_python_dependencies.bat` in `windows_release_dependencies.yml`, `windows_release_dependencies_manual.yml` and the nightly.

**Pass the flag** from all 8 `.ci/windows_*_base_files/**/*.bat` launchers that invoke `main.py`. CRLF preserved.

**Make CI able to catch a regression.** `--quick-test-for-ci --enable-manager` exits 0 even with the package missing, so the smoke tests now also `grep -q "\[START\] ComfyUI-Manager"` on the startup log. Verified both directions against real captured logs: passes when the manager loaded, fails when it was absent.

`comfy/cli_args.py` is untouched — the flag default stays `False`; only the shipped launchers opt in.

## Verification

- `ruff check .` → clean (repo-wide, as CI runs it); all five edited workflow YAMLs parse
- `--quick-test-for-ci --cpu --enable-manager` with the package installed → **exit 0**, `[START] ComfyUI-Manager`, and the registry fetch degrades gracefully to a warning when offline (so the new CI assertion will not flake on registry downtime)
- `update.py`'s new loop exercised against the real source block across five scenarios: fresh portable (installs both), no-op re-run, manager pin bumped (installs manager only), core requirements changed (installs core only), and downgrade to a ComfyUI without `manager_requirements.txt` (skips cleanly)
- Launcher coverage audited: 8/8 carry the flag, none missed, CRLF unchanged on every one

## Decisions for the team — please weigh in before this leaves draft

**1. Default network posture.** This is the real question, and it is a product/security call, not a code one. ComfyUI-Manager contacts the custom-node registry **at startup**, not only when the dialog is opened (`network_mode: public`, observed fetching `custom-node-list.json` during startup tasks). Core's own guidance forbids adding outbound requests to ComfyUI; this does not add any to core, but it does change what a stock Portable does out of the box. If that is not acceptable, say so and I will close this.

**2. Download size.** `comfyui_manager==4.2.2` pulls GitPython, PyGithub, cryptography, PyNaCl, chardet, toml and `uv`. Measured uncompressed: **~78 MB** (48 MB of that is the `uv` binary, ~15 MB cryptography, 5 MB the manager itself). `transformers`/`huggingface-hub` are already core deps. That is material for an archive whose build step deletes torch `.lib` files with the comment *"I need the space"*. Someone should approve the budget, and the `.7z` delta should be measured on a real build.

**3. Existing installs get the dependency but not the flag.** `update.py` will install the manager package on the next `update_comfyui.bat`, but it never rewrites `run_*.bat` (those live outside the checkout). So existing users pay the download and still launch with the manager off until they download a fresh archive. I left it that way deliberately — rewriting user-editable launchers on update seems worse — but flagging it since it means "on by default" is true for new downloads only.

**4. `advanced/run_nvidia_gpu_disable_api_nodes.bat` got the flag too.** `--disable-api-nodes` restricts Comfy's own API nodes and has nothing to do with the manager, so excluding it would ship the package unusable with no explanation. If that launcher is meant to be the reduced-network variant, tell me and I will drop the flag there.

**5. Cache key not bumped.** `update_comfyui_and_python_dependencies.bat` is stored in an immutable `actions/cache` entry keyed on `${{ runner.os }}-build-cu<cu>-<python_minor>`, so existing keys will keep serving the old script. This does **not** affect the shipped portable (the manager is installed at package time, uncached) — only that one helper script. I did not bump the keys unilaterally because it forces a full torch wheel rebuild for every cuda variant; that is release-engineering's call.

**6. Version skew ownership.** The frontend hides the UI and nags when the Manager backend is older than 4.2.1, so the pin in `manager_requirements.txt` now needs a named owner who bumps it with Manager releases.