### PR TITLE
Fix userdata paths on another drive raising instead of returning 403

### DIFF
--- a/app/app_settings.py
+++ b/app/app_settings.py
@@ -17,6 +17,8 @@ class AppSettings():
         except KeyError as e:
             logging.error("User settings not found.")
             raise web.HTTPUnauthorized() from e
+        if file is None:
+            raise web.HTTPForbidden()
         if os.path.isfile(file):
             try:
                 with open(file) as f:
@@ -30,6 +32,8 @@ class AppSettings():
     def save_settings(self, request, settings):
         file = self.user_manager.get_request_user_filepath(
             request, "comfy.settings.json")
+        if file is None:
+            raise web.HTTPForbidden()
         with open(file, "w") as f:
             f.write(json.dumps(settings, indent=4))
 

--- a/app/user_manager.py
+++ b/app/user_manager.py
@@ -129,6 +129,9 @@ class UserManager():
                 return web.json_response({"storage": "server", "users": self.users})
             else:
                 user_dir = self.get_request_user_filepath(request, None, create_dir=False)
+                if not user_dir:
+                    return web.Response(status=403, text="Invalid user directory")
+
                 return web.json_response({
                     "storage": "server",
                     "migrated": os.path.exists(user_dir)

--- a/app/user_manager.py
+++ b/app/user_manager.py
@@ -82,7 +82,7 @@ class UserManager():
         path = user_root
 
         # prevent leaving /{type}
-        if os.path.commonpath((root_dir, user_root)) != root_dir:
+        if not folder_paths.is_within_directory(root_dir, user_root):
             return None
 
         if file is not None:
@@ -92,7 +92,7 @@ class UserManager():
 
             # prevent leaving /{type}/{user}
             path = os.path.abspath(os.path.join(user_root, file))
-            if os.path.commonpath((user_root, path)) != user_root:
+            if not folder_paths.is_within_directory(user_root, path):
                 return None
 
         parent = os.path.split(path)[0]

--- a/tests-unit/app_test/user_manager_path_test.py
+++ b/tests-unit/app_test/user_manager_path_test.py
@@ -1,0 +1,48 @@
+"""Tests for the path containment check in UserManager.get_request_user_filepath().
+
+The `file` parameter comes straight from the /userdata routes, so a value the
+containment check cannot handle must return None (the routes answer 403) rather
+than raise out of the request handler.
+"""
+
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import folder_paths
+from app.user_manager import UserManager
+
+
+@pytest.fixture
+def user_manager():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        original_dir = folder_paths.get_user_directory()
+        folder_paths.set_user_directory(temp_dir)
+        with patch('app.user_manager.args') as mock_args:
+            mock_args.multi_user = False
+            yield UserManager()
+        folder_paths.set_user_directory(original_dir)
+
+
+@pytest.fixture
+def mock_request():
+    request = MagicMock()
+    request.headers = {}
+    return request
+
+
+def test_parent_traversal_is_rejected(user_manager, mock_request):
+    with patch('app.user_manager.args') as mock_args:
+        mock_args.multi_user = False
+        path = user_manager.get_request_user_filepath(mock_request, "../../evil.json", create_dir=False)
+    assert path is None
+
+
+@pytest.mark.skipif(os.name != "nt", reason="only Windows paths carry a drive letter")
+def test_other_drive_is_rejected(user_manager, mock_request):
+    with patch('app.user_manager.args') as mock_args:
+        mock_args.multi_user = False
+        path = user_manager.get_request_user_filepath(mock_request, r"Z:\evil.json", create_dir=False)
+    assert path is None

--- a/tests-unit/app_test/user_manager_path_test.py
+++ b/tests-unit/app_test/user_manager_path_test.py
@@ -10,6 +10,7 @@ import tempfile
 from unittest.mock import MagicMock, patch
 
 import pytest
+from aiohttp import web
 
 import folder_paths
 from app.user_manager import UserManager
@@ -33,6 +34,13 @@ def mock_request():
     return request
 
 
+def symlink(link, target):
+    try:
+        os.symlink(target, link, target_is_directory=os.path.isdir(target))
+    except OSError as e:
+        pytest.skip(f"cannot create a symlink here: {e}")
+
+
 def test_parent_traversal_is_rejected(user_manager, mock_request):
     with patch('app.user_manager.args') as mock_args:
         mock_args.multi_user = False
@@ -46,3 +54,30 @@ def test_other_drive_is_rejected(user_manager, mock_request):
         mock_args.multi_user = False
         path = user_manager.get_request_user_filepath(mock_request, r"Z:\evil.json", create_dir=False)
     assert path is None
+
+
+def test_symlinked_user_root_is_rejected(user_manager, mock_request):
+    with tempfile.TemporaryDirectory() as outside:
+        symlink(os.path.join(folder_paths.get_user_directory(), "default"), outside)
+        with patch('app.user_manager.args') as mock_args:
+            mock_args.multi_user = False
+            assert user_manager.get_request_user_filepath(mock_request, "comfy.settings.json", create_dir=False) is None
+            with pytest.raises(web.HTTPForbidden):
+                user_manager.settings.get_settings(mock_request)
+            with pytest.raises(web.HTTPForbidden):
+                user_manager.settings.save_settings(mock_request, {})
+
+
+def test_symlinked_settings_file_is_rejected(user_manager, mock_request):
+    user_root = os.path.join(folder_paths.get_user_directory(), "default")
+    os.makedirs(user_root)
+    with tempfile.TemporaryDirectory() as outside:
+        target = os.path.join(outside, "comfy.settings.json")
+        with open(target, "w") as f:
+            f.write("{}")
+        symlink(os.path.join(user_root, "comfy.settings.json"), target)
+        with patch('app.user_manager.args') as mock_args:
+            mock_args.multi_user = False
+            assert user_manager.get_request_user_filepath(mock_request, "comfy.settings.json", create_dir=False) is None
+            with pytest.raises(web.HTTPForbidden):
+                user_manager.settings.get_settings(mock_request)


### PR DESCRIPTION
On Windows, `os.path.commonpath` raises `ValueError: Paths don't have the same drive` when the two paths sit on different drive letters. `UserManager.get_request_user_filepath` calls it directly on the `file` value coming from the `/userdata` routes, and `os.path.join(user_root, "Z:\evil.json")` simply returns `Z:\evil.json`, so the check raises instead of returning `None`. The exception escapes the handler: `GET /userdata/Z%3A%5Cevil.json` answers 500 with a traceback in the log rather than the 403 the route documents, and the drive does not even have to exist. `/userdata?dir=...`, `/v2/userdata` (it only catches `KeyError`), and the POST/DELETE/move routes go through the same helper. On Linux both paths are absolute under `/`, so `commonpath` returns and the request is rejected normally.

`folder_paths.is_within_directory` already exists for this and its docstring names the different-drive case explicitly, so I used it here the same way #15216 did for `get_save_image_path`. One side effect worth calling out: the helper realpaths both operands, so a symlink placed *inside* a user directory that points outside it is now rejected too. That matches how the input/output/temp directories are already checked.

That side effect showed a second hole: a refused path comes back as `None`, and while the `/userdata` routes answer 403 for it, `AppSettings.get_settings`/`save_settings` passed it to `os.path.isfile`/`open` and the `/users` route to `os.path.exists`, so it raised `TypeError` and the request ended as a 500. Those three now answer 403 like the other routes.

Tests: I added `tests-unit/app_test/user_manager_path_test.py`. `test_other_drive_is_rejected` fails on Windows before the change with the `ValueError` above and passes after; it is skipped off Windows since the drive letter is what triggers it. Two more tests symlink the user directory, then `comfy.settings.json`, out of the user directory and check both the refusal and the 403; they skip where symlinks cannot be created. Full `pytest tests-unit` on Linux went from 1804 passed / 12 skipped to 1805 passed / 13 skipped on the first commit; for the follow-up commit I only ran `tests-unit/app_test`.

AI tools used


