### PR TITLE
Fix linear_input_act to respect _full_precision_mm fallback

### DIFF
--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -968,7 +968,8 @@ def linear_input_act(linear, x, input_act):
     if (comfy.model_management.in_training
             or not isinstance(weight, QuantizedTensor)
             or weight._layout_cls != "TensorWiseINT8Layout"
-            or getattr(weight._params, "transposed", False)):
+            or getattr(weight._params, "transposed", False)
+            or getattr(linear, "_full_precision_mm", False)):
         return linear(INPUT_ACT_EAGER[input_act](x))
 
     # want_requant keeps a vbar-streamed layer on the INT8 path when a LoRA is

--- a/tests-unit/comfy_quant/test_mixed_precision.py
+++ b/tests-unit/comfy_quant/test_mixed_precision.py
@@ -1,4 +1,5 @@
 import unittest
+import unittest.mock
 import torch
 import sys
 import os
@@ -339,6 +340,42 @@ class TestMixedPrecisionOps(unittest.TestCase):
             self.assertEqual(seen_weight_types, [torch.Tensor])
         finally:
             mm.supports_int8_compute = orig_supports_int8
+
+    def test_linear_input_act_respects_full_precision_mm_fallback(self):
+        """linear_input_act folds an activation into the INT8 GEMM's input quantizer,
+        bypassing Linear.forward entirely. On a device where the fast int8 kernel is
+        disabled (e.g. MPS, which lacks aten::_int_mm), it must honor _full_precision_mm
+        and dequantize instead, exactly like Linear.forward_comfy_cast_weights does
+        (see Comfy-Org/ComfyUI#16284)."""
+        operations = ops.mixed_precision_ops({}, compute_dtype=torch.bfloat16)
+
+        torch.manual_seed(456)
+        weight = torch.randn(32, 64, dtype=torch.bfloat16)
+        bias = torch.randn(32, dtype=torch.bfloat16)
+
+        layer = operations.Linear(64, 32, bias=True, device="cpu", dtype=torch.bfloat16)
+        layer.weight = torch.nn.Parameter(
+            QuantizedTensor.from_float(weight, "TensorWiseINT8Layout"), requires_grad=False
+        )
+        layer.bias = torch.nn.Parameter(bias, requires_grad=False)
+        layer.quant_format = "int8_tensorwise"
+        layer._full_precision_mm = True
+
+        x = torch.randn(4, 128, dtype=torch.bfloat16)
+
+        orig_int8_linear = ops.quant_ops.ck.int8_linear
+        ops.quant_ops.ck.int8_linear = unittest.mock.Mock(
+            side_effect=NotImplementedError("aten::_int_mm not implemented")
+        )
+        try:
+            output = ops.linear_input_act(layer, x, "swiglu")
+        finally:
+            ops.quant_ops.ck.int8_linear = orig_int8_linear
+
+        expected = torch.nn.functional.linear(
+            ops.INPUT_ACT_EAGER["swiglu"](x), layer.weight.dequantize(), bias
+        )
+        torch.testing.assert_close(output, expected)
 
     def test_supports_int8_compute_treats_mps_mode_as_unsupported_when_device_is_none(self):
         """Call sites (like pick_operations' default) may omit load_device. On an


### PR DESCRIPTION
## Summary

Fixes #16284.

`MixedPrecisionOps.Linear.forward_comfy_cast_weights` already dequantizes to
full precision when `_full_precision_mm` is set on a layer (set for INT8
formats that #16130 disables on devices without `aten::_int_mm`, e.g. MPS).
But `linear_input_act` — the fused `linear(act(x))` path used by MiniMax H3's
MLP down-projection (`comfy/ldm/minimax/model.py:210`) and a few other models
— never checked that flag. It only bailed out to the eager/full-precision path
for training, non-quantized weights, non-INT8 layouts, or transposed weights.
So on MPS, a layer correctly marked `_full_precision_mm = True` still fell
through into `quant_ops.ck.int8_linear(...)`, which calls `torch._int_mm`, and
crashed with:

```
NotImplementedError: The operator 'aten::_int_mm' is not currently implemented for the MPS device.
```

The fix adds the same `_full_precision_mm` check already used by
`Linear.forward_comfy_cast_weights` to `linear_input_act`'s existing early-out
condition, so it dequantizes and falls back to a plain `linear()` call in
that case too.

## Test plan

Added `test_linear_input_act_respects_full_precision_mm_fallback` to
`tests-unit/comfy_quant/test_mixed_precision.py`. It builds a
`TensorWiseINT8Layout`-quantized `Linear` layer with `_full_precision_mm =
True`, mocks `quant_ops.ck.int8_linear` to raise `NotImplementedError`
(simulating MPS), and asserts `linear_input_act` still produces the correct
`linear(swiglu(x))` output without ever calling the mocked kernel.

Confirmed the test fails without the fix (reproducing the exact error from
the issue), and passes with it:

```
$ git checkout HEAD~1 -- comfy/ops.py   # temporarily drop the fix, keep the test
$ python -m pytest tests-unit/comfy_quant/test_mixed_precision.py -k full_precision_mm_fallback
...
E   NotImplementedError: aten::_int_mm not implemented
FAILED tests-unit/comfy_quant/test_mixed_precision.py::TestMixedPrecisionOps::test_linear_input_act_respects_full_precision_mm_fallback

$ git checkout HEAD -- comfy/ops.py     # restore the fix
$ python -m pytest tests-unit/comfy_quant/test_mixed_precision.py -v
...
10 passed in 1.99s
```

Also ran `ruff check` on the changed files with no issues.

- [x] Added a regression test and confirmed it fails without the fix
- [x] Full `tests-unit/comfy_quant/` suite passes (10/10)
- [x] `ruff check comfy/ops.py tests-unit/comfy_quant/test_mixed_precision.py` passes

## AI assistance disclosure

This change was developed with the assistance of Claude Code (Anthropic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
