### PR TITLE
Report how many seconds a node spent on each activity

### DIFF
--- a/comfy_execution/progress.py
+++ b/comfy_execution/progress.py
@@ -1,3 +1,5 @@
+import logging
+import time
 from typing import TypedDict, Dict, Optional, Tuple
 from typing_extensions import override, NotRequired
 from PIL import Image
@@ -28,6 +30,7 @@ class NodeProgressState(TypedDict):
     value: float
     max: float
     activity: NotRequired[str]  # what a running node is spending time on, e.g. "loading"
+    seconds: NotRequired[Dict[str, float]]  # set when the node finishes: "total" plus one entry per activity seen
 
 
 class ProgressHandler(ABC):
@@ -180,6 +183,8 @@ class WebUIProgressHandler(ProgressHandler):
             }
             if "activity" in state:
                 active_nodes[node_id]["activity"] = state["activity"]
+            if "seconds" in state:
+                active_nodes[node_id]["seconds"] = state["seconds"]
 
         # Send a combined progress_state message with all node states
         # Include client_id to ensure message is only sent to the initiating client
@@ -246,6 +251,7 @@ class ProgressRegistry:
         self.dynprompt = dynprompt
         self.nodes: Dict[str, NodeProgressState] = {}
         self.handlers: Dict[str, ProgressHandler] = {}
+        self.clocks: Dict[str, dict] = {}
 
     def register_handler(self, handler: ProgressHandler) -> None:
         """Register a progress handler"""
@@ -282,6 +288,8 @@ class ProgressRegistry:
         entry["state"] = NodeState.Running
         entry["value"] = 0.0
         entry["max"] = 1.0
+        now = time.perf_counter()
+        self.clocks[node_id] = {"started": now, "since": now, "activity": None, "seconds": {}}
 
         # Notify all enabled handlers
         for handler in self.handlers.values():
@@ -313,6 +321,7 @@ class ProgressRegistry:
             entry.pop("activity", None)
         else:
             entry["activity"] = activity
+        self._close_stretch(node_id, activity)
 
         # Notify all enabled handlers
         for handler in self.handlers.values():
@@ -321,11 +330,29 @@ class ProgressRegistry:
                     node_id, entry["value"], entry["max"], entry, self.prompt_id
                 )
 
+    def _close_stretch(self, node_id: str, next_activity: str | None) -> None:
+        clock = self.clocks.get(node_id)
+        if clock is None:
+            return
+        now = time.perf_counter()
+        if clock["activity"] is not None:
+            clock["seconds"][clock["activity"]] = clock["seconds"].get(clock["activity"], 0.0) + now - clock["since"]
+        clock["activity"] = next_activity
+        clock["since"] = now
+
     def finish_progress(self, node_id: str) -> None:
         """Finish progress tracking for a node"""
         entry = self.ensure_entry(node_id)
         entry["state"] = NodeState.Finished
         entry["value"] = entry["max"]
+        entry.pop("activity", None)
+        self._close_stretch(node_id, None)
+        clock = self.clocks.pop(node_id, None)
+        if clock is not None:
+            seconds = {k: round(v, 3) for k, v in clock["seconds"].items()}
+            seconds["total"] = round(time.perf_counter() - clock["started"], 3)
+            entry["seconds"] = seconds
+            logging.debug("node %s %s seconds: %s", node_id, self.dynprompt.get_node(node_id)["class_type"], seconds)
 
         # Notify all enabled handlers
         for handler in self.handlers.values():

--- a/tests-unit/execution_test/progress_seconds_test.py
+++ b/tests-unit/execution_test/progress_seconds_test.py
@@ -1,0 +1,96 @@
+import types
+from unittest.mock import Mock
+
+import comfy_execution.progress as progress
+from comfy_execution.progress import ProgressRegistry, WebUIProgressHandler
+
+
+class Clock:
+    def __init__(self):
+        self.now = 100.0
+
+    def advance(self, seconds):
+        self.now += seconds
+
+    def perf_counter(self):
+        return self.now
+
+
+def make_registry(monkeypatch):
+    clock = Clock()
+    monkeypatch.setattr(progress, "time", types.SimpleNamespace(perf_counter=clock.perf_counter))
+    dynprompt = Mock()
+    dynprompt.get_display_node_id.side_effect = lambda n: n
+    dynprompt.get_parent_node_id.return_value = None
+    dynprompt.get_real_node_id.side_effect = lambda n: n
+    dynprompt.get_node.return_value = {"class_type": "KSampler"}
+    return ProgressRegistry(prompt_id="p", dynprompt=dynprompt), clock
+
+
+def test_seconds_sum_every_stretch_of_an_activity(monkeypatch):
+    registry, clock = make_registry(monkeypatch)
+    registry.start_progress("1")
+    clock.advance(1.0)
+    registry.set_activity("1", "loading")
+    clock.advance(2.0)
+    registry.set_activity("1", None)
+    clock.advance(0.5)
+    registry.set_activity("1", "loading")
+    clock.advance(3.0)
+    registry.set_activity("1", None)
+    clock.advance(0.25)
+    registry.finish_progress("1")
+
+    assert registry.nodes["1"]["seconds"] == {"loading": 5.0, "total": 6.75}
+    assert "activity" not in registry.nodes["1"]
+
+
+def test_switching_activities_closes_the_previous_stretch(monkeypatch):
+    registry, clock = make_registry(monkeypatch)
+    registry.start_progress("1")
+    registry.set_activity("1", "loading")
+    clock.advance(1.0)
+    registry.set_activity("1", "downloading")
+    clock.advance(4.0)
+    registry.finish_progress("1")
+
+    assert registry.nodes["1"]["seconds"] == {"loading": 1.0, "downloading": 4.0, "total": 5.0}
+
+
+def test_cached_node_reports_no_seconds(monkeypatch):
+    registry, _ = make_registry(monkeypatch)
+    registry.finish_progress("1")
+
+    assert "seconds" not in registry.nodes["1"]
+
+
+def test_two_nodes_are_timed_separately(monkeypatch):
+    registry, clock = make_registry(monkeypatch)
+    registry.start_progress("1")
+    registry.set_activity("1", "downloading")
+    clock.advance(1.0)
+    registry.start_progress("2")
+    registry.set_activity("2", "loading")
+    clock.advance(2.0)
+    registry.set_activity("1", None)
+    registry.finish_progress("1")
+    clock.advance(1.0)
+    registry.finish_progress("2")
+
+    assert registry.nodes["1"]["seconds"] == {"downloading": 3.0, "total": 3.0}
+    assert registry.nodes["2"]["seconds"] == {"loading": 3.0, "total": 3.0}
+
+
+def test_seconds_are_sent_only_once_the_node_finishes(monkeypatch):
+    registry, clock = make_registry(monkeypatch)
+    server = Mock(client_id="c")
+    handler = WebUIProgressHandler(server)
+    handler.set_registry(registry)
+    registry.register_handler(handler)
+
+    registry.start_progress("1")
+    assert "seconds" not in server.send_sync.call_args[0][1]["nodes"]["1"]
+
+    clock.advance(2.0)
+    registry.finish_progress("1")
+    assert server.send_sync.call_args[0][1]["nodes"]["1"]["seconds"] == {"total": 2.0}


### PR DESCRIPTION
The only clock in the engine covers the whole workflow ("Prompt executed in 4.0 seconds"), so nobody can say how long one node took, or whether a slow first run was the model copy or the compute.

The progress registry already sees every node start, activity change and finish. It now keeps a clock per running node, adds up the seconds each activity was set, and puts `seconds` (one entry per activity plus "total") on the node's entry when it finishes; the WebUI handler sends it in progress_state only when present. A cached node reports nothing. Logged at DEBUG per node.

Not covered: a node that raises reports nothing, because the executor's error path never reaches the registry. A node that expands a subgraph or awaits async work keeps one clock from first start to final finish, so its total includes the wait.

Stacked on #16248 (which is on #16202); retarget as those merge.

Tests: tests-unit/execution_test/progress_seconds_test.py (fake clock).
