### PR TITLE
Bump comfyui-frontend-package to 1.52.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-comfyui-frontend-package==1.51.10
+comfyui-frontend-package==1.52.7
 comfyui-workflow-templates==0.11.59
 comfyui-embedded-docs==0.5.11
 torch


### PR DESCRIPTION
✅ **PyPI package confirmed available** — `comfyui-frontend-package==1.52.7` has been published and verified.

Bumps frontend to 1.52.7

Test quickly:

```bash
python main.py --front-end-version Comfy-Org/ComfyUI_frontend@1.52.7
```

- Diff: [v1.51.10...v1.52.7](https://github.com/Comfy-Org/ComfyUI_frontend/compare/v1.51.10...v1.52.7)
- PyPI: https://pypi.org/project/comfyui-frontend-package/1.52.7/
- npm: https://www.npmjs.com/package/@comfyorg/comfyui-frontend-types/v/1.52.7

---
Opened manually — the automated `create-comfyui-pr` job (release-weekly-comfyui.yaml run 34652778287) failed 3x on a PR_GH_TOKEN GitHub API rate-limit error during checkout, unrelated to this change's content. Same branch, commit message, and PR body the automation would have produced; release-done verification (PyPI availability, no stranded commits past v1.52.7 on core/1.52) already passed in that run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EnqcS6124qaS7gtZ85qPy9