### PR TITLE
TAG: Tangential Amplifying Guidance (Algorithm 2)

### DIFF
--- a/comfy_extras/nodes_tag.py
+++ b/comfy_extras/nodes_tag.py
@@ -1,0 +1,64 @@
+# References:
+# https://hyeon-cho.github.io/TAG/
+# https://arxiv.org/abs/2510.04533
+# https://github.com/hyeon-cho/Tangential-Amplifying-Guidance
+from typing import override
+from comfy_api.latest import io, ComfyExtension
+
+
+# Algorithm 2: Tangential Amplifying Guidance
+def tangential_amplify(x, prev_x, t_scale, r_scale):
+    dims = tuple(dim + 1 for dim, size in enumerate(x.shape[1:]) if size > 1)
+    v_r = prev_x / (prev_x.norm(p=2, dim=dims, keepdim=True) + 1e-8)
+    dx = x - prev_x
+    radial_update = (dx * v_r).sum(dim=dims, keepdim=True) * v_r
+    tangential_update = dx - radial_update
+    return prev_x + t_scale * tangential_update + r_scale * radial_update
+
+
+class TangentialAmplifyingGuidance(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="TangentialAmplifyingGuidance",
+            display_name="Tangential Amplifying Guidance",
+            category="experimental",
+            inputs=[
+                io.Model.Input("model"),
+                io.Float.Input("t_scale", default=1.05, min=0.0, max=10.0, step=0.001, tooltip="scale for the tangential (orthogonal) component"),
+                io.Float.Input("r_scale", default=1.0, min=0.0, max=10.0, step=0.001, tooltip="scale for the radial (parallel) component"),
+                io.Float.Input("start_percent", default=0.0, min=0.0, max=1.0, step=0.01, advanced=True),
+                io.Float.Input("end_percent", default=1.0, min=0.0, max=1.0, step=0.01, advanced=True),
+            ],
+            outputs=[
+                io.Model.Output()
+            ],
+            is_experimental=True,
+        )
+
+    @classmethod
+    def execute(cls, model, t_scale, r_scale, start_percent, end_percent) -> io.NodeOutput:
+        ms = model.get_model_object("model_sampling")
+        sigma_hi = ms.percent_to_sigma(start_percent)
+        sigma_lo = ms.percent_to_sigma(end_percent)
+
+        def post_cfg_function(args):
+            if not (sigma_lo <= args["sigma"] <= sigma_hi):
+                return args["denoised"]
+            return tangential_amplify(args["denoised"], args["input"], t_scale, r_scale)
+
+        m = model.clone()
+        m.set_model_sampler_post_cfg_function(post_cfg_function)
+        return io.NodeOutput(m)
+
+
+class TangentialAmplifyingExtension(ComfyExtension):
+    @override
+    async def get_node_list(self) -> list[type[io.ComfyNode]]:
+        return [
+            TangentialAmplifyingGuidance,
+        ]
+
+
+async def comfy_entrypoint() -> TangentialAmplifyingExtension:
+    return TangentialAmplifyingExtension()

--- a/comfy_extras/nodes_tag.py
+++ b/comfy_extras/nodes_tag.py
@@ -2,7 +2,7 @@
 # https://hyeon-cho.github.io/TAG/
 # https://arxiv.org/abs/2510.04533
 # https://github.com/hyeon-cho/Tangential-Amplifying-Guidance
-from typing import override
+from typing_extensions import override
 from comfy_api.latest import io, ComfyExtension
 
 

--- a/comfy_extras/nodes_tag.py
+++ b/comfy_extras/nodes_tag.py
@@ -43,7 +43,7 @@ class TangentialAmplifyingGuidance(io.ComfyNode):
         sigma_lo = ms.percent_to_sigma(end_percent)
 
         def post_cfg_function(args):
-            if not (sigma_lo <= args["sigma"] <= sigma_hi):
+            if not (sigma_lo <= args["sigma"].flatten()[0] <= sigma_hi):
                 return args["denoised"]
             return tangential_amplify(args["denoised"], args["input"], t_scale, r_scale)
 

--- a/nodes.py
+++ b/nodes.py
@@ -2483,6 +2483,7 @@ async def init_builtin_extra_nodes():
         "nodes_string.py",
         "nodes_camera_trajectory.py",
         "nodes_edit_model.py",
+        "nodes_tag.py",
         "nodes_tcfg.py",
         "nodes_seedvr.py",
         "nodes_context_windows.py",


### PR DESCRIPTION
Since https://github.com/Comfy-Org/ComfyUI/pull/10403 still isn't accepted, here is another TAG (_Algorithm 2: Tangential Amplifying Guidance_ from [paper](https://openreview.net/pdf?id=1XJqPy2LhA), [repo](https://github.com/hyeon-cho/Tangential-Amplifying-Guidance/blob/70d35dce1fcbead8fd69259c8b4e96afa8400e72/pipelines/pipeline_tag_stablediffusionXL.py#L448-L458)) implementation. This version adds extra parameters `start_percent` and `end_percent` to control effect over time. It also fixes Anima incompatibility. Closes https://github.com/Comfy-Org/ComfyUI/issues/10323

## What's up with dims?
`dims = tuple(dim + 1 for dim, size in enumerate(x.shape[1:]) if size > 1)` added as a hacky way to support non-sd models

Original implementation uses `dim=(1, 2, 3)` ([sd](https://github.com/hyeon-cho/Tangential-Amplifying-Guidance/blob/70d35dce1fcbead8fd69259c8b4e96afa8400e72/pipelines/pipeline_tag_stablediffusion.py#L317), [sdxl](https://github.com/hyeon-cho/Tangential-Amplifying-Guidance/blob/70d35dce1fcbead8fd69259c8b4e96afa8400e72/pipelines/pipeline_tag_stablediffusionXL.py#L448), [sd3](https://github.com/hyeon-cho/Tangential-Amplifying-Guidance/blob/70d35dce1fcbead8fd69259c8b4e96afa8400e72/pipelines/pipeline_tag_stablediffusion3.py#L373)) in SD-based pipelines, targeting C, H, W. This is not always the case, ex. Anima uses [B, C, T, H, W] schema, thus original code will work in unintended way. I decided to throw away first dim, since it's almost always a Batch, and to filter others with size > 1, since T size for Anima expected to be 1

This is a hack, until we have a proper way to target tensor dimensions via it's semantic meaning for particular models / latents / tensors in `get_dims("C", "H", "W")` manner. Same issue was present in https://github.com/Comfy-Org/ComfyUI/pull/15007 and fixed in a similar, hacky model-agnostic manner, but in FreSca case it will be `get_dims("H", "W")`

## Why set it as post-cfg function?
It follows original implementation, which introduces TAG after applying CFG ([cfg_apply](https://github.com/hyeon-cho/Tangential-Amplifying-Guidance/blob/70d35dce1fcbead8fd69259c8b4e96afa8400e72/pipelines/pipeline_tag_stablediffusion.py#L303-L305), [then_tag](https://github.com/hyeon-cho/Tangential-Amplifying-Guidance/blob/70d35dce1fcbead8fd69259c8b4e96afa8400e72/pipelines/pipeline_tag_stablediffusion.py#L310-L313)):

`noise_pred = noise_pred_uncond + self.guidance_scale * (noise_pred_text - noise_pred_uncond)` first,
and only then `# 7.1 TAG: decompose the sampler update into radial and tangential parts`

so it should go right after 
https://github.com/Comfy-Org/ComfyUI/blob/c75d8c966c29cb0392259af791f43373315b72db/comfy/samplers.py#L598

and placed in sampler_post_cfg_function
https://github.com/Comfy-Org/ComfyUI/blob/c75d8c966c29cb0392259af791f43373315b72db/comfy/samplers.py#L600

I believe that despite @chaObserv [claim](https://github.com/Comfy-Org/ComfyUI/pull/10403#issuecomment-3419637011), it amplifies the tangential components of the update increment. It calculates cond-scaled update `dx` from latents, then projects it, amplifies and returns old `args["input"] + amplified_update`. This is general approach, that will work even with custom guiders. Algorithm 2 is ok and expected to work after `"sampler_cfg_function"`, mirroring original project idea. Overall, it seems TAG better be used right after sampling step, without any prior modifications of `args["denoised"]`, but it's up to user to apply it this way