### PR TITLE
Honor the disabled int8 format in the fused activation kernel

### DIFF
--- a/comfy/ops.py
+++ b/comfy/ops.py
@@ -966,6 +966,11 @@ def linear_input_act(linear, x, input_act):
     """
     weight = linear.weight
     if (comfy.model_management.in_training
+            # A layer whose format is disabled on this device (no torch._int_mm on MPS,
+            # say) is marked for the dequantized path, and the fused kernel is the one
+            # place that has to honor it too: it calls the INT8 matmul directly, so
+            # skipping this check reaches the very operator the format was disabled for.
+            or getattr(linear, "_full_precision_mm", False)
             or not isinstance(weight, QuantizedTensor)
             or weight._layout_cls != "TensorWiseINT8Layout"
             or getattr(weight._params, "transposed", False)):

--- a/tests-unit/comfy_quant/test_mixed_precision.py
+++ b/tests-unit/comfy_quant/test_mixed_precision.py
@@ -340,6 +340,101 @@ class TestMixedPrecisionOps(unittest.TestCase):
         finally:
             mm.supports_int8_compute = orig_supports_int8
 
+    def _int8_layer_on_a_device_without_int_mm(self, seed=4242):
+        """A loaded int8_tensorwise Linear marked for the dequantized path, as
+        pick_operations marks it on a device whose int8 matmul is unusable."""
+        import comfy.model_management as mm
+
+        orig_supports_int8 = mm.supports_int8_compute
+        mm.supports_int8_compute = lambda device=None: False
+        try:
+            model_config = SimpleNamespace(quant_config={"layer": {"format": "int8_tensorwise"}})
+            operations = ops.pick_operations(torch.bfloat16, torch.bfloat16, model_config=model_config)
+
+            torch.manual_seed(seed)
+            weight = torch.randn(16, 256, dtype=torch.bfloat16)
+            bias = torch.randn(16, dtype=torch.bfloat16)
+            q_weight = QuantizedTensor.from_float(weight, "TensorWiseINT8Layout", per_channel=True)
+            state_dict, _ = comfy.utils.convert_old_quants(
+                {
+                    "layer.weight": q_weight._qdata,
+                    "layer.bias": bias,
+                    "layer.weight_scale": q_weight._params.scale,
+                },
+                metadata={"_quantization_metadata": json.dumps(
+                    {"layers": {"layer": {"format": "int8_tensorwise"}}})},
+            )
+            model = torch.nn.Module()
+            model.layer = operations.Linear(256, 16, device="cpu", dtype=torch.bfloat16)
+            model.load_state_dict(state_dict, strict=False)
+        finally:
+            mm.supports_int8_compute = orig_supports_int8
+
+        self.assertIsInstance(model.layer.weight, QuantizedTensor)
+        self.assertTrue(model.layer._full_precision_mm)
+        return model.layer
+
+    def test_linear_input_act_honors_the_disabled_int8_format(self):
+        """The fused activation+INT8 kernel must honor the same disabled-format
+        routing the layer's forward honors (Comfy-Org/ComfyUI#16284).
+
+        MiniMax H3's MLP down-projection goes through linear_input_act, not the
+        layer's forward, so on MPS it reached torch._int_mm and raised
+        NotImplementedError even after #16130 marked int8 as disabled there. The
+        INT8 kernel is stubbed to raise the way MPS does, so this test fails on
+        the unfixed path for the reported reason rather than by inspection."""
+        layer = self._int8_layer_on_a_device_without_int_mm()
+
+        def _unimplemented_like_mps(*a, **kw):
+            raise NotImplementedError(
+                "The operator 'aten::_int_mm' is not currently implemented for the MPS device.")
+
+        seen_weight_types = []
+        orig_forward = layer._forward
+
+        def _capturing_forward(input, weight, bias, _orig=orig_forward):
+            seen_weight_types.append(type(weight))
+            return _orig(input, weight, bias)
+
+        layer._forward = _capturing_forward
+        orig_int8_linear = ops.quant_ops.ck.int8_linear
+        ops.quant_ops.ck.int8_linear = _unimplemented_like_mps
+        try:
+            x = torch.randn(4, 512, dtype=torch.bfloat16)
+            out = ops.linear_input_act(layer, x, "swiglu")
+        finally:
+            ops.quant_ops.ck.int8_linear = orig_int8_linear
+            layer._forward = orig_forward
+
+        self.assertEqual(out.shape, (4, 16))
+        # Dequantized, for the same reason as the layer's own forward: handing a
+        # QuantizedTensor to plain linear() would dispatch back into the disabled path.
+        self.assertEqual(seen_weight_types, [torch.Tensor])
+        # And the answer is the eager activation followed by the layer.
+        torch.testing.assert_close(out, layer(ops.INPUT_ACT_EAGER["swiglu"](x)))
+
+    def test_linear_input_act_still_fuses_where_int8_is_usable(self):
+        """The fix must not disable the fused kernel on devices that can run it."""
+        layer = self._int8_layer_on_a_device_without_int_mm(seed=99)
+        # Same layer, but this device can run the INT8 matmul.
+        layer._full_precision_mm = False
+
+        calls = []
+
+        def _recording_int8_linear(x, qdata, scale, bias, dtype, **kwargs):
+            calls.append(kwargs.get("input_act"))
+            return torch.zeros(x.shape[:-1] + (qdata.shape[0],), dtype=dtype)
+
+        orig_int8_linear = ops.quant_ops.ck.int8_linear
+        ops.quant_ops.ck.int8_linear = _recording_int8_linear
+        try:
+            out = ops.linear_input_act(layer, torch.randn(4, 512, dtype=torch.bfloat16), "swiglu")
+        finally:
+            ops.quant_ops.ck.int8_linear = orig_int8_linear
+
+        self.assertEqual(calls, ["swiglu"])
+        self.assertEqual(out.shape, (4, 16))
+
     def test_supports_int8_compute_treats_mps_mode_as_unsupported_when_device_is_none(self):
         """Call sites (like pick_operations' default) may omit load_device. On an
         MPS machine that must still report int8 as unsupported instead of


### PR DESCRIPTION
Fixes #16284. One condition in `comfy/ops.py`, plus two tests.

## What was happening

#16130 marks a layer for the dequantized path when its format is disabled on the device, and `forward_comfy_cast_weights` honors it:

```python
if self._full_precision_mm and isinstance(weight, QuantizedTensor):
    weight = weight.dequantize()
```

`linear_input_act` never consulted it. It checks `in_training`, the layout class and `transposed`, then calls `quant_ops.ck.int8_linear` directly — so a layer whose int8 format is disabled still reached `torch._int_mm`.

MiniMax H3's MLP down-projection is exactly that call (`comfy/ldm/minimax/model.py:210`), which is why the template still failed on MPS after #16130 while `fc1` in the same block was fine: `fc1` goes through the layer's `forward`.

The fix adds `_full_precision_mm` to the early-out that already exists for the LoRA and dtype cases, so the call routes through the layer's `forward` and dequantizes there. No new code path.

## Verified on the actual device

An M-series Mac, `torch.backends.mps.is_available()` true and `supports_int8_compute(mps)` false. Same loaded `int8_tensorwise` layer (`_full_precision_mm` is `True`), moved to `mps`, driven through `linear_input_act` with the real comfy-kitchen kernel:

**Before**

```
RESULT: NotImplementedError: The operator 'aten::_int_mm' is not currently implemented for the MPS device. …
```

**After**

```
RESULT: ok, shape (4, 16) | max abs diff vs eager: 0.0
```

The reference is `layer(INPUT_ACT_EAGER["swiglu"](x))`, so the dequantized answer is identical to the eager activation-then-linear one, not merely close.

I did not run the full MiniMax H3 template (I do not have those checkpoints here), so what is measured is the layer call that the traceback ends in, on the device it fails on.

## Tests

`tests-unit/comfy_quant/test_mixed_precision.py`, next to the #16130 test and sharing its loading helper (`pick_operations` with `supports_int8_compute` forced false, so the layer is marked the way a real MPS load marks it):

- `test_linear_input_act_honors_the_disabled_int8_format` — the INT8 kernel is stubbed to raise the way MPS does, so the test fails on the unfixed path **for the reported reason** rather than by inspection. It also pins that the layer receives a plain `torch.Tensor` (handing a `QuantizedTensor` to plain `linear()` would dispatch straight back into the disabled path, the same invariant the #16130 test pins) and that the result equals the eager reference.
- `test_linear_input_act_still_fuses_where_int8_is_usable` — with `_full_precision_mm` false the fused kernel is still called, with `input_act="swiglu"`. This one passes with and without the fix, which is what makes it a guard against the fix quietly disabling the optimization everywhere.

`pytest tests-unit/comfy_quant/` → 11 passed. Pre-fix control, `comfy/ops.py` reverted and tests kept: the first test fails with `NotImplementedError: The operator 'aten::_int_mm' …`, the second still passes.

(`tests-unit/comfy_test/` cannot be collected in my environment — no `torchvision`, `torchaudio`, `torchsde` or `av` installed — so I ran the quant suite only.)

## Scope

Only the int8 fused-activation path. #15967 reports the same symptom on an M3 Max and may be this same call; #15133 is a different op site. The `convrot` and `convrot_groupsize` arguments and the fused kernel itself are untouched.

AI disclosure: written by Claude (Anthropic) under my review and testing; no human reviewed it besides me.
