### PR TITLE
Raise clear error when a non-generation model is used with TextGenerate

### DIFF
--- a/comfy/sd1_clip.py
+++ b/comfy/sd1_clip.py
@@ -309,7 +309,7 @@ class SDClipModel(torch.nn.Module, ClipTokenWeightEncoder):
         return self.transformer.load_state_dict(sd, strict=False, assign=getattr(self, "can_assign_sd", False))
 
     def generate(self, tokens, do_sample, max_length, temperature, top_k, top_p, min_p, repetition_penalty, seed, presence_penalty=0.0):
-        if not hasattr(self.transformer, "generate"):
+        if not callable(getattr(self.transformer, "generate", None)):
             raise RuntimeError(
                 "The loaded model ({}) does not support text generation. "
                 "The TextGenerate node requires a language model (LLM) such as Qwen, LLaMA, or Gemma, "

--- a/comfy/sd1_clip.py
+++ b/comfy/sd1_clip.py
@@ -309,6 +309,12 @@ class SDClipModel(torch.nn.Module, ClipTokenWeightEncoder):
         return self.transformer.load_state_dict(sd, strict=False, assign=getattr(self, "can_assign_sd", False))
 
     def generate(self, tokens, do_sample, max_length, temperature, top_k, top_p, min_p, repetition_penalty, seed, presence_penalty=0.0):
+        if not hasattr(self.transformer, "generate"):
+            raise RuntimeError(
+                "The loaded model ({}) does not support text generation. "
+                "The TextGenerate node requires a language model (LLM) such as Qwen, LLaMA, or Gemma, "
+                "not a CLIP text encoder. Please load the correct model type.".format(type(self.transformer).__name__)
+            )
         if isinstance(tokens, dict):
             tokens_only = next(iter(tokens.values())) # todo: get this better?
         else:

--- a/tests-unit/comfy_test/sd1_clip_generate_test.py
+++ b/tests-unit/comfy_test/sd1_clip_generate_test.py
@@ -1,0 +1,26 @@
+import types
+
+import pytest
+
+from comfy.sd1_clip import SDClipModel
+
+
+def test_generate_raises_clear_error_for_non_generation_model():
+    """A CLIP text encoder (no .generate on the underlying transformer) must
+    fail with an actionable RuntimeError instead of a bare AttributeError
+    from deep inside the model call."""
+    fake_self = types.SimpleNamespace(transformer=object())
+
+    with pytest.raises(RuntimeError, match="does not support text generation"):
+        SDClipModel.generate(
+            fake_self,
+            tokens=[[(0, 1.0)]],
+            do_sample=False,
+            max_length=8,
+            temperature=1.0,
+            top_k=1,
+            top_p=1.0,
+            min_p=0.0,
+            repetition_penalty=1.0,
+            seed=0,
+        )

--- a/tests-unit/comfy_test/sd1_clip_generate_test.py
+++ b/tests-unit/comfy_test/sd1_clip_generate_test.py
@@ -24,3 +24,24 @@ def test_generate_raises_clear_error_for_non_generation_model():
             repetition_penalty=1.0,
             seed=0,
         )
+
+
+def test_generate_raises_clear_error_for_non_callable_generate_attribute():
+    """A transformer with a non-callable `generate` attribute (e.g. None)
+    must also fail with the actionable RuntimeError, not an incidental
+    TypeError from trying to call it."""
+    fake_self = types.SimpleNamespace(transformer=types.SimpleNamespace(generate=None))
+
+    with pytest.raises(RuntimeError, match="does not support text generation"):
+        SDClipModel.generate(
+            fake_self,
+            tokens=[[(0, 1.0)]],
+            do_sample=False,
+            max_length=8,
+            temperature=1.0,
+            top_k=1,
+            top_p=1.0,
+            min_p=0.0,
+            repetition_penalty=1.0,
+            seed=0,
+        )


### PR DESCRIPTION
Fixes #16237

## Problem

Loading a plain CLIP text encoder checkpoint (e.g. via `CLIPLoader`) and
feeding it into the `TextGenerate` node crashes with a bare, unhandled
`AttributeError` deep inside `torch.nn.Module.__getattr__`:

```
AttributeError: 'CLIPTextModel' object has no attribute 'generate'
```

`CLIP.generate()` (`comfy/sd.py`) delegates to `SD1ClipModel.generate()`
(`comfy/sd1_clip.py`), which delegates to `SDClipModel.generate()`
(`comfy/sd1_clip.py`), which unconditionally calls
`self.transformer.generate(...)`. When the loaded checkpoint resolves to a
plain CLIP text encoder (`comfy.clip_model.CLIPTextModel`, which has no
`generate` method — only LLM-style text encoders such as Gemma/Qwen/LLaMA
implement it), this call fails with the raw `AttributeError` shown above,
which gives the user no indication of what went wrong or how to fix it.

A previous attempt at this (#13291) added a `hasattr` check in
`CLIP.generate()` on `self.cond_stage_model`, but `cond_stage_model`
(`SD1ClipModel`) always has a `generate` method (it's the one defined at
`comfy/sd1_clip.py:749`) — the missing method lives two layers deeper, on
`self.transformer`. That check could never trigger, which is why the PR
was closed as a no-op ("I still have the same error message as before").

## Fix

Add the capability check at the point where the failure actually
originates — `SDClipModel.generate()`, right before it touches
`self.transformer` — and raise an actionable `RuntimeError` instead of
letting the `AttributeError` propagate from inside PyTorch internals.

## Testing

Added `tests-unit/comfy_test/sd1_clip_generate_test.py`, which calls
`SDClipModel.generate()` with a stand-in `self.transformer` that has no
`generate` method and asserts a `RuntimeError` mentioning "does not support
text generation" is raised.

Verified the fix directly (the sandboxed environment here has a
torch/torchvision version mismatch that pre-dates this change and blocks
`pytest` collection for every file under `tests-unit/comfy_test`, e.g.
`model_detection_test.py` fails identically with `RuntimeError: operator
torchvision::nms does not exist`; this is unrelated to `sd1_clip.py`):

Before the fix (`git checkout HEAD~1 -- comfy/sd1_clip.py`), calling
`SDClipModel.generate()` on a transformer without `generate` raises:
```
AttributeError: 'types.SimpleNamespace' object has no attribute 'process_tokens'
```
(the same class of uncaught, unrelated `AttributeError` reported in the
issue — it just happens to bottom out one call earlier because the stub
`self` also lacks other attributes the real model has).

After the fix:
```
RuntimeError: The loaded model (object) does not support text generation. The TextGenerate node requires a language model (LLM) such as Qwen, LLaMA, or Gemma, not a CLIP text encoder. Please load the correct model type.
```

`ruff check comfy/sd1_clip.py tests-unit/comfy_test/sd1_clip_generate_test.py` passes.

## AI assistance disclosure

This change was written by an AI coding agent (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
