### PR TITLE
Fix nvfp4 crash in Qwen3-VL generate() with image input

### DIFF
--- a/comfy/text_encoders/qwen3vl.py
+++ b/comfy/text_encoders/qwen3vl.py
@@ -63,7 +63,7 @@ class Qwen3VL(BaseLlama, BaseQwen3, BaseGenerate, torch.nn.Module):
         if embed["type"] == "image":
             # Qwen3-VL normalizes to [-1, 1] (mean/std 0.5), unlike Qwen2.5-VL's CLIP normalization.
             image, grid = comfy.text_encoders.qwen_vl.process_qwen2vl_images(embed["data"], patch_size=16, image_mean=[0.5, 0.5, 0.5], image_std=[0.5, 0.5, 0.5])
-            merged, deepstack = self.visual(image.to(device, dtype=torch.float32), grid)
+            merged, deepstack = self.visual(image.to(device, dtype=self.dtype), grid)
             return merged, {"grid": grid, "deepstack": deepstack}
         return None, None
 


### PR DESCRIPTION
## Summary
- `use_quantized_matmul()` (#16189) forces the fast native quantized matmul kernel on every `MixedPrecisionOp` linear layer in the model during `CLIP.generate()`, including the Qwen3-VL vision tower. That kernel only accepts fp16/bf16 activations.
- `Qwen3VL.preprocess_embed` hardcodes the vision tower's input dtype to `torch.float32`. This was harmless under the previous dequantized full-precision matmul path, but now crashes with `RuntimeError: Unsupported dtype code (only FP16/BF16 supported): 0` when nvfp4-quantized weights are loaded and `.generate()` is used with image input (e.g. VLM-style captioning/prompting through Qwen3-VL).
- Fix: use the model's compute dtype (`self.dtype`) for the vision tower input instead of hardcoded `float32`, matching how the rest of the model (the Llama decoder) already runs.

Can test with https://huggingface.co/SergiusFlavius/Qwen3-VL-4B-Instruct-heretic-NVFP4 and using the Krea 2 workflow. 

## Test plan
- [x] Traced the crash from a reported traceback back to this line, confirmed via code inspection that `use_quantized_matmul` applies indiscriminately to the vision tower's quantized linear layers while the vision tower's activations were hardcoded to float32.
- [x] Reporter applied the one-line fix locally and confirmed `.generate()` with image input on an nvfp4 Qwen3-VL checkpoint completes without the dtype error.
- [ ] CI

AI Assisted