### PR TITLE
Fix execution time display for prompts running over 24 hours

### DIFF
--- a/main.py
+++ b/main.py
@@ -410,7 +410,12 @@ def prompt_worker(q, server_instance):
 
             # Log Time in a more readable way after 10 minutes
             if execution_time > 600:
-                execution_time = time.strftime("%H:%M:%S", time.gmtime(execution_time))
+                # Format manually instead of with time.gmtime: %H is hour-of-day
+                # and wraps at 24, so a prompt running longer than a day silently
+                # loses whole days (29h17m07s was logged as "05:17:07").
+                total_seconds = int(execution_time)
+                execution_time = "{}:{:02d}:{:02d}".format(
+                    total_seconds // 3600, total_seconds % 3600 // 60, total_seconds % 60)
                 logging.info(f"Prompt executed in {execution_time}", extra={'color': 'green'})
             else:
                 logging.info("Prompt executed in {:.2f} seconds".format(execution_time), extra={'color': 'green'})


### PR DESCRIPTION
### Problem
`time.gmtime()` converts a duration into a calendar time struct, where `%H` is
hour-of-day and wraps at 24. Any prompt that runs longer than a day silently
loses whole days from the logged duration.
### How I hit it
A video generation on a Strix Halo box (362 frames at 736x1120) actually took
29h17m07s. The log said:
```
Prompt executed in 05:17:07
```
Understated by exactly 24 hours, which made the run look roughly four times
faster than it was. It is an easy one to trust and act on, since 05:17:07 is a
perfectly plausible duration for that job.
Reproduction:
```python
>>> import time
>>> time.strftime("%H:%M:%S", time.gmtime(105427))   # 29h17m07s
'05:17:07'
>>> time.gmtime(105427).tm_yday                      # the discarded day
2
```
### Fix
Format the seconds arithmetically so the hour field can exceed 24. Output is
unchanged for every run under a day, and the 10 minute threshold and the
`HH:MM:SS` shape both stay as they are. The value is only used in this log
line, so there are no downstream consumers to worry about.
```
Prompt executed in 29:17:07
```
